### PR TITLE
Improvements for testdrive: Firefox compatibility & JSON parsing

### DIFF
--- a/testdrive/index.html
+++ b/testdrive/index.html
@@ -270,8 +270,7 @@
 				var sample = $('<samp>').append('<span class="langname">' + record.lang + '</span><span class="sentence">' + record.sample + '</span>');
 				div.append(sample);
 			});
-			$.get(font.name + '.charmap', function(data){
-				data = JSON.parse(data);
+			$.getJSON(font.name + '.charmap', function(data){
 				var uhash = [];
 				var whash = [];
 				for(var j = 0; j < data.length; j++) {

--- a/testdrive/index.html
+++ b/testdrive/index.html
@@ -8,43 +8,43 @@
 		}
 		@font-face {
 			font-family: IosevkaWEB;
-			src: url(iosevka-regular.woff) format(woff), url(iosevka-regular.ttf) format(truetype);
+			src: url('iosevka-regular.woff') format('woff'), url('iosevka-regular.ttf') format('truetype');
 		}
 		@font-face {
 			font-family: IosevkaWEB;
 			font-style: italic;
-			src: url(iosevka-italic.woff) format(woff), url(iosevka-italic.ttf) format(truetype);
+			src: url('iosevka-italic.woff') format('woff'), url('iosevka-italic.ttf') format('truetype');
 		}
 		@font-face {
 			font-family: IosevkaWEB;
 			font-weight: bold;
-			src: url(iosevka-bold.woff) format(woff), url(iosevka-bold.ttf) format(truetype);
+			src: url('iosevka-bold.woff') format('woff'), url('iosevka-bold.ttf') format('truetype');
 		}
 		@font-face {
 			font-family: IosevkaWEB;
 			font-style: italic;
 			font-weight: bold;
-			src: url(iosevka-bolditalic.woff) format(woff), url(iosevka-bolditalic.ttf) format(truetype);
+			src: url('iosevka-bolditalic.woff') format('woff'), url('iosevka-bolditalic.ttf') format('truetype');
 		}
 		@font-face {
 			font-family: IosevkaCCWEB;
-			src: url(iosevkacc-regular.woff) format(woff), url(iosevkacc-regular.ttf) format(truetype);
-		}
-		@font-face {
-			font-family: IosevkaCCWEB;
-			font-style: italic;
-			src: url(iosevkacc-italic.woff) format(woff), url(iosevkacc-italic.ttf) format(truetype);
-		}
-		@font-face {
-			font-family: IosevkaCCWEB;
-			font-weight: bold;
-			src: url(iosevkacc-bold.woff) format(woff), url(iosevkacc-bold.ttf) format(truetype);
+			src: url('iosevkacc-regular.woff') format('woff'), url('iosevkacc-regular.ttf') format('truetype');
 		}
 		@font-face {
 			font-family: IosevkaCCWEB;
 			font-style: italic;
+			src: url('iosevkacc-italic.woff') format('woff'), url('iosevkacc-italic.ttf') format('truetype');
+		}
+		@font-face {
+			font-family: IosevkaCCWEB;
 			font-weight: bold;
-			src: url(iosevkacc-bolditalic.woff) format(woff), url(iosevkacc-bolditalic.ttf) format(truetype);
+			src: url('iosevkacc-bold.woff') format('woff'), url('iosevkacc-bold.ttf') format('truetype');
+		}
+		@font-face {
+			font-family: IosevkaCCWEB;
+			font-style: italic;
+			font-weight: bold;
+			src: url('iosevkacc-bolditalic.woff') format('woff'), url('iosevkacc-bolditalic.ttf') format('truetype');
 		}
 		a {
 			color: black;


### PR DESCRIPTION
I have noticed that the font preview is broken in Firefox due to incorrect `src` declaration in `@font-face`, so I have fixed it and made also a small improvement to the charmap code.

I'm not sure though if the `gh-pages` branch is generated from the `testdrive/index.html`. Should I send a new PR against that branch?