### PR TITLE
Add underscore.low variant, selectable via v-underscore-low.

### DIFF
--- a/glyphs/symbol-punctuation.ptl
+++ b/glyphs/symbol-punctuation.ptl
@@ -414,11 +414,17 @@ symbol-block 'Typographic Symbols'
 
 
 symbol-block 'Dashes'
-	create-glyph 'underscore' : glyph-construction
+	create-glyph 'underscore.high' : glyph-construction
 		set-width WIDTH
 		assign-unicode '_'
 		
 		include : HBarBottom SB RIGHTSB 0
+
+	composite 'underscore.low' glyphs.'underscore.high' [Upright] [Translate 0 (DESCENDER * 0.9)] [Italify]
+	select-variant 'underscore' '_' 'high' {
+		.cv20 'underscore.high'
+		.cv21 'underscore.low'
+	}
 	
 	create-glyph 'overline' : glyph-construction
 		assign-unicode 0x203E

--- a/parameters.toml
+++ b/parameters.toml
@@ -72,8 +72,8 @@ ss05 = ['cv12']
 ss06 = ['cv13']
 ss07 = ['cv14']
 ss08 = ['cv15']
-ss09 = ['cv16', 'cv18']
-ss10 = ['cv17', 'cv19']
+ss09 = ['cv16', 'cv18', 'cv20']
+ss10 = ['cv17', 'cv19', 'cv21']
 
 # Spacings
 [cjk]
@@ -261,3 +261,7 @@ asciitilde = 'low'
 asterisk = 'high'
 [v-asterisk-low.variantSelector]
 asterisk = 'low'
+[v-underscore-high.variantSelector]
+underscore = 'high'
+[v-underscore-low.variantSelector]
+underscore = 'low'


### PR DESCRIPTION
Hello, 

Like the low variants of ~ and *, I have created a variant for underscore that puts it below the baseline.
I copied the approach used by your other variant selectors, if I am doing it incorrectly, please let me know. I put it in the same groups as the other high/low selectors.

I am not sure what `[Upright]` or `[Italify]` will do. Also, I was only guessing that `[Translate 0 ...]` means translate position around the Y axis, so please correct me if this is mistaken.

Thanks!
