### PR TITLE
[WIP] Support for Braille patterns

### DIFF
--- a/buildglyphs.ptl
+++ b/buildglyphs.ptl
@@ -564,6 +564,7 @@ export as build : define [buildFont para recursive recursiveCodes] : begin
 	$$include 'glyphs/symbol-math.ptl'
 	$$include 'glyphs/symbol-letter.ptl'
 	$$include 'glyphs/symbol-geometric.ptl'
+	$$include 'glyphs/symbol-braille.ptl'
 	$$include 'glyphs/symbol-other.ptl'
 	
 	# Autobuilds

--- a/glyphs/symbol-braille.ptl
+++ b/glyphs/symbol-braille.ptl
@@ -1,0 +1,1815 @@
+###### Braille patterns
+
+local leftMiddle : MIDDLE - (0.25 * WIDTH)
+local rightMiddle : MIDDLE + (0.25 * WIDTH)
+
+local offsetY : 0.25 * (parenMid - parenTop)
+
+local brailleHalfStroke : 0.5 * [adviceBlackness 3.375]
+local brailleStress : brailleHalfStroke * 1.1
+local brailleDotsRadius : DOTRADIUS * [Math.min 1 (brailleStress / HALFSTROKE)]
+
+symbol-block 'Braille Patterns'
+	### Basics / Templates
+	sketch # brailleBlank
+		set-width WIDTH
+		save 'brailleBlank' 0x2800
+
+	sketch # braille1
+		include glyphs.brailleBlank
+		include : DotAt (leftMiddle) (parenMid - 3 * offsetY) brailleDotsRadius
+		save 'braille1' 0x2801
+
+	sketch # braille2
+		include glyphs.brailleBlank
+		include : DotAt (leftMiddle) (parenMid - 1 * offsetY) brailleDotsRadius
+		save 'braille2' 0x2802
+
+	sketch # braille3
+		include glyphs.brailleBlank
+		include : DotAt (leftMiddle) (parenMid + 1 * offsetY) brailleDotsRadius
+		save 'braille3' 0x2804
+
+	sketch # braille4
+		include glyphs.brailleBlank
+		include : DotAt (rightMiddle) (parenMid - 3 * offsetY) brailleDotsRadius
+		save 'braille4' 0x2808
+
+	sketch # braille5
+		include glyphs.brailleBlank
+		include : DotAt (rightMiddle) (parenMid - 1 * offsetY) brailleDotsRadius
+		save 'braille5' 0x2810
+
+	sketch # braille6
+		include glyphs.brailleBlank
+		include : DotAt (rightMiddle) (parenMid + 1 * offsetY) brailleDotsRadius
+		save 'braille6' 0x2820
+
+	sketch # braille7
+		include glyphs.brailleBlank
+		include : DotAt (leftMiddle) (parenMid + 3 * offsetY) brailleDotsRadius
+		save 'braille7' 0x2840
+
+	sketch # braille8
+		include glyphs.brailleBlank
+		include : DotAt (rightMiddle) (parenMid + 3 * offsetY) brailleDotsRadius
+		save 'braille8' 0x2880
+
+	### Inheriting characters
+
+	sketch # braille12
+		include glyphs.braille1
+		include glyphs.braille2
+		save 'braille12' 0x2803
+
+	sketch # braille13
+		include glyphs.braille1
+		include glyphs.braille3
+		save 'braille13' 0x2805
+
+	sketch # braille23
+		include glyphs.braille2
+		include glyphs.braille3
+		save 'braille23' 0x2806
+
+	sketch # braille123
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		save 'braille123' 0x2807
+
+	sketch # braille14
+		include glyphs.braille1
+		include glyphs.braille4
+		save 'braille14' 0x2809
+
+	sketch # braille24
+		include glyphs.braille2
+		include glyphs.braille4
+		save 'braille24' 0x280A
+
+	sketch # braille124
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille4
+		save 'braille124' 0x280B
+
+	sketch # braille34
+		include glyphs.braille3
+		include glyphs.braille4
+		save 'braille34' 0x280C
+
+	sketch # braille134
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille4
+		save 'braille134' 0x280D
+
+	sketch # braille234
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		save 'braille234' 0x280E
+
+	sketch # braille1234
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		save 'braille1234' 0x280F
+
+	sketch # braille15
+		include glyphs.braille1
+		include glyphs.braille5
+		save 'braille15' 0x2811
+
+	sketch # braille25
+		include glyphs.braille2
+		include glyphs.braille5
+		save 'braille25' 0x2812
+
+	sketch # braille125
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille5
+		save 'braille125' 0x2813
+
+	sketch # braille35
+		include glyphs.braille3
+		include glyphs.braille5
+		save 'braille35' 0x2814
+
+	sketch # braille135
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille5
+		save 'braille135' 0x2815
+
+	sketch # braille235
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille5
+		save 'braille235' 0x2816
+
+	sketch # braille1235
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille5
+		save 'braille1235' 0x2817
+
+	sketch # braille45
+		include glyphs.braille4
+		include glyphs.braille5
+		save 'braille45' 0x2818
+
+	sketch # braille145
+		include glyphs.braille1
+		include glyphs.braille4
+		include glyphs.braille5
+		save 'braille145' 0x2819
+
+	sketch # braille245
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille5
+		save 'braille245' 0x281A
+
+	sketch # braille1245
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille5
+		save 'braille1245' 0x281B
+
+	sketch # braille345
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		save 'braille345' 0x281C
+
+	sketch # braille1345
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		save 'braille1345' 0x281D
+
+	sketch # braille2345
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		save 'braille2345' 0x281E
+
+	sketch # braille12345
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		save 'braille12345' 0x281F
+
+	sketch # braille16
+		include glyphs.braille1
+		include glyphs.braille6
+		save 'braille16' 0x2821
+
+	sketch # braille26
+		include glyphs.braille2
+		include glyphs.braille6
+		save 'braille26' 0x2822
+
+	sketch # braille126
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille6
+		save 'braille126' 0x2823
+
+	sketch # braille36
+		include glyphs.braille3
+		include glyphs.braille6
+		save 'braille36' 0x2824
+
+	sketch # braille136
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille6
+		save 'braille136' 0x2825
+
+	sketch # braille236
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille6
+		save 'braille236' 0x2826
+
+	sketch # braille1236
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille6
+		save 'braille1236' 0x2827
+
+	sketch # braille46
+		include glyphs.braille4
+		include glyphs.braille6
+		save 'braille46' 0x2828
+
+	sketch # braille146
+		include glyphs.braille1
+		include glyphs.braille4
+		include glyphs.braille6
+		save 'braille146' 0x2829
+
+	sketch # braille246
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille6
+		save 'braille246' 0x282A
+
+	sketch # braille1246
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille6
+		save 'braille1246' 0x282B
+
+	sketch # braille346
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille6
+		save 'braille346' 0x282C
+
+	sketch # braille1346
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille6
+		save 'braille1346' 0x282D
+
+	sketch # braille2346
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille6
+		save 'braille2346' 0x282E
+
+	sketch # braille12346
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille6
+		save 'braille12346' 0x282F
+
+	sketch # braille56
+		include glyphs.braille5
+		include glyphs.braille6
+		save 'braille56' 0x2830
+
+	sketch # braille156
+		include glyphs.braille1
+		include glyphs.braille5
+		include glyphs.braille6
+		save 'braille156' 0x2831
+
+	sketch # braille256
+		include glyphs.braille2
+		include glyphs.braille5
+		include glyphs.braille6
+		save 'braille256' 0x2832
+
+	sketch # braille1256
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille5
+		include glyphs.braille6
+		save 'braille1256' 0x2833
+
+	sketch # braille356
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille6
+		save 'braille356' 0x2834
+
+	sketch # braille1356
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille6
+		save 'braille1356' 0x2835
+
+	sketch # braille2356
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille6
+		save 'braille2356' 0x2836
+
+	sketch # braille12356
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille6
+		save 'braille12356' 0x2837
+
+	sketch # braille456
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		save 'braille456' 0x2838
+
+	sketch # braille1456
+		include glyphs.braille1
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		save 'braille1456' 0x2839
+
+	sketch # braille2456
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		save 'braille2456' 0x283A
+
+	sketch # braille12456
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		save 'braille12456' 0x283B
+
+	sketch # braille3456
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		save 'braille3456' 0x283C
+
+	sketch # braille13456
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		save 'braille13456' 0x283D
+
+	sketch # braille23456
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		save 'braille23456' 0x283E
+
+	sketch # braille123456
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		save 'braille123456' 0x283F
+
+	sketch # braille17
+		include glyphs.braille1
+		include glyphs.braille7
+		save 'braille17' 0x2841
+
+	sketch # braille27
+		include glyphs.braille2
+		include glyphs.braille7
+		save 'braille27' 0x2842
+
+	sketch # braille127
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille7
+		save 'braille127' 0x2843
+
+	sketch # braille37
+		include glyphs.braille3
+		include glyphs.braille7
+		save 'braille37' 0x2844
+
+	sketch # braille137
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille7
+		save 'braille137' 0x2845
+
+	sketch # braille237
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille7
+		save 'braille237' 0x2846
+
+	sketch # braille1237
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille7
+		save 'braille1237' 0x2847
+
+	sketch # braille47
+		include glyphs.braille4
+		include glyphs.braille7
+		save 'braille47' 0x2848
+
+	sketch # braille147
+		include glyphs.braille1
+		include glyphs.braille4
+		include glyphs.braille7
+		save 'braille147' 0x2849
+
+	sketch # braille247
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille7
+		save 'braille247' 0x284A
+
+	sketch # braille1247
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille7
+		save 'braille1247' 0x284B
+
+	sketch # braille347
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille7
+		save 'braille347' 0x284C
+
+	sketch # braille1347
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille7
+		save 'braille1347' 0x284D
+
+	sketch # braille2347
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille7
+		save 'braille2347' 0x284E
+
+	sketch # braille12347
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille7
+		save 'braille12347' 0x284F
+
+	sketch # braille57
+		include glyphs.braille5
+		include glyphs.braille7
+		save 'braille57' 0x2850
+
+	sketch # braille157
+		include glyphs.braille1
+		include glyphs.braille5
+		include glyphs.braille7
+		save 'braille157' 0x2851
+
+	sketch # braille257
+		include glyphs.braille2
+		include glyphs.braille5
+		include glyphs.braille7
+		save 'braille257' 0x2852
+
+	sketch # braille1257
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille5
+		include glyphs.braille7
+		save 'braille1257' 0x2853
+
+	sketch # braille357
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille7
+		save 'braille357' 0x2854
+
+	sketch # braille1357
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille7
+		save 'braille1357' 0x2855
+
+	sketch # braille2357
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille7
+		save 'braille2357' 0x2856
+
+	sketch # braille12357
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille7
+		save 'braille12357' 0x2857
+
+	sketch # braille457
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille7
+		save 'braille457' 0x2858
+
+	sketch # braille1457
+		include glyphs.braille1
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille7
+		save 'braille1457' 0x2859
+
+	sketch # braille2457
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille7
+		save 'braille2457' 0x285A
+
+	sketch # braille12457
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille7
+		save 'braille12457' 0x285B
+
+	sketch # braille3457
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille7
+		save 'braille3457' 0x285C
+
+	sketch # braille13457
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille7
+		save 'braille13457' 0x285D
+
+	sketch # braille23457
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille7
+		save 'braille23457' 0x285E
+
+	sketch # braille123457
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille7
+		save 'braille123457' 0x285F
+
+	sketch # braille67
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille67' 0x2860
+
+	sketch # braille167
+		include glyphs.braille1
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille167' 0x2861
+
+	sketch # braille267
+		include glyphs.braille2
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille267' 0x2862
+
+	sketch # braille1267
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille1267' 0x2863
+
+	sketch # braille367
+		include glyphs.braille3
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille367' 0x2864
+
+	sketch # braille1367
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille1367' 0x2865
+
+	sketch # braille2367
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille2367' 0x2866
+
+	sketch # braille12367
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille12367' 0x2867
+
+	sketch # braille467
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille467' 0x2868
+
+	sketch # braille1467
+		include glyphs.braille1
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille1467' 0x2869
+
+	sketch # braille2467
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille2467' 0x286A
+
+	sketch # braille12467
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille12467' 0x286B
+
+	sketch # braille3467
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille3467' 0x286C
+
+	sketch # braille13467
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille13467' 0x286D
+
+	sketch # braille23467
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille23467' 0x286E
+
+	sketch # braille123467
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille123467' 0x286F
+
+	sketch # braille567
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille567' 0x2870
+
+	sketch # braille1567
+		include glyphs.braille1
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille1567' 0x2871
+
+	sketch # braille2567
+		include glyphs.braille2
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille2567' 0x2872
+
+	sketch # braille12567
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille12567' 0x2873
+
+	sketch # braille3567
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille3567' 0x2874
+
+	sketch # braille13567
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille13567' 0x2875
+
+	sketch # braille23567
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille23567' 0x2876
+
+	sketch # braille123567
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille123567' 0x2877
+
+	sketch # braille4567
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille4567' 0x2878
+
+	sketch # braille14567
+		include glyphs.braille1
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille14567' 0x2879
+
+	sketch # braille24567
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille24567' 0x287A
+
+	sketch # braille124567
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille124567' 0x287B
+
+	sketch # braille34567
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille34567' 0x287C
+
+	sketch # braille134567
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille134567' 0x287D
+
+	sketch # braille234567
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille234567' 0x287E
+
+	sketch # braille1234567
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		save 'braille1234567' 0x287F
+
+	sketch # braille18
+		include glyphs.braille1
+		include glyphs.braille8
+		save 'braille18' 0x2881
+
+	sketch # braille28
+		include glyphs.braille2
+		include glyphs.braille8
+		save 'braille28' 0x2882
+
+	sketch # braille128
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille8
+		save 'braille128' 0x2883
+
+	sketch # braille38
+		include glyphs.braille3
+		include glyphs.braille8
+		save 'braille38' 0x2884
+
+	sketch # braille138
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille8
+		save 'braille138' 0x2885
+
+	sketch # braille238
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille8
+		save 'braille238' 0x2886
+
+	sketch # braille1238
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille8
+		save 'braille1238' 0x2887
+
+	sketch # braille48
+		include glyphs.braille4
+		include glyphs.braille8
+		save 'braille48' 0x2888
+
+	sketch # braille148
+		include glyphs.braille1
+		include glyphs.braille4
+		include glyphs.braille8
+		save 'braille148' 0x2889
+
+	sketch # braille248
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille8
+		save 'braille248' 0x288A
+
+	sketch # braille1248
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille8
+		save 'braille1248' 0x288B
+
+	sketch # braille348
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille8
+		save 'braille348' 0x288C
+
+	sketch # braille1348
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille8
+		save 'braille1348' 0x288D
+
+	sketch # braille2348
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille8
+		save 'braille2348' 0x288E
+
+	sketch # braille12348
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille8
+		save 'braille12348' 0x288F
+
+	sketch # braille58
+		include glyphs.braille5
+		include glyphs.braille8
+		save 'braille58' 0x2890
+
+	sketch # braille158
+		include glyphs.braille1
+		include glyphs.braille5
+		include glyphs.braille8
+		save 'braille158' 0x2891
+
+	sketch # braille258
+		include glyphs.braille2
+		include glyphs.braille5
+		include glyphs.braille8
+		save 'braille258' 0x2892
+
+	sketch # braille1258
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille5
+		include glyphs.braille8
+		save 'braille1258' 0x2893
+
+	sketch # braille358
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille8
+		save 'braille358' 0x2894
+
+	sketch # braille1358
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille8
+		save 'braille1358' 0x2895
+
+	sketch # braille2358
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille8
+		save 'braille2358' 0x2896
+
+	sketch # braille12358
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille8
+		save 'braille12358' 0x2897
+
+	sketch # braille458
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille8
+		save 'braille458' 0x2898
+
+	sketch # braille1458
+		include glyphs.braille1
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille8
+		save 'braille1458' 0x2899
+
+	sketch # braille2458
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille8
+		save 'braille2458' 0x289A
+
+	sketch # braille12458
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille8
+		save 'braille12458' 0x289B
+
+	sketch # braille3458
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille8
+		save 'braille3458' 0x289C
+
+	sketch # braille13458
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille8
+		save 'braille13458' 0x289D
+
+	sketch # braille23458
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille8
+		save 'braille23458' 0x289E
+
+	sketch # braille123458
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille8
+		save 'braille123458' 0x289F
+
+	sketch # braille68
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille68' 0x28A0
+
+	sketch # braille168
+		include glyphs.braille1
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille168' 0x28A1
+
+	sketch # braille268
+		include glyphs.braille2
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille268' 0x28A2
+
+	sketch # braille1268
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille1268' 0x28A3
+
+	sketch # braille368
+		include glyphs.braille3
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille368' 0x28A4
+
+	sketch # braille1368
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille1368' 0x28A5
+
+	sketch # braille2368
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille2368' 0x28A6
+
+	sketch # braille12368
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille12368' 0x28A7
+
+	sketch # braille468
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille468' 0x28A8
+
+	sketch # braille1468
+		include glyphs.braille1
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille1468' 0x28A9
+
+	sketch # braille2468
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille2468' 0x28AA
+
+	sketch # braille12468
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille12468' 0x28AB
+
+	sketch # braille3468
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille3468' 0x28AC
+
+	sketch # braille13468
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille13468' 0x28AD
+
+	sketch # braille23468
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille23468' 0x28AE
+
+	sketch # braille123468
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille123468' 0x28AF
+
+	sketch # braille568
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille568' 0x28B0
+
+	sketch # braille1568
+		include glyphs.braille1
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille1568' 0x28B1
+
+	sketch # braille2568
+		include glyphs.braille2
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille2568' 0x28B2
+
+	sketch # braille12568
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille12568' 0x28B3
+
+	sketch # braille3568
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille3568' 0x28B4
+
+	sketch # braille13568
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille13568' 0x28B5
+
+	sketch # braille23568
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille23568' 0x28B6
+
+	sketch # braille123568
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille123568' 0x28B7
+
+	sketch # braille4568
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille4568' 0x28B8
+
+	sketch # braille14568
+		include glyphs.braille1
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille14568' 0x28B9
+
+	sketch # braille24568
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille24568' 0x28BA
+
+	sketch # braille124568
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille124568' 0x28BB
+
+	sketch # braille34568
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille34568' 0x28BC
+
+	sketch # braille134568
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille134568' 0x28BD
+
+	sketch # braille234568
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille234568' 0x28BE
+
+	sketch # braille1234568
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille8
+		save 'braille1234568' 0x28BF
+
+	sketch # braille78
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille78' 0x28C0
+
+	sketch # braille178
+		include glyphs.braille1
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille178' 0x28C1
+
+	sketch # braille278
+		include glyphs.braille2
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille278' 0x28C2
+
+	sketch # braille1278
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille1278' 0x28C3
+
+	sketch # braille378
+		include glyphs.braille3
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille378' 0x28C4
+
+	sketch # braille1378
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille1378' 0x28C5
+
+	sketch # braille2378
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille2378' 0x28C6
+
+	sketch # braille12378
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille12378' 0x28C7
+
+	sketch # braille478
+		include glyphs.braille4
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille478' 0x28C8
+
+	sketch # braille1478
+		include glyphs.braille1
+		include glyphs.braille4
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille1478' 0x28C9
+
+	sketch # braille2478
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille2478' 0x28CA
+
+	sketch # braille12478
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille12478' 0x28CB
+
+	sketch # braille3478
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille3478' 0x28CC
+
+	sketch # braille13478
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille13478' 0x28CD
+
+	sketch # braille23478
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille23478' 0x28CE
+
+	sketch # braille123478
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille123478' 0x28CF
+
+	sketch # braille578
+		include glyphs.braille5
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille578' 0x28D0
+
+	sketch # braille1578
+		include glyphs.braille1
+		include glyphs.braille5
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille1578' 0x28D1
+
+	sketch # braille2578
+		include glyphs.braille2
+		include glyphs.braille5
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille2578' 0x28D2
+
+	sketch # braille12578
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille5
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille12578' 0x28D3
+
+	sketch # braille3578
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille3578' 0x28D4
+
+	sketch # braille13578
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille13578' 0x28D5
+
+	sketch # braille23578
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille23578' 0x28D6
+
+	sketch # braille123578
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille123578' 0x28D7
+
+	sketch # braille4578
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille4578' 0x28D8
+
+	sketch # braille14578
+		include glyphs.braille1
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille14578' 0x28D9
+
+	sketch # braille24578
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille24578' 0x28DA
+
+	sketch # braille124578
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille124578' 0x28DB
+
+	sketch # braille34578
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille34578' 0x28DC
+
+	sketch # braille134578
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille134578' 0x28DD
+
+	sketch # braille234578
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille234578' 0x28DE
+
+	sketch # braille1234578
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille1234578' 0x28DF
+
+	sketch # braille678
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille678' 0x28E0
+
+	sketch # braille1678
+		include glyphs.braille1
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille1678' 0x28E1
+
+	sketch # braille2678
+		include glyphs.braille2
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille2678' 0x28E2
+
+	sketch # braille12678
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille12678' 0x28E3
+
+	sketch # braille3678
+		include glyphs.braille3
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille3678' 0x28E4
+
+	sketch # braille13678
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille13678' 0x28E5
+
+	sketch # braille23678
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille23678' 0x28E6
+
+	sketch # braille123678
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille123678' 0x28E7
+
+	sketch # braille4678
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille4678' 0x28E8
+
+	sketch # braille14678
+		include glyphs.braille1
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille14678' 0x28E9
+
+	sketch # braille24678
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille24678' 0x28EA
+
+	sketch # braille124678
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille124678' 0x28EB
+
+	sketch # braille34678
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille34678' 0x28EC
+
+	sketch # braille134678
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille134678' 0x28ED
+
+	sketch # braille234678
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille234678' 0x28EE
+
+	sketch # braille1234678
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille1234678' 0x28EF
+
+	sketch # braille5678
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille5678' 0x28F0
+
+	sketch # braille15678
+		include glyphs.braille1
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille15678' 0x28F1
+
+	sketch # braille25678
+		include glyphs.braille2
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille25678' 0x28F2
+
+	sketch # braille125678
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille125678' 0x28F3
+
+	sketch # braille35678
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille35678' 0x28F4
+
+	sketch # braille135678
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille135678' 0x28F5
+
+	sketch # braille235678
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille235678' 0x28F6
+
+	sketch # braille1235678
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille1235678' 0x28F7
+
+	sketch # braille45678
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille45678' 0x28F8
+
+	sketch # braille145678
+		include glyphs.braille1
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille145678' 0x28F9
+
+	sketch # braille245678
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille245678' 0x28FA
+
+	sketch # braille1245678
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille1245678' 0x28FB
+
+	sketch # braille345678
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille345678' 0x28FC
+
+	sketch # braille1345678
+		include glyphs.braille1
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille1345678' 0x28FD
+
+	sketch # braille2345678
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille2345678' 0x28FE
+
+	sketch # braille12345678
+		include glyphs.braille1
+		include glyphs.braille2
+		include glyphs.braille3
+		include glyphs.braille4
+		include glyphs.braille5
+		include glyphs.braille6
+		include glyphs.braille7
+		include glyphs.braille8
+		save 'braille12345678' 0x28FF

--- a/makesupport.mk
+++ b/makesupport.mk
@@ -10,7 +10,7 @@ snapshot/assets :
 PATELC = node ./node_modules/patel/bin/patel-c
 SUPPORT_FILES_FROM_PTL = support/glyph.js support/spiroexpand.js support/spirokit.js parameters.js support/anchor.js support/point.js support/transform.js
 SUPPORT_FILES = $(SUPPORT_FILES_FROM_PTL) generator.js emptyfont.toml parameters.toml support/fairify.js
-GLYPH_SEGMENTS = glyphs/common-shapes.ptl glyphs/overmarks.ptl glyphs/letters-unified-basic.ptl glyphs/letters-unified-extended.ptl  glyphs/numbers.ptl glyphs/symbol-punctuation.ptl glyphs/symbol-math.ptl glyphs/symbol-geometric.ptl glyphs/symbol-other.ptl glyphs/symbol-letter.ptl glyphs/autobuilds.ptl
+GLYPH_SEGMENTS = glyphs/common-shapes.ptl glyphs/overmarks.ptl glyphs/letters-unified-basic.ptl glyphs/letters-unified-extended.ptl  glyphs/numbers.ptl glyphs/symbol-punctuation.ptl glyphs/symbol-math.ptl glyphs/symbol-geometric.ptl glyphs/symbol-other.ptl glyphs/symbol-braille.ptl glyphs/symbol-letter.ptl glyphs/autobuilds.ptl
 SCRIPTS = $(SUPPORT_FILES) buildglyphs.js
 SCRIPTS_FROM_aki = $(SUPPORT_FILES_FROM_PTL) buildglyphs.js
 


### PR DESCRIPTION
![](https://cloud.githubusercontent.com/assets/240167/14977575/53720bee-1115-11e6-8f04-ffa2ca4dd7f6.png)

**Do not merge just yet!**

I worked on a pretty simple Unicode block, namely "Braille patterns (`2800..28FF`)". I tried to fit it in the rest of the font as good as possible.
*This is just a proposal!* I will work on details and Italic support of these characters as long as this change is considered useful.

```
⠀⠁⠂⠃⠄⠅⠆⠇⠈⠉⠊⠋⠌⠍⠎⠏⠐⠑⠒⠓⠔⠕⠖⠗⠘⠙⠚⠛⠜⠝⠞⠟⠠⠡⠢⠣⠤⠥⠦
⠧⠨⠩⠪⠫⠬⠭⠮⠯⠰⠱⠲⠳⠴⠵⠶⠷⠸⠹⠺⠻⠼⠽⠾⠿⡀⡁⡂⡃⡄⡅⡆⡇⡈⡉⡊⡋⡌⡍
⡎⡏⡐⡑⡒⡓⡔⡕⡖⡗⡘⡙⡚⡛⡜⡝⡞⡟⡠⡡⡢⡣⡤⡥⡦⡧⡨⡩⡪⡫⡬⡭⡮⡯⡰⡱⡲⡳⡴
⡵⡶⡷⡸⡹⡺⡻⡼⡽⡾⡿⢀⢁⢂⢃⢄⢅⢆⢇⢈⢉⢊⢋⢌⢍⢎⢏⢐⢑⢒⢓⢔⢕⢖⢗⢘⢙⢚⢛
⢜⢝⢞⢟⢠⢡⢢⢣⢤⢥⢦⢧⢨⢩⢪⢫⢬⢭⢮⢯⢰⢱⢲⢳⢴⢵⢶⢷⢸⢹⢺⢻⢼⢽⢾⢿⣀⣁⣂
⣃⣄⣅⣆⣇⣈⣉⣊⣋⣌⣍⣎⣏⣐⣑⣒⣓⣔⣕⣖⣗⣘⣙⣚⣛⣜⣝⣞⣟⣠⣡⣢⣣⣤⣥⣦⣧⣨⣩
⣪⣫⣬⣭⣮⣯⣰⣱⣲⣳⣴⣵⣶⣷⣸⣹⣺⣻⣼⣽⣾⣿
```

Currently, I have still some problems:

- [ ] I somehow managed to compile `fontforge` without TrueType hinting support, I will fix that (currently, characters look like garbage on Windows when compiled on my setup)
- [ ] Some characters don't render in BabelMap, they show up and look just fine when opening the font in FontForge (might be a problem with missing hints)
- [ ] I'm not 100% confident with `patel-c`, so this whole code could be written much shorter and efficient. I will figure out how to do that.

My question is: Do you think Braille pattern support is a good thing to have in Iosevka? I see them used as spinners (instead of `|/-\`) and you can plot bitmaps with them (2x4 pixels per character).