### PR TITLE
Add a Guarani pangram to the demo list

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,7 @@
         {lang: <span class=hljs-string>'German'</span>,        sample: <span class=hljs-string>'Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.'</span>},
         {lang: <span class=hljs-string>'Greek'</span>,         sample: <span class=hljs-string>'Ταχίστη αλώπηξ βαφής ψημένη γη, δρασκελίζει υπέρ νωθρού κυνός.'</span>},
         {lang: <span class=hljs-string>'Ancient Greek'</span>, sample: <span class=hljs-string>'Ἄδμηθ’, ὁρᾷς γὰρ τἀμὰ πράγμαθ’ ὡς ἔχει, λέξαι θέλω σοι πρὶν θανεῖν ἃ βούλομαι. '</span>},
+        {lang: <span class=hljs-string>'Guarani'</span>,       sample: <span class=hljs-string>'Hĩlandiagua kuñanguéra oho peteĩ saʼyju ypaʼũme Gavõme omboʼe hag̃ua ingyleñeʼẽ mitãnguérare neʼẽndyʼỹ.'</span>},
         {lang: <span class=hljs-string>'Hungarian'</span>,     sample: <span class=hljs-string>'Jó foxim és don Quijote húszwattos lámpánál ülve egy pár bűvös cipőt készít.'</span>},
         {lang: <span class=hljs-string>'Icelandic'</span>,     sample: <span class=hljs-string>'Kæmi ný öxi hér, ykist þjófum nú bæði víl og ádrepa.'</span>},
         {lang: <span class=hljs-string>'Irish'</span>,         sample: <span class=hljs-string>'Ċuaiġ bé ṁórṡáċ le dlúṫspád fíorḟinn trí hata mo ḋea-ṗorcáin ḃig.'</span>},

--- a/specimen.js
+++ b/specimen.js
@@ -49,6 +49,7 @@ var sampleSentences = [
 	{ code: 'de', lang: 'German', sample: 'Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich. Waſſerschloſʒ' },
 	{ code: 'el', lang: 'Greek', sample: 'Ταχίστη αλώπηξ βαφής ψημένη γη, δρασκελίζει υπέρ νωθρού κυνός.' },
 	{ code: 'el', lang: 'Ancient Greek', sample: 'Ἄδμηθ’, ὁρᾷς γὰρ τἀμὰ πράγμαθ\' ὡς ἔχει, λέξαι θέλω σοι πρὶν θανεῖν ἃ βούλομαι. ' },
+	{ code: 'gn', lang: 'Guarani', sample: 'Hĩlandiagua kuñanguéra oho peteĩ saʼyju ypaʼũme Gavõme omboʼe hag̃ua ingyleñeʼẽ mitãnguérare neʼẽndyʼỹ.' },
 	{ code: 'hu', lang: 'Hungarian', sample: 'Jó foxim és don Quijote húszwattos lámpánál ülve egy pár bűvös cipőt készít.' },
 	{ code: 'is', lang: 'Icelandic', sample: 'Kæmi ný öxi hér, ykist þjófum nú bæði víl og ádrepa.' },
 	{ code: 'ga', lang: 'Irish', sample: 'Ċuaiġ bé ṁórṡáċ le dlúṫspád fíorḟinn trí hata mo ḋea-ṗorcáin ḃig.' },


### PR DESCRIPTION
I know that you don’t probably want to have each and every language on the demo list of your home page, but I thought it would be cool to highlight the fact that this is one of the very few fonts (open-source or commercial) that support the complete Guarani alphabet today (thanks for that, by the way!); most foundries completely ignore this language, even though it’s spoken by the ~90% of the Paraguayan population.