### PR TITLE
Add ruble symbol

### DIFF
--- a/glyphs/symbol-letter.ptl
+++ b/glyphs/symbol-letter.ptl
@@ -104,6 +104,12 @@ export : define [apply] : begin
 		include : HOverlayBar (SB * 0.5) (SB * 3 + STROKE * HVCONTRAST) [mix 0 XH 0.4]
 		save 'frenchFranc' 0x20A3
 
+	sketch # ruble
+		include glyphs.P AS_BASE
+		include : HOverlayBar [mix SB 0 0.7] [mix SB RIGHTSB 0.1] (CAP * 0.48)
+		include : HOverlayBar [mix SB 0 0.7] [mix SB RIGHTSB 0.8] (CAP * 0.3)
+		save 'ruble' 0x20BD
+
 	### 'Letterlike Symbols'
 	sketch # numero
 		local fine : adviceBlackness 4.5


### PR DESCRIPTION
I tried doing the requested  #156 glyph. 

I tried looking at how you implemented the currency symbols. It looks fine for Regular but on Bold it looks quite messy, but I don't know where to start fixing that.

Iosevka | Iosevka Slab | [unicode-table.com](https://unicode-table.com/en/20BD/)
:---:|:---:|:---:
<img width="190" alt="ruble_iosevka" src="https://cloud.githubusercontent.com/assets/3930615/23571650/bb1363d4-006a-11e7-9cd1-25f4806fc743.png"> | <img width="180" alt="iosevka-slab-ruble" src="https://cloud.githubusercontent.com/assets/3930615/23571907/fc66802c-006b-11e7-9c02-e18a352acd31.png"> | <img width="200" alt="screen shot 2017-03-03 at 23 32 51" src="https://cloud.githubusercontent.com/assets/3930615/23571538/297c4602-006a-11e7-99cb-135419882c4d.png">