### PR TITLE
Add stylistic set ss10 for 'Envy Code R' style

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The current available styles are:
   - `term` : Disable ligations. When this style is present, the font built will not contain ligatures, and its family name will be set to “`Iosevka Term`”. In case of your OS or editor cannot handle ligatures correctly, you can disable ligations with it.
   - `stress-fw` : When included, full-width characters varying form `U+FF00` to `U+FFFF` will be boxed to present a clear distinguish between ASCII and Full-width. The family name will be set to “`Iosevka StFW`”.
 * All registered `ss##` and `cv##` feature tags, including:
-  * `ss01`~`ss09` : Predefined stylistic sets based on other Monospace fonts.
+  * `ss01`~`ss10` : Predefined stylistic sets based on other Monospace fonts.
   * `cv01`~`cv45` : Standalone character variants.
 * Styles for individual characters. They are easy-to-understand names of the `cv##` styles, including:
   * Styles for letter `l`:

--- a/snapshot/index.html
+++ b/snapshot/index.html
@@ -56,6 +56,9 @@
 			</li><li>
 				<span class="tag">ss09</span><span class="description">Source Code Pro Style</span>
 				<span class="sample" style="font-feature-settings:'ss09'"><b>@</b>re<b>a</b><b>l</b> fox.qu<b>i</b>ck(h)<b>{</b> <b>*</b><b>i</b>s<b>_</b>brown &amp;&amp; <b>i</b>t<b>_</b>jumps<b>_</b>over(do<b>g</b>es.<b>l</b><b>a</b>zy) <b>}</b> <b>0</b>123456789</span><span class="sample italic" style="font-feature-settings:'ss09'"><b>@</b>re<b>a</b><b>l</b> fox.qu<b>i</b>ck(h)<b>{</b> <b>*</b><b>i</b>s<b>_</b>brown &amp;&amp; <b>i</b>t<b>_</b>jumps<b>_</b>over(do<b>g</b>es.<b>l</b><b>a</b>zy) <b>}</b> <b>0</b>123456789</span>
+			</li><li>
+				<span class="tag">ss10</span><span class="description">Envy Code R Style</span>
+				<span class="sample" style="font-feature-settings:'ss10'"><b>@</b>re<b>a</b><b>l</b> fox.qu<b>i</b>ck(h)<b>{</b> <b>*</b><b>i</b>s<b>_</b>brown &amp;&amp; <b>i</b>t<b>_</b>jumps<b>_</b>over(do<b>g</b>es.<b>l</b><b>a</b>zy) <b>}</b> <b>0</b>123456789</span><span class="sample italic" style="font-feature-settings:'ss09'"><b>@</b>re<b>a</b><b>l</b> fox.qu<b>i</b>ck(h)<b>{</b> <b>*</b><b>i</b>s<b>_</b>brown &amp;&amp; <b>i</b>t<b>_</b>jumps<b>_</b>over(do<b>g</b>es.<b>l</b><b>a</b>zy) <b>}</b> <b>0</b>123456789</span>
 			</li>
 		</ol><div class="hr">Character Variants</div>
 		<ol class="narrow">

--- a/variants.toml
+++ b/variants.toml
@@ -256,3 +256,7 @@ design = ['v-at-long', 'v-a-doublestorey', 'v-l-serifed', 'v-i-serifed', 'v-aste
 [composite.ss09]
 design = ['v-at-long', 'v-l-italic', 'v-asterisk-low', 'v-zero-dotted', 'v-dollar-open', 'v-numbersign-slanted']
 upright = ['v-i-hooky']
+
+# Envy Code R Style
+[composite.ss10]
+design = ['v-at-long', 'v-a-doublestorey', 'v-underscore-low', 'v-g-singlestorey', 'v-i-hooky', 'v-l-hooky', 'v-asterisk-low']


### PR DESCRIPTION
Hi, really like Iosevka!

[Envy Code R](https://damieng.com/envy-code-r) is a font I created many years ago that would work well as a stylistic set for Iosevka as it isn't that close to any of the other stylistic sets (uses hooked il)

Input Sans Mono has a [Envy Code R style](http://input.fontbureau.com/preview/?size=14&language=python&theme=solarized-dark&family=InputSans&width=300&weight=300&line-height=1.2&a=0&g=ss&i=topserif&l=topserif&zero=slash&asterisk=0&braces=0&preset=envy&customize=please) as well.