### PR TITLE
Add optional GE ligature (in manner of ZALE feature)

### DIFF
--- a/meta/feature/ligation.ptl
+++ b/meta/feature/ligation.ptl
@@ -19,6 +19,7 @@ export : define [progLigNameMap] : object
 	.XV00 {'arrow2', 'plusplus', 'dotoper', 'logic', 'brst', 'coq'}
 	# "special" tags
 	.ZALE {'arrowZALE'} # <= as arrow
+	.ZAGE {'arrowZAGE'} # >= as arrow
 	# common feature tags
 	.XCCC {}
 	.dlig {'arrow2', 'plusplus', 'dotoper', 'logic', 'brst', 'dlig'}
@@ -355,6 +356,9 @@ export : define [buildLigations chain-rule lookupOrder commonList features looku
 				chain-rule # -<, =<
 					arrowStick ~> [only 'arrow2' : lsx 'fj']
 					less       ~> preserved
+				chain-rule # >=
+					greater    ~> preserved
+					equal      ~> [only 'arrowZAGE' : lsx 'jf']
 		# <<, >>, <<<, >>>
 		includeLookup
 			.type 'gsub_chaining'


### PR DESCRIPTION
A simple optional >= ligature to match the <= arrow available using `ZALE`.

I'd love to help implement some other simple equality operators (==, !=, ~=, ===) and am perfectly happy with them remaining full-width, but haven't figured out how to make them work yet.