### PR TITLE
Build only needed weights and slants

### DIFF
--- a/build-plans.toml
+++ b/build-plans.toml
@@ -233,3 +233,5 @@ oblique = "oblique"
 # upright = ["upright-only", "styles"]   # Upright-only styles
 # italic = ["italic-only", "styles"]     # Italic-only styles
 # oblique = ["oblique-only", "styles"]   # Oblique-only styles
+# weights = ["regular", "bold"]          # Build only regular and bold fonts
+# slants = ["upright", "italic"]         # Build only upright and italic fonts

--- a/verdafile.js
+++ b/verdafile.js
@@ -102,9 +102,11 @@ oracle(`o:font-building-parameters`).def(async target => {
 	const fontInfos = {};
 	const bp = {};
 	for (const p in buildPlans) {
-		const { pre, post, prefix, family } = buildPlans[p];
+		const { pre, post, prefix, family, weights, slants } = buildPlans[p];
 		const targets = [];
 		for (const suffix in suffixMapping) {
+			if (weights && !weights.includes(suffixMapping[suffix].weight)) continue;
+			if (slants && !slants.includes(suffixMapping[suffix].slant)) continue;
 			const fileName = [prefix, suffix].join("-");
 			const preHives = [...pre.design, ...pre[suffixMapping[suffix].slant]];
 			const postHives = [...post.design, ...post[suffixMapping[suffix].slant]];


### PR DESCRIPTION
Allow to choose what weights and slants to build.
E.g. I build special version for terminal and only need regular and bold weights. But also I build browser version and it's not convenient to comment and uncomment weights.