### PR TITLE
Fix vertical alignment

### DIFF
--- a/meta/aesthetics.ptl
+++ b/meta/aesthetics.ptl
@@ -181,8 +181,8 @@ export : define [setFontMetrics para metrics font] : begin
 	set font.OS_2.usWinDescent      ([Math.abs desc] + descenderPad)
 	set font.OS_2.sTypoDescender    (desc - descenderPad)
 
-	set font.hhea.lineGap           (para.leading - asc + DESCENDER)
-	set font.OS_2.sTypoLineGap      (para.leading - asc + desc)
+	set font.hhea.lineGap           0
+	set font.OS_2.sTypoLineGap      0
 
 	set font.OS_2.sxHeight          XH
 	set font.OS_2.sCapHeight        CAP

--- a/parameters.toml
+++ b/parameters.toml
@@ -6,7 +6,7 @@ designer = 'Belleve Invis'
 description = 'Spatial efficient monospace font family for programming. Built from code. http://be5invis.github.io/Iosevka'
 
 leading = 1250     # Default line height times 1000.
-descenderPad = 0   # Additional line height, added to descender.
+descenderPad = 65  # Additional line height, added to descender.
 width = 500        # Character width. Increase this if you think that Iosevka is too narrow.
 cap = 735          # Cap height (as well as ascender).
 xheight = 530      # X-height.


### PR DESCRIPTION
Iosevka is a great font, but it has vertical alignment problem on macOS, see 

- <https://github.com/be5invis/Iosevka/issues/105>
- <https://github.com/be5invis/Iosevka/issues/43>
- <https://github.com/be5invis/Iosevka/issues/80>

It seems that Iosevka use descenderPad to fix the vertical alignment problem, by enlarging descenderPad. 

I did some experiments and measured in fontforge, by enlarging descenderPad to 65, the alignment problem will be fixed.

However, only enlarge descenderPad will result in new problem (The bottom padding will be too large on some editor). This is because that some text render will use ascent/descent/lineGap. I have checked google's roboto font and apple's SF font, these fonts's lineGap was set to zero.

With lineGap set to zero, and descenderPad set to 65, the vertical alignment will be fixed without introducing new problems.

**Before fix**

<img width="602" alt="0" src="https://user-images.githubusercontent.com/23468295/60159387-a15dc600-9825-11e9-9421-be5b02c15389.png">

**After**

<img width="602" alt="1" src="https://user-images.githubusercontent.com/23468295/60159496-db2ecc80-9825-11e9-87d6-2992f1b1400e.png">

For now I only test the fixed-built on macOS and Windows 7 Virtual Machine, further check is needed.

You can download the fixed-built:
[iosevka-hyzeta.zip](https://github.com/be5invis/Iosevka/files/3329924/iosevka-hyzeta.zip)
