### PR TITLE
Move 'colors' from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 	},
 	"dependencies": {
 		"caryll-shapeops": "^0.3.1",
+		"colors": "^1.3.3",
 		"libspiro-js": "^0.3.1",
 		"megaminx": "^0.9.0",
 		"object-assign": "^4.1.1",
@@ -26,7 +27,6 @@
 		"yargs": "^12.0.0"
 	},
 	"devDependencies": {
-		"colors": "^1.3.3",
 		"patel": "^0.33.1",
 		"patrisika-scopes": "^0.11.1",
 		"eslint": "^5.2.0",


### PR DESCRIPTION
Because `checkenv` is run on install and requires `colors/safe`, trying to build and install without installing dev dependencies fails. Moving it to `dependencies` solves the issue.