### PR TITLE
reverse 4438176 and cb4280e

### DIFF
--- a/meta/aesthetics.ptl
+++ b/meta/aesthetics.ptl
@@ -186,8 +186,8 @@ export : define [setFontMetrics para metrics font] : begin
 	set font.OS_2.usWinDescent      ([Math.abs desc] + descenderPad + winMetricPad)
 	set font.OS_2.sTypoDescender    (desc - descenderPad + winMetricPad)
 
-	set font.hhea.lineGap           0
-	set font.OS_2.sTypoLineGap      0
+	set font.hhea.lineGap           (para.leading - asc + DESCENDER)
+	set font.OS_2.sTypoLineGap      (para.leading - asc + desc)
 
 	set font.OS_2.sxHeight          XH
 	set font.OS_2.sCapHeight        CAP

--- a/parameters.toml
+++ b/parameters.toml
@@ -6,7 +6,7 @@ designer = 'Belleve Invis'
 description = 'Spatial efficient monospace font family for programming. Built from code. http://be5invis.github.io/Iosevka'
 
 leading = 1250     # Default line height times 1000.
-descenderPad = 65  # Additional line height, added to descender.
+descenderPad = 0   # Additional line height, added to descender.
 width = 500        # Character width. Increase this if you think that Iosevka is too narrow.
 cap = 735          # Cap height (as well as ascender).
 xheight = 530      # X-height.


### PR DESCRIPTION
reverse <https://github.com/be5invis/Iosevka/commit/44381761e358042fba17f14c8c2e79e0ce806662> and <https://github.com/be5invis/Iosevka/commit/cb4280ed9d4484f3c827b75ec29632671c1d0860>

<https://github.com/be5invis/Iosevka/commit/44381761e358042fba17f14c8c2e79e0ce806662> and <https://github.com/be5invis/Iosevka/commit/cb4280ed9d4484f3c827b75ec29632671c1d0860> changed line height mechanics, and are blamed for <https://github.com/be5invis/Iosevka/issues/355> and <https://github.com/be5invis/Iosevka/issues/360>. We shouldn't use this new mechanics before we have done enough experiments to make sure it won't break.