### PR TITLE
Nine variant

### DIFF
--- a/glyphs/numbers.ptl
+++ b/glyphs/numbers.ptl
@@ -175,7 +175,7 @@ export : define [apply] : begin
 		reverse-last
 		branch
 			if SLAB : include : DownwardLeftSerif (SB + OXE) CAP VJUT
-			save 'seven.normal'
+			save 'seven.standard'
 		branch
 			include : DownwardLeftSerif (SB + OXE) CAP VJUT
 			save 'seven.force-serifed'

--- a/glyphs/numbers.ptl
+++ b/glyphs/numbers.ptl
@@ -250,7 +250,17 @@ export : define [apply] : begin
 			curl r (CAP * 0.35)
 			hookend O
 			g4 SB HOOK
-		save 'nine' '9'
+		save 'nine.standard'
+
+	sketch # nine.rotatedsix
+		include markset.capital
+		set-width WIDTH
+		include glyphs.six
+		apply-transform : Translate (-WIDTH) (-CAP)
+		apply-transform : Rotate (Math.PI)
+		save 'nine.180six'
+
+	select-variant 'nine' '9'
 
 	sketch # ten
 		include markset.capital

--- a/variants.toml
+++ b/variants.toml
@@ -302,6 +302,15 @@ seven = "standard"
 tag = "cv65"
 seven = "force-serifed"
 
+[simple.v-nine-standard]
+tag = "cv66"
+nine = "standard"
+
+[simple.v-nine-180six]
+tag = "cv67"
+nine = "180six"
+
+
 [default]
 design = [
 	'v-m-longleg',
@@ -325,6 +334,7 @@ design = [
 	'v-capital-j-serifed',
 	'v-r-standard',
 	'v-seven-standard',
+	'v-nine-standard',
 	'others'
 ]
 upright = [

--- a/variants.toml
+++ b/variants.toml
@@ -294,9 +294,9 @@ r = "narrow"
 [simple.v-j-narrow]
 dotlessj = "narrow"
 
-[simple.v-seven-normal]
+[simple.v-seven-standard]
 tag = "cv64"
-seven = "normal"
+seven = "standard"
 
 [simple.v-seven-force-serifed]
 tag = "cv65"
@@ -324,7 +324,7 @@ design = [
 	'v-capital-i-serifed',
 	'v-capital-j-serifed',
 	'v-r-standard',
-	'v-seven-normal',
+	'v-seven-standard',
 	'others'
 ]
 upright = [


### PR DESCRIPTION
Adds a variant of the number nine glyph that is the number six glyph rotated on its head:

![image](https://user-images.githubusercontent.com/3930615/66270799-f78bcd80-e846-11e9-8277-bee3e982bd8b.png)

*I also changed the default glyph variant of seven to use `standard` instead of `normal` to be more in line with other glyphs, see `r`.*

*ps: if you have any suggestions for a better name than `180six` I'm all for it, I just couldn't think of a better one^^*