### PR TITLE
Add font-display: swap strategy for webfonts

### DIFF
--- a/utility/make-webfont-css.js
+++ b/utility/make-webfont-css.js
@@ -9,6 +9,7 @@ module.exports = function(output, family, hs, formats) {
 		ans += `
 @font-face {
 	font-family: '${family + " Web"}';
+	font-display: swap;
 	font-weight: ${term.cssWeight};
 	font-style: ${term.cssStyle};
 	src: ${src};
@@ -19,6 +20,7 @@ module.exports = function(output, family, hs, formats) {
 			ans += `
 @font-face {
 	font-family: '${family + " Web Oblique"}';
+	font-display: swap;
 	font-weight: ${term.cssWeight};
 	src: ${src};
 }


### PR DESCRIPTION
#### What

I have added `font-display: swap` property on `@font-face` rules of the webfont css.

#### Why

`font-display: swap` enables zero block period and infinite swap period when the web-font is in-flight. This makes the text immediately available to the user as opposed to the default 3 second delay by the browsers.

TLDR; it provides a better accessibility by displaying the text in system fonts till the custom font loads.

#### References
- [Controlling Font Performance with font-display](https://developers.google.com/web/updates/2016/02/font-display#swap)
- [`font-display` for the Masses](https://css-tricks.com/font-display-masses/#article-header-id-2)