### PR TITLE
Add Ubuntu Mono stylistic set

### DIFF
--- a/build-plans.toml
+++ b/build-plans.toml
@@ -129,6 +129,14 @@ design = ["ss11"]
 family = "Iosevka Term SS11"
 design = ["term", "ss11"]
 
+[buildPlans.iosevka-ss12]
+family = "Iosevka SS12"
+design = ["ss12"]
+
+[buildPlans.iosevka-term-ss12]
+family = "Iosevka Term SS12"
+design = ["term", "ss12"]
+
 [buildPlans.iosevka-aile]
 family  = "Iosevka Aile"
 design  = ["type", "shape-straight-bar", "v-at-fourfold", "v-j-narrow", 'v-capital-i-straight', 'v-capital-j-straight', 'v-g-singlestorey', 'v-r-narrow', "no-cv-ss", "no-ligation"]
@@ -193,6 +201,8 @@ iosevka-ss10 = "iosevka-ss10"
 iosevka-term-ss10 = "iosevka-term-ss10"
 iosevka-ss11 = "iosevka-ss11"
 iosevka-term-ss11 = "iosevka-term-ss11"
+iosevka-ss12 = "iosevka-ss12"
+iosevka-term-ss12 = "iosevka-term-ss12"
 experimental-iosevka-aile = "iosevka-aile"
 experimental-iosevka-etoile = "iosevka-etoile"
 experimental-iosevka-extended = "iosevka-extended"

--- a/variants.toml
+++ b/variants.toml
@@ -394,3 +394,7 @@ design = ['v-at-threefold', 'v-a-doublestorey', 'v-underscore-low', 'v-g-singles
 # X Window Style
 [composite.ss11]
 design = ['v-g-singlestorey', 'v-zero-unslashed', 'v-tilde-high', 'v-brace-straight', 'v-dollar-through', 'v-three-flattop', 'v-at-threefold']
+
+# Ubuntu Mono Style
+[composite.ss12]
+design = ['v-at-threefold', 'v-a-doublestorey', 'v-f-straight', 'v-g-singlestorey', 'v-underscore-low', 'v-i-italic', 'v-l-italic', 'v-m-shortleg', 'v-y-straight', 'v-brace-straight', 'v-zero-dotted', 'v-one-serifed', 'v-numbersign-slanted']


### PR DESCRIPTION
This PR adds a variant for Ubuntu Mono style and closes be5invis#358.

@be5invis I'm unsure how [stylesets.png](https://raw.githubusercontent.com/be5invis/Iosevka/master/images/stylesets.png) can be updated. Do you want me to Photoshop it for the new variant?