### PR TITLE
Add Ubuntu Mono style variant

### DIFF
--- a/build-plans.toml
+++ b/build-plans.toml
@@ -171,6 +171,14 @@ design = ["ss11"]
 family = "Iosevka Term SS11"
 design = ["term", "ss11"]
 
+[buildPlans.iosevka-ss12]
+family = "Iosevka SS12"
+design = ["ss12"]
+
+[buildPlans.iosevka-term-ss12]
+family = "Iosevka Term SS12"
+design = ["term", "ss12"]
+
 [buildPlans.iosevka-aile]
 family  = "Iosevka Aile"
 design  = ["type", "v-at-fourfold", "v-j-narrow", 'v-capital-i-straight', 'v-capital-j-straight', 'v-g-singlestorey', 'v-r-narrow', "no-cv-ss", "no-ligation"]
@@ -255,6 +263,8 @@ iosevka-ss10 = "iosevka-ss10"
 iosevka-term-ss10 = "iosevka-term-ss10"
 iosevka-ss11 = "iosevka-ss11"
 iosevka-term-ss11 = "iosevka-term-ss11"
+iosevka-ss12 = "iosevka-ss12"
+iosevka-term-ss12 = "iosevka-term-ss12"
 
 # Experimental variants
 experimental-iosevka-aile = "iosevka-aile"

--- a/snapshot/index.html
+++ b/snapshot/index.html
@@ -65,6 +65,9 @@
 		</li><li>
 			<span class="tag">ss11</span><span class="description">X Windows Fixed Style</span>
 			<span class="sample" style="font-feature-settings:'ss11'"><b>@</b>re<b>a</b><b>l</b> fox.qu<b>i</b>ck(h)<b>{</b> <b>*</b><b>i</b>s<b>_</b>brown &amp;&amp; <b>i</b>t<b>_</b>jumps<b>_</b>over(do<b>g</b>es.<b>l</b><b>a</b>zy) <b>}</b> <b>0</b>12<b>3</b>456789</span><span class="sample italic" style="font-feature-settings:'ss11'"><b>@</b>re<b>a</b><b>l</b> fox.qu<b>i</b>ck(h)<b>{</b> <b>*</b><b>i</b>s<b>_</b>brown &amp;&amp; <b>i</b>t<b>_</b>jumps<b>_</b>over(do<b>g</b>es.<b>l</b><b>a</b>zy) <b>}</b> <b>0</b>12<b>3</b>456789</span>
+		</li><li>
+			<span class="tag">ss12</span><span class="description">Ubuntu Mono Style</span>
+			<span class="sample" style="font-feature-settings:'ss12'"><b>@</b>re<b>a</b><b>l</b> fox.qu<b>i</b>ck(h)<b>{</b> <b>*</b><b>i</b>s<b>_</b>brown &amp;&amp; <b>i</b>t<b>_</b>jumps<b>_</b>over(do<b>g</b>es.<b>l</b><b>a</b>zy) <b>}</b> <b>0</b>12<b>3</b>456789</span><span class="sample italic" style="font-feature-settings:'ss12'"><b>@</b>re<b>a</b><b>l</b> fox.qu<b>i</b>ck(h)<b>{</b> <b>*</b><b>i</b>s<b>_</b>brown &amp;&amp; <b>i</b>t<b>_</b>jumps<b>_</b>over(do<b>g</b>es.<b>l</b><b>a</b>zy) <b>}</b> <b>0</b>12<b>3</b>456789</span>
 		</li>
 	</ol>
 </section>

--- a/variants.toml
+++ b/variants.toml
@@ -403,3 +403,7 @@ design = ['v-at-threefold', 'v-a-doublestorey', 'v-underscore-low', 'v-g-singles
 # X Window Style
 [composite.ss11]
 design = ['v-g-singlestorey', 'v-zero-unslashed', 'v-tilde-high', 'v-brace-straight', 'v-dollar-through', 'v-three-flattop', 'v-at-threefold']
+
+# Ubuntu Mono Style
+[composite.ss12]
+design = ['v-at-threefold', 'v-a-doublestorey', 'v-f-straight', 'v-g-singlestorey', 'v-underscore-low', 'v-i-italic', 'v-l-italic', 'v-m-shortleg', 'v-y-straight', 'v-brace-straight', 'v-zero-dotted', 'v-one-serifed', 'v-numbersign-slanted']


### PR DESCRIPTION
As requested in be5invis/Iosevka#388, raising a new PR on `dev` with build plans, variants and snapshots for Ubuntu Mono style.