### PR TITLE
Update OpenBSD installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Quit your editor/program. Unzip and open the folder.
   - Arch Linux users can install the font from the AUR [here](https://aur.archlinux.org/packages/ttf-iosevka) using an AUR wrapper or by doing it manually. [All variants](https://aur.archlinux.org/packages/?O=0&SeB=nd&K=ttf-iosevka&SB=n&SO=a&PP=50&do_Search=Go).
   - Void Linux users can install the font with `xbps-install font-iosevka`.
 * **FreeBSD**: The font can be installed with `pkg install iosevka`.
-* **OpenBSD**: The font can be installed with `pkg_add iosevka-fonts-<variant>`. Run `pkg_info -Q iosevka-fonts` to see which variants are available.
+* **OpenBSD**: Run `pkg_info -Q iosevka` to see which Iosevka packages are available. Use `pkg_add` to install the chosen package(s).
 
 ## Weights, Variants and OpenType features
 


### PR DESCRIPTION
I've just committed an update to the OpenBSD port which drops the
`-fonts` package suffix. These new instructions remain correct for
before and after this change.

(Same PR as before, just to the dev branch, not master).