### PR TITLE
Fix `spacing` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,12 +313,12 @@ Configuration of build plans are organized under `[buildPlans.<plan name>]` sect
 * `family`: String, defines the family name of your custom variant.
 * `spacing`: Optional, String, denotes the spacing of the custom variant. Valid values include:
   - `term`: Make the symbols' width suitable for terminal emulators. Arrows and geometric symbols ill become narrower.
-  - `force-monospace`: Apply `term` spacing changes and further:
+  - `fontconfig-mono`: Apply `term` spacing changes and further:
     - Completely remove wide glyphs. All non-combining glyphs will be exactly the same width.
     - Remove `NWID` and `WWID` OpenType feature.
     
     This spacing is recommended for Linux users who customize for their terminal fonts: certain applications, including FontConfig, recognizes a font as monospace if and only if its every non-combining glyphs having the same width.
-  - `fixed`: Apply `force-monospace` changes and remove ligations.
+  - `fixed`: Apply `fontconfig-mono` changes and remove ligations.
 * `serifs`: Optional, String, configures style of serifs.
   - When set to `slab`, the font will be converted into slab-serif.
   - Otherwise the font will be sans-serif.

--- a/changes/4.0.0-beta.3.md
+++ b/changes/4.0.0-beta.3.md
@@ -1,2 +1,3 @@
  * Fix variant application of fraction 1/10 (U+2152, #736).
  * Make variant application effective on LATIN SMALL LETTER WITH STROKE (U+0167, #737).
+ * Updated readme to reflect change in spacing parameter `force-monospace` to `fontconfig-mono`.


### PR DESCRIPTION
c1c3ce79ee1f127a66bb3e504d7d7d6cb8de3cef changed `design: sp-force-monospace` to `spacing: fontconfig-mono`, but the Readme to `spacing: force-monospace`.