### PR TITLE
Add more metric overrides

### DIFF
--- a/font-src/support/parameters.js
+++ b/font-src/support/parameters.js
@@ -126,6 +126,8 @@ const metricOverrideHandlers = {
 	leading: numericFieldHandler,
 	winMetricAscenderPad: numericFieldHandler,
 	winMetricDescenderPad: numericFieldHandler,
+	SymbolMid: numericFieldHandler,
+	parenSize: numericFieldHandler,
 	powerlineScaleY: numericFieldHandler,
 	powerlineScaleX: numericFieldHandler,
 	powerlineShiftY: numericFieldHandler,


### PR DESCRIPTION
Allow override of `SymbolMid` and `parenSize`.