### PR TITLE
Allow inherit ligations from `calt`

### DIFF
--- a/font-src/support/ligation-data.js
+++ b/font-src/support/ligation-data.js
@@ -21,7 +21,7 @@ module.exports = function applyLigationData(data, para, argv) {
 	}
 
 	para.ligation = {
-		defaultBuildup: defaultBuildup,
+		defaultBuildup,
 		caltBuildup: []
 	};
 	if (argv.ligations) {

--- a/font-src/support/ligation-data.js
+++ b/font-src/support/ligation-data.js
@@ -3,8 +3,7 @@
 const Parameters = require("./parameters");
 
 module.exports = function applyLigationData(data, para, argv) {
-	const optInBuildup = {};
-	const optOutBuildup = {};
+	const defaultBuildup = {};
 
 	const hives = {};
 	hives["default"] = { caltBuildup: [] };
@@ -17,18 +16,12 @@ module.exports = function applyLigationData(data, para, argv) {
 		if (!comp.tag) continue;
 
 		const ligSets = createBuildup(data.simple, comp.buildup);
-		if (comp.isOptOut) {
-			optOutBuildup[comp.tag] = ligSets;
-		} else {
-			optInBuildup[comp.tag] = ligSets;
-		}
-		if (!comp.isOptOut) {
-			hives["ligset-" + gr] = { caltBuildup: ligSets };
-		}
+		defaultBuildup[comp.tag] = ligSets;
+		hives["ligset-" + gr] = { caltBuildup: ligSets };
 	}
 
 	para.ligation = {
-		defaultBuildup: { ...optInBuildup, ...optOutBuildup },
+		defaultBuildup: defaultBuildup,
 		caltBuildup: []
 	};
 	if (argv.ligations) {

--- a/font-src/support/ligation-data.js
+++ b/font-src/support/ligation-data.js
@@ -8,8 +8,8 @@ module.exports = function applyLigationData(data, para, argv) {
 	const hives = {};
 	hives["default"] = { caltBuildup: [] };
 	for (const gr in data.simple) {
-		hives["enable-" + gr] = { appends: { caltBuildup: [data.simple[gr].ligGroup] } };
-		hives["disable-" + gr] = { removes: { caltBuildup: [data.simple[gr].ligGroup] } };
+		hives[`ligset-enable-${gr}`] = { appends: { caltBuildup: [data.simple[gr].ligGroup] } };
+		hives[`ligset-disable-${gr}`] = { removes: { caltBuildup: [data.simple[gr].ligGroup] } };
 	}
 	for (const gr in data.composite) {
 		const comp = data.composite[gr];
@@ -17,7 +17,7 @@ module.exports = function applyLigationData(data, para, argv) {
 
 		const ligSets = createBuildup(data.simple, comp.buildup);
 		defaultBuildup[comp.tag] = ligSets;
-		hives["ligset-" + gr] = { caltBuildup: ligSets };
+		hives[`ligset-inherit-${gr}`] = { caltBuildup: ligSets };
 	}
 
 	para.ligation = {
@@ -26,18 +26,18 @@ module.exports = function applyLigationData(data, para, argv) {
 	};
 	if (argv.ligations) {
 		if (argv.ligations.inherits)
-			Parameters.apply(para.ligation, hives, ["ligset-" + argv.ligations.inherits]);
+			Parameters.apply(para.ligation, hives, [`ligset-inherit-${argv.ligations.inherits}`]);
 		if (argv.ligations.disables)
 			Parameters.apply(
 				para.ligation,
 				hives,
-				argv.ligations.disables.map(x => `disable-${x}`)
+				argv.ligations.disables.map(x => `ligset-disable-${x}`)
 			);
 		if (argv.ligations.enables)
 			Parameters.apply(
 				para.ligation,
 				hives,
-				argv.ligations.enables.map(x => `enable-${x}`)
+				argv.ligations.enables.map(x => `ligset-enable-${x}`)
 			);
 	}
 };

--- a/params/ligation-set.toml
+++ b/params/ligation-set.toml
@@ -124,12 +124,13 @@ desc = 'Transform `:>` into `:` and a narrow arrow.'
 
 ###################################################################################################
 
-[composite.calt]
-isOptOut = true # This feature is on by default by many software
+# This feature is on by default by many software
+[composite.default-calt]
 tag     = 'calt'
 buildup = ['center-ops', 'arrow', 'html-comment', 'trig', 'llgg', 'llggeq', 'eqeq', 'exeq', 'ineq', 'plusplus', 'kern-dotty']
 brief   = 'Default'
 desc    = 'Default setting in text editors'
+longDesc = 'Inherit default ligation set'
 
 [composite.dlig]
 tag     = 'dlig'

--- a/private-build-plans.sample.toml
+++ b/private-build-plans.sample.toml
@@ -31,9 +31,9 @@ l = 'italic'
 # Configure ligations
 
 [buildPlans.iosevka-custom.ligations]
-inherits = "calt"   # Optional; inherits an existing ligation set
-disables = []       # Optional; disable specific ligation groups, overrides inherited ligation set
-enables  = []       # Optional; enable specific ligation groups, overrides inherited ligation set
+inherits = "default-calt"   # Optional; inherits an existing ligation set
+disables = []               # Optional; disable specific ligation groups, overrides inherited ligation set
+enables  = []               # Optional; enable specific ligation groups, overrides inherited ligation set
 
 # End ligation section
 ###################################################################################################

--- a/utility/amend-readme/index.js
+++ b/utility/amend-readme/index.js
@@ -177,7 +177,6 @@ async function processLigSetPreDef() {
 	const headerPath = path.resolve(__dirname, "fragments/description-predefined-ligation-sets.md");
 	md.log(await fs.readFile(headerPath, "utf-8"));
 	for (const gr in ligData.rawSets) {
-		if (ligData.rawSets[gr].isOptOut) continue;
 		const longDesc =
 			ligData.rawSets[gr].longDesc ||
 			`Default ligation set would be assigned to ${ligData.rawSets[gr].desc}`;


### PR DESCRIPTION
Add `calt` to `hives` so `inherit = 'calt'` works.

Also get rid of `optInBuildup`/`optOutBuildup` because they just merged into `para.ligation.defaultBuildup`.