### PR TITLE
Streamlined instructions to build from source with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,17 +288,17 @@ You will find TTFs, as well as WOFF(2) web fonts and one Webfont CSS in the `dis
 
 ### Using a Docker container
 
-[Here](https://github.com/avivace/fonts-iosevka) you can find a Docker container handling the build environment for you.
+A Docker container handling the build environment for you can be found [here](https://github.com/avivace/fonts-iosevka).
 
-To pull it from Docker Hub, run
+To pull it from Docker Hub and start a standard build of the latest released version, run
 
 ```
 docker run -it -v $(pwd):/build avivace/iosevka-build
 ```
 
-It will start a standard build of the latest released version. Fonts files will be placed in the `dist` folder.
+Fonts files will be placed in the `dist` folder.
 
-You can provide `private-build.plans.toml` for a customized build or specify the desired release appending `-e FONT_VERSION=X.X.X`. to the Docker command.
+You can provide `private-build.plans.toml` for a customized build and/or specify the desired release appending `-e FONT_VERSION=X.X.X`. to the Docker command.
 
 ## Customized Build
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,17 @@ You will find TTFs, as well as WOFF(2) web fonts and one Webfont CSS in the `dis
 
 ### Using a Docker container
 
-Refer to these [instructions.](https://github.com/ejuarezg/containers/tree/master/iosevka_font#container-method)
+[Here](https://github.com/avivace/fonts-iosevka) you can find a Docker container handling the build environment for you.
+
+To pull it from Docker Hub, run
+
+```
+docker run -it -v $(pwd):/build avivace/iosevka-build
+```
+
+It will start a standard build of the latest released version. Fonts files will be placed in the `dist` folder.
+
+You can provide `private-build.plans.toml` for a customized build or specify the desired release appending `-e FONT_VERSION=X.X.X`. to the Docker command.
 
 ## Customized Build
 


### PR DESCRIPTION
This PR introduces a new Docker container based on the one previously linked and some brief instructions for the basic use case, directly in this README. Additional options are in the external linked repository.

It is also pushed to Docker Hub, so users can launch custom (and default) builds of the font just with one command.

My only concern is `private-build-plans.toml` being mentioned just before its introduction in the following paragraph.

Any feedback?