### PR TITLE
Add raised-turn-comma variant for ascii-grave

### DIFF
--- a/font-src/glyphs/symbol/punctuation.ptl
+++ b/font-src/glyphs/symbol/punctuation.ptl
@@ -1269,6 +1269,7 @@ glyph-block Symbol-Punctuation-Quotes-And-Primes : begin
 
 	alias 'asciiSingleQuote.raisedComma' null 'closeSingleQuote'
 	alias 'asciiGrave.raisedInverseComma' null 'revertSingleQuote'
+	alias 'asciiGrave.raisedTurnComma' null 'openSingleQuote'
 
 	select-variant 'asciiSingleQuote' 0x27
 	select-variant 'asciiGrave' 0x60

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1798,6 +1798,11 @@ rank = 2
 description = "Show ASCII grave (`` ` ``) as raised comma."
 selector.asciiGrave = 'raisedInverseComma'
 
+[prime.ascii-grave.variants.raised-turn-comma]
+rank = 3
+description = "Show ASCII grave (`` ` ``) as raised turned comma."
+selector.asciiGrave = 'raisedTurnComma'
+
 ########## "Untagged" variants, used for Aile, etc.
 
 [prime.f.variants.narrow]

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1800,7 +1800,7 @@ selector.asciiGrave = 'raisedInverseComma'
 
 [prime.ascii-grave.variants.raised-turn-comma]
 rank = 3
-description = "Show ASCII grave (`` ` ``) as raised turned comma."
+description = "Show ASCII grave (`` ` ``) as raised turned comma, identical to curly open single quote symbols (U+2018)."
 selector.asciiGrave = 'raisedTurnComma'
 
 ########## "Untagged" variants, used for Aile, etc.


### PR DESCRIPTION
This glyph is commonly used in Lisp literature (e.g. PAIP) for backquote.