### PR TITLE
Replace deprecated brew cask command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Quit your editor/program. Unzip and open the folder.
   * Standard distribution in Homebrew: 
     ```bash
     brew tap homebrew/cask-fonts
-    brew cask install font-iosevka
+    brew install --cask font-iosevka
     ```
   *  Search for other variants using `brew search font-iosevka` and install what you want.
   * Customizable install using Homebrew: see [robertgzr/homebrew-tap](https://github.com/robertgzr/homebrew-tap).


### PR DESCRIPTION
# What this PR fixes

`brew cask` was [completely deprecated](https://brew.sh/2020/12/01/homebrew-2.6.0/) in Homebrew 2.6.0.

Current Homebrew install script raises an error, `Error: Calling brew cask install is disabled! Use brew install [--cask] instead.`.

This PR fixes this issue by replacing `brew cask install` command with `brew install --cask`, as advised by Homebrew.