### PR TITLE
Support custom weights, widths and slopes when collecting TTCs

### DIFF
--- a/verdafile.js
+++ b/verdafile.js
@@ -367,22 +367,16 @@ const DistWoff2 = file.make(
 ///////////////////////////////////////////////////////////
 
 const CollectPlans = computed(`metadata:collect-plans`, async target => {
-	const [rawPlans, suffixMapping] = await target.need(RawPlans, StandardSuffixes);
+	const [rawPlans] = await target.need(RawPlans);
 	return await getCollectPlans(
 		target,
 		rawPlans.collectPlans,
-		suffixMapping,
 		rawPlans.collectConfig,
 		fnStandardTtc
 	);
 });
 
-const StandardSuffixes = computed(`metadata:standard-suffixes`, async target => {
-	const [rp] = await target.need(RawPlans);
-	return getSuffixMapping(rp.weights, rp.slopes, rp.widths);
-});
-
-async function getCollectPlans(target, rawCollectPlans, suffixMapping, config, fnFileName) {
+async function getCollectPlans(target, rawCollectPlans, config, fnFileName) {
 	const glyfTtcComposition = {},
 		ttcComposition = {},
 		ttcContents = {},
@@ -396,6 +390,7 @@ async function getCollectPlans(target, rawCollectPlans, suffixMapping, config, f
 		for (const prefix of collect.from) {
 			const [gri] = await target.need(BuildPlanOf(prefix));
 			const ttfFileNameSet = new Set(gri.targets);
+			const suffixMapping = getSuffixMapping(gri.weights, gri.slopes, gri.widths);
 			for (const suffix in suffixMapping) {
 				const sfi = suffixMapping[suffix];
 				const ttcFileName = fnFileName(


### PR DESCRIPTION
When using `private-build-plans.toml` with some weight, width or slope names outside of the standard sets defined in `build-plans.toml`, any font variations which had at least one nonstandard suffix component were built normally as TTFs, but were not added to TTCs, because only suffixes for combinations of standard weight, width and slope names were considered by `getCollectPlans()`.  Change `getCollectPlans()` to get the suffix mapping for every build plan instead of using standard suffixes for all plans, so that any custom weight/width/slope names would be handled properly.


Fixes #1026.

-----

Retargeted to `dev` as requested.