### PR TITLE
Support `SOURCE_DATE_EPOCH` for reproducible builds

### DIFF
--- a/font-src/gen/empty-font.js
+++ b/font-src/gen/empty-font.js
@@ -3,7 +3,7 @@
 const { Ot } = require("ot-builder");
 
 module.exports = function () {
-	return {
+	var font = {
 		head: new Ot.Head.Table(),
 		hhea: new Ot.MetricHead.Hhea(),
 		os2: new Ot.Os2.Table(4),
@@ -11,4 +11,9 @@ module.exports = function () {
 		maxp: Ot.Maxp.Table.TrueType(),
 		name: new Ot.Name.Table()
 	};
+	if (process.env.SOURCE_DATE_EPOCH) {
+		font.head.created  = new Date(process.env.SOURCE_DATE_EPOCH * 1000);
+		font.head.modified = new Date(process.env.SOURCE_DATE_EPOCH * 1000);
+	}
+	return font;
 };


### PR DESCRIPTION
If the `SOURCE_DATE_EPOCH` environment variable is set, use its value for timestamps in the generated TTF files to make builds reproducible: https://reproducible-builds.org/docs/source-date-epoch/

I'm not sure whether this is the proper place to put this code (the place where these fields are initialized with `new Date()` is `node_modules/@ot-builder/ot-metadata/lib/head.js`), but at least it works this way (I tried to run a build locally in NixOS, and another build on the GitHub-hosted action runner with Ubuntu 20.04, setting `SOURCE_DATE_EPOCH=315532800`, and the resulting TTF and TTC files came out identical).

Other utilities that process TTF and TTC files can also modify these timestamp fields, but apparently `otb-ttc-bundle` keeps the values of those fields unchanged, and `ttfautohint` also supports `SOURCE_DATE_EPOCH`.

BTW, another related issue that affects timestamps is https://github.com/ot-builder/monorepo/issues/89 (but a simple workaround for that is setting `TZ=UTC`).