### PR TITLE
Add Docker build command which is compatible with Powershell

### DIFF
--- a/doc/custom-build.md
+++ b/doc/custom-build.md
@@ -18,6 +18,12 @@ To pull it from Docker Hub and start a standard build of the latest released ver
 docker run -it -v $(pwd):/build avivace/iosevka-build
 ```
 
+If you are using Powershell, run
+
+```
+docker run -it -v ${pwd}:/build avivace/iosevka-build
+```
+
 Fonts files will be placed in the `dist` folder.
 
 You can provide `private-build.plans.toml` for a customized build and/or specify the desired release appending `-e FONT_VERSION=X.X.X`. to the Docker command.


### PR DESCRIPTION
The docker build command `docker run -it -v $(pwd):/build avivace/iosevka-build` in docs/custom-build.md is not compatible with Powershell due to the incorrect braces. In this pull request I added a functionally equivalent command which replaces the parentheses with curly brackets, which is compatible with Powershell.

Note: the original command is intact, I have only added a new command below it.