### PR TITLE
Fix 404 for Sample Configuration

### DIFF
--- a/doc/custom-build.md
+++ b/doc/custom-build.md
@@ -515,7 +515,7 @@ will:
 
 #### Sample Configuration
 
-A sample configuration could be found at [private-build-plans.sample.toml](private-build-plans.sample.toml).
+A sample configuration could be found at [private-build-plans.sample.toml](https://github.com/be5invis/Iosevka/blob/master/private-build-plans.sample.toml).
 
 ### TTC Building
 


### PR DESCRIPTION
Currently the Sample Configuration link to `private-build-plans.sample.toml` 404s. Added a static link to the config on main.