### PR TITLE
Add note to build docs on limiting cloned size via --depth

### DIFF
--- a/doc/custom-build.md
+++ b/doc/custom-build.md
@@ -1,5 +1,11 @@
 # Building Iosevka from Source
+### Cloning
+Note that this repo has a 30+ GB commit history. If you only want the current files and future changes, you can avoid downloading so much by cloning the repo with a [`--depth`](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt) limit. Example:
+```
+git clone --depth 1 https://github.com/be5invis/Iosevka.git 
+```
 
+### Building
 To build Iosevka you should:
 
 1. Ensure that [`nodejs`](http://nodejs.org) (≥ 14.0.0) and [`ttfautohint`](http://www.freetype.org/ttfautohint/) are present, and accessible from `PATH`.


### PR DESCRIPTION
When cloning, I had assumed the repo's files were just huge for some reason until I saw in https://github.com/be5invis/Iosevka/issues/1122 that it was really just the commit history

This publicizes that more and may save others some bandwidth.

-----

Repeat of incorrectly submitted #1395 

Thanks for the beautiful font! I switched over to it a few days ago and it's been fantastic. Simply the most I've ever liked a font, and the customization options are superb.