### PR TITLE
Implement U+1ACC and U+1DFF

### DIFF
--- a/font-src/glyphs/auto-build/transformed.ptl
+++ b/font-src/glyphs/auto-build/transformed.ptl
@@ -622,6 +622,7 @@ glyph-block Autobuild-Transformed : begin
 		list 0x1E08F 'cyrl/Ukrainiani'
 
 	createMedievalCombs Descender XH : list
+		list 0x1ACC 'gInsular'
 		list 0x1DDA 'g'
 		list 0x1DD7 'cCedilla'
 		list 0x1DE9 'latn/beta'

--- a/font-src/glyphs/marks/below.ptl
+++ b/font-src/glyphs/marks/below.ptl
@@ -268,6 +268,13 @@ glyph-block Mark-Below : begin
 		set-mark-anchor 'below' markMiddle 0 markMiddle belowMarkStack
 		set-base-anchor 'belowBrace' markMiddle belowMarkMid
 
+	create-glyph 'greaterAndDownArrowheadBelow' 0x1DFF : glyph-proc
+		set-width 0
+		include : WithTransform [Translate (-markExtend) 0] : refer-glyph 'greaterBelow'
+		include : WithTransform [Translate (+markExtend) 0] : refer-glyph 'downArrowHeadBelow'
+		set-mark-anchor 'below' markMiddle 0 markMiddle belowMarkStack
+		set-base-anchor 'belowBrace' markMiddle belowMarkMid
+
 	create-glyph 'braceBelow' 0x1ABD : glyph-proc
 		set-width 0
 		set-mark-anchor 'belowBrace' markMiddle belowMarkMid markMiddle belowMarkMid


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21302803/224560756-f19ecfa0-46dd-4ec0-af35-59ec1ad4a978.png)

Implements U+1DFF `Combining Right Arrowhead and Down Arrowhead Below` (Left 1) and U+1ACC `Combining Latin Small Letter Insular G` (Left 2), based on the right two (U+0356, U+1DDA).