### PR TITLE
Correct glyph for U225B, re-add old form at U2A6E

### DIFF
--- a/changes/21.1.2.md
+++ b/changes/21.1.2.md
@@ -3,6 +3,8 @@
   - LATIN CAPITAL LETTER AA (`U+A732`).
   - LATIN SMALL LETTER AA (`U+A733`).
   - LATIN CAPITAL LETTER AO (`U+A734`) (#1623).
+  - EQUALS WITH ASTERISK (`U+2A6E`)
 * Fix shape artifacts of `U+499`, `U+1D93`, `U+1D94`, `U+A731` (#1580, #1617, #1618).
 * Fix shape artifacts of cursive `k` (#1619).
 * Fix shape artifacts of R-derivatives (#1620).
+* Use correct glyph for `U+225B`

--- a/font-src/glyphs/auto-build/composite.ptl
+++ b/font-src/glyphs/auto-build/composite.ptl
@@ -1053,8 +1053,9 @@ glyph-block AutoBuild-Accented-Equal : begin
 	createAccentedOp 'equal' 7 0.5 0 (aboveMarkBot - (SymbolMid - XH / 2)) : list
 		list 0x2259 {"triangularWedge.NWID"}
 		list 0x225a {"triangularVee.NWID"}
-		list 0x225b {"asterisk.pentaSMid"}
+		list 0x225b {"blackStar.NWID"}
 		list 0x225c {"whiteTriangleUp.NWID"}
+		list 0x2a6e {"asterisk.pentaSMid"}
 	createAccentedOp 'sqrt' 5 0.5 (-Width / 4) [mix OperBot OperTop 0.6] : list
 		list 0x221b {"three.lnum"}
 		list 0x221c {"four.lnum"}


### PR DESCRIPTION
The star-equals operator is intended to display as an equals with a literal star operator as found elsewhere in the same Mathematical Operators block. The asterisk-equals operator exists in the Supplemental Mathematical Operators block which uses the original glyph from the font.