### PR TITLE
Drop unneeded Unicode decomposition overrides

### DIFF
--- a/font-src/meta/unicode-knowledge.ptl
+++ b/font-src/meta/unicode-knowledge.ptl
@@ -122,12 +122,6 @@ export : define decompOverrides : object
 
 	0x47C  { 'cyrl/BroadOmega' 'cyrlPsiliAbove' 'cyrlPokrytieAbove' }
 	0x47D  { 'cyrl/broadOmega' 'cyrlPsiliAbove' 'cyrlPokrytieAbove' }
-	0x498  { 'cyrl/Ze' 'cedillaBelow' }
-	0x499  { 'cyrl/ze' 'cedillaBelow' }
-	0x4AA  { 'cyrl/Es' 'cedillaBelow' }
-	0x4AB  { 'cyrl/es' 'cedillaBelow' }
-	0x4B0  { 'cyrl/Ue' 'barOver' }
-	0x4B1  { 'cyrl/ue' 'barOver' }
 
 	0x1D7C { 'latn/iota' 'barOver' }
 	0x1D7D { 'p' 'longBarOver' }


### PR DESCRIPTION
These overrides have recently been defined elsewhere as named glyphs in the process of populating Cyrillic Extended-D and are now redundant to keep around.