### PR TITLE
Fix Shape of Tilde with Dot Above, Below

### DIFF
--- a/changes/22.0.1.md
+++ b/changes/22.0.1.md
@@ -11,3 +11,4 @@
 * Optimize shape of Iotified-A (#1640).
 * Fix variant application of `cv19 `on `U+04B4`, `U+04B5`, `U+A68A`, and `U+A68B` (#1646).
 * Fix shape of Square Lozenge (#1643).
+* Fix shape of Tilde with Dot Above (`U+2E1E`) and Tilde with Dot Below (`U+2E1F`).

--- a/font-src/glyphs/symbol/math/relation.ptl
+++ b/font-src/glyphs/symbol/math/relation.ptl
@@ -244,9 +244,6 @@ glyph-block Symbol-Math-Relation-Sym : begin
 		refer-glyph 'sym'
 		DrawAt Middle PlusTop (DotRadius * kr * OperatorStroke / Stroke - ov)
 
-	alias 'dotTilde' 0x2E1E 'oneDotSym'
-	turned 'tildeDot' 0x2E1F 'dotTilde' Middle SymbolMid
-
 	WithDotVariants 'twoDotSym' 0x223B : function [DrawAt kr ov] : composite-proc
 		refer-glyph 'sym'
 		DrawAt Middle PlusTop (DotRadius * kr * OperatorStroke / Stroke - ov)

--- a/font-src/glyphs/symbol/punctuation/ascii-marks.ptl
+++ b/font-src/glyphs/symbol/punctuation/ascii-marks.ptl
@@ -39,6 +39,12 @@ glyph-block Symbol-Punctuation-Ascii-Marks : begin
 	select-variant 'asciiTilde' '~'
 	select-variant 'asciiCaret' '^'
 
+	WithDotVariants 'dotTilde' 0x2E1E : function [DrawAt kr ov] : composite-proc
+		refer-glyph 'asciiTilde.low'
+		DrawAt Middle PlusTop (DotRadius * kr * OperatorStroke / Stroke - ov)
+
+	turned 'tildeDot' 0x2E1F 'dotTilde' Middle SymbolMid
+
 	for-width-kinds WideWidth1
 		create-glyph [MangleName 'swungDash'] [MangleUnicode 0x2053] : glyph-proc
 			include [refer-glyph : MangleName 'swungDash.high'] AS_BASE ALSO_METRICS


### PR DESCRIPTION
I made the mistake of assuming the tilde operator was based on the ascii middle tilde