### PR TITLE
Fix el-midhook variant

### DIFF
--- a/changes/22.0.1.md
+++ b/changes/22.0.1.md
@@ -9,6 +9,6 @@
   - LATIN SMALL LETTER TURNED OE WITH STROKE (`U+AB41`).
   - LATIN SMALL LETTER TURNED OE WITH HORIZONTAL STROKE (`U+AB42`).
 * Optimize shape of Iotified-A (#1640).
-* Fix variant application of `cv19 `on `U+04B4`, `U+04B5`, `U+A68A`, and `U+A68B` (#1646).
+* Fix variant application of `cv19` on `U+04B4`, `U+04B5`, `U+A68A`, and `U+A68B` (#1646).
 * Fix shape of Square Lozenge (#1643).
 * Fix shape of Tilde with Dot Above (`U+2E1E`) and Tilde with Dot Below (`U+2E1F`).

--- a/changes/22.0.2.md
+++ b/changes/22.0.2.md
@@ -2,3 +2,4 @@
   - SHOULDERED OPEN BOX (`U+237D`) (#1657).
   - MODIFIER LETTER SHORT EQUALS SIGN (`U+A78A`) (#1658).
 * Make square brackets shallower to harmonize with other brackets (#1662).
+* Fix serifs and variant application of `cv67` on `U+0521`.

--- a/font-src/glyphs/letter/cyrillic/el.ptl
+++ b/font-src/glyphs/letter/cyrillic/el.ptl
@@ -81,13 +81,21 @@ glyph-block Letter-Cyrillic-El : begin
 		include : CyrElShape df.leftSB xm CAP BODY-STRAIGHT [if SLAB SLAB-ALL SLAB-NONE] df.mvs
 		include : MidHook.m df CAP
 
-	create-glyph 'cyrl/elMidHook' 0x521 : glyph-proc
+	create-glyph 'cyrl/elMidHook.straight' : glyph-proc
 		local df : DivFrame para.diversityM 3
 		local xm : df.middle + 0.5 * df.mvs * HVContrast
-		include : MarkSet.capDesc
-		include : CyrElShape df.leftSB xm XH BODY-STRAIGHT [if SLAB SLAB-ALL SLAB-NONE] df.mvs
+		include : MarkSet.p
+		include : CyrElShape df.leftSB xm XH BODY-STRAIGHT [if SLAB [if para.isItalic SLAB-LOWER SLAB-ALL] SLAB-NONE] df.mvs
+		include : MidHook.m df XH
+
+	create-glyph 'cyrl/elMidHook.tailed' : glyph-proc
+		local df : DivFrame para.diversityM 3
+		local xm : df.middle + 0.5 * df.mvs * HVContrast
+		include : MarkSet.p
+		include : CyrElShape df.leftSB xm XH BODY-TAILED [if SLAB [if para.isItalic SLAB-TAILED-I SLAB-TAILED-U] SLAB-NONE] df.mvs
 		include : MidHook.m df XH
 
 	select-variant 'cyrl/el' 0x43B
+	select-variant 'cyrl/elMidHook' 0x521 (follow -- 'cyrl/el')
 	alias 'cyrl/El.BGR' null 'grek/Lambda'
 	alias 'cyrl/el.BGR' null 'turnv'


### PR DESCRIPTION
Probably fixes Cyrillic Small El with Midhook on the italic serif and variant application.