### PR TITLE
Fix glyphs of Combining Acute Tone, Combining Grave Tone, and Spacing Greek Tonos

### DIFF
--- a/changes/22.1.1.md
+++ b/changes/22.1.1.md
@@ -34,4 +34,6 @@
   - UPSIDE-DOWN FACE (`U+1F643`).
 * Fix broken shape of CYRILLIC SMALL LETTER KOMI ZJE (`U+0505`) under quasi-proportionals (#1695).
 * Fix width of NARROW NO-BREAK SPACE (`U+202F`) under quasi-proportionals.
+* Fix glyph of GREEK TONOS (`U+0384`).
+* Disunify COMBINING GRAVE TONE MARK (`U+0340`) and COMBINING ACUTE TONE MARK (`U+0341`) from Greek Varia and Greek Oxia as they are actually intended for Vietnamese.
 * Improve mark placement of LATIN SMALL LETTER H WITH CIRCUMFLEX (`U+0125`), LATIN SMALL LETTER K WITH CARON (`U+01E9`), LATIN SMALL LETTER H WITH CARON (`U+021F`), and LATIN SMALL LETTER H WITH DOT ABOVE (`U+1E23`).

--- a/font-src/glyphs/marks/above.ptl
+++ b/font-src/glyphs/marks/above.ptl
@@ -655,6 +655,9 @@ glyph-block Mark-Above : begin
 	select-variant 'candrabinduAbove' 0x310 (follow -- 'diacriticDot')
 	turned 'turncandrabinduAbove' 0x352 'candrabinduAbove' markMiddle aboveMarkMid
 
+	alias 'graveToneAbove' 0x340 'graveAbove'
+	alias 'acuteToneAbove' 0x341 'acuteAbove'
+
 	create-glyph 'tonosAbove' : glyph-proc
 		set-width 0
 		include : StdAnchors.narrow
@@ -668,7 +671,7 @@ glyph-block Mark-Above : begin
 		include : refer-glyph 'tonosAbove'
 		include : StdAnchors.impl 'grekUpperTonos' 0 0
 
-	create-glyph 'variaAbove' 0x340 : glyph-proc
+	create-glyph 'variaAbove' : glyph-proc
 		set-width 0
 		include : StdAnchors.medium
 
@@ -681,7 +684,7 @@ glyph-block Mark-Above : begin
 		include : refer-glyph 'variaAbove'
 		include : StdAnchors.impl 'grekUpperTonos' 0 0
 
-	create-glyph 'oxiaAbove' 0x341 : glyph-proc
+	create-glyph 'oxiaAbove' : glyph-proc
 		set-width 0
 		include : StdAnchors.medium
 
@@ -701,7 +704,7 @@ glyph-block Mark-Above : begin
 
 	alias 'koronisAbove' 0x343 'commaAbove'
 
-	create-glyph 'dialytikaTonosAbove' 0x0344 : glyph-proc
+	create-glyph 'dialytikaTonosAbove' 0x344 : glyph-proc
 		set-width 0
 		include : WithTransform [ApparentTranslate 0 (-1/8 * AccentHeight)]  : refer-glyph 'dialytikaAbove'
 		include : WithTransform [ApparentTranslate 0 0] : refer-glyph 'tonosAbove'

--- a/font-src/meta/unicode-knowledge.ptl
+++ b/font-src/meta/unicode-knowledge.ptl
@@ -13,6 +13,8 @@ export : define upperGrekMarkToTonosTf : object
 	'oxiaAbove'        'oxiaGrekUpperTonos'
 	'graveAbove'       'variaGrekUpperTonos'
 	'acuteAbove'       'oxiaGrekUpperTonos'
+	'graveToneAbove'   'variaGrekUpperTonos'
+	'acuteToneAbove'   'oxiaGrekUpperTonos'
 	'commaAbove'       'commaGrekUpperTonos'
 	'revCommaAbove'    'revCommaGrekUpperTonos'
 	'psiliVaria'       'psiliVariaGrekUpperTonos'
@@ -48,6 +50,8 @@ export : define decompOverrides : object
 	0x146  { 'n' 'commaBelow' }
 	0x156  { 'R' 'commaBelow' }
 	0x157  { 'r' 'commaBelow' }
+	0x1E10 { 'D' 'commaBelow' }
+	0x1E11 { 'd' 'commaBelow' }
 
 	# Spacing marks
 	0xA8   { 'markBaseSpace' 'dieresisAbove' }
@@ -88,7 +92,7 @@ export : define decompOverrides : object
 	0x2F7  { 'markBaseSpace' 'tildeBelow' }
 	0x2FF  { 'markBaseSpace' 'leftArrowBelow' }
 	0x37A  { 'markBaseSpace' 'iotaBelow' }
-	0x384  { 'markBaseSpace' 'barAbove' }
+	0x384  { 'markBaseSpace' 'tonosAbove' }
 	0x385  { 'markBaseSpace' 'dialytikaTonosAbove' }
 	0x1FBD { 'markBaseSpace' 'commaAbove' }
 	0x1FBE { 'markBaseSpace' 'iotaBelow' }
@@ -107,6 +111,7 @@ export : define decompOverrides : object
 	0xAB6B { 'markBaseSpace' 'rightTackOver' }
 
 	0x167  { 't' 'barOver' }
+
 	0x197  { 'I' 'barOver' }
 	0x19A  { 'l' 'barOver' }
 	0x1BB  { 'two.lnum' 'longBarOver' }
@@ -139,19 +144,13 @@ export : define decompOverrides : object
 	0x3CD { 'grek/upsilon' 'tonosAbove' }
 	0x3CE { 'grek/omega'   'tonosAbove' }
 
-	0x1FD2 { 'grek/iota' 'dialytikaVariaAbove' }
-	0x1FD3 { 'grek/iota' 'dialytikaOxiaAbove' }
-	0x1FE2 { 'grek/upsilon' 'dialytikaVariaAbove' }
-	0x1FE3 { 'grek/upsilon' 'dialytikaOxiaAbove' }
-
 	0x47C  { 'cyrl/BroadOmega' 'cyrlPsiliAbove' 'cyrlPokrytieAbove' }
 	0x47D  { 'cyrl/broadOmega' 'cyrlPsiliAbove' 'cyrlPokrytieAbove' }
 
-	0x1D7C { 'latn/iota' 'barOver' }
-	0x1D7D { 'p' 'longBarOver' }
+	0x1D7C { 'latn/iota'     'barOver' }
+	0x1D7D { 'p'             'longBarOver' }
 	0x1D7F { 'latinupsilon1' 'longBarOver' }
-	0x1E10 { 'D' 'commaBelow' }
-	0x1E11 { 'd' 'commaBelow' }
+
 	0x1E9C { 'longs' 'shortSlashOver' }
 	0x1EDA { 'OHorn' 'acuteAbove' }
 	0x1EDB { 'oHorn' 'acuteAbove' }
@@ -164,6 +163,11 @@ export : define decompOverrides : object
 	0x1EE2 { 'OHorn' 'dotBelow' }
 	0x1EE3 { 'oHorn' 'dotBelow' }
 
+	0x1FD2 { 'grek/iota'    'dialytikaVariaAbove' }
+	0x1FD3 { 'grek/iota'    'dialytikaOxiaAbove' }
+	0x1FE2 { 'grek/upsilon' 'dialytikaVariaAbove' }
+	0x1FE3 { 'grek/upsilon' 'dialytikaOxiaAbove' }
+
 	0x2c61 { 'l' 'dblBarOver' }
 	0x2c65 { 'a' 'slashOver' }
 	0x2c66 { 't' 'longSlashOver' }
@@ -175,5 +179,6 @@ export : define decompOverrides : object
 	0xA7BB { 'a' 'EgyptologicalYodAbove' }
 	0xA7BD { 'i' 'EgyptologicalYodAbove' }
 	0xA7BF { 'u' 'EgyptologicalYodAbove' }
+
 	0xAB30 { 'scripta' 'longBarOver' }
-	0xAB3F { 'turnc' 'slashOver' }
+	0xAB3F { 'turnc'   'slashOver' }


### PR DESCRIPTION
Acute tone and Grave tone have nothing to do with Greek. They are compatibility characters for legacy Vietnamese encoding schemes from a time when special handling of e.g. Ấ was difficult. In the context of modern Unicode, however, they are handled identically to `U+0300` and `U+0301`.

Also, the old glyph for spacing Greek Tonos was a leftover from the first draft of my Tonos/Oxia disunification commit before you improved it.