### PR TITLE
fix variants of italic eszet under SS12, SS17, and SS18

### DIFF
--- a/changes/22.1.2.md
+++ b/changes/22.1.2.md
@@ -18,3 +18,4 @@
 * Fix glyphs of RING EQUAL TO (`U+2257`) and EQUALS WITH ASTERISK (`U+2A6E`).
 * Fix glyph of IDENTICAL WITH DOT ABOVE (`U+2A67`).
 * Disunify glyphs of LATIN LETTER SMALL CAPITAL BARRED B (`U+1D03`) and MODIFIER LETTER CAPITAL BARRED B (`U+1D2F`) from LATIN CAPITAL LETTER B WITH STROKE (`U+0243`).
+* Fix variant assignments of italic eszet under SS12 and SS17.

--- a/changes/22.1.2.md
+++ b/changes/22.1.2.md
@@ -18,4 +18,5 @@
 * Fix glyphs of RING EQUAL TO (`U+2257`) and EQUALS WITH ASTERISK (`U+2A6E`).
 * Fix glyph of IDENTICAL WITH DOT ABOVE (`U+2A67`).
 * Disunify glyphs of LATIN LETTER SMALL CAPITAL BARRED B (`U+1D03`) and MODIFIER LETTER CAPITAL BARRED B (`U+1D2F`) from LATIN CAPITAL LETTER B WITH STROKE (`U+0243`).
-* Fix variant assignments of italic eszet under SS12 and SS17.
+* Fix variant assignments of italic long S under SS17 and SS18.
+* Fix variant assignments of italic eszet under SS12, SS17, and SS18.

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -8214,6 +8214,7 @@ w = "cursive"
 x = "cursive"
 y = "cursive"
 z = "cursive"
+long-s = "bent-hook-descending"
 eszet = "longs-s-lig-descending"
 
 [composite.ss17.slab-override.italic]
@@ -8259,6 +8260,8 @@ percent = "rings-continuous-slash"
 
 [composite.ss18.italic]
 f = "extended-crossbar-at-x-height"
+long-s = "flat-hook-descending"
+eszet = "longs-s-lig-descending"
 
 [composite.ss18.slab-override.design]
 capital-g = "toothless-rounded-serifed-hooked"

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -7889,6 +7889,7 @@ a = "single-storey-earless-corner-tailed"
 d = "tailed-serifless"
 f = "tailed"
 u = "tailed"
+eszet = "longs-s-lig-tailed"
 
 [composite.ss12.slab-override.design]
 capital-d = "more-rounded-bilateral-serifed"
@@ -8213,6 +8214,7 @@ w = "cursive"
 x = "cursive"
 y = "cursive"
 z = "cursive"
+eszet = "longs-s-lig-descending"
 
 [composite.ss17.slab-override.italic]
 g = "single-storey-serifed"


### PR DESCRIPTION
Image showing original Ubuntu Mono Italic, Recursive Mono Linear Italic, and Input Mono Italic fonts:
![image](https://github.com/be5invis/Iosevka/assets/37010132/6f96f439-f1a6-4de2-94ce-7f252df5bee3)
Italic Long S under Ubuntu Mono Italic and Input Mono Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/572405fb-f249-4d45-b277-a06f23e47896)
Recursive mono doesn't have a long S glyph but it can be inferred from taking cues from both its eszet and f glyphs:
![image](https://github.com/be5invis/Iosevka/assets/37010132/160575dc-855d-453d-a741-8eed4b264cc0)

