### PR TITLE
Fix variant assignments of italic letters

### DIFF
--- a/changes/22.1.3.md
+++ b/changes/22.1.3.md
@@ -1,4 +1,4 @@
-Add Characters:
+* Add Characters:
   - CYRILLIC SMALL LETTER NARROW O (`U+1C82`) (#1517).
   - CYRILLIC SMALL LETTER UNBLENDED UK (`U+1C88`) (#1517).
   - COMBINING CYRILLIC LETTER ES-TE (`U+2DF5`) (#1720).
@@ -9,3 +9,9 @@ Add Characters:
   - CYRILLIC SMALL LETTER YN (`U+A65F`) (#1142, #1517).
   - LATIN CAPITAL LETTER INSULAR D (`U+A779`) (#1688).
   - LATIN SMALL LETTER INSULAR D (`U+A77A`) (#1688).
+* Fix variant assignment of `cv26` under `ss16`.
+* Fix variant assignment of `cv31` under `ss13`.
+* Fix variant assignments of `cv32` under `ss03` and `ss15`, 
+* Fix variant assignments of `cv51` under `ss01`, `ss05`, `ss09`, `ss10`, `ss12`, and `ss16`.
+* Fix variant assignments of `cv52` under `ss10` and `ss16`.
+* Fix variant assignment of `cv71` under `ss15`.

--- a/changes/22.1.3.md
+++ b/changes/22.1.3.md
@@ -11,7 +11,7 @@
   - LATIN SMALL LETTER INSULAR D (`U+A77A`) (#1688).
 * Fix variant assignment of `cv26` under `ss16`.
 * Fix variant assignment of `cv31` under `ss13`.
-* Fix variant assignments of `cv32` under `ss03` and `ss15`, 
+* Fix variant assignments of `cv32` under `ss03` and `ss15`.
 * Fix variant assignments of `cv51` under `ss01`, `ss05`, `ss09`, `ss10`, `ss12`, and `ss16`.
 * Fix variant assignments of `cv52` under `ss10` and `ss16`.
 * Fix variant assignment of `cv71` under `ss15`.

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -7327,6 +7327,7 @@ k = "straight-serifless"
 l = "zshaped"
 u = "toothed"
 y = "straight-turn"
+long-s = "flat-hook"
 eszet = "longs-s-lig"
 lower-lambda = "straight-turn"
 lower-iota = "flat-tailed"
@@ -7465,6 +7466,7 @@ question = "corner-flat-hooked"
 [composite.ss03.italic]
 a = "single-storey-serifless"
 f = "flat-hook-tailed"
+g = "single-storey-serifless"
 i = "tailed-serifed"
 k = "cursive-serifless"
 l = "tailed"
@@ -7486,6 +7488,7 @@ cyrl-ka = "symmetric-touching-serifed"
 [composite.ss03.slab-override.italic]
 a = "single-storey-serifed"
 f = "flat-hook-tailed"
+g = "single-storey-serifed"
 k = "cursive-serifed"
 
 
@@ -7564,6 +7567,7 @@ l = "tailed-serifed"
 r = "corner-hooked-serifed"
 u = "toothed"
 y = "straight-turn"
+long-s = "bent-hook"
 eszet = "longs-s-lig"
 lower-iota = "tailed-serifed"
 lower-lambda = "straight-turn"
@@ -7823,7 +7827,6 @@ lig-neq = "more-slanted"
 a = "single-storey-serifless"
 g = "single-storey-serifless"
 i = "tailed-serifed"
-long-s = "flat-hook-tailed"
 
 [composite.ss09.slab-override.design]
 capital-d = "more-rounded-bilateral-serifed"
@@ -7857,6 +7860,8 @@ k = "symmetric-connected-serifless"
 l = "hooky"
 t = "flat-hook"
 y = "cursive-flat-hook"
+long-s = "flat-hook"
+eszet = "sulzbacher"
 cyrl-capital-u = "cursive-flat-hook"
 one = "base"
 four = "closed"
@@ -7948,6 +7953,7 @@ a = "single-storey-earless-corner-tailed"
 d = "tailed-serifless"
 f = "tailed"
 u = "tailed"
+long-s = "bent-hook-tailed"
 eszet = "longs-s-lig-tailed"
 
 [composite.ss12.slab-override.design]
@@ -7975,6 +7981,7 @@ capital-k = "symmetric-touching-serifless"
 a = "double-storey-tailed"
 d = "toothed-serifless"
 e = "flat-crossbar"
+f = "serifless"
 g = "single-storey-serifless"
 i = "hooky"
 k = "symmetric-touching-serifless"
@@ -8004,6 +8011,7 @@ capital-g = "toothless-corner-serifed-hooked"
 capital-k = "symmetric-touching-serifed"
 a = "single-storey-earless-corner-serifed"
 d = "toothed-serifed"
+f = "serifed"
 g = "single-storey-serifed"
 k = "symmetric-touching-serifed"
 
@@ -8120,6 +8128,7 @@ brace = "curly-flat-boundary"
 [composite.ss15.italic]
 a = "single-storey-serifless"
 f = "flat-hook-diagonal-tailed"
+g = "single-storey-serifless"
 i = "serifed-diagonal-tailed"
 j = "diagonal-tailed-serifed"
 k = "diagonal-tailed-cursive-serifless"
@@ -8132,7 +8141,6 @@ x = "cursive"
 y = "cursive"
 z = "cursive"
 long-s = "flat-hook-tailed"
-cyrl-capital-u = "cursive-flat-hook"
 ampersand = "closed"
 
 [composite.ss15.slab-override.design]
@@ -8141,6 +8149,7 @@ k = "straight-serifed"
 
 [composite.ss15.slab-override.italic]
 a = "single-storey-serifed"
+g = "single-storey-serifed"
 k = "diagonal-tailed-cursive-top-left-serifed"
 
 
@@ -8177,6 +8186,7 @@ t = "standard-short-neck2"
 u = "motion-serifed"
 y = "straight-turn"
 long-s = "flat-hook"
+eszet = "longs-s-lig"
 capital-gamma = "serifed"
 cyrl-capital-ze = "bilateral-inward-serifed"
 cyrl-ze = "unilateral-inward-serifed"
@@ -8200,14 +8210,8 @@ brace = "straight"
 number-sign = "slanted"
 percent = "rings-continuous-slash"
 
-[composite.ss16.italic]
-a = "single-storey-earless-corner-serifed"
-
 [composite.ss16.slab-override.design]
 capital-k = "symmetric-connected-serifed"
-
-[composite.ss16.slab-override.italic]
-a = "single-storey-earless-corner-serifed"
 
 
 


### PR DESCRIPTION
I looked at the source fonts of these stylistic sets and confirmed that this is how they handle the italic forms of these characters in question.