### PR TITLE
above-baseline crossed Q (#1533)

### DIFF
--- a/changes/24.0.0.md
+++ b/changes/24.0.0.md
@@ -1,4 +1,5 @@
 * \[**BREAKING**\] Add taller slash, broken slash and broken zero variants for Zero. As a result, current variants are reordered (#1307, #1509, #1678).
+* \[**BREAKING**\] Add above-baseline crossed variant for Q. As a result, current variants are reordered (#1533).
 * \[**BREAKING**\] Rectify the variant atlas. As a result, if a character's variant list has motion-serifed, then it will have serifless and serifed variants: the serifed-ness will no longer be controlled by SLAB variable. The characters influenced are `M`, `N`, `P`, `R`, `U`, `V`, `W`, `b`, `h`, `m`, `n`, `p`, `q`, `u`, `v`, `w`, `y`.
 * Add diagonal-tailed variants for lowercase Iota (#1737).
 * Make `VXSF` to influence Eth too (#1738).

--- a/font-src/glyphs/letter/latin/upper-q.ptl
+++ b/font-src/glyphs/letter/latin/upper-q.ptl
@@ -117,6 +117,13 @@ glyph-block Letter-Latin-Upper-Q : begin
 			flat df.rightSB shift [heading Upward]
 			curl (df.middle + OX) (k * (df.rightSB - df.middle) + shift) [heading Upward]
 
+	define [QCrossingBaseline df top sw] : begin
+		define cor : DiagCor (0.5 * (top - Stroke)) (df.rightSB - df.middle - OX)
+		return : dispiro
+			widths.center (cor * sw)
+			flat df.rightSB 0 [heading Upward]
+			curl (df.middle + OX) (0.5 * (top - Stroke)) [heading Upward]
+
 	define [QVerticalCrossing df top sw] : begin
 		return : union
 			VBar.m df.middle [mix Descender HalfStroke 1.75] 0 sw
@@ -154,6 +161,7 @@ glyph-block Letter-Latin-Upper-Q : begin
 		curlyTailed         { QStdBody                Stroke             QCurlyTail         'if'      'p' }
 		crossingCurlyTailed { QStdBody                QInnerVertSw       QCrossingCurlyTail 'if'      'p' }
 		crossing            { QStdBody               [AdviceStroke 4]    QCrossing          'capital' 'e' }
+		crossingBaseline    { QStdBody               [AdviceStroke 4]    QCrossingBaseline  'capital' 'e' }
 		verticalCrossing    { QStdBody                QInnerVertSw       QVerticalCrossing  'if'      'p' }
 		horizontalTailed    { QHorizontalTailedBody  [AdviceStroke 3]    QHorizontalTail    'capital' 'e' }
 		detachedTailed      { QStdBody                Stroke             QDetachedTail      'if'      'p' }

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1109,28 +1109,33 @@ rank = 4
 description = "`Q` with a tail crossing the ring"
 selector.Q = "crossing"
 
-[prime.capital-q.variants.vertical-crossing]
+[prime.capital-q.variants.crossing-baseline]
 rank = 5
+description = "`Q` with a tail above baseline crossing the ring"
+selector.Q = "crossingBaseline"
+
+[prime.capital-q.variants.vertical-crossing]
+rank = 6
 description = "`Q` with a vertical tail crossing the ring"
 selector.Q = "verticalCrossing"
 
 [prime.capital-q.variants.horizontal-tailed]
-rank = 6
+rank = 7
 description = "`Q` with a horizontal tail, like Univers"
 selector.Q = "horizontalTailed"
 
 [prime.capital-q.variants.detached-tailed]
-rank = 7
+rank = 8
 description = "`Q` with a oblique tail detached"
 selector.Q = "detachedTailed"
 
 [prime.capital-q.variants.detached-bend-tailed]
-rank = 8
+rank = 9
 description = "`Q` with a bend tail detached"
 selector.Q = "detachedBendTailed"
 
 [prime.capital-q.variants.open-swash]
-rank = 9
+rank = 10
 description = "`Q` with open contour and swash-y shape"
 selector.Q = "openSwash"
 


### PR DESCRIPTION
![image](https://github.com/be5invis/Iosevka/assets/21302803/b27904e6-a962-4785-9118-317667402450)

Stroke goes from lower right to center, aligned with the lower edge of H's Hbar, judging by the samples given.

Assuming the slanted stroke cap(?) is not part of the request.