### PR TITLE
Optimize height of DIVIDES and PARALLEL TO

### DIFF
--- a/changes/24.0.0.md
+++ b/changes/24.0.0.md
@@ -35,5 +35,6 @@
   - LEFT VERTICAL BAR WITH QUILL (`U+2E20`).
   - RIGHT VERTICAL BAR WITH QUILL (`U+2E21`).
   - DOUBLE HYPHEN (`U+2E40`).
+* Improve height of glyphs derived from DIVIDES (`U+2223`) and PARALLEL TO (`U+2225`) to be the same as APL tacks as they are often used as APL stiles.
 * Add diagonal-tailed variants for lowercase Iota (#1737).
 * Make `VXSF` to influence Eth too (#1738).

--- a/font-src/glyphs/symbol/math/logicals.ptl
+++ b/font-src/glyphs/symbol/math/logicals.ptl
@@ -20,6 +20,15 @@ glyph-block Symbol-Math-Logicals : begin
 
 	local top TackTop
 	local bot TackBot
+
+	create-glyph 'stile' 0x2223 : glyph-proc
+		include : VBar.m Middle bot top OperatorStroke
+
+	create-glyph 'parallel' 0x2225 : glyph-proc
+		local sw : AdviceStroke 3.5
+		include : VBar.m (Middle - Width * 0.175) bot top sw
+		include : VBar.m (Middle + Width * 0.175) bot top sw
+
 	create-glyph 'vdash' 0x22A2 : glyph-proc
 		include : HBar.m SB RightSB SymbolMid OperatorStroke
 		include : VBar.l SB top bot OperatorStroke
@@ -116,6 +125,12 @@ glyph-block Symbol-Math-Logicals : begin
 
 	turned 'barRingBelow' 0x2AF0 'barRingAbove' Middle SymbolMid
 	turned 'topRingBelow' 0x2AF1 'botRingAbove' Middle SymbolMid
+
+	create-glyph 'interleave' 0x2AF4 : glyph-proc
+		local sw : AdviceStroke 4.25
+		include : VBar.m (Middle - Width * 0.2625) bot top sw
+		include : VBar.m  Middle                   bot top sw
+		include : VBar.m (Middle + Width * 0.2625) bot top sw
 
 	create-glyph 'endOfProof' 0x220E : glyph-proc
 		include : Rect TackTop TackBot SB RightSB

--- a/font-src/glyphs/symbol/math/other.ptl
+++ b/font-src/glyphs/symbol/math/other.ptl
@@ -13,34 +13,30 @@ glyph-block Symbol-Math-Other : begin
 	alias 'whiteDiamondOperator' 0x22C4 'whiteDiamondOperatorImpl.NWID'
 	alias 'mathstar' 0x22C6 'blackStar.NWID'
 
-	alias 'divides' 0x2223 'bar.upright'
-
 	create-glyph 'notdivides' 0x2224 : glyph-proc
-		include : refer-glyph 'divides'
+		include : refer-glyph 'stile'
 		include : dispiro
 			widths.center NotGlyphSw
-			flat [mix SB RightSB 0.1] [mix SymbolMid ParenBot 0.5]
-			curl [mix SB RightSB 0.9] [mix SymbolMid ParenTop 0.5]
-
-	alias 'parallel' 0x2225 'doubleBar.upright'
+			flat [mix SB RightSB 0.1] [mix SymbolMid TackBot 0.5]
+			curl [mix SB RightSB 0.9] [mix SymbolMid TackTop 0.5]
 
 	create-glyph 'notparallel' 0x2226 : glyph-proc
 		include : refer-glyph 'parallel'
 		include : dispiro
 			widths.center NotGlyphSw
-			flat SB [mix SymbolMid ParenBot 0.5]
-			curl RightSB [mix SymbolMid ParenTop 0.5]
+			flat SB [mix SymbolMid TackBot 0.5]
+			curl RightSB [mix SymbolMid TackTop 0.5]
 
 	create-glyph 'barStroke' 0x27CA : glyph-proc
-		include : refer-glyph 'divides'
+		include : refer-glyph 'stile'
 		include : HBar.m [mix SB RightSB 0.1] [mix SB RightSB 0.9] SymbolMid OverlayStroke
 
 	create-glyph 'revnotdivides' 0x2AEE : glyph-proc
-		include : refer-glyph 'divides'
+		include : refer-glyph 'stile'
 		include : dispiro
 			widths.center NotGlyphSw
-			flat [mix SB RightSB 0.1] [mix SymbolMid ParenTop 0.5]
-			curl [mix SB RightSB 0.9] [mix SymbolMid ParenBot 0.5]
+			flat [mix SB RightSB 0.1] [mix SymbolMid TackTop 0.5]
+			curl [mix SB RightSB 0.9] [mix SymbolMid TackBot 0.5]
 
 	create-glyph 'doubleBarStroke' 0x2AF2 : glyph-proc
 		include : refer-glyph 'parallel'
@@ -49,8 +45,6 @@ glyph-block Symbol-Math-Other : begin
 	create-glyph 'doubleBarTilde' 0x2AF3 : composite-proc
 		refer-glyph 'parallel'
 		refer-glyph 'sym'
-
-	alias 'interleave' 0x2AF4 'tripleBar.upright'
 
 	create-glyph 'tripleBarStroke' 0x2AF5 : glyph-proc
 		include : refer-glyph 'interleave'

--- a/font-src/glyphs/symbol/math/relation.ptl
+++ b/font-src/glyphs/symbol/math/relation.ptl
@@ -42,8 +42,6 @@ glyph-block Symbol-Math-Relation-Equal : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Symbol-Math-Relation-Common : EqualHalfSpace dH EqualHoleWidth
 	glyph-block-export EqualShape EqualHole IdentShape IdentHole
-	glyph-block-import Mark-Shared-Metrics : markExtend markHalfStroke
-	glyph-block-import Mark-Above : TildeShape
 
 	glyph-block-export : EqualShape
 	define [EqualShape left right] : union
@@ -169,24 +167,21 @@ glyph-block Symbol-Math-Relation-Equal : begin
 
 	create-glyph 'equalDoubleSlash' 0x29E3 : composite-proc
 		EqualShape [mix SB 0 0.5] [mix RightSB Width 0.5]
-		refer-glyph 'doubleSlash'
+		refer-glyph 'slantedParallel'
 
 	create-glyph 'equalDoubleSlashTilde' 0x29E4 : composite-proc
 		refer-glyph 'equalDoubleSlash'
-		TildeShape
-			ttop -- ParenTop + AccentClearance + AccentHeight * 0.75
-			tbot -- ParenTop + AccentClearance
-			leftEnd -- (Middle - markExtend * 1.5)
-			rightEnd -- (Middle + markExtend * 1.5)
-			hs -- markHalfStroke
+		MarkSet.tack
+		refer-glyph 'tildeAbove'
+		clear-anchors
 
 	create-glyph 'identDoubleSlash' 0x29E5 : composite-proc
 		IdentShape [mix SB 0 0.5] [mix RightSB Width 0.5]
-		refer-glyph 'doubleSlash'
+		refer-glyph 'slantedParallel'
 
-	create-glyph 'equalDivides' 0x29E7 : composite-proc
+	create-glyph 'recordMark' 0x29E7 : composite-proc
 		refer-glyph 'equal'
-		refer-glyph 'divides'
+		refer-glyph 'stile'
 
 	turned 'equalDot' 0x2A66 'oneDotApproxEq' Middle SymbolMid
 
@@ -203,9 +198,9 @@ glyph-block Symbol-Math-Relation-Equal : begin
 		IdentShape [mix SB 0 0.5] [mix RightSB Width 0.5]
 		refer-glyph 'interleave'
 
-	create-glyph 'identDivides' 0x2BD2 : composite-proc
+	create-glyph 'groupMark' 0x2BD2 : composite-proc
 		refer-glyph 'ident'
-		refer-glyph 'divides'
+		refer-glyph 'stile'
 
 glyph-block Symbol-Math-Relation-Addons : begin
 	glyph-block-import CommonShapes

--- a/font-src/glyphs/symbol/punctuation/slashes-and-number-sign.ptl
+++ b/font-src/glyphs/symbol/punctuation/slashes-and-number-sign.ptl
@@ -49,6 +49,12 @@ glyph-block Symbol-Punctuation-Slashes-And-Number-Sign : begin
 		Joining.set currentGlyph Joining.Classes.Left
 		include : SlashShape 0 slashDefaultRight
 
+	create-glyph 'slantedParallel' : glyph-proc
+		define w : AdviceStroke 3
+		define b : Math.max w (Width * 0.15)
+		include : SlashShape (slashDefautLeft - b) (slashDefaultRight - b) TackTop TackBot w
+		include : SlashShape (slashDefautLeft + b) (slashDefaultRight + b) TackTop TackBot w
+
 	local backslashWidth : (slashDefaultRight - slashDefautLeft) * (1 + TanSlope * 2)
 	define [BackslashShape l r] : glyph-proc
 		local cor : (1 / 2) * HVContrast / [Math.sqrt (1 - [Math.pow ((r - l - Stroke) / (ParenTop - ParenBot)) 2])]


### PR DESCRIPTION
They are historically used as radicals in the various tack-derived glyphs.
Also, they have HTML tag names of `&shortmid;` and `&shortparallel;` etc. which further suggests they should be smaller than regular ASCII-derived pipe characters.

```
|‖ǀǁ∣∤∥∦⋕
⟊⟂⦀⧣⧤⧥⧧⩨⩩
⫮⫲⫳⫴⫵⫼⫽⯒
```

Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/8458d4c1-9e69-44d7-a6b9-d49274feee27)

Italic (cv99):
![image](https://github.com/be5invis/Iosevka/assets/37010132/ab7c424a-395a-4431-9aec-e2bb98e1d213)


Heavy:
![image](https://github.com/be5invis/Iosevka/assets/37010132/7312a2d4-32eb-4a39-a173-3d39c610c9b8)

Thin:
![image](https://github.com/be5invis/Iosevka/assets/37010132/03150553-500a-44ab-9d37-66d62a09afc7)
