### PR TITLE
Description fixes

### DIFF
--- a/changes/24.0.1.md
+++ b/changes/24.0.1.md
@@ -1,1 +1,2 @@
  * Fix missing serif in cursive-motion-serifed variants of `y` (#1751).
+ * Correct description of various character variants.

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -3537,7 +3537,7 @@ selectorAffix.wHookTop = "straightAsymmetric"
 [prime.w.variants-buildup.stages.body.cursive]
 rank = 7
 groupRank = 3
-descriptionAffix = "body shape with vertical sides"
+descriptionAffix = "cursive shape"
 selectorAffix.w = "cursive"
 selectorAffix."w/sansSerif" = "cursive"
 selectorAffix.wHookTop = "cursive"
@@ -4272,28 +4272,28 @@ selector."cyrl/Ksi" = "serifless"
 
 [prime.cyrl-capital-ze.variants.unilateral-serifed]
 rank = 2
-description = "Cyrillic Capital Ze (`З`) with serif"
+description = "Cyrillic Capital Ze (`З`) with serif at top"
 selector."latn/Epsilon" = "unilateralSerifed"
 selector."cyrl/Ze" = "unilateralSerifed"
 selector."cyrl/Ksi" = "unilateralSerifed"
 
 [prime.cyrl-capital-ze.variants.bilateral-serifed]
 rank = 3
-description = "Cyrillic Capital Ze (`З`) with serif"
+description = "Cyrillic Capital Ze (`З`) with serif at both top and bottom"
 selector."latn/Epsilon" = "bilateralSerifed"
 selector."cyrl/Ze" = "bilateralSerifed"
 selector."cyrl/Ksi" = "unilateralSerifed"
 
 [prime.cyrl-capital-ze.variants.unilateral-inward-serifed]
 rank = 4
-description = "Cyrillic Capital Ze (`З`) with inward serif"
+description = "Cyrillic Capital Ze (`З`) with inward serif at top"
 selector."latn/Epsilon" = "unilateralInwardSerifed"
 selector."cyrl/Ze" = "unilateralInwardSerifed"
 selector."cyrl/Ksi" = "unilateralInwardSerifed"
 
 [prime.cyrl-capital-ze.variants.bilateral-inward-serifed]
 rank = 5
-description = "Cyrillic Capital Ze (`З`) with inward serif"
+description = "Cyrillic Capital Ze (`З`) with inward serif at both top and bottom"
 selector."latn/Epsilon" = "bilateralInwardSerifed"
 selector."cyrl/Ze" = "bilateralInwardSerifed"
 selector."cyrl/Ksi" = "unilateralInwardSerifed"
@@ -4315,7 +4315,7 @@ selector."cyrl/ksi" = "serifless"
 
 [prime.cyrl-ze.variants.unilateral-serifed]
 rank = 2
-description = "Cyrillic Lower Ze (`з`) with serif"
+description = "Cyrillic Lower Ze (`з`) with serif at top"
 selector."latn/epsilon" = "unilateralSerifed"
 selector."latn/epsilon/descBase" = "bilateralSerifed"
 selector."cyrl/ze" = "unilateralSerifed"
@@ -4323,7 +4323,7 @@ selector."cyrl/ksi" = "unilateralSerifed"
 
 [prime.cyrl-ze.variants.bilateral-serifed]
 rank = 3
-description = "Cyrillic Lower Ze (`з`) with serif"
+description = "Cyrillic Lower Ze (`з`) with serif at both top and bottom"
 selector."latn/epsilon" = "bilateralSerifed"
 selector."latn/epsilon/descBase" = "bilateralSerifed"
 selector."cyrl/ze" = "bilateralSerifed"
@@ -4331,7 +4331,7 @@ selector."cyrl/ksi" = "unilateralSerifed"
 
 [prime.cyrl-ze.variants.unilateral-inward-serifed]
 rank = 4
-description = "Cyrillic Lower Ze (`з`) with inward serif"
+description = "Cyrillic Lower Ze (`з`) with inward serif at top"
 selector."latn/epsilon" = "unilateralInwardSerifed"
 selector."latn/epsilon/descBase" = "unilateralInwardSerifedDesc"
 selector."cyrl/ze" = "unilateralInwardSerifed"
@@ -4339,7 +4339,7 @@ selector."cyrl/ksi" = "unilateralInwardSerifed"
 
 [prime.cyrl-ze.variants.bilateral-inward-serifed]
 rank = 5
-description = "Cyrillic Lower Ze (`з`) with inward serif"
+description = "Cyrillic Lower Ze (`з`) with inward serif at both top and bottom"
 selector."latn/epsilon" = "bilateralInwardSerifed"
 selector."latn/epsilon/descBase" = "unilateralInwardSerifedDesc"
 selector."cyrl/ze" = "bilateralInwardSerifed"
@@ -4545,6 +4545,7 @@ tag = "cv68"
 
 [prime.cyrl-en.variants-buildup]
 entry = "tail"
+descriptionLeader = "Cyrillic Lower En (`н`)"
 
 [prime.cyrl-en.variants-buildup.stages.tail."*"]
 next = "serifs"
@@ -4842,7 +4843,7 @@ selectorAffix."cyrl/ya" = ""
 
 [prime.cyrl-ya.variants-buildup.stages.tails.tailed]
 rank = 2
-descriptionAffix = "serifs"
+descriptionAffix = "tail"
 selectorAffix."cyrl/ya" = "tailed"
 
 [prime.cyrl-ya.variants-buildup.stages.serifs.serifless]
@@ -5757,7 +5758,7 @@ selector.dollar = "through"
 
 [prime.dollar.variants.interrupted]
 rank = 3
-description = "Dollar symbol with strike-through vertical bar"
+description = "Dollar symbol with interrupted strike-through vertical bar"
 selector.dollar = "interrupted"
 
 [prime.dollar.variants.open-cap]
@@ -5772,7 +5773,7 @@ selector.dollar = "throughCap"
 
 [prime.dollar.variants.interrupted-cap]
 rank = 6
-description = "Dollar symbol with strike-through vertical bar, not exceeding baseline and ascender"
+description = "Dollar symbol with interrupted strike-through vertical bar, not exceeding baseline and ascender"
 selector.dollar = "interruptedCap"
 
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -809,7 +809,7 @@ selector.Q = "curlyTailed"
 [prime.capital-q.variants.crossing-curly-tailed]
 rank = 2
 groupRank = 1
-description = "`Q` with a curly tail"
+description = "`Q` with a curly tail crossing the ring"
 selector.Q = "crossingCurlyTailed"
 
 [prime.capital-q.variants.straight]
@@ -868,6 +868,7 @@ tag = "cv17"
 
 [prime.capital-r.variants-buildup]
 entry = "openness"
+descriptionLeader = "`R`"
 
 [prime.capital-r.variants-buildup.stages.openness."*"]
 next = "leg"
@@ -892,21 +893,21 @@ mode = "prepend"
 
 [prime.capital-r.variants-buildup.stages.leg.straight]
 rank = 1
-description = "straight leg"
+descriptionAffix = "straight leg"
 selectorAffix.R = "straight"
 selectorAffix."R/sansSerif" = "straight"
 selectorAffix.RRotunda = "straight"
 
 [prime.capital-r.variants-buildup.stages.leg.curly]
 rank = 2
-description = "curly leg"
+descriptionAffix = "curly leg"
 selectorAffix.R = "curly"
 selectorAffix."R/sansSerif" = "curly"
 selectorAffix.RRotunda = "curly"
 
 [prime.capital-r.variants-buildup.stages.leg.standing]
 rank = 3
-description = "standing leg (like Helvetica)"
+descriptionAffix = "standing leg (like Helvetica)"
 selectorAffix.R = "standing"
 selectorAffix."R/sansSerif" = "standing"
 selectorAffix.RRotunda = "standing"
@@ -1085,6 +1086,7 @@ tag = "cv21"
 
 [prime.capital-v.variants-buildup]
 entry = "body"
+descriptionLeader = "`V`"
 
 [prime.capital-v.variants-buildup.stages.body."*"]
 next = "serifs"
@@ -1310,7 +1312,7 @@ tag = "cv25"
 
 [prime.capital-z.variants-buildup]
 entry = "body"
-descriptionLeader = "`z`"
+descriptionLeader = "`Z`"
 
 [prime.capital-z.variants-buildup.stages.body."*"]
 next = "serifs"
@@ -3571,7 +3573,7 @@ tag = "cv48"
 
 [prime.x.variants-buildup]
 entry = "body"
-descriptionLeader = "`X`"
+descriptionLeader = "`x`"
 
 [prime.x.variants-buildup.stages.body."*"]
 next = "serifs"
@@ -4672,7 +4674,7 @@ tag = "cv71"
 
 [prime.cyrl-capital-u.variants-buildup]
 entry = "body"
-descriptionLeader = "`y`"
+descriptionLeader = "Cyrillic Capital U (`У`)"
 
 [prime.cyrl-capital-u.variants-buildup.stages.body."*"]
 next = "hook"
@@ -4737,6 +4739,7 @@ tag = "cv72"
 
 [prime.cyrl-capital-ya.variants-buildup]
 entry = "openness"
+descriptionLeader = "Cyrillic Capital Ya (`Я`)"
 
 [prime.cyrl-capital-ya.variants-buildup.stages.openness."*"]
 next = "leg"
@@ -4757,17 +4760,17 @@ mode = "prepend"
 
 [prime.cyrl-capital-ya.variants-buildup.stages.leg.straight]
 rank = 1
-description = "straight leg"
+descriptionAffix = "straight leg"
 selectorAffix."cyrl/Ya" = "straight"
 
 [prime.cyrl-capital-ya.variants-buildup.stages.leg.curly]
 rank = 2
-description = "curly leg"
+descriptionAffix = "curly leg"
 selectorAffix."cyrl/Ya" = "curly"
 
 [prime.cyrl-capital-ya.variants-buildup.stages.leg.standing]
 rank = 3
-description = "standing leg (like Helvetica)"
+descriptionAffix = "standing leg (like Helvetica)"
 selectorAffix."cyrl/Ya" = "standing"
 
 [prime.cyrl-capital-ya.variants-buildup.stages.serifs.serifless]
@@ -4790,6 +4793,7 @@ tag = "cv73"
 
 [prime.cyrl-ya.variants-buildup]
 entry = "openness"
+descriptionLeader = "Cyrillic Lower Ya (`я`)"
 
 [prime.cyrl-ya.variants-buildup.stages.openness."*"]
 next = "leg"
@@ -4813,19 +4817,19 @@ mode = "prepend"
 [prime.cyrl-ya.variants-buildup.stages.leg.straight]
 rank = 1
 groupRank = 1
-description = "straight leg"
+descriptionAffix = "straight leg"
 selectorAffix."cyrl/ya" = "straight"
 
 [prime.cyrl-ya.variants-buildup.stages.leg.curly]
 rank = 2
 groupRank = 2
-description = "curly leg"
+descriptionAffix = "curly leg"
 selectorAffix."cyrl/ya" = "curly"
 
 [prime.cyrl-ya.variants-buildup.stages.leg.standing]
 rank = 3
 groupRank = 3
-description = "standing leg (like Helvetica)"
+descriptionAffix = "standing leg (like Helvetica)"
 selectorAffix."cyrl/ya" = "standing"
 
 [prime.cyrl-ya.variants-buildup.stages.tails."*"]
@@ -4988,14 +4992,14 @@ selectorAffix."zero/forceUnslashed" = ""
 [prime.zero.variants-buildup.stages.body.oval]
 rank = 2
 keyAffix = "oval"
-descriptionAffix = "standard shape"
+descriptionAffix = "oval shape"
 selectorAffix.zero = "oval"
 selectorAffix."zero/forceSlashed" = "oval"
 selectorAffix."zero/forceUnslashed" = "oval"
 
 [prime.zero.variants-buildup.stages.overlays.unslashed]
 rank = 1
-description = "slash"
+descriptionAffix = "slash"
 descriptionJoiner = "without"
 selectorAffix.zero = "unslashed"
 selectorAffix."zero/forceSlashed" = "slashed"
@@ -5003,119 +5007,119 @@ selectorAffix."zero/forceUnslashed" = "unslashed"
 
 [prime.zero.variants-buildup.stages.overlays.slashed]
 rank = 2
-description = "slash"
+descriptionAffix = "slash"
 selectorAffix.zero = "slashed"
 selectorAffix."zero/forceSlashed" = "slashed"
 selectorAffix."zero/forceUnslashed" = "unslashed"
 
 [prime.zero.variants-buildup.stages.overlays.reverse-slashed]
 rank = 3
-description = "revese slash"
+descriptionAffix = "revese slash"
 selectorAffix.zero = "reverseSlashed"
 selectorAffix."zero/forceSlashed" = "slashed"
 selectorAffix."zero/forceUnslashed" = "unslashed"
 
 [prime.zero.variants-buildup.stages.overlays.tall-slashed]
 rank = 4
-description = "tall slash"
+descriptionAffix = "tall slash"
 selectorAffix.zero = "tallSlashed"
 selectorAffix."zero/forceSlashed" = "tallSlashed"
 selectorAffix."zero/forceUnslashed" = "unslashed"
 
 [prime.zero.variants-buildup.stages.overlays.tall-reverse-slashed]
 rank = 5
-description = "tall reverse slash"
+descriptionAffix = "tall reverse slash"
 selectorAffix.zero = "tallReverseSlashed"
 selectorAffix."zero/forceSlashed" = "tallSlashed"
 selectorAffix."zero/forceUnslashed" = "unslashed"
 
 [prime.zero.variants-buildup.stages.overlays.dotted]
 rank = 6
-description = "center dot"
+descriptionAffix = "center dot"
 selectorAffix.zero = "dotted"
 selectorAffix."zero/forceSlashed" = "slashed"
 selectorAffix."zero/forceUnslashed" = "unslashed"
 
 [prime.zero.variants-buildup.stages.overlays.long-dotted]
 rank = 7
-description = "long center dot"
+descriptionAffix = "long center dot"
 selectorAffix.zero = "longDotted"
 selectorAffix."zero/forceSlashed" = "slashed"
 selectorAffix."zero/forceUnslashed" = "unslashed"
 
 [prime.zero.variants-buildup.stages.overlays.slashed-split]
 rank = 8
-description = "slash separated from the outline"
+descriptionAffix = "slash separated from the outline"
 selectorAffix.zero = "slashedSplit"
 selectorAffix."zero/forceSlashed" = "slashedSplit"
 selectorAffix."zero/forceUnslashed" = "unslashed"
 
 [prime.zero.variants-buildup.stages.overlays.reverse-slashed-split]
 rank = 9
-description = "reverse slash separated from the outline"
+descriptionAffix = "reverse slash separated from the outline"
 selectorAffix.zero = "reverseSlashedSplit"
 selectorAffix."zero/forceSlashed" = "slashedSplit"
 selectorAffix."zero/forceUnslashed" = "unslashed"
 
 [prime.zero.variants-buildup.stages.overlays.broken-slash]
 rank = 10
-description = "slash broken in the middle (like in Fixedsys)"
+descriptionAffix = "slash broken in the middle (like in Fixedsys)"
 selectorAffix.zero = "brokenSlash"
 selectorAffix."zero/forceSlashed" = "brokenSlash"
 selectorAffix."zero/forceUnslashed" = "unslashed"
 
 [prime.zero.variants-buildup.stages.overlays.broken-reverse-slash]
 rank = 11
-description = "reverse slash broken in the middle"
+descriptionAffix = "reverse slash broken in the middle"
 selectorAffix.zero = "brokenReverseSlash"
 selectorAffix."zero/forceSlashed" = "brokenSlash"
 selectorAffix."zero/forceUnslashed" = "unslashed"
 
 [prime.zero.variants-buildup.stages.overlays.broken-vertical-bar]
 rank = 12
-description = "vertical bar broken in the middle"
+descriptionAffix = "vertical bar broken in the middle"
 selectorAffix.zero = "brokenVerticalBar"
 selectorAffix."zero/forceSlashed" = "brokenSlash"
 selectorAffix."zero/forceUnslashed" = "unslashed"
 
 [prime.zero.variants-buildup.stages.overlays.slashed-cutout]
 rank = 13
-description = "a slash cutout"
+descriptionAffix = "a slash cutout"
 selectorAffix.zero = "slashedCutout"
 selectorAffix."zero/forceSlashed" = "slashed"
 selectorAffix."zero/forceUnslashed" = "unslashed"
 
 [prime.zero.variants-buildup.stages.overlays.reverse-slashed-cutout]
 rank = 14
-description = "a reverse-slash cutout"
+descriptionAffix = "a reverse-slash cutout"
 selectorAffix.zero = "reverseSlashedCutout"
 selectorAffix."zero/forceSlashed" = "slashed"
 selectorAffix."zero/forceUnslashed" = "unslashed"
 
 [prime.zero.variants-buildup.stages.overlays.tall-slashed-cutout]
 rank = 15
-description = "a taller slash cutout"
+descriptionAffix = "a taller slash cutout"
 selectorAffix.zero = "tallSlashedCutout"
 selectorAffix."zero/forceSlashed" = "tallSlashed"
 selectorAffix."zero/forceUnslashed" = "unslashed"
 
 [prime.zero.variants-buildup.stages.overlays.tall-reverse-slashed-cutout]
 rank = 16
-description = "a taller reverse-slash cutout"
+descriptionAffix = "a taller reverse-slash cutout"
 selectorAffix.zero = "tallReverseSlashedCutout"
 selectorAffix."zero/forceSlashed" = "tallSlashed"
 selectorAffix."zero/forceUnslashed" = "unslashed"
 
 [prime.zero.variants-buildup.stages.overlays.vertical-bar-cutout]
 rank = 17
-description = "a vertical bar cutout"
+descriptionAffix = "a vertical bar cutout"
 selectorAffix.zero = "verticalBarCutout"
 selectorAffix."zero/forceSlashed" = "slashed"
 selectorAffix."zero/forceUnslashed" = "unslashed"
 
 [prime.zero.variants-buildup.stages.overlays.top-right-cutout]
 rank = 18
-description = "the top-right bit cutout"
+descriptionAffix = "the top-right bit cutout"
 selectorAffix.zero = "topRightCutout"
 selectorAffix."zero/forceSlashed" = "slashed"
 selectorAffix."zero/forceUnslashed" = "unslashed"


### PR DESCRIPTION
Searched through the variant descriptions because I saw some "undefined with serifs".

Here's what I managed to find and fix:
* Several characters without a description prefix (R, V, ya, etc)
* A few characters have a wrong prefix (wrong capitalization, R <-> ya, etc)
* Some variants have missing descriptions due to the buildup part having a `description` instead of `descriptionAffix` (idk about `keyAffix`)
* Some variants have duplicate descriptions
* Some variants have inaccurate descriptions (leading to gems like "undefined with serifs; without serifs")
![image](https://github.com/be5invis/Iosevka/assets/21302803/369aae85-a976-4621-8e4d-25dc8370151b)

I might have missed some, however, since all I did was a naive regex search on `variants.toml` and duplicate search on `custom_build.md`. It might be a good idea to review the `custom_build.md` page again after regeneration.

There are also some stuff with default ligation set (`Default ligation set would be assigned to undefined.`) but I'm not sure what to do with that for now. Just do a search on "undefined" on the custom build page and you'll get the idea.