### PR TITLE
A few more description fixes

### DIFF
--- a/changes/24.1.1.md
+++ b/changes/24.1.1.md
@@ -1,5 +1,3 @@
-* Fix hook alignment of LATIN SMALL LETTER T WITH HOOK AND RETROFLEX HOOK (`U+1DF09`) (#1754).
-* Fix `cv86` application to HYPHEN WITH DIAERESIS (`U+2E1A`) (#1755).
 * Add characters
   - COMBINING DOT ABOVE LEFT (`U+1DF8`) (#1597).
   - COMBINING DOT BELOW LEFT (`U+1DFA`) (#1597).
@@ -7,3 +5,6 @@
   - LATIN SMALL LETTER REVERSED SCRIPT G (`U+1DF01`) (#1597).
   - LATIN SMALL LETTER REVERSED K (`U+1DF03`) (#1597).
   - LATIN SMALL LETTER REVERSED ENG (`U+1DF07`) (#1597).
+* Fix hook alignment of LATIN SMALL LETTER T WITH HOOK AND RETROFLEX HOOK (`U+1DF09`) (#1754).
+* Fix `cv86` application to HYPHEN WITH DIAERESIS (`U+2E1A`) (#1755).
+* Correct description of `k` and eszet (`ß`) variants.

--- a/params/ligation-set.toml
+++ b/params/ligation-set.toml
@@ -51,6 +51,7 @@ desc = 'Treat dot (`.`) as operator and perform chained centering'
 [simple.center-op-influence-colon]
 ligGroup =  "center-op-influence-colon"
 samples = ["<:", "<:>", ":>", ":=", "=:", ":-", "-:"]
+desc = 'Treat colon (`:`) as operator and perform chained centering'
 
 
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2376,7 +2376,7 @@ selectorAffix.kDescender = "topLeftSerifed"
 [prime.k.variants-buildup.stages.serifs.bottom-right-serifed]
 rank = 3
 disableIf = [ { body = "diagonal-tailed-cursive" } ]
-descriptionAffix = "serifs at top left"
+descriptionAffix = "serifs at bottom right"
 selectorAffix.k = "bottomRightSerifed"
 selectorAffix."k/sansSerif" = "serifless"
 selectorAffix.kHookTop = "bottomRightSerifed"
@@ -3959,7 +3959,7 @@ tag = "cv52"
 
 [prime.eszet.variants-buildup]
 entry = "body"
-description = "Eszet (`ß`)"
+descriptionLeader = "Eszet (`ß`)"
 
 [prime.eszet.variants-buildup.stages.body."*"]
 next = "terminal"


### PR DESCRIPTION
Missed issues from last time (#1752)
* Eszet descriptionLeader is not set properly
* `k` bottom-right serif description is same as top-left
* A ligature settings that didn't have a description