### PR TITLE
Add SALTIRE (`U+2613`), fix CROSS MARK (`U+274C`)

### DIFF
--- a/changes/24.1.1.md
+++ b/changes/24.1.1.md
@@ -1,6 +1,7 @@
 * Add characters
   - COMBINING DOT ABOVE LEFT (`U+1DF8`) (#1597).
   - COMBINING DOT BELOW LEFT (`U+1DFA`) (#1597).
+  - SALTIRE (`U+2613`).
   - MERCURY (`U+263F`).
   - MEDIUM SMALL WHITE CIRCLE (`U+26AC`).
   - NEUTER (`U+26B2`).
@@ -17,6 +18,7 @@
   - LATIN SMALL LETTER REVERSED K (`U+1DF03`) (#1597).
   - LATIN SMALL LETTER REVERSED ENG (`U+1DF07`) (#1597).
 * Fix hook alignment of LATIN SMALL LETTER T WITH HOOK AND RETROFLEX HOOK (`U+1DF09`) (#1754).
+* Improve glyph of CROSS MARK (`U+274C`) to be both heavy and large to match its intended counterpart HEAVY LARGE CIRCLE (`U+2B55`).
 * Disunify LATIN CAPITAL LETTER OMEGA (`U+A7B6`) and LATIN SMALL LETTER OMEGA (`U+A7B7`) from CYRILLIC CAPITAL LETTER BROAD OMEGA (`U+A64C`) and CYRILLIC SMALL LETTER BROAD OMEGA (`U+A64D`).
 * Fix `cv86` application to HYPHEN WITH DIAERESIS (`U+2E1A`) (#1755).
 * Correct description of `k` and eszet (`ß`) variants.

--- a/font-src/glyphs/symbol/geometric/stars.ptl
+++ b/font-src/glyphs/symbol/geometric/stars.ptl
@@ -45,11 +45,13 @@ glyph-block Symbol-Geometric-Stars : for-width-kinds WideWidth1
 	define exHeavySw    : UnicodeWeightGrade 11   Geom.Scalar
 
 	define AsteriskCfg : list
+		* { .name 'saltire'               .unicode 0x2613  .sides  4 .phase (1/8) .sw normalSw                }
+
 		* { .name 'heavyGreekCross'       .unicode 0x271A  .sides  4 .phase 0     .sw heavySw                 }
 		* { .name 'heavyAsterisk'         .unicode 0x2731  .sides  6 .phase 0     .sw heavySw     .cThin 0.9  }
 		* { .name 'eightSpokedAsterisk'   .unicode 0x2733  .sides  8 .phase 0     .sw normalSw    .cThin 0.75 }
 		* { .name 'sixteenSpokedAsterisk' .unicode 0x273A  .sides 16 .phase 0     .sw semiLightSw .cThin 0.75 }
-		* { .name 'crossMark'             .unicode 0x274C  .sides  4 .phase (1/8) .sw normalSw                }
+		* { .name 'crossMark'             .unicode 0x274C  .sides  4 .phase (1/8) .sw heavySw     .pMag  [GeometricSizes Geom].Large.size }
 		* { .name 'lightVertBar'          .unicode 0x2758  .sides  2 .phase 0     .sw lightSw                 }
 		* { .name 'mediumVertBar'         .unicode 0x2759  .sides  2 .phase 0     .sw mediumSw                }
 		* { .name 'heavyVertBar '         .unicode 0x275A  .sides  2 .phase 0     .sw heavySw                 }
@@ -91,9 +93,10 @@ glyph-block Symbol-Geometric-Stars : for-width-kinds WideWidth1
 			set-width Geom.Width
 			foreach [j : range 0 sides] : begin
 				local angle : 2 * Math.PI * (j / sides + phase)
+				local mag : fallback pMag 1
 				include : dispiro
 					corner Geom.MidX Geom.MidY [widths.center (sw * [fallback cThin 1])]
 					corner
-						Geom.MidX + Geom.Size * [Math.sin (-angle)]
-						Geom.MidY + Geom.Size * [Math.cos (-angle)]
+						Geom.MidX + Geom.Size * mag * [Math.sin (-angle)]
+						Geom.MidY + Geom.Size * mag * [Math.cos (-angle)]
 						widths.center sw


### PR DESCRIPTION
Cross Mark is intended to pair with Heavy Large Circle in e.g. a game of Tic Tac Toe or the answer to a "yes"/"no" choice question
```
❌⭕
🞨🞩☓🞪🞫🞬🞭🞮
```
![image](https://github.com/be5invis/Iosevka/assets/37010132/11c044c2-5319-49e9-a1ac-4d27b0433a03)
