### PR TITLE
fix mistake from previous PR

### DIFF
--- a/params/variants.toml
+++ b/params/variants.toml
@@ -6439,6 +6439,7 @@ brace = "straight"
 number-sign = "slanted"
 at = "fourfold"
 percent = "rings-continuous-slash"
+lower-eth = "straight-bar"
 
 [composite.ss01.slab-override.design]
 capital-d = "more-rounded-bilateral-serifed"
@@ -6455,7 +6456,6 @@ cyrl-capital-ka = "straight-serifed"
 cyrl-ka = "straight-serifed"
 cyrl-capital-u = "straight-turn-serifed"
 seven = "straight-serifed"
-lower-eth = "straight-bar"
 
 
 


### PR DESCRIPTION
`vxaa` mistakenly went on the slab override of `ss01` instead of the regular one. This corrects that.