### PR TITLE
Zhwe shape fix

### DIFF
--- a/changes/24.1.2.md
+++ b/changes/24.1.2.md
@@ -1,1 +1,1 @@
-* Fix broken geometry of CYRILLIC CAPITAL LETTER ZHWE (`U+A684`) and CYRILLIC SMALL LETTER ZHWE (`U+A685`) under `cv64 = 3` or `5` (#1769).
+* Fix broken geometry of CYRILLIC CAPITAL LETTER ZHWE (`U+A684`) and CYRILLIC SMALL LETTER ZHWE (`U+A685`) under some settings of `cv63` and `cv64` (#1769).

--- a/changes/24.1.2.md
+++ b/changes/24.1.2.md
@@ -1,0 +1,1 @@
+* Fix broken geometry of CYRILLIC CAPITAL LETTER ZHWE (`U+A684`) and CYRILLIC SMALL LETTER ZHWE (`U+A685`) under `cv64 = 3` or `5` (#1769).

--- a/font-src/glyphs/letter/cyrillic/dzzhe-zhwe.ptl
+++ b/font-src/glyphs/letter/cyrillic/dzzhe-zhwe.ptl
@@ -101,7 +101,7 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 
 		define [ZhweZheShape legShape fSlab df top hook] : glyph-proc
 			local [object subDf sw] : SubDfDim 0 2 df
-			local ze : CyrZe 0 0 top 0 subDf.leftSB subDf.rightSB 0.65 hook sw
+			local ze : CyrZe 0 0 top 0 subDf.leftSB subDf.rightSB 0.65 hook (0.5 * sw)
 			include : difference [CyrRightZheShape legShape fSlab df top subDf.middle] [ze.ShapeMask]
 
 		glyph-block-import Letter-Cyrillic-De : CyrDeItalicShapeT


### PR DESCRIPTION
Trying to fix #1769.

Turns out the shape for Ze under `cv64 = 3` is *slightly* different from the others, causing this broken geometry:
![image](https://github.com/be5invis/Iosevka/assets/21302803/406a50fd-50ec-4cc2-9bb8-0175a74b19c6)

I'm not sure what a good fix for this is (without creating a right-zhe for each variant of ze), so I just shrunk the `sw` for the mask so that the shape connect properly for now.

The capital letter also has a small defect ![image](https://github.com/be5invis/Iosevka/assets/21302803/8ea41194-2927-4190-8f72-574b845d790e) which I don't know the cause of (rounding errors?), but the hack above solves this as well.