### PR TITLE
Harmonize various pitchfork-derived glyphs

### DIFF
--- a/changes/24.1.2.md
+++ b/changes/24.1.2.md
@@ -1,1 +1,2 @@
 * Fix broken geometry of CYRILLIC CAPITAL LETTER ZHWE (`U+A684`) and CYRILLIC SMALL LETTER ZHWE (`U+A685`) under some settings of `cv63` and `cv64` (#1769).
+* Improve glyphs of PITCHFORK WITH TEE TOP (`U+2ADA`) ... NONFORKING (`U+2ADD`) such that their terminals are of consistent height with each other.

--- a/font-src/glyphs/symbol/math/v-and-cup.ptl
+++ b/font-src/glyphs/symbol/math/v-and-cup.ptl
@@ -178,10 +178,12 @@ glyph-block Symbol-Math-VAndCup : begin
 	turned 'doubleCap' 0x22D2 'doubleCup' Middle SymbolMid
 
 	define pitchForkTop : [mix OperBot OperTop 1.2] + Stroke / 4
+	define pitchForkSw  : AdviceStroke 3.25
+	
 	create-glyph 'pitchFork' 0x22D4 : composite-proc
-		UShape [DivFrame 1] OperTop OperBot (stroke -- [AdviceStroke 3.25])
+		UShape [DivFrame 1] OperTop OperBot (stroke -- pitchForkSw)
 		FlipAround Middle SymbolMid
-		VBar.m Middle OperBot pitchForkTop [AdviceStroke 3.25]
+		VBar.m Middle OperBot pitchForkTop pitchForkSw
 
 	create-glyph 'elementUp' 0x27D2 : glyph-proc
 		include [refer-glyph 'thinCup'] AS_BASE ALSO_METRICS
@@ -204,23 +206,18 @@ glyph-block Symbol-Math-VAndCup : begin
 
 	turned 'elementDown' 0x2AD9 'elementUp' Middle SymbolMid
 
-	create-glyph 'transversalIntersection' 0x2ADB : glyph-proc
-		local top : mix SymbolMid OperTop 0.5
-		local bot : mix SymbolMid OperBot 0.5
-		include : UShape [DivFrame 1] top bot (stroke -- ThinCupStroke)
-		include : FlipAround Middle [mix top bot 0.5]
-		include : VBar.m Middle OperBot OperTop ThinCupStroke
+	create-glyph 'transversalIntersection' 0x2ADB : composite-proc
+		UShape [DivFrame 1] OperTop OperBot (stroke -- pitchForkSw)
+		FlipAround Middle SymbolMid
+		VBar.m Middle (OperBot + OperTop - pitchForkTop) pitchForkTop pitchForkSw
 
-	create-glyph 'pitchForkTeeTop' 0x2ADA : glyph-proc
+	create-glyph 'pitchForkTee' 0x2ADA : glyph-proc
 		include [refer-glyph 'pitchFork'] AS_BASE ALSO_METRICS
-		include : HBar.t [mix Middle SB 0.5] [mix Middle RightSB 0.5] pitchForkTop OperatorStroke
+		include : HBar.t SB RightSB pitchForkTop pitchForkSw
 
 	create-glyph 'nonForking' 0x2ADD : glyph-proc
-		local top : mix SymbolMid OperTop 0.75
-		local bot : mix SymbolMid OperBot 0.75
-		local mid : mix SymbolMid OperTop 0.25
-		include : UShape [DivFrame 1] mid bot (stroke -- ThinCupStroke)
-		include : VBar.m Middle bot top ThinCupStroke
+		include : UShape [DivFrame 1] SymbolMid OperBot (stroke -- pitchForkSw)
+		include : VBar.m Middle OperBot OperTop pitchForkSw
 
 	create-glyph 'forking' 0x2ADC : glyph-proc
 		include [refer-glyph 'nonForking'] AS_BASE ALSO_METRICS


### PR DESCRIPTION
I've given these glyphs a second thought after I took a look at what Pragmata Pro does: 
`⫙⫚⫛⫝̸⫝`
![image](https://github.com/be5invis/Iosevka/assets/37010132/665d6d38-c4a9-4aff-83ae-688f1c4087e9)
Here's my attempt at improving them for Iosevka without changing the original PITCHFORK (`U+22D4`) glyph:
`⋔`, `⫙⫚⫛⫝̸⫝`
![image](https://github.com/be5invis/Iosevka/assets/37010132/7ef7a9a8-208c-42ca-84d6-d4ac64bcdf64)