### PR TITLE
Some curly tail characters

### DIFF
--- a/changes/24.1.2.md
+++ b/changes/24.1.2.md
@@ -1,3 +1,10 @@
+* Add characters
+  - LATIN SMALL LETTER SCRIPT G WITH CROSSED-TAIL (`U+AB36`).
+  - LATIN SMALL LETTER M WITH CROSSED-TAIL (`U+AB3A`).
+  - LATIN SMALL LETTER N WITH CROSSED-TAIL (`U+AB3B`).
+  - LATIN SMALL LETTER ENG WITH CROSSED-TAIL (`U+AB3C`).
+  - MODIFIER LETTER SMALL S WITH CURL (`U+107BA`).
+  - LATIN SMALL LETTER S WITH CURL (`U+1DF1E`).
 * Fix broken geometry of CYRILLIC CAPITAL LETTER ZHWE (`U+A684`) and CYRILLIC SMALL LETTER ZHWE (`U+A685`) under some settings of `cv63` and `cv64` (#1769).
 * Improve glyphs of PITCHFORK WITH TEE TOP (`U+2ADA`) ... NONFORKING (`U+2ADD`) such that their terminals are of consistent height with each other.
 * Fix alignment in various APL characters (#1771).

--- a/font-src/glyphs/auto-build/transformed.ptl
+++ b/font-src/glyphs/auto-build/transformed.ptl
@@ -258,6 +258,7 @@ glyph-block Autobuild-Transformed : begin
 			list 0x107B0 'vHookRight'
 			list 0x107A9 'rFlap'
 			list 0x107A8 'rRTail'
+			list 0x107BA 'sCurlyTail'
 			list 0x10784 'smcpB'
 			list 0x107AA 'smcpR'
 			list 0x10796 'smcpH'

--- a/font-src/glyphs/letter/latin/lower-g.ptl
+++ b/font-src/glyphs/letter/latin/lower-g.ptl
@@ -9,7 +9,7 @@ glyph-block Letter-Latin-Lower-G : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Shapes : OBarLeft OBarRight DToothlessRise DMBlend
-	glyph-block-import Letter-Shared-Shapes : FlatHookDepth PalatalHook VerticalHook
+	glyph-block-import Letter-Shared-Shapes : FlatHookDepth PalatalHook VerticalHook CurlyTail
 
 	define [OverlayW bw] : glyph-proc
 		define l : mix 0 SB 0.3
@@ -101,6 +101,17 @@ glyph-block Letter-Latin-Lower-G : begin
 				arcvh.superness DesignParameters.tightHookSuperness
 				flat (df.rightSB - hd.x) Descender
 				curl xTerminal Descender
+		export : define [CrossedHook df y0] : begin
+			local fine : AdviceStroke 3.5 df.div
+			local m1 : df.rightSB - df.mvs * HVContrast
+			local rinner : (-Descender - 2 * fine) / 3
+			local x2 : mix df.rightSB m1 0.25
+			local y2 : Descender + O
+			return : dispiro
+				widths.rhs df.mvs
+				flat df.rightSB y0 [heading Downward]
+				curl df.rightSB (Descender + SmallArchDepthA)
+				CurlyTail fine rinner m1 Descender df.leftSB x2 y2
 
 		export : define [SeriflessBody df top] : glyph-proc
 			include : OBarRight.shape (top -- top) (left -- df.leftSB) (right -- df.rightSB) (sw -- df.mvs)
@@ -172,6 +183,12 @@ glyph-block Letter-Latin-Lower-G : begin
 			include [refer-glyph "g.\(suffix)"] AS_BASE ALSO_METRICS
 			include : OverlayW [AdviceStroke2 2 4 XH]
 
+		create-glyph "gScriptCrossedTail.\(suffix)" : glyph-proc
+			include : MarkSet.p
+			set-base-anchor 'overlay' Middle (XH / 2)
+			define df : DivFrame 1
+			include : bodyShape df XH
+			include : SingleStorey.CrossedHook df (XH - hookStart)
 
 	select-variant 'g' 'g'
 	link-reduced-variant 'g/sansSerif' 'g' MathSansSerif
@@ -182,6 +199,7 @@ glyph-block Letter-Latin-Lower-G : begin
 	select-variant 'gScript' 0x261 (shapeFrom -- 'g') (follow -- 'gScript')
 	select-variant 'GScript' 0xA7AC (follow -- 'gScript')
 	select-variant 'gPalatalHook' 0x1D83 (follow -- 'gScript')
+	select-variant 'gScriptCrossedTail' 0xAB36
 
 
 	alias 'cyrl/de.SRB' null 'gScript'

--- a/font-src/glyphs/letter/latin/lower-m.ptl
+++ b/font-src/glyphs/letter/latin/lower-m.ptl
@@ -11,7 +11,7 @@ glyph-block Letter-Latin-Lower-M : begin
 	glyph-block-import Letter-Shared : CreateAccentedComposition
 	glyph-block-import Letter-Shared-Shapes : SerifFrame RightwardTailedBar DToothlessRise DMBlend
 	glyph-block-import Letter-Shared-Shapes : nShoulder nShoulderMask
-	glyph-block-import Letter-Shared-Shapes : CyrDescender PalatalHook VerticalHook
+	glyph-block-import Letter-Shared-Shapes : CyrDescender PalatalHook VerticalHook CurlyTail
 
 	define [SmallMSmooth df] : df.div * (0.5 * SmallArchDepth + 0.375 * Stroke)
 	define [SmallMShoulderSpiro] : with-params [left right top bottom width fine df coBottom] : glyph-proc
@@ -134,7 +134,7 @@ glyph-block Letter-Latin-Lower-M : begin
 			curl df.rightSB rbot [heading Downward]
 
 		include : tagged 'barL' : VBar.l df.leftSB lbot (top - DToothlessRise) df.mvs
-		include : tagged 'barM' : VBar.m     df.middle mbot (top - DToothlessRise) df.mvs
+		include : tagged 'barM' : VBar.m df.middle mbot (top - DToothlessRise) df.mvs
 
 	define [EarlessRoundedDoubleArchSmallMShape top lbot mbot rbot df] : glyph-proc
 		include : union
@@ -235,6 +235,29 @@ glyph-block Letter-Latin-Lower-M : begin
 				include : FlipAround df.middle ((Width - SB) / 2)
 				include : Translate 0 (SB / 2)
 
+		create-glyph "mCrossedTail.\(suffix)" : glyph-proc
+			local df : DivFrame para.diversityM 4
+			set-width df.width
+			include : df.markSet.e
+
+			local fine : AdviceStroke 5.5 df.div
+			local rinner : XH * 0.15 - fine * 0.75
+			local m1 : df.rightSB - df.mvs * HVContrast
+			local m2 : [mix (df.middle + 0.5 * df.mvs * HVContrast) m1 0.35] - 0.5 * fine * HVContrast
+			local x2 : df.rightSB + SideJut
+			local y2 : rinner * 2 + fine - O
+			include : Body XH 0 [if shortLeg [SmallMShortLegHeight XH df] 0] (y2 + O) df
+			include : dispiro
+				straight.down.start df.rightSB (y2 + O) [widths.rhs.heading df.mvs Downward]
+				CurlyTail fine rinner m1 0 m2 x2 y2 (adj -- 0)
+
+			include : Serifs df XH 0 [if shortLeg [SmallMShortLegHeight XH df] 0] 0 true earless
+			if (SLAB && [not shortLeg] && Serifs === FullSerifs) : begin
+				local sf : SerifFrame.fromDf df XH 0
+				if (sf.enoughSpaceForFullSerifs && m2 - (df.middle + sf.jutIn) < 0.01 * Width) : begin
+					eject-contour 'serifMB'
+					include sf.mb.left
+
 	select-variant 'm' 'm'
 	select-variant 'm/tailless' (shapeFrom -- 'm')
 	select-variant 'capitalSmallM' (follow -- 'm')
@@ -256,6 +279,7 @@ glyph-block Letter-Latin-Lower-M : begin
 	select-variant 'mLTail' 0x271
 	select-variant 'turnmLeg' 0x270 (follow -- 'm')
 	select-variant 'turnmSideways' 0x1D1F (follow -- 'm')
+	select-variant 'mCrossedTail' 0xAB3A (follow -- 'mLTail')
 
 	turned 'turnm' 0x26F 'm' HalfAdvance (XH / 2)
 	turned 'capitalTurnm' 0x19C 'capitalSmallM' HalfAdvance (CAP / 2)

--- a/font-src/glyphs/letter/latin/lower-n.ptl
+++ b/font-src/glyphs/letter/latin/lower-n.ptl
@@ -21,6 +21,7 @@ glyph-block Letter-Latin-Lower-N : begin
 	define [NHTB top] : VBar.l SB 0 top
 	define [NTopLeftSerif top] : tagged 'serifLT' : HSerif.lt SB top SideJut
 	define [NBottomLeftSerif y] : tagged 'serifLB' : HSerif.mb (SB + HalfStroke * HVContrast) y Jut
+	define [NBottomLeftOuterSerif y] : tagged 'serifLB' : HSerif.lb SB y SideJut
 
 	define [NBottomRightSerifUpright y] : glyph-proc
 		include : tagged 'serifRB' : HSerif.mb (RightSB - HalfStroke * HVContrast) y Jut
@@ -97,14 +98,14 @@ glyph-block Letter-Latin-Lower-N : begin
 			if sRB : include : sRB 0
 
 		create-glyph "eng.\(suffix)" : glyph-proc
-			include : MarkSet.e
+			include : MarkSet.p
 			include : Body XH SB RightSB 0 Stroke
 			include : VerticalHook.r RightSB 0 (-HookX) Hook
 			if sLT : include : sLT XH
 			if sLB : include : sLB 0
 
 		create-glyph "nHookBottom.\(suffix)" : glyph-proc
-			include : MarkSet.e
+			include : MarkSet.p
 			include : Body XH SB RightSB 0 Stroke
 			include : VerticalHook.r RightSB 0 HookX Hook
 			if sLT : include : sLT XH
@@ -114,13 +115,13 @@ glyph-block Letter-Latin-Lower-N : begin
 			include : MarkSet.e
 			local fine : AdviceStroke 4
 			local rinner : clamp (Width * 0.065) (XH * 0.05) (fine * 0.35)
-			local wide : AdviceStroke 3
+			local sw : AdviceStroke 3
 			local m1 : Math.min RightSB (Width - rinner * 2 - fine - OX)
 			local x2 : mix SB m1 0.5
 			local y2 : -fine
-			include : Body XH SB m1 (rinner * 2 + fine) wide
+			include : Body XH SB m1 (rinner * 2 + fine) sw
 			include : dispiro
-				straight.down.start m1 (rinner * 2 + fine - O) [widths.rhs.heading wide Downward]
+				straight.down.start m1 (rinner * 2 + fine - O) [widths.rhs.heading sw Downward]
 				CurlyTail fine rinner m1 0 (m1 + rinner * 2 + fine) x2 y2
 			if sLT : include : sLT XH
 			if sLB : include : sLB 0
@@ -141,6 +142,36 @@ glyph-block Letter-Latin-Lower-N : begin
 			if sLB : include : sLB 0
 			if sRB : include : sRB Descender
 
+		create-glyph "nCrossedTail.\(suffix)" : glyph-proc
+			include : MarkSet.e
+			local fine : AdviceStroke 4
+			local rinner : XH * 0.15 - fine * 0.75
+			local sw : AdviceStroke 3
+			local m1 : RightSB - sw * HVContrast
+			local m2 : [mix SB RightSB 0.5] - 0.5 * fine * HVContrast
+			local x2 : RightSB + SideJut
+			local y2 : rinner * 2 + fine - O
+			include : Body XH SB RightSB (y2 + O) sw
+			include : dispiro
+				straight.down.start RightSB y2 [widths.rhs.heading sw Downward]
+				CurlyTail fine rinner m1 0 m2 x2 y2 (adj -- 0.2)
+			if sLT : include : sLT XH
+			if sLB : include : [if (m2 - (SB + HalfStroke * HVContrast + Jut) > 0.01 * Width) NBottomLeftSerif NBottomLeftOuterSerif] 0
+
+		create-glyph "engCrossedTail.\(suffix)" : glyph-proc
+			include : MarkSet.p
+			include : Body XH SB RightSB 0 Stroke
+			local fine : AdviceStroke 3.5
+			local rinner : (-Descender - 2 * fine) / 3
+			local m1 : RightSB - Stroke * HVContrast
+			local x2 : mix RightSB m1 0.25
+			local y2 : Descender + O
+			include : dispiro
+				straight.down.start RightSB (-O) [widths.rhs.heading Stroke Downward]
+				CurlyTail fine rinner m1 Descender (m1 - HookX) x2 y2
+			if sLT : include : sLT XH
+			if sLB : include : sLB 0
+
 	select-variant 'n' 'n'
 	link-reduced-variant 'n/sansSerif' 'n' MathSansSerif
 	link-reduced-variant 'n/descBase' 'n'
@@ -152,6 +183,8 @@ glyph-block Letter-Latin-Lower-N : begin
 	link-reduced-variant 'eng/phoneticRight' 'eng'
 	select-variant 'nHookBottom' 0x273 (follow -- 'eng')
 	select-variant 'nCurlyTail' 0x235 (follow -- 'eng')
+	select-variant 'nCrossedTail' 0xAB3B (follow -- 'eng')
+	select-variant 'engCrossedTail' 0xAB3C (follow -- 'eng')
 	select-variant 'NExt' 0x220 (follow -- 'n')
 	select-variant 'nExt' 0x19E (follow -- 'n')
 
@@ -170,6 +203,7 @@ glyph-block Letter-Latin-Lower-N : begin
 
 	derive-glyphs 'nltail' 0x272 'n' : lambda [src srl] : glyph-proc
 		include [refer-glyph src] AS_BASE
+		include : MarkSet.p
 		eject-contour 'serifLB'
 		include : VerticalHook.l SB 0 (-HookX) Hook
 

--- a/font-src/glyphs/letter/latin/s.ptl
+++ b/font-src/glyphs/letter/latin/s.ptl
@@ -15,11 +15,12 @@ glyph-block Letter-Latin-S : begin
 	glyph-block-import Letter-Shared-Shapes : ArcStartSerifWidth ArcStartSerifDepth
 	glyph-block-import Letter-Shared-Shapes : SerifedArcStart SerifedArcEnd
 	glyph-block-import Letter-Shared-Shapes : ArcStartSerif ArcEndSerif
-	glyph-block-import Letter-Shared-Shapes : PalatalHook RetroflexHook CyrDescender
+	glyph-block-import Letter-Shared-Shapes : PalatalHook RetroflexHook CyrDescender CurlyTail
 
 	define SLAB-NONE      0
 	define SLAB-CLASSICAL 1
 	define SLAB-INWARD    2
+	define CURLY-TAIL     10
 
 	define SOBot  OX
 
@@ -40,6 +41,15 @@ glyph-block Letter-Latin-S : begin
 			g4.down.mid (deltaX + SB - Width) (top - archDepth) [widths.lhs gap]
 			alsoThru.g2 0.5 0.5 [widths.center ess]
 			g4.down.mid (deltaX + RightSB - Width - SOBot) (bot + archDepth) [widths.rhs gap]
+
+	define [SCurlyTail sw] : begin
+		local fine : AdviceStroke2 3 4 XH
+		local rinner : ((XH * 0.5) - fine * 2 - sw * 0.5) / 3
+		local m1 : RightSB - SOBot - sw * HVContrast
+		local x2 : RightSB - sw * 0.3
+		local y2 : -XH * 0.05
+
+		return : CurlyTail fine rinner m1 0 (SB + SOBot) x2 y2
 
 	define [SStrokeImpl top bot st sb stroke refSwEss] : begin
 		local ess : refSwEss * stroke / Stroke
@@ -115,6 +125,9 @@ glyph-block Letter-Latin-S : begin
 			g4   (RightSB + OX - SOBot) (archDepth) [widths 0 stroke]
 
 			match sb
+				[Just CURLY-TAIL] : list
+					arcvh
+					SCurlyTail stroke
 				[Just SLAB-CLASSICAL] : SerifedArcEnd.RtlRhs SB Middle 0 stroke SHook
 				[Just SLAB-INWARD] : list
 					arcvh
@@ -317,6 +330,13 @@ glyph-block Letter-Latin-S : begin
 				flat (RightSB - 1) Descender [widths sw 0]
 				curl RightSB Descender
 
+		create-glyph "sCurlyTail.\(suffix)" : glyph-proc
+			local sw : AdviceStroke2 2 3 XH
+			include : MarkSet.e
+			include : SmallSStrokeImpl doTS CURLY-TAIL sw EssLower
+			include : SAutoSlabStart doTS XH sw Hook
+			include : SAutoSlabEnd   doBS 0  sw Hook
+
 	select-variant 'S' 'S'
 	link-reduced-variant 'S/sansSerif' 'S' MathSansSerif
 	select-variant 's' 's'
@@ -336,6 +356,7 @@ glyph-block Letter-Latin-S : begin
 
 	select-variant 'SSwash' 0x2C7E
 	select-variant 'sSwash' 0x23F
+	select-variant 'sCurlyTail' 0x1DF1E (follow -- 'sSwash')
 
 	select-variant 'S/descBase' (shapeFrom -- 'S') (follow -- 'SRTail')
 	select-variant 's/ascBase' (shapeFrom -- 's')

--- a/font-src/glyphs/letter/latin/s.ptl
+++ b/font-src/glyphs/letter/latin/s.ptl
@@ -44,7 +44,7 @@ glyph-block Letter-Latin-S : begin
 
 	define [SCurlyTail sw] : begin
 		local fine : AdviceStroke2 3 4 XH
-		local rinner : ((XH * 0.5) - fine * 2 - sw * 0.5) / 3
+		local rinner : ((XH * 0.5) - fine * 2 - sw * 0.5) / 4
 		local m1 : RightSB - SOBot - sw * HVContrast
 		local x2 : RightSB - sw * 0.3
 		local y2 : -XH * 0.05

--- a/font-src/glyphs/letter/latin/upper-n.ptl
+++ b/font-src/glyphs/letter/latin/upper-n.ptl
@@ -71,7 +71,8 @@ glyph-block Letter-Latin-Upper-N : begin
 			include : VBar.r RightSB 0 CAP
 
 		create-glyph "Nltail.\(suffix)" : glyph-proc
-			include [refer-glyph "N.\(suffix)"] AS_BASE ALSO_METRICS
+			include [refer-glyph "N.\(suffix)"] AS_BASE
+			include : MarkSet.capDesc
 			eject-contour 'serifLB'
 			include : VerticalHook.l SB 0 (-HookX) Hook
 

--- a/font-src/glyphs/letter/shared.ptl
+++ b/font-src/glyphs/letter/shared.ptl
@@ -147,7 +147,7 @@ glyph-block Letter-Shared-Shapes : begin
 	glyph-block-export CurlyTail
 	define [CurlyTail] : with-params [fine rinner xleft bottom right x2 y2 [adj 0.4] [adj2 0.4] [adj3 0]] : begin
 		local ltr : right > xleft
-		set right : right - fine * [if ltr 1 (-1)]
+		set right : right - fine * [if ltr 1 (-1)] * HVContrast
 		local mid : mix [mix xleft right 0.5] (right - rinner * [if ltr 1 (-1)]) adj
 		local midu : mix [mix xleft right 0.5] (right - rinner * [if ltr 1 (-1)]) adj2
 		return : list
@@ -655,6 +655,8 @@ glyph-block Letter-Shared-Shapes : begin
 
 			set this.mb : object
 				full : tagged 'serifMB' : HSerif.mbAsymmetric [mix lBarCenter rBarCenter 0.5] bot jutIn jutIn swSerif
+				left : tagged 'serifMB' : HSerif.mbAsymmetric [mix lBarCenter rBarCenter 0.5] bot jutIn 0 swSerif
+				right : tagged 'serifMB' : HSerif.mbAsymmetric [mix lBarCenter rBarCenter 0.5] bot 0 jutIn swSerif
 			set this.mt : object
 				full : tagged 'serifMT' : HSerif.mtAsymmetric [mix lBarCenter rBarCenter 0.5] top jutIn jutIn swSerif
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1960,6 +1960,7 @@ selectorAffix.g = ""
 selectorAffix."g/sansSerif" = ""
 selectorAffix."gScript" = ""
 selectorAffix."gScript/hookTopBase" = ""
+selectorAffix."gScriptCrossedTail" = ""
 
 [prime.g.variants-buildup.stages.openness."*"]
 next = "END"
@@ -1971,6 +1972,7 @@ selectorAffix.g = "doubleStorey"
 selectorAffix."g/sansSerif" = "doubleStorey"
 selectorAffix."gScript" = "singleStoreySerifless"
 selectorAffix."gScript/hookTopBase" = "singleStoreySerifless"
+selectorAffix."gScriptCrossedTail" = "singleStoreySerifless"
 
 [prime.g.variants-buildup.stages.openness.open]
 rank = 1
@@ -1979,6 +1981,7 @@ selectorAffix.g = "openDoubleStorey"
 selectorAffix."g/sansSerif" = "openDoubleStorey"
 selectorAffix."gScript" = "singleStoreySerifless"
 selectorAffix."gScript/hookTopBase" = "singleStoreySerifless"
+selectorAffix."gScriptCrossedTail" = "singleStoreySerifless"
 
 [prime.g.variants-buildup.stages.stroey.single-storey]
 next = "hook"
@@ -1988,6 +1991,7 @@ selectorAffix.g = "singleStorey"
 selectorAffix."g/sansSerif" = "singleStorey"
 selectorAffix."gScript" = "singleStorey"
 selectorAffix."gScript/hookTopBase" = "singleStorey"
+selectorAffix."gScriptCrossedTail" = "singleStorey"
 
 [prime.g.variants-buildup.stages.hook."*"]
 next = "ear"
@@ -1999,6 +2003,7 @@ selectorAffix.g = ""
 selectorAffix."g/sansSerif" = ""
 selectorAffix."gScript" = ""
 selectorAffix."gScript/hookTopBase" = ""
+selectorAffix."gScriptCrossedTail" = ""
 
 [prime.g.variants-buildup.stages.hook.flat-hook]
 rank = 2
@@ -2007,6 +2012,7 @@ selectorAffix.g = "flatHook"
 selectorAffix."g/sansSerif" = "flatHook"
 selectorAffix."gScript" = "flatHook"
 selectorAffix."gScript/hookTopBase" = "flatHook"
+selectorAffix."gScriptCrossedTail" = ""
 
 [prime.g.variants-buildup.stages.ear.serifless]
 rank = 1
@@ -2014,6 +2020,7 @@ selectorAffix.g = "serifless"
 selectorAffix."g/sansSerif" = "serifless"
 selectorAffix."gScript" = "serifless"
 selectorAffix."gScript/hookTopBase" = "serifless"
+selectorAffix."gScriptCrossedTail" = "serifless"
 
 [prime.g.variants-buildup.stages.ear.serifed]
 rank = 2
@@ -2022,6 +2029,7 @@ selectorAffix.g = "serifed"
 selectorAffix."g/sansSerif" = "serifless"
 selectorAffix."gScript" = "serifed"
 selectorAffix."gScript/hookTopBase" = "serifless"
+selectorAffix."gScriptCrossedTail" = "serifed"
 
 [prime.g.variants-buildup.stages.ear.earless-corner]
 rank = 3
@@ -2030,6 +2038,7 @@ selectorAffix.g = "earlessCorner"
 selectorAffix."g/sansSerif" = "earlessCorner"
 selectorAffix."gScript" = "earlessCorner"
 selectorAffix."gScript/hookTopBase" = "earlessCornerHTB"
+selectorAffix."gScriptCrossedTail" = "earlessCorner"
 
 [prime.g.variants-buildup.stages.ear.earless-rounded]
 rank = 4
@@ -2038,6 +2047,7 @@ selectorAffix.g = "earlessRounded"
 selectorAffix."g/sansSerif" = "earlessRounded"
 selectorAffix."gScript" = "earlessRounded"
 selectorAffix."gScript/hookTopBase" = "earlessRoundedHTB"
+selectorAffix."gScriptCrossedTail" = "earlessRounded"
 
 
 


### PR DESCRIPTION
![image](https://github.com/be5invis/Iosevka/assets/21302803/20e54671-bb5d-4c41-895f-af798bf659f6)
* Adds some of the curly tail (or "crossed-tail") characters. The superscript `𐞺` completes Latin Ext F.
* Modified the CurlyTail code so that the `right` position is a bit more logical. This affects all other existing curly tail characters, but not too much to cause any distortion (in fact, a few of them extrude less outside the boundary after the change)
* `ꬶꬼ` kinda based on j with curl (`ʝ`), but the curl squashed to prevent overlapping with the body.
* `𝼞` based on alveopalatal c (`ɕ`). Same adjustment as above.
* Originally I tried to align `ꬻꬺ` with `ȵ`, but realized that the curl for cross-tail n would look to squashed in thin weight. They are aligned by XH for now.
  * In Noto Sans Mono, the curl point slightly downward (achievable by removing `O` in the `y2` parameter). But since most other fonts (including the Unicode sample) point horizontally, I follow that version.
  * I'm really unsure about `ꬺ`: The current setting tries to balance between 
    1. Preventing overlaps (other than the cross)
    2. Preventing the start of the curl from bending weirdly due to the `mid` variable shifting too far right (still slightly visible in `ꬻ`) ![image](https://github.com/be5invis/Iosevka/assets/21302803/8cbe2005-a2f0-469a-a8de-1154bea9e1d3)
    3. Preventing NaN angles due to the curl gap being too small
  
    But it looks a bit thin as a result. Maybe shifting the middle bar to the left is a solution, but since only unifont does that, I'm not sure if I should.
  * The inner serif of `ꬻ` will be omitted if the curl is too close (or overlaps) it. Same should happen for `ꬺ`, though I'm not sure if my implementation is correct.
* For `ꬶꬼ𝼞`, The `right` position is based on where the stroke will normally end without the curl (assuming default variant).
* Works with variants: ![image](https://github.com/be5invis/Iosevka/assets/21302803/c4631818-3a71-42f5-8396-b590ed4f5640)

