### PR TITLE
MarkSet Reconciliation, part 1

### DIFF
--- a/changes/24.1.4.md
+++ b/changes/24.1.4.md
@@ -1,1 +1,4 @@
 * Fix shape of `U+1D95` (#1790).
+* Fix combining mark anchors for several characters.
+* Fix upside down shape of `U+1D12`.
+* Fix variant assignment for `U+1D84` and `U+2C6A`.

--- a/font-src/glyphs/auto-build/composite.ptl
+++ b/font-src/glyphs/auto-build/composite.ptl
@@ -1342,7 +1342,7 @@ glyph-block Autobuild-Pnonetic-Ligatures : begin
 	createPhoneticLigatures ToLetter 'phonetic' para.diversityM 2 stdShrink 1 : list
 		list 0x02A3 { 'd/phoneticLeft'  'z'                     } 'b'
 		list 0x02A4 { 'd/phoneticLeft'  'ezh'                   } 'if'
-		list 0x02A5 { 'd/phoneticLeft'  'zCurlyTail'            } 'if'
+		list 0x02A5 { 'd/phoneticLeft'  'zCurlyTail'            } 'b'
 		list 0x02A6 { 't/phoneticLeft2' 's/phoneticRight'       } 'b'
 		list 0x02A7 { 't/teshLeft'      'esh'                   } 'if'
 		list 0x02A8 { 't/phoneticLeft1' 'cCurlyTail'            } 'b'
@@ -1350,7 +1350,7 @@ glyph-block Autobuild-Pnonetic-Ligatures : begin
 		list 0x02AA { 'l/phoneticLeft'  's/phoneticRight'       } 'b'
 		list 0x02AB { 'l/phoneticLeft'  'z'                     } 'b'
 		list 0xAB66 { 'd/phoneticLeft'  'zRTailBR'              } 'if'
-		list 0xAB67 { 't/phoneticLeft1' 'sRTail'                } 'p'
+		list 0xAB67 { 't/phoneticLeft1' 'sRTail'                } 'if'
 		list 0xFB00 { 'f'               'f'                     } null
 		list 0xFB01 { 'f/compLigLeft1'  'dotlessi/compLigRight' } null
 		list 0xFB02 { 'f/compLigLeft2'  'l/compLigRight'        } null

--- a/font-src/glyphs/auto-build/transformed.ptl
+++ b/font-src/glyphs/auto-build/transformed.ptl
@@ -184,7 +184,7 @@ glyph-block Autobuild-Transformed : begin
 			list 0x1DAA 'lPalatalHook'
 			list 0x1DAC 'mLTail'
 			list 0x1DAD 'turnmLeg'
-			list 0x1DAE 'nltail'
+			list 0x1DAE 'nLTail'
 			list 0x1DAF 'nHookBottom'
 			list 0x1DB0 'smcpN'
 			list 0x1DB1 'obar'

--- a/font-src/glyphs/letter/greek/lower-epsilon.ptl
+++ b/font-src/glyphs/letter/greek/lower-epsilon.ptl
@@ -209,7 +209,7 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 				union [ze.Shape] [ze.AutoStartSerifL] [ze.AutoEndSerifL]
 
 		create-glyph "cyrl/DzjeKomi.\(suffix)" : glyph-proc
-			include : MarkSet.capDesc
+			include : MarkSet.capital
 			local ze : CyrZe slabTop slabBot CAP 0 SB RightSB StdBlend Hook
 			define [object stroke midy] : ze.Dim
 			include : ze.ShapeHalf
@@ -218,7 +218,7 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 			include : CyrDescender.rSideJut (RightSB - OX * 2) 0
 
 		create-glyph "cyrl/dzjeKomi.\(suffix)" : glyph-proc
-			include : MarkSet.p
+			include : MarkSet.e
 			local ze : CyrZe slabTop slabBot XH 0 SB RightSB StdBlend SHook
 			define [object stroke midy] : ze.Dim
 			include : ze.ShapeHalf
@@ -269,12 +269,12 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 			if SLAB : include sf2.rt.full
 
 		create-glyph "cyrl/KsiBase.\(suffix)" : glyph-proc
-			include : MarkSet.capital
+			include : MarkSet.capDesc
 			include : let [ze : CyrZe slabTop SLAB-NONE CAP 0 SB RightSB StdBlend Hook]
 				union [ze.KsiBaseShape] [ze.AutoStartSerifL]
 
 		create-glyph "cyrl/ksiBase.\(suffix)" : glyph-proc
-			include : MarkSet.e
+			include : MarkSet.p
 			include : let [ze : CyrZe slabTop SLAB-NONE XH 0 SB RightSB StdBlend SHook]
 				union [ze.KsiBaseShape] [ze.AutoStartSerifL]
 

--- a/font-src/glyphs/letter/greek/lower-kappa-symbol.ptl
+++ b/font-src/glyphs/letter/greek/lower-kappa-symbol.ptl
@@ -4,7 +4,7 @@ import [mix linreg clamp fallback] from"../../../support/utils.mjs"
 
 glyph-module
 
-glyph-block Letter-Greek-Lower-Rho : begin
+glyph-block Letter-Greek-Lower-Kappa : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Shapes : VerticalHook
@@ -13,7 +13,7 @@ glyph-block Letter-Greek-Lower-Rho : begin
 
 	create-glyph "grek/kappaSymbol" 0x3F0 : glyph-proc
 		local df : DfKappasymbol
-		include : MarkSet.e
+		include : df.markSet.e
 		define xLeft : df.leftSB + 0.25 * df.mvs * HVContrast
 		define xRight : df.rightSB - 0.25 * df.mvs * HVContrast
 		define yBottom : 0 + 0.2 * Stroke
@@ -50,6 +50,8 @@ glyph-block Letter-Greek-Lower-Rho : begin
 			g2 (xRight - deltaX) (yTop - deltaY) [widths (swTermThin / 2) (swTerm / 2)]
 			g2 xRight yTop
 
-	derive-composites 'grek/kaiSymbol' 0x3D7 'grek/kappaSymbol'
-		let [df : DfKappasymbol]
-			VerticalHook.r df.rightSB 0 (-HookX) (Hook) (sw -- df.mvs) (yExtension -- Stroke)
+	create-glyph "grek/kaiSymbol" 0x3D7 : glyph-proc
+		include [refer-glyph "grek/kappaSymbol"] AS_BASE ALSO_METRICS
+		local df : DfKappasymbol
+		include : df.markSet.p
+		include : VerticalHook.r df.rightSB 0 (-HookX) (Hook) (sw -- df.mvs) (yExtension -- Stroke)

--- a/font-src/glyphs/letter/greek/upper-gamma.ptl
+++ b/font-src/glyphs/letter/greek/upper-gamma.ptl
@@ -124,8 +124,9 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 
 	select-variant 'grek/Digamma' 0x3DC (follow -- 'grek/Gamma')
 
-	derive-glyphs 'cyrl/GheHook' 0x494 'cyrl/Ghe' : lambda [src gr] : glyph-proc
+	derive-glyphs 'cyrl/GheMidHook' 0x494 'cyrl/Ghe' : lambda [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
+		include : MarkSet.capDesc
 		include : MidHook.general
 			left   -- (GammaBarLeft + Stroke * HVContrast)
 			right  -- RightSB
@@ -133,8 +134,9 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 			ada    -- ArchDepthA
 			adb    -- ArchDepthB
 
-	derive-glyphs 'cyrl/gheHook' 0x495 'cyrl/ghe.upright' : lambda [src gr] : glyph-proc
+	derive-glyphs 'cyrl/gheMidHook' 0x495 'cyrl/ghe.upright' : lambda [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
+		include : MarkSet.p
 		include : MidHook.general
 			left   -- (GammaBarLeft + Stroke * HVContrast)
 			right  -- RightSB

--- a/font-src/glyphs/letter/latin-ext/gha.ptl
+++ b/font-src/glyphs/letter/latin-ext/gha.ptl
@@ -30,7 +30,7 @@ glyph-block Letter-Latin-Gha : begin
 	create-glyph 'Gha' 0x1A2 : glyph-proc
 		local df : DivFrame para.diversityM 3
 		set-width df.width
-		include : df.markSet.capital
+		include : df.markSet.capDesc
 		include : GhaShape df CAP
 
 	create-glyph 'gha' 0x1A3 : glyph-proc

--- a/font-src/glyphs/letter/latin-ext/glottal-stop.ptl
+++ b/font-src/glyphs/letter/latin-ext/glottal-stop.ptl
@@ -40,7 +40,7 @@ glyph-block Letter-Latin-Glottal-Stop : begin
 			include : HSerif.mb Middle 0 Jut
 
 	create-glyph 'smallGlottalStop' 0x242 : glyph-proc
-		include : MarkSet.b
+		include : MarkSet.e
 		include : dispiro
 			widths.rhs
 			g4 SB (XH - Hook)
@@ -53,7 +53,7 @@ glyph-block Letter-Latin-Glottal-Stop : begin
 			include : HSerif.mb Middle 0 Jut
 
 	create-glyph 'smallRevGlottalStop' : glyph-proc
-		include : MarkSet.b
+		include : MarkSet.e
 		include : dispiro
 			widths.lhs
 			g4 RightSB (XH - Hook)

--- a/font-src/glyphs/letter/latin/c.ptl
+++ b/font-src/glyphs/letter/latin/c.ptl
@@ -194,12 +194,12 @@ glyph-block Letter-Latin-C : begin
 
 		create-glyph "revSmallCSideways.\(suffix)" : glyph-proc
 			local df : DivFrame (XH / Width) 2 (XH * 0.1 / SB)
+			include : df.markSet.e
 			local top : Width - SB
 			local p : mix 1 (Width / UPM) 0.5
 			include : PointingTo Width XH Width 0 : function [] : glyph-proc
 				local lf : CLetterForm df sty styBot top 0 (hook -- Hook * p)
 				include : lf.revFull
-				include : FlipAround df.middle (top / 2)
 				include : Translate 0 (SB / 2)
 
 		create-glyph "cHookTop.\(suffix)" : glyph-proc

--- a/font-src/glyphs/letter/latin/k.ptl
+++ b/font-src/glyphs/letter/latin/k.ptl
@@ -416,6 +416,7 @@ glyph-block Letter-Latin-K : begin
 
 		create-glyph "grek/KaiSymbol.\(suffix)" : glyph-proc
 			include [refer-glyph "K.\(suffix)"] AS_BASE ALSO_METRICS
+			include : MarkSet.capDesc
 			include : refer-glyph : match slabKS
 				0 'UpperKaiSymbolAttachment/sans'
 				1 'UpperKaiSymbolAttachment/serifed'

--- a/font-src/glyphs/letter/latin/lower-b.ptl
+++ b/font-src/glyphs/letter/latin/lower-b.ptl
@@ -83,10 +83,11 @@ glyph-block Letter-Latin-Lower-B : begin
 	CreateAccentedComposition 'bTildeOver' 0x1D6C 'b' 'tildeOverOnExension'
 	select-variant 'bHookTop' 0x253
 
-	derive-multi-part-glyphs 'bdot' 0x1E03 {'b' 'dotAbove'} : lambda [srcs gr] : glyph-proc
+	derive-multi-part-glyphs 'bDot' 0x1E03 {'b' 'dotAbove'} : lambda [srcs gr] : glyph-proc
 		local { base mark } srcs
-		include [refer-glyph base] AS_BASE ALSO_METRICS
-		include : WithTransform [ApparentTranslate HalfStroke (XH - Ascender)] [refer-glyph mark]
+		include : refer-glyph mark
+		include : Translate (Width + HalfStroke) 0
+		include [refer-glyph base] AS_BASE
 
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarLeft
 	create-glyph 'mathbb/b' 0x1D553 : glyph-proc

--- a/font-src/glyphs/letter/latin/lower-d.ptl
+++ b/font-src/glyphs/letter/latin/lower-d.ptl
@@ -164,7 +164,7 @@ glyph-block Letter-Latin-Lower-D : begin
 	derive-composites 'dHookTopBottom' 0x1D91 'dHookTop/hookBottomBase'
 		VerticalHook.r RightSB 0 HookX Hook
 
-	derive-multi-part-glyphs 'ddot' 0x1E0B {'d' 'dotAbove'} : lambda [srcs gr] : glyph-proc
+	derive-multi-part-glyphs 'dDot' 0x1E0B {'d' 'dotAbove'} : lambda [srcs gr] : glyph-proc
 		local { base mark } srcs
 		include : refer-glyph mark
 		include : Translate (Width - HalfStroke) 0

--- a/font-src/glyphs/letter/latin/lower-h.ptl
+++ b/font-src/glyphs/letter/latin/lower-h.ptl
@@ -84,13 +84,13 @@ glyph-block Letter-Latin-Lower-H : begin
 			include : Serifs fTailed true
 
 		create-glyph "hHookTopLTail.\(suffix)" : glyph-proc
-			include : MarkSet.b
+			include : MarkSet.if
 			include : refer-glyph "hHookTop.\(suffix)"
 			eject-contour 'serifRB'
 			include : VerticalHook.r RightSB 0 (-HookX) Hook
 
 		create-glyph "heng.\(suffix)" : glyph-proc
-			include : MarkSet.b
+			include : MarkSet.if
 			include : refer-glyph "h.\(suffix)"
 			eject-contour 'serifRB'
 			include : VerticalHook.r RightSB 0 (-HookX) Hook

--- a/font-src/glyphs/letter/latin/lower-m.ptl
+++ b/font-src/glyphs/letter/latin/lower-m.ptl
@@ -230,6 +230,7 @@ glyph-block Letter-Latin-Lower-M : begin
 			local realTop : XH / 2 + realHeight / 2
 			local realBot : XH / 2 - realHeight / 2
 			local df : DivFrame (realHeight / Width) 3 (XH * 0.1 / SB)
+			include : df.markSet.e
 			include : PointingTo Width realTop Width realBot : function [] : glyph-proc
 				include : mShapeBody df (Width - SB)
 				include : FlipAround df.middle ((Width - SB) / 2)

--- a/font-src/glyphs/letter/latin/lower-n.ptl
+++ b/font-src/glyphs/letter/latin/lower-n.ptl
@@ -201,9 +201,9 @@ glyph-block Letter-Latin-Lower-N : begin
 
 		derive-composites 'nApostrophe' 0x149 'n' 'nApostrophe/comma'
 
-	derive-glyphs 'nltail' 0x272 'n' : lambda [src srl] : glyph-proc
-		include [refer-glyph src] AS_BASE
+	derive-glyphs 'nLTail' 0x272 'n' : lambda [src srl] : glyph-proc
 		include : MarkSet.p
+		include [refer-glyph src]
 		eject-contour 'serifLB'
 		include : VerticalHook.l SB 0 (-HookX) Hook
 

--- a/font-src/glyphs/letter/latin/lower-t.ptl
+++ b/font-src/glyphs/letter/latin/lower-t.ptl
@@ -276,10 +276,10 @@ glyph-block Letter-Latin-Lower-T : begin
 			include : Style.Retroflex df top Descender
 
 		create-glyph "tHookTopRTail.\(suffix)" : glyph-proc
-			include : df.markSet.if
 			include : Style.Retroflex df XH Descender
 			local attach : currentGlyph.gizmo.unapply currentGlyph.baseAnchors.hooktopAttach
 			include : VerticalHook.m attach.x XH HookX (-Hook)
+			include : df.markSet.if
 
 		turned "turnt.\(suffix)" nothing "t.\(suffix)" df.middle (XH / 2) [df.markSet.p]
 
@@ -384,6 +384,7 @@ glyph-block Letter-Latin-Lower-T : begin
 
 	create-glyph 'mathbb/t' 0x1D565 : glyph-proc
 		define df : DivFrame 1
+		include : df.markSet.b
 		define xLeft : xSmallTBarLeftT df
 		include : HBar.t xLeft (xLeft + BBD) Ascender BBS
 		include : Standard.HookShapeT dispiro df false 0 Ascender 0 BBS

--- a/font-src/glyphs/letter/latin/u.ptl
+++ b/font-src/glyphs/letter/latin/u.ptl
@@ -193,16 +193,18 @@ glyph-block Letter-Latin-U : begin
 
 		create-glyph "uSideways.\(suffix)" : glyph-proc
 			local df : DivFrame (XH / Width) 2 (XH * 0.1 / SB)
+			include : df.markSet.e
 			include : PointingTo Width XH Width 0 : function [] : glyph-proc
 				include : Base  df (Width - SB)
 				include : Slabs df (Width - SB)
 				include : Translate 0 (SB / 2)
 
 		create-glyph "uDieresisSidewaysBase.\(suffix)" : glyph-proc
+			local df : DivFrame (XH / Width) 2 (XH * 0.1 / SB)
+			include : df.markSet.e
 			local ww : Width * para.diversityM
 			set-width ww
 			include : PointingTo ww XH ww 0 : function [] : glyph-proc
-				local df : DivFrame (XH / Width) 2 (XH * 0.1 / SB)
 				include : Base  df (ww - SB - 0.75 * para.diversityM * AccentHeight)
 				include : Slabs df (ww - SB - 0.75 * para.diversityM * AccentHeight)
 				include : Translate 0 (SB / 2)

--- a/font-src/glyphs/letter/latin/upper-h.ptl
+++ b/font-src/glyphs/letter/latin/upper-h.ptl
@@ -296,12 +296,12 @@ glyph-block Letter-Latin-Upper-H : begin
 
 	derive-glyphs 'cyrl/EnLHook' 0x528 'cyrl/En' : lambda [src srl] : glyph-proc
 		include : MarkSet.capDesc
-		include [refer-glyph src] AS_BASE
+		include [refer-glyph src]
 		eject-contour 'serifLB'
 		include : VerticalHook.l SB 0 (-HookX) Hook
 
 	derive-glyphs 'cyrl/enLHook' 0x529 'cyrl/en' : lambda [src srl] : glyph-proc
 		include : MarkSet.p
-		include [refer-glyph src] AS_BASE
+		include [refer-glyph src]
 		eject-contour 'serifLB'
 		include : VerticalHook.l SB 0 (-HookX) Hook

--- a/font-src/glyphs/letter/latin/upper-n.ptl
+++ b/font-src/glyphs/letter/latin/upper-n.ptl
@@ -70,9 +70,9 @@ glyph-block Letter-Latin-Upper-N : begin
 			include : VerticalHook.r RightSB 0 (-HookX) Hook
 			include : VBar.r RightSB 0 CAP
 
-		create-glyph "Nltail.\(suffix)" : glyph-proc
-			include [refer-glyph "N.\(suffix)"] AS_BASE
+		create-glyph "NLTail.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
+			include [refer-glyph "N.\(suffix)"]
 			eject-contour 'serifLB'
 			include : VerticalHook.l SB 0 (-HookX) Hook
 
@@ -93,7 +93,7 @@ glyph-block Letter-Latin-Upper-N : begin
 
 	select-variant 'Eng'    0x14A  (follow -- 'N')
 	select-variant 'smcpN'  0x274  (follow -- 'N')
-	select-variant 'Nltail' 0x19D  (follow -- 'N')
+	select-variant 'NLTail' 0x19D  (follow -- 'N')
 	select-variant 'currency/nairaSignBase' (follow -- 'N')
 
 	glyph-block-import Letter-Blackboard : BBS BBD

--- a/font-src/glyphs/letter/latin/upper-q.ptl
+++ b/font-src/glyphs/letter/latin/upper-q.ptl
@@ -198,7 +198,7 @@ glyph-block Letter-Latin-Upper-Q : begin
 	create-glyph 'mathbb/Q' 0x211A : glyph-proc
 		define [QInner] : OShapeOutline.NoOvershoot CAP 0 SB RightSB BBS ArchDepthA ArchDepthB
 
-		include : MarkSet.capital
+		include : MarkSet.capDesc
 		include : OShape CAP 0 SB RightSB BBS ArchDepthA ArchDepthB
 		include : intersection
 			QInner

--- a/font-src/glyphs/letter/latin/upper-t.ptl
+++ b/font-src/glyphs/letter/latin/upper-t.ptl
@@ -135,6 +135,7 @@ glyph-block Letter-Latin-Upper-T : begin
 
 		create-glyph "TRTailBR.\(suffix)" : glyph-proc
 			include [refer-glyph "T.\(suffix)"] AS_BASE ALSO_METRICS
+			include : MarkSet.capDesc
 			include : VerticalHook.m df.middle 0 HookX Hook
 
 		create-glyph "cyrl/TjeKomi.\(suffix)" : glyph-proc

--- a/font-src/glyphs/letter/latin/v.ptl
+++ b/font-src/glyphs/letter/latin/v.ptl
@@ -196,7 +196,7 @@ glyph-block Letter-Latin-V : begin
 			include : VBar.m Middle (0.5 * oHeight) oHeight [AdviceStroke 4]
 
 		create-glyph "cyrl/ukUnblended.\(suffix)" : glyph-proc
-			include : MarkSet.e
+			include : MarkSet.b
 			local vPartHeight : Ascender * 0.45 + HalfStroke
 			include : WithTransform [ApparentTranslate 0 (Ascender - vPartHeight)] : glyph-proc
 				include : VHookRightShape [DivFrame 1] fStraightBar vPartHeight

--- a/font-src/glyphs/letter/latin/z.ptl
+++ b/font-src/glyphs/letter/latin/z.ptl
@@ -233,7 +233,7 @@ glyph-block Letter-Latin-Z : begin
 			if slash  : include : slash  CAP
 
 		create-glyph "ZDTail.\(suffix)" : glyph-proc
-			include : MarkSet.capital
+			include : MarkSet.capDesc
 			include : capital MODE-ZDESC
 			if serifs : include : serifs CAP
 			if slash  : include : slash  CAP
@@ -257,7 +257,7 @@ glyph-block Letter-Latin-Z : begin
 				include : difference [ZemlyaBottomStroke] [bsMask CAP]
 
 		create-glyph "ZSwash.\(suffix)" : glyph-proc
-			include : MarkSet.capital
+			include : MarkSet.capDesc
 			include : capital MODE-ZSWASH
 			if serifs : include : serifs CAP
 			if slash  : include : slash  CAP
@@ -277,7 +277,7 @@ glyph-block Letter-Latin-Z : begin
 			if slash  : include : slash  XH
 
 		create-glyph "zDTail.\(suffix)" : glyph-proc
-			include : MarkSet.e
+			include : MarkSet.p
 			include : small MODE-ZDESC
 			if serifs : include : serifs XH
 			if slash  : include : slash  XH
@@ -301,7 +301,7 @@ glyph-block Letter-Latin-Z : begin
 				include : difference [ZemlyaBottomStroke] [bsMask XH]
 
 		create-glyph "zSwash.\(suffix)" : glyph-proc
-			include : MarkSet.e
+			include : MarkSet.p
 			include : small MODE-ZSWASH
 			if serifs : include : serifs XH
 			if slash  : include : slash  XH

--- a/font-src/glyphs/letter/shared.ptl
+++ b/font-src/glyphs/letter/shared.ptl
@@ -823,15 +823,16 @@ glyph-block Letter-Shared-Shapes : begin
 
 		# Retroflex hooks
 		glyph-block-export RetroflexHook
-		define RetroflexHook : Descenders : function [x y xLink yAttach yOverflow sw] : union
-			xLinkStroke xLink x yAttach sw
-			VerticalHook.m
-				x -- x
-				y -- y
-				xDepth -- HookX
-				yDepth -- Hook
-				sw -- sw
-				yExtension -- yAttach + yOverflow - y
+		define RetroflexHook : Descenders : function [x y xLink yAttach yOverflow sw] : glyph-proc
+			include : union
+				xLinkStroke xLink x yAttach sw
+				VerticalHook.m
+					x -- x
+					y -- y
+					xDepth -- HookX
+					yDepth -- Hook
+					sw -- sw
+					yExtension -- yAttach + yOverflow - y
 
 		# Left bar with hook at top, shared by multiple glyphs
 		glyph-block-export HooktopLeftBar

--- a/font-src/glyphs/number/7.ptl
+++ b/font-src/glyphs/number/7.ptl
@@ -94,6 +94,7 @@ glyph-block Digits-Seven : begin
 
 	glyph-block-import Letter-Blackboard : BBS BBD
 	create-glyph 'mathbb/seven' 0x1D7DF : glyph-proc
+		include : MarkSet.capital
 		local tr : RightSB - BBS / 2
 		local kDiag : DiagCorDs (CAP - BBS) (tr - SevenXLeft) (BBD * 0.75)
 		local xTerm : SevenXLeft - 0.25 * kDiag * BBD

--- a/font-src/glyphs/symbol/letter.ptl
+++ b/font-src/glyphs/symbol/letter.ptl
@@ -174,6 +174,7 @@ glyph-block Symbol-Letter : begin
 	turned 'turniota' 0x2129 'grek/iota' HalfAdvance (XH / 2)
 
 	create-glyph 'estimated' 0x212E : glyph-proc
+		include : MarkSet.capital
 		local fineArc : CAP * 0.0300
 		local fineBar : CAP * 0.0278
 		local thickBarWidth : (0.183 / [Math.sqrt 0.9]) * [Math.sqrt (CAP * (RightSB - SB))]
@@ -194,6 +195,7 @@ glyph-block Symbol-Letter : begin
 				Rect (CAP * 0.5) (CAP * 0.208) Middle Width
 
 	create-glyph 'mathAleph' 0x2135 : glyph-proc
+		include : MarkSet.capital
 		define p 0.3
 		include : XStrand true false SB CAP RightSB 0 0.1 0.4 0.28
 		include : intersection
@@ -216,6 +218,7 @@ glyph-block Symbol-Letter : begin
 				corner SB CAP
 
 	create-glyph 'mathBeth' 0x2136 : glyph-proc
+		include : MarkSet.capital
 		define pX 0.7
 		define pY 0.8
 		define turnX : mix SB RightSB pY
@@ -237,6 +240,7 @@ glyph-block Symbol-Letter : begin
 		local yBranch : mix 0 CAP 0.5
 
 		set-width df.width
+		include : df.markSet.capital
 
 		include : intersection [MaskAbove 0] : dispiro [widths.rhs]
 			flat xStart CAP
@@ -252,14 +256,16 @@ glyph-block Symbol-Letter : begin
 			g4 (df.leftSB + 0.2 * HVContrast * Stroke) O
 
 	create-glyph 'mathDalet' 0x2138 : glyph-proc
+		include : MarkSet.capital
 		include : HBar.t SB RightSB CAP
 		include : VBar.r [mix SB RightSB 0.75] 0 CAP
 
 	create-glyph 'informationSource' 0x2139 : glyph-proc
+		include : MarkSet.b
 		local sw : UnicodeWeightGrade 9 1
 		include : VBar.m Middle 0 XH sw
-		include : HSerif.lt     (Middle - sw / 2 * HVContrast) XH (LongJut / 2)
-		include : HSerif.lb  (Middle - sw / 2 * HVContrast) 0  (LongJut / 2)
+		include : HSerif.lt (Middle - sw / 2 * HVContrast) XH (LongJut / 2)
+		include : HSerif.lb (Middle - sw / 2 * HVContrast) 0  (LongJut / 2)
 		include : HSerif.rb (Middle + sw / 2 * HVContrast) 0  (LongJut / 2)
 		include : DotAt Middle (XH + AccentStackOffset) (DotRadius * sw / Stroke)
 

--- a/font-src/glyphs/symbol/punctuation/other-phonetic.ptl
+++ b/font-src/glyphs/symbol/punctuation/other-phonetic.ptl
@@ -15,6 +15,7 @@ glyph-block Symbol-Other-Phonetic : begin
 	local toneMarkRight : Width - toneMarkLeft
 
 	create-glyph 'triangleColon' 0x2D0 : glyph-proc
+		include : MarkSet.e
 		include : union
 			spiro-outline
 				corner (Middle - triangleSize * 1.35) XH
@@ -26,6 +27,7 @@ glyph-block Symbol-Other-Phonetic : begin
 				corner (Middle + triangleSize * 1.35) 0
 
 	create-glyph 'halfTriangleColon' 0x2D1 : glyph-proc
+		include : MarkSet.e
 		include : spiro-outline
 			corner (Middle - triangleSize * 1.35) XH
 			corner Middle (XH - triangleSize * 2.75)

--- a/font-src/glyphs/symbol/punctuation/quotes-and-primes.ptl
+++ b/font-src/glyphs/symbol/punctuation/quotes-and-primes.ptl
@@ -190,11 +190,13 @@ glyph-block Symbol-Punctuation-Quotes-And-Primes : begin
 	create-glyph 'Saltillo' 0xA78B : glyph-proc
 		local df : DivFrame para.diversityF
 		set-width df.width
+		include : df.markSet.capital
 		include : StraightQuoteShape df CAP (0.625 * XH)
 
 	create-glyph 'saltillo' 0xA78C : glyph-proc
 		local df : DivFrame para.diversityF
 		set-width df.width
+		include : df.markSet.b
 		include : StraightQuoteShape df Ascender XH
 
 	create-glyph 'asciiGrave/selector.straight' : glyph-proc

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2364,7 +2364,7 @@ descriptionAffix = "cursive loop plus diagonal tail"
 selectorAffix.k = "cursiveTailed"
 selectorAffix."k/sansSerif" = "cursiveTailed"
 selectorAffix.kHookTop = "cursiveTailed"
-selectorAffix.kDescender = "cursiveTailed"
+selectorAffix.kDescender = "cursive"
 
 [prime.k.variants-buildup.stages.serifs.serifless]
 rank = 1


### PR DESCRIPTION
I checked through most of the diacritic placements and tried to make unifying changes to the problematic ones.

However, there are more problems that I have initially thought, so I'll just put the fixes I'm sure are correct first, and leave everything else into a different issue later.

Fixed characters:
![image](https://github.com/be5invis/Iosevka/assets/21302803/38ddbedc-38c2-4760-bbec-b852a4416b69)

By category:
## Lower, Left Pointing Hook (Follow Eng `Ŋŋ`)
- `ɧ` U+0267
- `Ϗ` U+03CF
- `ϗ` U+03D7
- `ђ` U+0452
- `Ҕ` U+0494
- `ҕ` U+0495
- `Ԩ` U+0528*
- `ԩ` U+0529*
- `ꜧ` U+A727

\*: These follow `Ɲɲ`. However, there is another issue with these to be mentioned in a separate time.

## Lower, Right Pointing Hook/Tail
- `Ѯ` U+046E
- `ѯ` U+046F

## Swash Tail (Follow `ȿ` U+023F)
- `ɀ` U+0240
- `Ɀ` U+2C7F

## Pure mismapping
- `Ƣ` U+01A2 (`capital -> capDesc`)
- `ɂ` U+0242 (`b -> e`)
- `ʥ` U+02A5 (`if -> b`)
- `ˁ` U+02C1 (Base glyph: `b -> e`)
- `ᲈ` U+1C88 (`e -> b`)
- `ℚ` U+211A (`capital -> capDesc`)
- `Ꞌ` U+A78B (`(NONE) -> capital`)
- `ꞌ` U+A78C (`(NONE) -> b`)
- `ꭧ` U+AB67 (`p -> if`)*
- `𝕥` U+1D565 (`(NONE) -> b`)
- `𝟟` U+1D7EF (`(NONE) -> capital`)

\*: `ʂ` is not fixed. I'll explain why in the separate issue.

## Miscellaneous
- `ḃ` U+1E03 has the anchor set back to `b`
- A few letterlike symbols are given MarkSets because some others that aren't based on regular letters do have MarkSets (e.g. Weierstrass P) anyway: `℮ℵℶℷℸℹ`
- `ː` U+02D0 and `ˑ` U+02D1 are given MarkSets because they have superscript equivalents that have their anchor placement broken.
- Similarly, all sideway letters are given MarkSets for the same reason, which are definitely letters.
- `𝼉` U+1DF09 had a weird problem where its above anchor only works for one variant. This is fixed by including MarkSet at last, though idk if this is a correct solution.
- Some characters have their MarkSets adjusted after realizing how some descender functions work. 

## Non-anchor Issues
- `ᴒ` U+1D12 is upside down.
- `k` with attachments loses attachment in cursive-tailed variants.