### PR TITLE
3 variant characters and a few fixes

### DIFF
--- a/changes/24.1.4.md
+++ b/changes/24.1.4.md
@@ -1,6 +1,9 @@
 * Add Characters:
   - COMBINING DIAERESIS-RING (`U+1AB1`).
   - COMBINING X-X BELOW (`U+1AB5`).
+  - CYRILLIC SMALL LETTER LONG-LEGGED DE (`U+1C81`).
+  - CYRILLIC SMALL LETTER WIDE ES (`U+1C83`).
+  - CYRILLIC SMALL LETTER THREE-LEGGED TE (`U+1C85`).
   - COMBINING LATIN SMALL LETTER L WITH DOUBLE MIDDLE TILDE (`U+1DEC`) (#1673).
   - COMBINING WIDE INVERTED BRIDGE BELOW (`U+1DF9`).
   - COMBINING THREE DOTS ABOVE (`U+20DB`) .. COMBINING FOUR DOTS ABOVE (`U+20DC).
@@ -18,3 +21,4 @@
 * Fix combining mark anchors for several characters.
 * Fix upside down shape of `U+1D12`.
 * Fix variant assignment for `U+1D84` and `U+2C6A`.
+* Fix variant selector for CYRILLIC SMALL LETTER KOMI NJE (`U+050B`).

--- a/font-src/glyphs/auto-build/transformed.ptl
+++ b/font-src/glyphs/auto-build/transformed.ptl
@@ -863,7 +863,7 @@ glyph-block Autobuild-Rotated : begin
 
 	for-width-kinds WideWidth1 : do
 		local s : (RightSB - SB - O * 4 + (MosaicWidth - Width) * 0.5) / CAP
-		local df : Miniature {'eight.lnum.crossing' 'rotetedPropto' 'revS'}
+		local df : Miniature {'eight.lnum.crossing' 'rotatedPropto' 'revS'}
 			crowd        -- (4 / [Math.sqrt MosaicWidthScalar])
 			scale        -- s
 			forceUpright -- true
@@ -878,7 +878,7 @@ glyph-block Autobuild-Rotated : begin
 				include : Translate (MosaicWidth / 2) SymbolMid
 				include : Italify
 
-		InftyLikeShape 'propto'   0x221D 'rotetedPropto'
+		InftyLikeShape 'propto'   0x221D 'rotatedPropto'
 		InftyLikeShape 'infty'    0x221E 'eight.lnum.crossing'
 		InftyLikeShape 'invLazyS' 0x223E 'revS.serifless'
 

--- a/font-src/glyphs/letter/cyrillic/de.ptl
+++ b/font-src/glyphs/letter/cyrillic/de.ptl
@@ -97,7 +97,7 @@ glyph-block Letter-Cyrillic-De : begin
 		local df : DivFrame para.diversityM 3
 		set-width df.width
 		include : df.markSet.e
-		include : ExtendBelowBaseAnchors (-LongJut+ 0.5 * Stroke)
+		include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
 		include : CyrSoftDeShape XH df.leftSB df.rightSB df.mvs
 
 	create-glyph 'cyrl/de.italic' : glyph-proc

--- a/font-src/glyphs/letter/cyrillic/de.ptl
+++ b/font-src/glyphs/letter/cyrillic/de.ptl
@@ -10,7 +10,7 @@ glyph-block Letter-Cyrillic-De : begin
 	glyph-block-import Mark-Adjustment : ExtendBelowBaseAnchors
 
 	glyph-block-export CyrDeShape CyrDeItalicShapeT
-	define [CyrDeShape top left right _sw] : glyph-proc
+	define [CyrDeShape top left right _sw _desc] : glyph-proc
 		local descenderOverflow : if SLAB SideJut ((right - left) * 0.075)
 		local xCutLeft left
 		local xCutRight right
@@ -18,6 +18,7 @@ glyph-block Letter-Cyrillic-De : begin
 		local xTopRight : mix xCutLeft xCutRight : StrokeWidthBlend 0.95 0.96
 		local swOuter : fallback _sw Stroke
 		local swInner : swOuter * [AdviceStroke 2.75] / Stroke
+		local desc : fallback _desc : -LongJut + 0.5 * Stroke
 
 		include : HBar.b (xCutLeft - descenderOverflow) (xCutRight + descenderOverflow) 0 swOuter
 		include : VBar.r xTopRight 0 top swInner
@@ -26,13 +27,13 @@ glyph-block Letter-Cyrillic-De : begin
 			flat xTopLeft top
 			curl xTopLeft [mix 0 top 0.625]
 			g4   xCutLeft  swOuter
-		include : VBar.l (xCutLeft  - descenderOverflow) (-LongJut + 0.5 * swOuter) 0.1 swOuter
-		include : VBar.r (xCutRight + descenderOverflow) (-LongJut + 0.5 * swOuter) 0.1 swOuter
+		include : VBar.l (xCutLeft  - descenderOverflow) desc 0.1 swOuter
+		include : VBar.r (xCutRight + descenderOverflow) desc 0.1 swOuter
 
 		include : if SLAB
 			then : dispiro
 				widths.rhs swOuter
-				flat (xTopLeft - descenderOverflow) top
+				flat (xTopLeft  - descenderOverflow) top
 				curl (xTopRight + descenderOverflow) top
 			else : HBar.t xTopLeft xTopRight top swOuter
 
@@ -73,26 +74,30 @@ glyph-block Letter-Cyrillic-De : begin
 
 	create-glyph 'cyrl/De' 0x414 : glyph-proc
 		include : MarkSet.capital
-		include : ExtendBelowBaseAnchors (-LongJut)
+		include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
 		include : CyrDeShape CAP SB RightSB
 
 	create-glyph 'cyrl/de.upright' : glyph-proc
 		include : MarkSet.e
-		include : ExtendBelowBaseAnchors (-LongJut)
+		include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
 		include : CyrDeShape XH SB RightSB
+
+	create-glyph 'cyrl/deLongLeg' 0x1C81 : glyph-proc
+		include : MarkSet.p
+		include : CyrDeShape XH SB RightSB Stroke Descender
 
 	create-glyph 'cyrl/DeSoft' 0xA662 : glyph-proc
 		local df : DivFrame para.diversityM 3
 		set-width df.width
 		include : df.markSet.capital
-		include : ExtendBelowBaseAnchors (-LongJut)
+		include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
 		include : CyrSoftDeShape CAP df.leftSB df.rightSB df.mvs
 
 	create-glyph 'cyrl/deSoft' 0xA663 : glyph-proc
 		local df : DivFrame para.diversityM 3
 		set-width df.width
 		include : df.markSet.e
-		include : ExtendBelowBaseAnchors (-LongJut)
+		include : ExtendBelowBaseAnchors (-LongJut+ 0.5 * Stroke)
 		include : CyrSoftDeShape XH df.leftSB df.rightSB df.mvs
 
 	create-glyph 'cyrl/de.italic' : glyph-proc

--- a/font-src/glyphs/letter/cyrillic/dzzhe-zhwe.ptl
+++ b/font-src/glyphs/letter/cyrillic/dzzhe-zhwe.ptl
@@ -34,7 +34,7 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 			define df : DivFrame para.diversityM 3.5
 			set-width df.width
 			include : df.markSet.capital
-			include : ExtendBelowBaseAnchors (-LongJut)
+			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
 			set-base-anchor 'cvDecompose' 0 0
 			include : CyrDzzheDeShape df CAP
 
@@ -42,7 +42,7 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 			define df : DivFrame para.diversityM 3.5
 			set-width df.width
 			include : df.markSet.e
-			include : ExtendBelowBaseAnchors (-LongJut)
+			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
 			set-base-anchor 'cvDecompose' 0 0
 			include : CyrDzzheDeShape df XH
 

--- a/font-src/glyphs/letter/cyrillic/sha.ptl
+++ b/font-src/glyphs/letter/cyrillic/sha.ptl
@@ -7,42 +7,46 @@ glyph-module
 glyph-block Letter-Cyrillic-Sha : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : RightwardTailedBar CyrDescender
+	glyph-block-import Letter-Shared-Shapes : RightwardTailedBar CyrDescender SerifFrame
 
-	define [CyrShaShape top df] : glyph-proc
+	define [CyrShaShape top df fInv] : glyph-proc
 		include : union
-			HBar.b df.leftSB df.rightSB 0
+			[if fInv HBar.t HBar.b] df.leftSB df.rightSB [if fInv top 0]
 			VBar.l df.leftSB 0 top df.mvs
 			VBar.r df.rightSB 0 top df.mvs
 			VBar.m df.middle 0 top df.mvs
 
 		if SLAB : begin
-			include : tagged 'serifLB' : HSerif.lb df.leftSB 0 SideJut
-			include : tagged 'serifRB' : HSerif.rb df.rightSB 0 SideJut
+			local sf : SerifFrame.fromDf df top 0 (swSerif -- df.mvs)
 
-			local jut : Jut * df.mvs / Stroke + O
-			if (df.width > 7 * para.refJut) : begin
-				include : tagged 'serifLT'
-					HSerif.mt (df.leftSB + 0.5 * df.mvs * HVContrast) top jut df.mvs
-				include : tagged 'serifMT'
-					HSerif.mt df.middle top jut df.mvs
-				include : tagged 'serifRT'
-					HSerif.mt (df.rightSB - 0.5 * df.mvs * HVContrast) top jut df.mvs
+			if fInv : then : begin
+				include : composite-proc sf.lt.outer sf.rt.outer
+				if sf.enoughSpaceForFullSerifs
+					include : composite-proc sf.lb.full sf.mb.full sf.rb.full
+					include : composite-proc sf.lb.outer sf.rb.outer
 			: else : begin
-				include : tagged 'serifLT' : HSerif.lt df.leftSB top SideJut
-				include : tagged 'serifRT' : HSerif.rt df.rightSB top SideJut
+				include : composite-proc sf.lb.outer sf.rb.outer
+				if sf.enoughSpaceForFullSerifs
+					include : composite-proc sf.lt.full sf.mt.full sf.rt.full
+					include : composite-proc sf.lt.outer sf.rt.outer
 
 	create-glyph 'cyrl/Sha' 0x428 : glyph-proc
 		local df : DivFrame para.diversityM 3
 		set-width df.width
 		include : df.markSet.capital
-		include : CyrShaShape CAP df
+		include : CyrShaShape CAP df false
 
 	create-glyph 'cyrl/sha.upright' : glyph-proc
 		local df : DivFrame para.diversityM 3
 		set-width df.width
 		include : df.markSet.e
-		include : CyrShaShape XH df
+		include : CyrShaShape XH df false
+
+	create-glyph 'cyrl/teThreeLeg' 0x1C85 : glyph-proc
+		local df : DivFrame para.diversityM 3
+		set-width df.width
+		include : df.markSet.e
+		include : CyrShaShape XH df true
 
 	alias 'smcpMTurned' 0xA7FA 'cyrl/sha.upright'
 

--- a/font-src/glyphs/letter/greek/upper-gamma.ptl
+++ b/font-src/glyphs/letter/greek/upper-gamma.ptl
@@ -13,6 +13,7 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 	glyph-block-import Letter-Shared-Shapes : LetterBarOverlay PalatalHook
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarLeft
 	glyph-block-import Letter-Latin-Upper-F : xMidBarShrink
+	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors
 
 	define SLAB-NONE 0
 	define SLAB-TR   1
@@ -39,10 +40,6 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 		topLeftSerifed  { SLAB-LT    false }
 		topRightSerifed { SLAB-TR    false }
 		serifed         { SLAB-ALL   true  }
-
-	define CyrlGeMarks : object
-		capital : MarkSet.OfZone { .top (CAP + AccentStackOffset / 2) .bot 0 }
-		e       : MarkSet.OfZone { .top (XH + AccentStackOffset / 2) .bot 0 }
 
 	foreach { suffix { slabType doSB } } [Object.entries GammaConfig] : do
 		create-glyph "grek/Gamma.\(suffix)" : glyph-proc
@@ -91,22 +88,25 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 				jut -- MidJutSide
 
 		create-glyph "cyrl/Ge.\(suffix)" : glyph-proc
-			include : CyrlGeMarks.capital
+			include : MarkSet.capital
+			include : ExtendAboveBaseAnchors (CAP + LongJut - 0.5 * Stroke)
 			include : GammaShape CAP slabType
 			eject-contour 'serifRT'
-			include : VBar.r (RightSB - OX) CAP (CAP + AccentStackOffset)
+			include : VBar.r (RightSB - OX) CAP (CAP + LongJut - 0.5 * Stroke)
 
 		create-glyph "cyrl/ge.upright.\(suffix)" : glyph-proc
-			include : CyrlGeMarks.e
+			include : MarkSet.e
+			include : ExtendAboveBaseAnchors (XH + LongJut - 0.5 * Stroke)
 			include : GammaShape XH slabType
 			eject-contour 'serifRT'
-			include : VBar.r (RightSB - OX) XH (XH + AccentStackOffset)
+			include : VBar.r (RightSB - OX) XH (XH + LongJut - 0.5 * Stroke)
 
 		create-glyph "cyrl/ge.italic.\(suffix)" : glyph-proc
-			include : CyrlGeMarks.e
+			include : MarkSet.e
+			include : ExtendAboveBaseAnchors (XH + LongJut - 0.5 * Stroke)
 			include : GammaShape XH slabType
 			eject-contour 'serifRT'
-			include : VBar.r (RightSB - OX) XH (XH + AccentStackOffset)
+			include : VBar.r (RightSB - OX) XH (XH + LongJut - 0.5 * Stroke)
 
 	select-variant 'grek/Gamma' 0x393
 	link-reduced-variant 'grek/Gamma/sansSerif' 'grek/Gamma' MathSansSerif

--- a/font-src/glyphs/letter/latin/c.ptl
+++ b/font-src/glyphs/letter/latin/c.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Letter-Latin-C : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors
+	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors ExtendBelowBaseAnchors
 	glyph-block-import Mark-Shared-Metrics : markStroke
 	glyph-block-import Letter-Shared : CreateAccentedComposition
 	glyph-block-import Letter-Shared-Shapes : SerifFrame CurlyTail DToothlessRise
@@ -196,6 +196,17 @@ glyph-block Letter-Latin-C : begin
 				include : lf.revFull
 				include : Translate 0 (SB / 2)
 
+		create-glyph "cyrl/esWide.\(suffix)" : glyph-proc
+			local df : DivFrame para.diversityM 3
+			set-width df.width
+			include : df.markSet.e
+			local desc : -LongJut + 0.5 * Stroke
+			include : ExtendBelowBaseAnchors desc
+			local lf : CLetterForm df sty styBot XH desc
+				ada -- [df.archDepthA SmallArchDepth df.mvs]
+				adb -- [df.archDepthB SmallArchDepth df.mvs]
+			include : lf.full
+
 		create-glyph "cHookTop.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			local lf : CLetterForm [DivFrame 1] sty styBot XH 0
@@ -279,6 +290,7 @@ glyph-block Letter-Latin-C : begin
 	alias 'cyrl/es' 0x441 'c'
 	alias 'grek/lunateSmallSigma' 0x3F2 'c.serifless'
 	select-variant 'revSmallCSideways' 0x1D12 (follow -- 'c')
+	select-variant 'cyrl/esWide' 0x1C83 (follow -- 'c')
 
 	select-variant 'cTopSerifOnly' (shapeFrom -- 'c')
 

--- a/font-src/glyphs/letter/latin/k.ptl
+++ b/font-src/glyphs/letter/latin/k.ptl
@@ -398,7 +398,7 @@ glyph-block Letter-Latin-K : begin
 		create-glyph "KDescender.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : KBaseShape Stroke CAP CyrDescender
-			include : ExtendBelowBaseAnchors Descender
+			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
 
 		create-glyph "KBar.\(suffix)" : glyph-proc
 			include [refer-glyph "K.\(suffix)"] AS_BASE ALSO_METRICS
@@ -433,7 +433,7 @@ glyph-block Letter-Latin-K : begin
 		create-glyph "smcpKDescender.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : KBaseShape Stroke XH CyrDescender
-			include : ExtendBelowBaseAnchors Descender
+			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
 
 		create-glyph "smcpKVBar.\(suffix)" : glyph-proc
 			include : MarkSet.e
@@ -510,7 +510,7 @@ glyph-block Letter-Latin-K : begin
 		create-glyph "kDescender.\(suffix)" : glyph-proc
 			include : MarkSet.b
 			include : kBaseShape CyrDescender
-			include : ExtendBelowBaseAnchors Descender
+			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
 
 		create-glyph "kPalatalHook.\(suffix)" : glyph-proc
 			include : MarkSet.b

--- a/font-src/glyphs/letter/latin/lower-e.ptl
+++ b/font-src/glyphs/letter/latin/lower-e.ptl
@@ -11,6 +11,7 @@ glyph-block Letter-Latin-Lower-E : begin
 	glyph-block-import Letter-Shared-Shapes : FlatHookDepth RetroflexHook
 	glyph-block-import Mark-Shared-Metrics : markExtend markStroke markStress markFine
 	glyph-block-import Mark-Above : aboveMarkTop aboveMarkBot aboveMarkMid aboveMarkStack
+	glyph-block-import Mark-Adjustment : ExtendBelowBaseAnchors
 
 	define [xTerminalR df] : df.rightSB - OX * [if para.isItalic 0 0.5]
 
@@ -114,9 +115,11 @@ glyph-block Letter-Latin-Lower-E : begin
 		define divSub : (df.width - gap - df.mvs) / Width
 		define dfSub : DivFrame divSub 2
 		include : Body dfSub top df.mvs
-		if fDesc : include : difference
-			VBar.m dfSub.middle (-AccentStackOffset) (df.mvs + O) [AdviceStroke 3.5 df.div]
-			OShapeOutline.NoOvershoot top 0 dfSub.leftSB dfSub.rightSB df.mvs
+		if fDesc : begin
+			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
+			include : difference
+				VBar.m dfSub.middle (-LongJut + 0.5 * Stroke) (df.mvs + O) [AdviceStroke 3.5 df.div]
+				OShapeOutline.NoOvershoot top 0 dfSub.leftSB dfSub.rightSB df.mvs
 		include : Translate (Width * (df.div - divSub)) 0
 
 		local hd : FlatHookDepth df
@@ -207,13 +210,13 @@ glyph-block Letter-Latin-Lower-E : begin
 		create-glyph "cyrl/abk/CheDescender.\(suffix)" : glyph-proc
 			local df : DivFrame para.diversityM 2.5
 			set-width df.width
-			include : df.markSet.capDesc
+			include : df.markSet.capital
 			include : AbkCheShape Body df CAP 1
 
 		create-glyph "cyrl/abk/cheDescender.\(suffix)" : glyph-proc
 			local df : DivFrame para.diversityM 2.5
 			set-width df.width
-			include : df.markSet.p
+			include : df.markSet.e
 			include : AbkCheShape Body df XH 1
 
 	select-variant 'e' 'e'

--- a/font-src/glyphs/letter/latin/o.ptl
+++ b/font-src/glyphs/letter/latin/o.ptl
@@ -11,6 +11,7 @@ glyph-block Letter-Latin-O : begin
 	glyph-block-import Mark-Shared-Metrics : markHalfStroke
 	glyph-block-import Mark-Horn-And-Angle : HornBaseAnchor
 	glyph-block-import Mark-Above : RingDims RingShape
+	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors ExtendBelowBaseAnchors
 	glyph-block-import Letter-Shared : CreateAccentedComposition SetGrekUpperTonos
 	glyph-block-import Letter-Blackboard : BBS BBD
 
@@ -28,6 +29,7 @@ glyph-block Letter-Latin-O : begin
 
 	create-glyph 'cyrl/oNarrow' 0x1C82 : glyph-proc
 		local df : DivFrame para.diversityF 2
+		set-width df.width
 		include : df.markSet.e
 		local subDf : DivFrame 0.75 2
 		local ada : subDf.archDepthA SmallArchDepth subDf.mvs
@@ -255,18 +257,18 @@ glyph-block Letter-Latin-O : begin
 		local [object radiusIn radiusOut] : RingDims
 		include : RingShape Middle (O + Stroke + radiusIn)
 
-	define PolishOMarks : object
-		capital : MarkSet.OfZone { .top (CAP + AccentStackOffset / 2) .bot (-AccentStackOffset / 2) }
-		e       : MarkSet.OfZone { .top (XH + AccentStackOffset / 2) .bot (-AccentStackOffset / 2) }
-
 	create-glyph 'OPolish' 0xA7C0 : glyph-proc
 		include [refer-glyph 'O'] AS_BASE
-		include : PolishOMarks.capital
-		include : VBar.m Middle CAP (CAP + AccentStackOffset)
-		include : VBar.m Middle (-AccentStackOffset) 0
+		include : MarkSet.capital
+		include : ExtendAboveBaseAnchors (CAP + LongJut - 0.5 * Stroke)
+		include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
+		include : VBar.m Middle CAP (CAP + LongJut - 0.5 * Stroke)
+		include : VBar.m Middle (-LongJut + 0.5 * Stroke) 0
 
 	create-glyph 'oPolish' 0xA7C1 : glyph-proc
 		include [refer-glyph 'o'] AS_BASE
-		include : PolishOMarks.e
-		include : VBar.m Middle XH (XH + AccentStackOffset)
-		include : VBar.m Middle (-AccentStackOffset) 0
+		include : MarkSet.e
+		include : ExtendAboveBaseAnchors (XH + LongJut - 0.5 * Stroke)
+		include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
+		include : VBar.m Middle XH (XH + LongJut - 0.5 * Stroke)
+		include : VBar.m Middle (-LongJut + 0.5 * Stroke) 0

--- a/font-src/glyphs/letter/latin/upper-i.ptl
+++ b/font-src/glyphs/letter/latin/upper-i.ptl
@@ -9,6 +9,7 @@ glyph-block Letter-Latin-Upper-I : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared : SetGrekUpperTonos CreateAccentedComposition CreateOgonekComposition
+	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors
 
 	define [ISeriflessShape df top bot jut] : glyph-proc
 		include : VBar.m df.middle bot top
@@ -45,8 +46,10 @@ glyph-block Letter-Latin-Upper-I : begin
 		create-glyph "ILonga.\(suffix)" : glyph-proc
 			local df : DivFrame div
 			set-width df.width
-			include : df.markSet.capDesc
-			include : Body df CAP Descender jut
+			include : df.markSet.capital
+			local top : CAP + Ascender - XH
+			include : ExtendAboveBaseAnchors top
+			include : Body df top 0 jut
 
 	select-variant 'I' 'I'
 	link-reduced-variant 'I/sansSerif' 'I' MathSansSerif

--- a/font-src/glyphs/letter/latin/upper-t.ptl
+++ b/font-src/glyphs/letter/latin/upper-t.ptl
@@ -82,7 +82,7 @@ glyph-block Letter-Latin-Upper-T : begin
 
 		create-glyph "cyrl/TeDescender.\(suffix)" : glyph-proc
 			set-width df.width
-			include : df.markSet.capDesc
+			include : df.markSet.capital
 			set-base-anchor 'bottomRight' (df.middle + HalfStroke * HVContrast) 0
 			include : TShape df CAP doST doSB
 			include : CyrDescender.rSideJut
@@ -125,7 +125,7 @@ glyph-block Letter-Latin-Upper-T : begin
 
 		create-glyph "cyrl/teDescender.upright.\(suffix)" : glyph-proc
 			set-width df.width
-			include : df.markSet.p
+			include : df.markSet.e
 			include : TShape df XH doST doSB
 			include : CyrDescender.rSideJut
 				x -- (df.middle + HalfStroke * HVContrast)

--- a/font-src/glyphs/letter/shared.ptl
+++ b/font-src/glyphs/letter/shared.ptl
@@ -790,20 +790,20 @@ glyph-block Letter-Shared-Shapes : begin
 		# Descender of cyrillics
 		glyph-block-export CyrDescender
 		define CyrDescender : Descenders : function [x y xLink yAttach yOverflow sw] : glyph-proc
-			include : ExtendBelowBaseAnchors (y + Descender)
+			include : ExtendBelowBaseAnchors (y - LongJut + 0.5 * Stroke)
 			include : union
 				xLinkStroke xLink x yAttach sw
-				VBar.m x yAttach (y + Descender) sw
+				VBar.m x yAttach (y - LongJut + 0.5 * Stroke) sw
 
 		glyph-block-export CyrTailDescender
 		define CyrTailDescender : Descenders : function [x y xLink yAttach yOverflow sw] : glyph-proc
-			include : ExtendBelowBaseAnchors (y + Descender)
+			include : ExtendBelowBaseAnchors (y - LongJut + 0.5 * Stroke)
 			include : union
 				xLinkStroke xLink x yAttach sw
 				intersection
 					MaskBelow (yAttach + Stroke)
-					MaskAbove (y + Descender)
-					ExtLineCenter 16 sw (x + 0.24 * Descender) (y + 0.5 * sw + Descender) x y
+					MaskAbove (y - LongJut + 0.5 * Stroke)
+					ExtLineCenter 16 sw (x + 0.24 * Descender) (y + 0.5 * sw - Descender) x y
 
 		# Palatal Hooks
 		glyph-block-export PalatalHook

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -359,7 +359,6 @@ selector.leftHalfH = "serifless"
 selector.rightHalfH = "serifless"
 selector."H/sansSerif" = "serifless"
 selector.Hwair = "serifless"
-selector."cyrl/njeKomi" = "serifless"
 selector.HHookLeft = "serifless"
 selector."cyrl/Nje/leftHalf" = "serifless"
 selector."cyrl/Nje/leftHalf/reduced" = "serifless"
@@ -372,7 +371,6 @@ selector.leftHalfH = "topLeftSerifed"
 selector.rightHalfH = "serifless"
 selector."H/sansSerif" = "serifless"
 selector.Hwair = "topLeftSerifed"
-selector."cyrl/njeKomi" = "topLeftSerifed"
 selector.HHookLeft = "serifless"
 selector."cyrl/Nje/leftHalf" = "topLeftSerifed"
 selector."cyrl/Nje/leftHalf/reduced" = "topLeftSerifed"
@@ -385,7 +383,6 @@ selector.leftHalfH = "topLeftSerifed"
 selector.rightHalfH = "topLeftBottomRightSerifed"
 selector."H/sansSerif" = "serifless"
 selector.Hwair = "topLeftSerifed"
-selector."cyrl/njeKomi" = "topLeftSerifed"
 selector.HHookLeft = "topLeftBottomRightSerifed"
 selector."cyrl/Nje/leftHalf" = "topLeftSerifed"
 selector."cyrl/Nje/leftHalf/reduced" = "topLeftSerifed"
@@ -398,7 +395,6 @@ selector.leftHalfH = "serifed"
 selector.rightHalfH = "serifed"
 selector."H/sansSerif" = "serifless"
 selector.Hwair = "serifedExceptBottomRight"
-selector."cyrl/njeKomi" = "serifedExceptBottomRight"
 selector.HHookLeft = "serifed"
 selector."cyrl/Nje/leftHalf" = "serifed"
 selector."cyrl/Nje/leftHalf/reduced" = "serifedExceptBottomRight"
@@ -4576,6 +4572,7 @@ selectorAffix."cyrl/en.BGR" = ""
 selectorAffix."cyrl/en/descenderBase" = ""
 selectorAffix."cyrl/nje/leftHalf" = ""
 selectorAffix."cyrl/nje/leftHalf/reduced" = ""
+selectorAffix."cyrl/njeKomi" = ""
 
 [prime.cyrl-en.variants-buildup.stages.tail.tailed]
 rank = 2
@@ -4585,6 +4582,7 @@ selectorAffix."cyrl/en.BGR" = "tailed"
 selectorAffix."cyrl/en/descenderBase" = ""
 selectorAffix."cyrl/nje/leftHalf" = ""
 selectorAffix."cyrl/nje/leftHalf/reduced" = ""
+selectorAffix."cyrl/njeKomi" = ""
 
 [prime.cyrl-en.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -4595,6 +4593,7 @@ selectorAffix."cyrl/en.BGR" = "serifless"
 selectorAffix."cyrl/en/descenderBase" = "serifless"
 selectorAffix."cyrl/nje/leftHalf" = "serifless"
 selectorAffix."cyrl/nje/leftHalf/reduced" = "serifless"
+selectorAffix."cyrl/njeKomi" = "serifless"
 
 [prime.cyrl-en.variants-buildup.stages.serifs.top-left-serifed]
 rank = 2
@@ -4604,6 +4603,7 @@ selectorAffix."cyrl/en.BGR" = "topLeftSerifed"
 selectorAffix."cyrl/en/descenderBase" = "topLeftSerifed"
 selectorAffix."cyrl/nje/leftHalf" = "topLeftSerifed"
 selectorAffix."cyrl/nje/leftHalf/reduced" = "topLeftSerifed"
+selectorAffix."cyrl/njeKomi" = "topLeftSerifed"
 
 [prime.cyrl-en.variants-buildup.stages.serifs.top-left-bottom-right-serifed]
 rank = 3
@@ -4614,6 +4614,7 @@ selectorAffix."cyrl/en.BGR" = "topLeftBottomRightSerifed"
 selectorAffix."cyrl/en/descenderBase" = "topLeftSerifed"
 selectorAffix."cyrl/nje/leftHalf" = "topLeftSerifed"
 selectorAffix."cyrl/nje/leftHalf/reduced" = "topLeftSerifed"
+selectorAffix."cyrl/njeKomi" = "topLeftSerifed"
 
 [prime.cyrl-en.variants-buildup.stages.serifs.serifed]
 rank = 4
@@ -4623,6 +4624,7 @@ selectorAffix."cyrl/en.BGR" = "serifedBGR"
 selectorAffix."cyrl/en/descenderBase" = "serifed"
 selectorAffix."cyrl/nje/leftHalf" = "serifed"
 selectorAffix."cyrl/nje/leftHalf/reduced" = "serifedExceptBottomRight"
+selectorAffix."cyrl/njeKomi" = "serifedExceptBottomRight"
 
 
 


### PR DESCRIPTION
![image](https://github.com/be5invis/Iosevka/assets/21302803/cc7c5222-e908-44af-8519-1f0c3d182029)

Fixes:
- Applied set-width for narrow o, not sure if this fixes anything.
- Fixed Komi nje variant selector from H to lower En.
- Fixed I Longa, aligning it with Top Hook Capitals (like `Ƈ`)
- Modified Ukrainian Ge, Polish O etc to use extendAbove/Below instead of declaring a new MarkSet. Also realigned them with the others with similar component.

Implementation notes:
- Three-legged Te `ᲅ` for modern font purposes is identical to an inverted sha `ш`.
  - Also, sha now uses SerifFrame.
- Wide Es `ᲃ` from the source materials has 2 differing features:
  - It is wider than normal Es as its name suggests, which I try to mimick using `diversityM` instead of the normal width.
  The Ustav script, which these characters are from, has a narrower Es (like narrow o) to begin with,  
but I doubt we should change the modern style just for that.
  - It also stoops *slightly* below baseline, which I identify with De `д`, but not as stretched as Stretched C. As seen in these Old Cyrillic-compatible fonts I referenced last time in #1644:
  ![image](https://github.com/be5invis/Iosevka/assets/21302803/32745206-0643-4ae3-aefe-a843287f0a31)
- Long-legged De `ᲁ` has a contrasitively longer descender, where in the original script the descenders of the regular `д`s are noticeably shorter.
  - This unfortunately means we run into the descender depth problem again (sorry), which for now I just chose to sync all CyrDescender (and Tail) with the (untouched) depth of De, including the Upturn in Ukrainian Ge. This does make the value a bit clumsy (`LongJut - 0.5 * Stroke`) and dependent on weight, however.
  ![image](https://github.com/be5invis/Iosevka/assets/21302803/c775bebe-f99f-4884-aad3-c44ef5db8ff4)
  At least this is how most fonts do it anyway -- The cyrillic descenders are shorter than those that do touch the descender line, or the hooks at least.
- Italic forms probably not needed, considering these were only used in a script without italics/cursive. It can technically be done for Te and De (as is in Noto Serif, unifying with their regular forms), but it's probably meaningless to do so.

String showing all the descender glyphs (i found): `ⱧⱨⱩⱪⱫⱬДдЩщЦцҖҗҚқҢңҬҭҲҳҴҵҶҷҾҿӶӷӋӌԆԇԤԥԦԧԪԫԮԯꙠꙡꙢꙣ`