### PR TITLE
Further fixes

### DIFF
--- a/font-src/glyphs/letter/latin-ext/ezh.ptl
+++ b/font-src/glyphs/letter/latin-ext/ezh.ptl
@@ -164,5 +164,5 @@ glyph-block Letter-Latin-Ezh : begin
 			SerifedArcEnd.RtlRhs SB Middle bot Stroke hookDepth
 	create-glyph 'ezhRetroflexHook' 0x1D9A : glyph-proc
 		include : MarkSet.p
-		include : EzhShape XH (Descender + Hook) (terminalShape -- RetroflexConnectionTerminal)
-		include : RetroflexHook.l SB (Descender + Hook) (yAttach -- Descender + Hook * 2)
+		include : EzhShape XH 0 (terminalShape -- RetroflexConnectionTerminal)
+		include : RetroflexHook.l SB 0 (yAttach -- Hook)

--- a/font-src/glyphs/letter/latin-ext/long-s.ptl
+++ b/font-src/glyphs/letter/latin-ext/long-s.ptl
@@ -214,10 +214,10 @@ glyph-block Letter-Latin-Long-S : begin
 			maskOut -- [intersection [MaskBelow 0] [MaskLeft (Middle + HVContrast * HalfStroke)]]
 	create-glyph "eshRetroflexHook" 0x1D98 : glyph-proc
 		include : MarkSet.if
-		include : LongSShape Ascender (Descender + Hook) (HookX + 0.25 * Stroke) Hook
+		include : LongSShape Ascender 0 (HookX + 0.25 * Stroke) Hook
 		include : RetroflexHook.l
 			x -- Middle - (HookX + 0.25 * Stroke)
-			y -- Descender + Hook
+			y -- 0
 			yOverflow -- Stroke
 
 	create-glyph "eshCurlyTail" 0x286 : glyph-proc

--- a/font-src/glyphs/letter/latin/k.ptl
+++ b/font-src/glyphs/letter/latin/k.ptl
@@ -131,6 +131,7 @@ glyph-block Letter-Latin-K : begin
 
 			if hookDepth
 			: then : begin
+				include : ExtendBelowBaseAnchors hookDepth
 				include : tagged 'strokeRB' : dispiro
 					flat kshLeft (0.5 * top + stroke / 2) [widths.rhs.heading stroke Rightward]
 					curl [mix kshLeft right 0.5] (0.5 * top + stroke / 2)

--- a/font-src/glyphs/letter/shared.ptl
+++ b/font-src/glyphs/letter/shared.ptl
@@ -803,7 +803,7 @@ glyph-block Letter-Shared-Shapes : begin
 				intersection
 					MaskBelow (yAttach + Stroke)
 					MaskAbove (y - LongJut + 0.5 * Stroke)
-					ExtLineCenter 16 sw (x + 0.24 * Descender) (y + 0.5 * sw - Descender) x y
+					ExtLineCenter 16 sw (x + 0.24 * Descender) (y + 0.5 * sw + Descender) x y
 
 		# Palatal Hooks
 		glyph-block-export PalatalHook

--- a/font-src/glyphs/number/8.ptl
+++ b/font-src/glyphs/number/8.ptl
@@ -141,7 +141,7 @@ glyph-block Digits-Eight : begin
 
 
 	# There is an "eight without lower contour" shape used for /propto
-	create-glyph 'rotetedPropto' : glyph-proc # rotetedPropto
+	create-glyph 'rotatedPropto' : glyph-proc # rotatedPropto
 		local p 0.96
 		local py 0.4
 		local l (SB + OX)


### PR DESCRIPTION
Realized I left a half-changed glyph name in the previous pr #1809, a remnant of my unsuccessful attempt at using the autobuilt lazy S to make `ꬷ`

Also included a few other fixes I could find for hook characters:
1. Ka with Hook `Ӄӄ` is built as a "variant" of Ka instead of an attachment, which didn't shift down either
2. `ᶘᶚ` were still aligned as if the Retroflex Hook depth is `Hook`