### PR TITLE
Improve legibility of quadruple arrows

### DIFF
--- a/changes/24.1.5.md
+++ b/changes/24.1.5.md
@@ -2,3 +2,4 @@
   - CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH (`U+1F10F`).
   - CIRCLED C WITH OVERLAID BACKSLASH (`U+1F16E`).
 * Fix reversed shape of `U+1D12` (#1814).
+* Improve density of quadruple arrows for better legibility at smaller font sizes.

--- a/font-src/glyphs/symbol/arrow.ptl
+++ b/font-src/glyphs/symbol/arrow.ptl
@@ -323,7 +323,7 @@ glyph-block Symbol-Arrow : for-width-kinds WideWidth1
 
 	define [QuadrupleArrowBarShape w x1 y1 x2 y2] : begin
 		return : PointingTo x1 y1 x2 y2 : lambda [mag] : begin
-			local fine : Math.min (w / 5) arrowSw
+			local fine : Math.min (w / 6.4) arrowSw
 			local coFine : w / 2 - fine / 2
 			return : difference
 				union


### PR DESCRIPTION
Double arrows have a minimum gap size equal to the bar size; Triple arrows have a minimum gap size of 75% of the bar size; Quadruple arrows will now have a minimum gap size of 62.5% of the bar size.

This follows a trend of halving the distance between 100% and 50% with every additional bar. If there were a quintuple arrow in Unicode, then the gap should be 56.25% of the bar size, and so on, but never reaching 50%.

explanation:
3/4 = 0.75
4/6.4 = 0.625
5/8.888... = 0.5625

Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/f8c6cfcf-89a6-4ff9-a3e4-c321b888b375)

Heavy:
![image](https://github.com/be5invis/Iosevka/assets/37010132/42e1b253-3cfa-418e-9b34-3aa0bc85229d)

Thin:
![image](https://github.com/be5invis/Iosevka/assets/37010132/ab13f1dd-5e8b-4733-bb03-c89b5ee2019d)
