### PR TITLE
Add middle and XH serifed variants for long S without baseline serif

### DIFF
--- a/changes/25.0.0.md
+++ b/changes/25.0.0.md
@@ -1,3 +1,4 @@
+* \[**BREAKING**\] Add middle serifed and XH serifed variants for Long S (`U+017F`) without a baseline serif. As a result, current variants are reordered (#1807).
 * Add Characters:
   - CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH (`U+1F10F`).
   - CIRCLED C WITH OVERLAID BACKSLASH (`U+1F16E`).

--- a/font-src/glyphs/letter/latin-ext/long-s.ptl
+++ b/font-src/glyphs/letter/latin-ext/long-s.ptl
@@ -105,6 +105,8 @@ glyph-block Letter-Latin-Long-S : begin
 	# Non-descending variants
 	define SerifSuffixes : object
 		"Serifless"       { SLAB_SERIFLESS 1   }
+		"MiddleSerifed"   { SLAB_MIDDLE    0.5 }
+		"MiddleSerifedXH" { SLAB_MIDDLE_XH 0.5 }
 		"BottomSerifed"   { SLAB_BOTTOM    0.5 }
 		"DoubleSerifed"   { SLAB_DOUBLE    0.5 }
 		"DoubleSerifedXH" { SLAB_DOUBLE_XH 0.5 }

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -3922,39 +3922,38 @@ descriptionAffix = "serifs"
 selectorAffix."longs" = ""
 selectorAffix."longs/flatExt" = ""
 
-[prime.long-s.variants-buildup.stages.serifs.bottom-serifed]
+[prime.long-s.variants-buildup.stages.serifs.middle-serifed]
 rank = 2
+descriptionAffix = "middle serif"
+selectorAffix."longs" = "middleSerifed"
+selectorAffix."longs/flatExt" = "middleSerifed"
+
+[prime.long-s.variants-buildup.stages.serifs.middle-serifed-xh]
+rank = 3
+descriptionAffix = "middle serif at x-height"
+selectorAffix."longs" = "middleSerifedXH"
+selectorAffix."longs/flatExt" = "middleSerifedXH"
+
+[prime.long-s.variants-buildup.stages.serifs.bottom-serifed]
+rank = 4
 enableIf = [{ bottom = "non-descending" }]
 descriptionAffix = "bottom serif"
 selectorAffix."longs" = "bottomSerifed"
 selectorAffix."longs/flatExt" = "bottomSerifed"
 
 [prime.long-s.variants-buildup.stages.serifs.double-serifed]
-rank = 3
+rank = 5
 enableIf = [{ bottom = "non-descending" }]
 descriptionAffix = "bottom and middle serifs"
 selectorAffix."longs" = "doubleSerifed"
 selectorAffix."longs/flatExt" = "doubleSerifed"
 
 [prime.long-s.variants-buildup.stages.serifs.double-serifed-xh]
-rank = 4
+rank = 6
 enableIf = [{ bottom = "non-descending" }]
 descriptionAffix = "bottom and middle serifs at x-height"
 selectorAffix."longs" = "doubleSerifedXH"
 selectorAffix."longs/flatExt" = "doubleSerifedXH"
-
-[prime.long-s.variants-buildup.stages.serifs.middle-serifed]
-rank = 5
-enableIf = [{ bottom = "NOT non-descending" }]
-descriptionAffix = "middle serif"
-selectorAffix."longs" = "middleSerifed"
-selectorAffix."longs/flatExt" = "middleSerifed"
-
-[prime.long-s.variants-buildup.stages.serifs.middle-serifed-xh]
-rank = 6
-enableIf = [{ bottom = "NOT non-descending" }]
-descriptionAffix = "middle serif at x-height"
-selectorAffix."longs" = "middleSerifedXH"
 
 
 
@@ -6429,7 +6428,7 @@ j = "serifed"
 k = "straight-serifless"
 l = "zshaped"
 y = "straight-turn-serifless"
-long-s = "flat-hook-serifless"
+long-s = "flat-hook-middle-serifed"
 eszet = "longs-s-lig"
 lower-lambda = "straight-turn"
 lower-iota = "flat-tailed"
@@ -6463,7 +6462,7 @@ d = "toothed-serifed"
 f = "flat-hook-serifed"
 k = "straight-serifed"
 y = "straight-turn-serifed"
-long-s = "flat-hook-bottom-serifed"
+long-s = "flat-hook-double-serifed"
 cyrl-capital-ka = "straight-serifed"
 cyrl-ka = "straight-serifed"
 cyrl-capital-u = "straight-turn-serifed"
@@ -6630,7 +6629,7 @@ k = "straight-serifless"
 l = "serifed-flat-tailed"
 t = "flat-hook"
 y = "straight-turn-serifless"
-long-s = "flat-hook-serifless"
+long-s = "flat-hook-middle-serifed"
 eszet = "longs-s-lig"
 lower-lambda = "straight-turn"
 cyrl-capital-ka = "straight-serifless"
@@ -6663,7 +6662,7 @@ d = "toothed-serifed"
 f = "flat-hook-serifed"
 k = "straight-serifed"
 y = "straight-turn-serifed"
-long-s = "flat-hook-bottom-serifed"
+long-s = "flat-hook-double-serifed"
 cyrl-capital-ka = "straight-serifed"
 cyrl-ka = "straight-serifed"
 cyrl-capital-u = "straight-turn-serifed"
@@ -6865,6 +6864,7 @@ w = "curly-serifless"
 x = "curly-serifless"
 y = "curly-serifless"
 z = "curly-serifless"
+long-s = "bent-hook-middle-serifed"
 eszet = "longs-s-lig"
 lower-delta = "flat-top"
 lower-lambda = "curly"
@@ -6917,6 +6917,7 @@ v = "curly-serifed"
 w = "curly-serifed"
 x = "curly-serifed"
 y = "curly-serifed"
+long-s = "bent-hook-double-serifed"
 cyrl-capital-ka = "curly-serifed"
 cyrl-capital-u = "curly-serifed"
 cyrl-ka = "curly-serifed"
@@ -6950,7 +6951,7 @@ r = "hookless-serifless"
 w = "straight-flat-top-serifless"
 y = "straight-turn-serifless"
 eszet = "longs-s-lig"
-long-s = "flat-hook-serifless"
+long-s = "flat-hook-middle-serifed"
 lower-alpha = "tailed-barred"
 lower-lambda = "straight-turn"
 cyrl-capital-u = "straight-turn-serifless"
@@ -6986,7 +6987,7 @@ k = "straight-serifed"
 r = "hookless-serifed"
 w = "straight-flat-top-serifed"
 y = "straight-turn-serifed"
-long-s = "flat-hook-bottom-serifed"
+long-s = "flat-hook-double-serifed"
 cyrl-capital-u = "straight-turn-serifed"
 
 [composite.ss09.slab-override.italic]
@@ -7012,7 +7013,7 @@ k = "symmetric-connected-serifless"
 l = "hooky"
 t = "flat-hook"
 y = "cursive-flat-hook-serifless"
-long-s = "flat-hook-serifless"
+long-s = "flat-hook-middle-serifed"
 eszet = "sulzbacher"
 micro-sign = "toothless-rounded"
 cyrl-capital-u = "cursive-flat-hook-serifless"
@@ -7037,7 +7038,7 @@ f = "flat-hook-serifed"
 g = "single-storey-flat-hook-serifed"
 k = "symmetric-connected-serifed"
 y = "cursive-flat-hook-serifed"
-long-s = "flat-hook-bottom-serifed"
+long-s = "flat-hook-double-serifed"
 cyrl-capital-u = "cursive-flat-hook-serifed"
 
 
@@ -7165,7 +7166,7 @@ i = "hooky"
 k = "symmetric-touching-serifless"
 l = "hooky"
 y = "straight-turn-serifless"
-long-s = "flat-hook-serifless"
+long-s = "flat-hook-middle-serifed"
 eszet = "longs-s-lig"
 lower-iota = "tailed"
 cyrl-capital-u = "straight-turn-serifless"
@@ -7193,7 +7194,7 @@ f = "serifed"
 g = "single-storey-serifed"
 k = "symmetric-touching-serifed"
 y = "straight-turn-serifed"
-long-s = "flat-hook-bottom-serifed"
+long-s = "flat-hook-double-serifed"
 cyrl-capital-u = "straight-turn-serifed"
 seven = "bend-serifed"
 
@@ -7379,7 +7380,7 @@ r = "serifed"
 t = "standard-short-neck2"
 u = "toothed-motion-serifed"
 y = "straight-turn-serifless"
-long-s = "flat-hook-serifless"
+long-s = "flat-hook-middle-serifed"
 eszet = "longs-s-lig"
 capital-gamma = "serifed"
 cyrl-capital-ze = "bilateral-inward-serifed"
@@ -7412,7 +7413,7 @@ n = "straight-serifed"
 p = "eared-serifed"
 q = "earless-corner-straight-serifed"
 y = "straight-turn-serifed"
-long-s = "flat-hook-bottom-serifed"
+long-s = "flat-hook-double-serifed"
 cyrl-capital-ka = "symmetric-connected-serifed"
 cyrl-capital-u = "straight-turn-serifed"
 
@@ -7513,7 +7514,7 @@ k = "symmetric-connected-serifless"
 l = "serifed"
 q = "earless-corner-straight-serifless"
 y = "straight-turn-serifless"
-long-s = "flat-hook-serifless"
+long-s = "flat-hook-middle-serifed-xh"
 eszet = "longs-s-lig"
 lower-alpha = "tailed-barred"
 lower-lambda = "straight-turn"
@@ -7534,7 +7535,7 @@ micro-sign = "tailed"
 
 [composite.ss18.italic]
 f = "extended-crossbar-at-x-height"
-long-s = "flat-hook-descending"
+long-s = "flat-hook-descending-middle-serifed-xh"
 eszet = "longs-s-lig-descending"
 
 [composite.ss18.slab-override.design]
@@ -7546,7 +7547,7 @@ f = "serifed-crossbar-at-x-height"
 k = "symmetric-connected-serifed"
 q = "earless-corner-straight-serifed"
 y = "straight-turn-serifed"
-long-s = "flat-hook-bottom-serifed"
+long-s = "flat-hook-double-serifed-xh"
 cyrl-capital-u = "straight-turn-serifed"
 seven = "bend-serifed"
 


### PR DESCRIPTION
Below is a test using SS18 (Input Mono style)
Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/04dd4182-8267-41c8-a777-5b16ec58b39b)
Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/48bb779a-4f5a-45e8-b662-832961ea0215)
