### PR TITLE
Style set corrections, kappa variant assignments

### DIFF
--- a/changes/25.0.0.md
+++ b/changes/25.0.0.md
@@ -6,4 +6,10 @@
   - CYRILLIC SMALL LETTER DZZE (`U+A689`) (#1799).
   - MODIFIER LETTER CYRILLIC SMALL DZZE (`U+1E04A`) (#1799).
 * Fix reversed shape of `U+1D12` (#1814).
+* Fix effect of `cv23` on LATIN CAPITAL LETTER CHI (`A7B3`).
+* Make `cv36` affect LATIN SMALL LETTER KRA (`U+0138`) and GREEK SMALL LETTER KAPPA (`U+03BA`).
+* Fix variant assignment of `cv99` on `ss09`.
+* Fix variant assignment of `cv71` on `ss15`.
+* Fix variant assignment of `vxaa` on `ss16` and `ss17`.
+* Fix variant assignment of `vxsf` and `vxsg` on `ss18`.
 * Improve density of quadruple arrows for better legibility at smaller font sizes.

--- a/font-src/glyphs/letter/latin/k.ptl
+++ b/font-src/glyphs/letter/latin/k.ptl
@@ -556,7 +556,7 @@ glyph-block Letter-Latin-K : begin
 	select-variant 'grek/kappa' 0x3BA
 
 	select-variant 'smcpK' 0x1D0B (follow -- 'K')
-	alias 'latinkappa' 0x138 'smcpK'
+	select-variant 'latn/kappa' 0x138 (shapeFrom -- 'smcpK')
 	select-variant 'cyrl/ka' 0x43A (shapeFrom -- 'smcpK')
 	select-variant 'cyrl/kaDescender' 0x49B (shapeFrom -- 'smcpKDescender')
 	select-variant 'cyrl/ka.BGR' (shapeFrom -- 'k') (follow -- 'cyrl/ka')

--- a/font-src/glyphs/letter/latin/x.ptl
+++ b/font-src/glyphs/letter/latin/x.ptl
@@ -164,7 +164,7 @@ glyph-block Letter-Latin-X : begin
 
 	select-variant 'grek/chi' 0x3C7 (shapeFrom -- 'latn/chi')
 	select-variant 'latn/chi' 0xAB53 (follow -- 'x')
-	select-variant 'latn/Chi' 0xA7B3 (follow -- 'x')
+	select-variant 'latn/Chi' 0xA7B3 (follow -- 'X')
 
 
 	define [AddDescender Ctor] : function [src sel] : glyph-proc

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -525,7 +525,6 @@ descriptionAffix = "straight shape"
 selectorAffix.K = "straight"
 selectorAffix."K/sansSerif" = "straight"
 selectorAffix."grek/KaiSymbol" = "straight"
-selectorAffix."grek/kappa" = "straight"
 selectorAffix.KDescender = "straight"
 
 [prime.capital-k.variants-buildup.stages.body.curly]
@@ -534,7 +533,6 @@ descriptionAffix = "curly shape"
 selectorAffix.K = "curly"
 selectorAffix."K/sansSerif" = "curly"
 selectorAffix."grek/KaiSymbol" = "curly"
-selectorAffix."grek/kappa" = "curly"
 selectorAffix.KDescender = "curly"
 
 [prime.capital-k.variants-buildup.stages.body.symmetric-touching]
@@ -543,7 +541,6 @@ descriptionAffix = "symmetric legs touching the vertical bar"
 selectorAffix.K = "symmetricTouching"
 selectorAffix."K/sansSerif" = "symmetricTouching"
 selectorAffix."grek/KaiSymbol" = "symmetricTouching"
-selectorAffix."grek/kappa" = "symmetricTouching"
 selectorAffix.KDescender = "symmetricTouching"
 
 [prime.capital-k.variants-buildup.stages.body.symmetric-connected]
@@ -552,7 +549,6 @@ descriptionAffix = "symmetric legs connected to the vertical bar"
 selectorAffix.K = "symmetricConnected"
 selectorAffix."K/sansSerif" = "symmetricConnected"
 selectorAffix."grek/KaiSymbol" = "symmetricConnected"
-selectorAffix."grek/kappa" = "symmetricConnected"
 selectorAffix.KDescender = "symmetricConnected"
 
 [prime.capital-k.variants-buildup.stages.serifs.serifless]
@@ -562,7 +558,6 @@ descriptionJoiner = "without"
 selectorAffix.K = "serifless"
 selectorAffix."K/sansSerif" = "serifless"
 selectorAffix."grek/KaiSymbol" = "serifless"
-selectorAffix."grek/kappa" = "serifless"
 selectorAffix.KDescender = "serifless"
 
 [prime.capital-k.variants-buildup.stages.serifs.top-left-serifed]
@@ -571,7 +566,6 @@ descriptionAffix = "serifs at top left"
 selectorAffix.K = "topLeftSerifed"
 selectorAffix."K/sansSerif" = "serifless"
 selectorAffix."grek/KaiSymbol" = "topLeftSerifed"
-selectorAffix."grek/kappa" = "serifless"
 selectorAffix.KDescender = "topLeftSerifed"
 
 [prime.capital-k.variants-buildup.stages.serifs.bottom-right-serifed]
@@ -580,7 +574,6 @@ descriptionAffix = "serifs at bottom right"
 selectorAffix.K = "bottomRightSerifed"
 selectorAffix."K/sansSerif" = "serifless"
 selectorAffix."grek/KaiSymbol" = "bottomRightSerifed2"
-selectorAffix."grek/kappa" = "serifless"
 selectorAffix.KDescender = "bottomRightSerifed"
 
 [prime.capital-k.variants-buildup.stages.serifs.top-left-and-bottom-right-serifed]
@@ -589,7 +582,6 @@ descriptionAffix = "serifs at top left and bottom right"
 selectorAffix.K = "topLeftAndBottomRightSerifed"
 selectorAffix."K/sansSerif" = "serifless"
 selectorAffix."grek/KaiSymbol" = "topLeftAndBottomRightSerifed2"
-selectorAffix."grek/kappa" = "serifless"
 selectorAffix.KDescender = "topLeftSerifed"
 
 [prime.capital-k.variants-buildup.stages.serifs.serifed]
@@ -598,7 +590,6 @@ descriptionAffix = "serifs"
 selectorAffix.K = "serifed"
 selectorAffix."K/sansSerif" = "serifless"
 selectorAffix."grek/KaiSymbol" = "serifed2"
-selectorAffix."grek/kappa" = "serifless"
 selectorAffix.KDescender = "serifed"
 
 
@@ -2321,6 +2312,8 @@ selectorAffix.k = "straight"
 selectorAffix."k/sansSerif" = "straight"
 selectorAffix.kHookTop = "straight"
 selectorAffix.kDescender = "straight"
+selectorAffix."latn/kappa" = "straight"
+selectorAffix."grek/kappa" = "straight"
 
 [prime.k.variants-buildup.stages.body.curly]
 rank = 2
@@ -2329,6 +2322,8 @@ selectorAffix.k = "curly"
 selectorAffix."k/sansSerif" = "curly"
 selectorAffix.kHookTop = "curly"
 selectorAffix.kDescender = "curly"
+selectorAffix."latn/kappa" = "curly"
+selectorAffix."grek/kappa" = "curly"
 
 [prime.k.variants-buildup.stages.body.symmetric-touching]
 rank = 3
@@ -2337,6 +2332,8 @@ selectorAffix.k = "symmetricTouching"
 selectorAffix."k/sansSerif" = "symmetricTouching"
 selectorAffix.kHookTop = "symmetricTouching"
 selectorAffix.kDescender = "symmetricTouching"
+selectorAffix."latn/kappa" = "symmetricTouching"
+selectorAffix."grek/kappa" = "symmetricTouching"
 
 [prime.k.variants-buildup.stages.body.symmetric-connected]
 rank = 4
@@ -2345,6 +2342,8 @@ selectorAffix.k = "symmetricConnected"
 selectorAffix."k/sansSerif" = "symmetricConnected"
 selectorAffix.kHookTop = "symmetricConnected"
 selectorAffix.kDescender = "symmetricConnected"
+selectorAffix."latn/kappa" = "symmetricConnected"
+selectorAffix."grek/kappa" = "symmetricConnected"
 
 [prime.k.variants-buildup.stages.body.cursive]
 rank = 5
@@ -2353,6 +2352,8 @@ selectorAffix.k = "cursive"
 selectorAffix."k/sansSerif" = "cursive"
 selectorAffix.kHookTop = "cursive"
 selectorAffix.kDescender = "cursive"
+selectorAffix."latn/kappa" = "curly"
+selectorAffix."grek/kappa" = "curly"
 
 [prime.k.variants-buildup.stages.body.diagonal-tailed-cursive]
 rank = 6
@@ -2361,6 +2362,8 @@ selectorAffix.k = "cursiveTailed"
 selectorAffix."k/sansSerif" = "cursiveTailed"
 selectorAffix.kHookTop = "cursiveTailed"
 selectorAffix.kDescender = "cursive"
+selectorAffix."latn/kappa" = "curly"
+selectorAffix."grek/kappa" = "curly"
 
 [prime.k.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -2370,6 +2373,8 @@ selectorAffix.k = "serifless"
 selectorAffix."k/sansSerif" = "serifless"
 selectorAffix.kHookTop = "serifless"
 selectorAffix.kDescender = "serifless"
+selectorAffix."latn/kappa" = "serifless"
+selectorAffix."grek/kappa" = "serifless"
 
 [prime.k.variants-buildup.stages.serifs.top-left-serifed]
 rank = 2
@@ -2378,6 +2383,8 @@ selectorAffix.k = "topLeftSerifed"
 selectorAffix."k/sansSerif" = "serifless"
 selectorAffix.kHookTop = "serifless"
 selectorAffix.kDescender = "topLeftSerifed"
+selectorAffix."latn/kappa" = "topLeftSerifed"
+selectorAffix."grek/kappa" = "serifless"
 
 [prime.k.variants-buildup.stages.serifs.bottom-right-serifed]
 rank = 3
@@ -2387,6 +2394,8 @@ selectorAffix.k = "bottomRightSerifed"
 selectorAffix."k/sansSerif" = "serifless"
 selectorAffix.kHookTop = "bottomRightSerifed"
 selectorAffix.kDescender = "bottomRightSerifed"
+selectorAffix."latn/kappa" = "bottomRightSerifed"
+selectorAffix."grek/kappa" = "serifless"
 
 [prime.k.variants-buildup.stages.serifs.top-left-and-bottom-right-serifed]
 rank = 4
@@ -2396,6 +2405,8 @@ selectorAffix.k = "topLeftAndBottomRightSerifed"
 selectorAffix."k/sansSerif" = "serifless"
 selectorAffix.kHookTop = "bottomRightSerifed"
 selectorAffix.kDescender = "topLeftAndBottomRightSerifed"
+selectorAffix."latn/kappa" = "topLeftAndBottomRightSerifed"
+selectorAffix."grek/kappa" = "serifless"
 
 [prime.k.variants-buildup.stages.serifs.serifed]
 rank = 5
@@ -2405,6 +2416,8 @@ selectorAffix.k = "serifed"
 selectorAffix."k/sansSerif" = "serifless"
 selectorAffix.kHookTop = "serifed"
 selectorAffix.kDescender = "serifed"
+selectorAffix."latn/kappa" = "serifed"
+selectorAffix."grek/kappa" = "serifless"
 
 
 
@@ -6973,6 +6986,7 @@ asterisk = "penta-low"
 pilcrow = "low"
 number-sign = "slanted"
 dollar = "open"
+bar = "force-upright"
 micro-sign = "tailed"
 lig-neq = "more-slanted"
 
@@ -7336,7 +7350,6 @@ x = "cursive"
 y = "cursive-serifless"
 z = "cursive"
 long-s = "flat-hook-diagonal-tailed-middle-serifed"
-cyrl-capital-u = "straight-turn-serifed"
 ampersand = "closed"
 
 [composite.ss15.slab-override.design]
@@ -7344,6 +7357,7 @@ d = "toothed-serifed"
 k = "straight-serifed"
 w = "straight-flat-top-serifless"
 y = "straight-turn-serifed"
+cyrl-capital-u = "straight-turn-serifed"
 
 [composite.ss15.slab-override.italic]
 a = "single-storey-serifed"
@@ -7409,6 +7423,7 @@ paren = "large-contour"
 brace = "straight"
 number-sign = "slanted"
 percent = "rings-continuous-slash"
+lower-eth = "straight-bar"
 
 [composite.ss16.slab-override.design]
 capital-d = "more-rounded-bilateral-serifed"
@@ -7466,6 +7481,9 @@ ampersand = "upper-open"
 at = "fourfold"
 dollar = "interrupted"
 cent = "bar-interrupted"
+partial-derivative = "straight-bar"
+lower-eth = "straight-bar"
+micro-sign = "tailed"
 punctuation-dot = "square"
 diacritic-dot = "square"
 brace = "curly-flat-boundary"

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2352,8 +2352,8 @@ selectorAffix.k = "cursive"
 selectorAffix."k/sansSerif" = "cursive"
 selectorAffix.kHookTop = "cursive"
 selectorAffix.kDescender = "cursive"
-selectorAffix."latn/kappa" = "curly"
-selectorAffix."grek/kappa" = "curly"
+selectorAffix."latn/kappa" = "straight"
+selectorAffix."grek/kappa" = "straight"
 
 [prime.k.variants-buildup.stages.body.diagonal-tailed-cursive]
 rank = 6
@@ -2362,8 +2362,8 @@ selectorAffix.k = "cursiveTailed"
 selectorAffix."k/sansSerif" = "cursiveTailed"
 selectorAffix.kHookTop = "cursiveTailed"
 selectorAffix.kDescender = "cursive"
-selectorAffix."latn/kappa" = "curly"
-selectorAffix."grek/kappa" = "curly"
+selectorAffix."latn/kappa" = "straight"
+selectorAffix."grek/kappa" = "straight"
 
 [prime.k.variants-buildup.stages.serifs.serifless]
 rank = 1


### PR DESCRIPTION
Firstly, some corrections to stylistic sets' variation assignments are made based on the source fonts.

Secondly, in a large variety of fonts, latin Kra and greek Kappa often follow a slightly different serifed form from small capital K.
Example from [Wikipedia](https://en.wikipedia.org/wiki/Kra_(letter)):
![image](https://github.com/be5invis/Iosevka/assets/37010132/f9b99710-3575-4b7b-b5ed-5668cca7e699)

Additionally, Latin Capital Chi should follow Capital X similarly to how Latin Capital Beta follows Capital B.

Below is a test using the default slab configuration.

From left to right:
Latin Capital K, Latin Kra, Latin Small K, Greek Kappa, Latin Capital X, Latin Capital Chi, Latin Small Chi, and Greek Chi.
`KĸkκXꞳꭓχ`

Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/6b2d13af-7872-44e2-872d-fa659dcedd6c)
Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/01603d5c-c4a7-4179-b376-42e27762e572)
