### PR TITLE
Add 3 Greek Alpha variants for `ss12` and `ss14`

### DIFF
--- a/changes/25.0.0.md
+++ b/changes/25.0.0.md
@@ -1,4 +1,5 @@
 * \[**BREAKING**\] Add middle serifed and XH serifed variants for Long S (`U+017F`) without a baseline serif. As a result, current variants are reordered (#1807).
+* Add tailless bar, earless corner, and earless corner tailed variants for Greek Alpha (`U+03B1`).
 * Add Characters:
   - CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH (`U+1F10F`).
   - CIRCLED C WITH OVERLAID BACKSLASH (`U+1F16E`).
@@ -9,7 +10,7 @@
 * Fix effect of `cv23` on LATIN CAPITAL LETTER CHI (`A7B3`).
 * Make `cv36` affect LATIN SMALL LETTER KRA (`U+0138`) and GREEK SMALL LETTER KAPPA (`U+03BA`).
 * Fix variant assignment of `cv99` on `ss09`.
-* Fix variant assignment of `cv71` on `ss15`.
+* Fix variant assignment of `cv71` on `ss12` and `ss15`.
 * Fix variant assignment of `vxaa` on `ss16` and `ss17`.
 * Fix variant assignment of `vxsf` and `vxsg` on `ss18`.
 * Improve density of quadruple arrows for better legibility at smaller font sizes.

--- a/font-src/glyphs/letter/greek/lower-alpha.ptl
+++ b/font-src/glyphs/letter/greek/lower-alpha.ptl
@@ -34,5 +34,8 @@ glyph-block Letter-Greek-Lower-Alpha : begin
 
 		set-base-anchor 'overlay' (middle - OX) (XH * OverlayPos)
 
+	alias 'grek/alpha.barred' null 'a.singleStoreySerifless'
 	alias 'grek/alpha.tailedBarred' null 'a.singleStoreyTailed'
+	alias 'grek/alpha.barredEarlessCorner' null 'a.singleStoreyEarlessCornerSerifless'
+	alias 'grek/alpha.tailedBarredEarlessCorner' null 'a.singleStoreyEarlessCornerTailed'
 	select-variant 'grek/alpha'  0x3B1

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -4048,10 +4048,25 @@ rank = 1
 description = "Greek lower Alpha (`α`) with a cross-like shape at right"
 selector."grek/alpha" = "crossing"
 
-[prime.lower-alpha.variants.tailed-barred]
+[prime.lower-alpha.variants.barred]
 rank = 2
+description = "Greek lower Alpha (`α`) with a straight right bar"
+selector."grek/alpha" = "barred"
+
+[prime.lower-alpha.variants.tailed-barred]
+rank = 3
 description = "Greek lower Alpha (`α`) with a straight right bar and tail"
 selector."grek/alpha" = "tailedBarred"
+
+[prime.lower-alpha.variants.barred-earless-corner]
+rank = 4
+description = "Greek lower Alpha (`α`) with a straight right bar and earless (corner top-right)"
+selector."grek/alpha" = "barredEarlessCorner"
+
+[prime.lower-alpha.variants.tailed-barred-earless-corner]
+rank = 5
+description = "Greek lower Alpha (`α`) with a straight right bar, earless (corner top-right), and curly tail"
+selector."grek/alpha" = "tailedBarredEarlessCorner"
 
 
 
@@ -7109,7 +7124,7 @@ r = "earless-corner-serifless"
 u = "toothless-corner-serifless"
 y = "straight-turn-serifless"
 eszet = "longs-s-lig"
-lower-alpha = "tailed-barred"
+lower-alpha = "barred-earless-corner"
 lower-iota = "tailed-serifed"
 lower-lambda = "straight-turn"
 lower-mu = "toothless-corner"
@@ -7141,8 +7156,8 @@ p = "earless-corner-serifed"
 u = "tailed-serifless"
 long-s = "bent-hook-tailed"
 eszet = "longs-s-lig-tailed"
+lower-alpha = "tailed-barred-earless-corner"
 lower-mu = "tailed"
-cyrl-capital-u = "straight-turn-serifed"
 micro-sign = "tailed"
 
 [composite.ss12.slab-override.design]
@@ -7161,6 +7176,7 @@ u = "toothless-corner-serifed"
 y = "straight-turn-serifed"
 cyrl-capital-ka = "symmetric-touching-serifed"
 cyrl-ka = "symmetric-touching-serifed"
+cyrl-capital-u = "straight-turn-serifed"
 
 [composite.ss12.slab-override.italic]
 d = "tailed-serifed"
@@ -7242,7 +7258,7 @@ u = "toothless-rounded-serifless"
 w = "straight-flat-top-serifless"
 y = "straight-serifless"
 long-s = "flat-hook-serifless"
-lower-alpha = "tailed-barred"
+lower-alpha = "barred"
 lower-delta = "flat-top"
 lower-mu = "tailless"
 lower-xi = "rounded"


### PR DESCRIPTION
Also fix `ss12`'s variant assignment for Cyrillic Capital U under italics, as it should have been under slab.

The following variant additions are based on the original fonts.

`αaУ`

`ss12` Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/c611ef9a-3c72-420e-9de8-ec6f54f86c86)
`ss12` Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/f4e9ccec-bf12-43ac-9475-98741f940810)
`ss14` Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/232e0c03-be90-4a5c-9881-5a04265f74bf)
`ss14` Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/6b07cd23-81a3-47d0-b071-f3c27013f395)
