### PR TITLE
Eta and Insular R fixes

### DIFF
--- a/changes/25.0.0.md
+++ b/changes/25.0.0.md
@@ -1,15 +1,17 @@
 * \[**BREAKING**\] Add middle serifed and XH serifed variants for Long S (`U+017F`) without a baseline serif. As a result, current variants are reordered (#1807).
 * Add tailless bar, earless corner, and earless corner tailed variants for Greek Alpha (`U+03B1`).
 * Add Characters:
-  - CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH (`U+1F10F`).
-  - CIRCLED C WITH OVERLAID BACKSLASH (`U+1F16E`).
   - CYRILLIC CAPITAL LETTER DZZE (`U+A688`) (#1799).
   - CYRILLIC SMALL LETTER DZZE (`U+A689`) (#1799).
-  - MODIFIER LETTER CYRILLIC SMALL DZZE (`U+1E04A`) (#1799).
   - LATIN CAPITAL LETTER G WITH OBLIQUE STROKE (`U+A7A0`) ... LATIN SMALL LETTER S WITH OBLIQUE STROKE (`U+A7A9`) (#1818).
+  - MODIFIER LETTER CYRILLIC SMALL DZZE (`U+1E04A`) (#1799).
+  - CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH (`U+1F10F`).
+  - CIRCLED C WITH OVERLAID BACKSLASH (`U+1F16E`).
 * Fix reversed shape of `U+1D12` (#1814).
+* Fix right leg height of LATIN CAPITAL LETTER INSULAR R (`U+A782`) and LATIN SMALL LETTER INSULAR R (`U+A783`).
 * Fix effect of `cv23` on LATIN CAPITAL LETTER CHI (`A7B3`).
 * Make `cv36` affect LATIN SMALL LETTER KRA (`U+0138`) and GREEK SMALL LETTER KAPPA (`U+03BA`).
+* Make `cv39` affect GREEK SMALL LETTER ETA (`U+03B7`).
 * Fix variant assignment of `cv99` on `ss09`.
 * Fix variant assignment of `cv71` on `ss12` and `ss15`.
 * Fix variant assignment of `vxaa` on `ss16` and `ss17`.

--- a/font-src/glyphs/letter/latin/lower-n.ptl
+++ b/font-src/glyphs/letter/latin/lower-n.ptl
@@ -142,6 +142,13 @@ glyph-block Letter-Latin-Lower-N : begin
 			if sLB : include : sLB 0
 			if sRB : include : sRB Descender
 
+		create-glyph "grek/eta.\(suffix)" : glyph-proc
+			include : MarkSet.p
+			set-base-anchor 'lf' (SB + HalfStroke) 0
+			include : Body XH SB RightSB Descender Stroke
+			if sLT : include : sLT XH
+			if sLB : include : sLB 0
+
 		create-glyph "nCrossedTail.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			local fine : AdviceStroke 4
@@ -174,16 +181,16 @@ glyph-block Letter-Latin-Lower-N : begin
 
 		create-glyph "RInsular.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
-			include : Body CAP SB RightSB (0 + TailY - HalfStroke) Stroke
-			include : RetroflexHook.rExt RightSB (0 + TailY - HalfStroke)
+			include : Body CAP SB RightSB (XH - SmallArchDepthB + O) Stroke
+			include : EndingTail RightSB 0 (XH - SmallArchDepthB) Stroke
 			include : VBar.l SB Descender 0
 			if sLT : include : sLT CAP
 			if sLB : include : sLB Descender
 
 		create-glyph "rInsular.\(suffix)" : glyph-proc
 			include : MarkSet.p
-			include : Body XH SB RightSB (0 + TailY - HalfStroke) Stroke
-			include : RetroflexHook.rExt RightSB (0 + TailY - HalfStroke)
+			include : Body XH SB RightSB (XH - SmallArchDepthB + O) Stroke
+			include : EndingTail RightSB 0 (XH - SmallArchDepthB) Stroke
 			include : VBar.l SB Descender 0
 			if sLT : include : sLT XH
 			if sLB : include : sLB Descender
@@ -199,6 +206,7 @@ glyph-block Letter-Latin-Lower-N : begin
 	link-reduced-variant 'eng/phoneticRight' 'eng'
 	select-variant 'nHookBottom' 0x273 (follow -- 'eng')
 	select-variant 'nCurlyTail' 0x235 (follow -- 'eng')
+	select-variant 'grek/eta' 0x3B7 (follow -- 'eng')
 	select-variant 'nCrossedTail' 0xAB3B (follow -- 'eng')
 	select-variant 'engCrossedTail' 0xAB3C (follow -- 'eng')
 	select-variant 'RInsular' 0xA782 (follow -- 'eng')
@@ -221,20 +229,6 @@ glyph-block Letter-Latin-Lower-N : begin
 		include [refer-glyph src] AS_BASE ALSO_METRICS
 		eject-contour 'serifLB'
 		include : PalatalHook.lExt SB 0
-
-	# eta
-	create-glyph 'grek/eta' 0x3B7 : glyph-proc
-		include : MarkSet.p
-		set-base-anchor 'lf' (SB + HalfStroke) 0
-
-		include : nShoulder
-			left -- (SB + Stroke * HVContrast)
-			right -- RightSB
-			bottom -- Descender
-		include : VBar.l SB 0 XH
-		if SLAB : begin
-			include : tagged 'serifLT' : HSerif.lt SB XH SideJut
-
 
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarLeft
 	create-glyph 'mathbb/n' 0x1D55F : glyph-proc

--- a/font-src/glyphs/letter/latin/lower-n.ptl
+++ b/font-src/glyphs/letter/latin/lower-n.ptl
@@ -181,16 +181,16 @@ glyph-block Letter-Latin-Lower-N : begin
 
 		create-glyph "RInsular.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
-			include : Body CAP SB RightSB (XH - SmallArchDepthB + O) Stroke
-			include : EndingTail RightSB 0 (XH - SmallArchDepthB) Stroke
+			include : Body CAP SB RightSB (0 - Descender - HalfStroke) Stroke
+			include : RetroflexHook.rExt RightSB (0 - Descender - HalfStroke)
 			include : VBar.l SB Descender 0
 			if sLT : include : sLT CAP
 			if sLB : include : sLB Descender
 
 		create-glyph "rInsular.\(suffix)" : glyph-proc
 			include : MarkSet.p
-			include : Body XH SB RightSB (XH - SmallArchDepthB + O) Stroke
-			include : EndingTail RightSB 0 (XH - SmallArchDepthB) Stroke
+			include : Body XH SB RightSB (0 - Descender - HalfStroke) Stroke
+			include : RetroflexHook.rExt RightSB (0 - Descender - HalfStroke)
 			include : VBar.l SB Descender 0
 			if sLT : include : sLT XH
 			if sLB : include : sLB Descender


### PR DESCRIPTION
Most fonts have Greek Small Eta follow lowercase N, most noticeably on Ubuntu mono which inherits its earless cornered shape.

Additionally, using a full retroflex hook for Insular R puts both legs too close to each other. The left leg should descend below the baseline, but the right leg should not.

`Ꞃꞃnηῃ`

Sans:
![image](https://github.com/be5invis/Iosevka/assets/37010132/085e4b8f-2c2d-45d1-a5ae-0806c34fbdae)

Slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/14579c95-1216-4314-aca1-5853418faef8)

`ss12`:
![image](https://github.com/be5invis/Iosevka/assets/37010132/45c4b022-534e-410b-a44d-c48bde439bd9)

Original Ubuntu Mono font:
![image](https://github.com/be5invis/Iosevka/assets/37010132/787b1a7f-26e1-4a83-b4fa-40f65e10fc04)
