### PR TITLE
Fix math sans serif linking for new eta/mu variants

### DIFF
--- a/font-src/glyphs/letter/latin/lower-n.ptl
+++ b/font-src/glyphs/letter/latin/lower-n.ptl
@@ -210,6 +210,7 @@ glyph-block Letter-Latin-Lower-N : begin
 	select-variant 'RInsular' 0xA782 (follow -- 'eng')
 	select-variant 'rInsular' 0xA783 (follow -- 'eng')
 	select-variant 'grek/eta' 0x3B7
+	link-reduced-variant 'grek/eta/sansSerif' 'grek/eta' MathSansSerif
 	select-variant 'NExt' 0x220 (follow -- 'n')
 	select-variant 'nExt' 0x19E (follow -- 'n')
 

--- a/font-src/glyphs/letter/latin/u.ptl
+++ b/font-src/glyphs/letter/latin/u.ptl
@@ -229,6 +229,7 @@ glyph-block Letter-Latin-U : begin
 	select-variant 'u/uRTailBase' (shapeFrom -- 'u')
 
 	select-variant 'grek/mu' 0x3BC
+	link-reduced-variant 'grek/mu/sansSerif' 'grek/mu' MathSansSerif
 	select-variant 'micro'   0xB5  (shapeFrom -- 'grek/mu')
 
 	select-variant 'cyrl/i.italic' (shapeFrom -- 'u')

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2745,6 +2745,7 @@ selectorAffix."n/descBase" = ""
 selectorAffix.eng = ""
 selectorAffix."eng/phoneticRight" = ""
 selectorAffix."grek/eta" = ""
+selectorAffix."grek/eta/sansSerif" = ""
 selectorAffix."cyrl/pe.italic" = ""
 selectorAffix."cyrl/peItalicDescBase" = ""
 
@@ -2757,6 +2758,7 @@ selectorAffix."n/descBase" = "earlessCorner"
 selectorAffix.eng = "earlessCorner"
 selectorAffix."eng/phoneticRight" = "earlessCornerHTB"
 selectorAffix."grek/eta" = "earlessCorner"
+selectorAffix."grek/eta/sansSerif" = "earlessCorner"
 selectorAffix."cyrl/pe.italic" = ""
 selectorAffix."cyrl/peItalicDescBase" = ""
 
@@ -2769,6 +2771,7 @@ selectorAffix."n/descBase" = "earlessRounded"
 selectorAffix.eng = "earlessRounded"
 selectorAffix."eng/phoneticRight" = "earlessRoundedHTB"
 selectorAffix."grek/eta" = "earlessRounded"
+selectorAffix."grek/eta/sansSerif" = "earlessRounded"
 selectorAffix."cyrl/pe.italic" = ""
 selectorAffix."cyrl/peItalicDescBase" = ""
 
@@ -2784,6 +2787,7 @@ selectorAffix."n/descBase" = "straight"
 selectorAffix.eng = "straight"
 selectorAffix."eng/phoneticRight" = "straight"
 selectorAffix."grek/eta" = "straight"
+selectorAffix."grek/eta/sansSerif" = "straight"
 selectorAffix."cyrl/pe.italic" = "straight"
 selectorAffix."cyrl/peItalicDescBase" = "straight"
 
@@ -2796,6 +2800,7 @@ selectorAffix."n/descBase" = "straight"
 selectorAffix.eng = "straight"
 selectorAffix."eng/phoneticRight" = "straight"
 selectorAffix."grek/eta" = "straight"
+selectorAffix."grek/eta/sansSerif" = "straight"
 selectorAffix."cyrl/pe.italic" = "tailed"
 selectorAffix."cyrl/peItalicDescBase" = "straight"
 
@@ -2809,6 +2814,7 @@ selectorAffix."n/descBase" = "serifless"
 selectorAffix.eng = "serifless"
 selectorAffix."eng/phoneticRight" = "serifless"
 selectorAffix."grek/eta" = "serifless"
+selectorAffix."grek/eta/sansSerif" = "serifless"
 selectorAffix."cyrl/pe.italic" = "serifless"
 selectorAffix."cyrl/peItalicDescBase" = "serifless"
 
@@ -2822,6 +2828,7 @@ selectorAffix."n/descBase" = "topLeftSerifed"
 selectorAffix.eng = "topLeftSerifed"
 selectorAffix."eng/phoneticRight" = "topLeftSerifed"
 selectorAffix."grek/eta" = "topLeftSerifed"
+selectorAffix."grek/eta/sansSerif" = "serifless"
 selectorAffix."cyrl/pe.italic" = "topLeftSerifed"
 selectorAffix."cyrl/peItalicDescBase" = "motionSerifed"
 
@@ -2835,6 +2842,7 @@ selectorAffix."n/descBase" = "topLeftSerifed"
 selectorAffix.eng = "topLeftSerifed"
 selectorAffix."eng/phoneticRight" = "topLeftSerifed"
 selectorAffix."grek/eta" = "topLeftSerifed"
+selectorAffix."grek/eta/sansSerif" = "serifless"
 selectorAffix."cyrl/pe.italic" = "motionSerifed"
 selectorAffix."cyrl/peItalicDescBase" = "motionSerifed"
 
@@ -2847,6 +2855,7 @@ selectorAffix."n/descBase" = "serifed"
 selectorAffix.eng = "serifed"
 selectorAffix."eng/phoneticRight" = "serifed"
 selectorAffix."grek/eta" = "topLeftSerifed"
+selectorAffix."grek/eta/sansSerif" = "serifless"
 selectorAffix."cyrl/pe.italic" = "serifed"
 selectorAffix."cyrl/peItalicDescBase" = "serifed"
 
@@ -4219,43 +4228,51 @@ next = "serifs"
 rank = 1
 descriptionAffix = "toothed shape"
 selectorAffix."grek/mu" = "toothed"
+selectorAffix."grek/mu/sansSerif" = "toothed"
 
 [prime.lower-mu.variants-buildup.stages.body.tailed]
 rank = 2
 descriptionAffix = "tailed shape"
 selectorAffix."grek/mu" = "tailed"
+selectorAffix."grek/mu/sansSerif" = "tailed"
 
 [prime.lower-mu.variants-buildup.stages.body.toothless-corner]
 rank = 3
 descriptionAffix = "toothless (corner bottom-right) shape"
 selectorAffix."grek/mu" = "toothlessCorner"
+selectorAffix."grek/mu/sansSerif" = "toothlessCorner"
 
 [prime.lower-mu.variants-buildup.stages.body.toothless-rounded]
 rank = 4
 descriptionAffix = "toothless (rounded) shape"
 selectorAffix."grek/mu" = "toothlessRounded"
+selectorAffix."grek/mu/sansSerif" = "toothlessRounded"
 
 [prime.lower-mu.variants-buildup.stages.serifs.serifless]
 rank = 1
 descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix."grek/mu" = "serifless"
+selectorAffix."grek/mu/sansSerif" = "serifless"
 
 [prime.lower-mu.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
 descriptionAffix = "motion serifs at top-left and bottom-right"
 selectorAffix."grek/mu" = "motionSerifed"
+selectorAffix."grek/mu/sansSerif" = "serifless"
 
 [prime.lower-mu.variants-buildup.stages.serifs.bottom-right-serifed]
 rank = 3
 disableIf = [{ body = "NOT toothed" }]
 descriptionAffix = "serif at bottom-right"
 selectorAffix."grek/mu" = "bottomRightSerifed"
+selectorAffix."grek/mu/sansSerif" = "serifless"
 
 [prime.lower-mu.variants-buildup.stages.serifs.serifed]
 rank = 4
 descriptionAffix = "serifs"
 selectorAffix."grek/mu" = "serifed"
+selectorAffix."grek/mu/sansSerif" = "serifless"
 
 
 


### PR DESCRIPTION
Below is a comparison between the plain greek letters and math bold sans serif under `ss16`.

`η𝝶μ𝝻`
![image](https://github.com/be5invis/Iosevka/assets/37010132/d8683ff7-84a3-483f-aa01-3c9b52cd4506)