### PR TITLE
Add bottom-only serif variant for Gamma for `cv12`

### DIFF
--- a/changes/25.0.0.md
+++ b/changes/25.0.0.md
@@ -10,6 +10,7 @@
   - `micro-sign`.`toothless-corner` → `micro-sign`.`toothless-corner-serifless`
   - `micro-sign`.`toothless-rounded` → `micro-sign`.`toothless-rounded-serifless`
 * Add tailless bar, earless corner, and earless corner tailed variants for Greek Alpha (`U+03B1`).
+* Add bottom serifed variant for Greek Gamma (`U+0393`).
 * Add serifed variants for Greek Mu (`U+03BC`).
 * Add Characters:
   - CYRILLIC CAPITAL LETTER DZZE (`U+A688`) (#1799).
@@ -24,6 +25,7 @@
 * Fix reversed shape of `U+1D12` (#1814).
 * Fix right leg height of LATIN CAPITAL LETTER INSULAR R (`U+A782`) and LATIN SMALL LETTER INSULAR R (`U+A783`).
 * Fix effect of `cv23` on LATIN CAPITAL LETTER CHI (`A7B3`).
+* Fix effect of `cv46` on LATIN SMALL LETTER TURNED V (`U+028C`).
 * Make `cv36` affect LATIN SMALL LETTER KRA (`U+0138`) and GREEK SMALL LETTER KAPPA (`U+03BA`).
 * Make `cv39` affect GREEK SMALL LETTER ETA (`U+03B7`).
 * Fix variant assignment of `cv45` on `ss16`.

--- a/font-src/glyphs/letter/greek/upper-gamma.ptl
+++ b/font-src/glyphs/letter/greek/upper-gamma.ptl
@@ -15,10 +15,11 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 	glyph-block-import Letter-Latin-Upper-F : xMidBarShrink
 	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors
 
-	define SLAB-NONE 0
-	define SLAB-TR   1
-	define SLAB-LT   2
-	define SLAB-ALL  3
+	define SLAB-NONE   0
+	define SLAB-TR     1
+	define SLAB-LT     2
+	define SLAB-BOTTOM 3
+	define SLAB-ALL    4
 
 	define GammaBarLeft (SB * 1.5)
 	define [GammaShape top slabType] : glyph-proc
@@ -30,16 +31,20 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 				include : HSerif.lb (GammaBarLeft + HVContrast * HalfStroke) 0 Jut
 				include : HSerif.rb (GammaBarLeft + HVContrast * HalfStroke) 0 MidJutSide
 				include : tagged 'serifRT' : VSerif.dr (RightSB - OX) top VJut
+			[Just SLAB-BOTTOM] : begin
+				include : HSerif.lb (GammaBarLeft + HVContrast * HalfStroke) 0 Jut
+				include : HSerif.rb (GammaBarLeft + HVContrast * HalfStroke) 0 MidJutSide
 			[Just SLAB-LT] : begin
 				include : HSerif.lt GammaBarLeft top SideJut
 			[Just SLAB-TR] : begin
 				include : tagged 'serifRT' : VSerif.dr (RightSB - OX) top VJut
 
 	define GammaConfig : object
-		serifless       { SLAB-NONE  false }
-		topLeftSerifed  { SLAB-LT    false }
-		topRightSerifed { SLAB-TR    false }
-		serifed         { SLAB-ALL   true  }
+		serifless       { SLAB-NONE   false }
+		topLeftSerifed  { SLAB-LT     false }
+		topRightSerifed { SLAB-TR     false }
+		bottomSerifed   { SLAB-BOTTOM false }
+		serifed         { SLAB-ALL    true  }
 
 	foreach { suffix { slabType doSB } } [Object.entries GammaConfig] : do
 		create-glyph "grek/Gamma.\(suffix)" : glyph-proc
@@ -118,7 +123,7 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 	select-variant 'cyrl/ghe.upright'
 	select-variant 'cyrl/gheDescender.upright' (follow -- 'cyrl/ghe.upright')
 	select-variant 'cyrl/gheDHook.upright' (follow -- 'cyrl/ghe.upright')
-	alias 'grek/smcpGamma' 0x1D26 'cyrl/ghe.upright'
+	select-variant 'grek/smcpGamma' 0x1D26 (shapeFrom -- 'cyrl/ghe.upright') (follow -- 'grek/Gamma')
 	select-variant 'cyrl/ge.upright'
 	select-variant 'cyrl/ge.italic'
 

--- a/font-src/glyphs/letter/latin/v.ptl
+++ b/font-src/glyphs/letter/latin/v.ptl
@@ -282,10 +282,7 @@ glyph-block Letter-Latin-V : begin
 	select-variant 'cyrl/Yn' 0xA65E (follow -- 'VHookRight')
 	alias 'cyrl/izhitsa' 0x475 'vHookRight'
 
-
-	turned 'turnv.straight' nothing 'v.straight' Middle (XH / 2)
-	turned 'turnv.curly' nothing 'v.curly' Middle (XH / 2)
-	select-variant 'turnv' 0x28C (follow -- 'grek/Lambda')
+	turned 'turnv' 0x28C 'v/nonCursive' Middle (XH / 2)
 
 	glyph-block-export BBVShape BBVInnerMaskShape BBVOuterMaskShape
 	define [BBVShape l r kd ks top] : glyph-proc

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -4125,8 +4125,19 @@ selector."cyrl/ghe.upright" = "topRightSerifed"
 selector."cyrl/ge.upright" = "serifless"
 selector."cyrl/ge.italic" = "serifless"
 
-[prime.capital-gamma.variants.serifed]
+[prime.capital-gamma.variants.bottom-serifed]
 rank = 3
+description = "Standard capital Gamma (`Γ`) with bottom serif"
+selector."grek/Gamma" = "bottomSerifed"
+selector."grek/Gamma/sansSerif" = "serifless"
+selector."cyrl/Ghe" = "bottomSerifed"
+selector."cyrl/Ge" = "bottomSerifed"
+selector."cyrl/ghe.upright" = "serifless"
+selector."cyrl/ge.upright" = "serifless"
+selector."cyrl/ge.italic" = "serifless"
+
+[prime.capital-gamma.variants.serifed]
+rank = 4
 description = "Standard capital Gamma (`Γ`) with motion serifs at top and bottom"
 selector."grek/Gamma" = "serifed"
 selector."grek/Gamma/sansSerif" = "serifless"
@@ -7276,6 +7287,7 @@ u = "toothless-corner-serifless"
 y = "straight-turn-serifless"
 eszet = "longs-s-lig"
 lower-alpha = "barred-earless-corner"
+capital-gamma = "bottom-serifed"
 lower-iota = "tailed-serifed"
 lower-lambda = "straight-turn"
 lower-mu = "toothless-corner-serifless"
@@ -7327,6 +7339,7 @@ q = "earless-corner-straight-serifed"
 u = "toothless-corner-serifed"
 y = "straight-turn-serifed"
 lower-mu = "toothless-corner-serifed"
+capital-gamma = "serifed"
 cyrl-capital-ka = "symmetric-touching-serifed"
 cyrl-ka = "symmetric-touching-serifed"
 cyrl-em = "slanted-sides-hanging-serifed"


### PR DESCRIPTION
Also disunify small turned V with capital lambda.

From left to right: Capital Gamma, Small Capital Gamma, Small Ghe, Capital Lambda, Small Capital Lambda, Small Turned V.

`ΓᴦгΛᴧʌ`

Default Slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/5896b630-59dd-4bf1-b3ad-022f7b215a37)

Default Slab Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/17ff820d-0bf6-4767-af20-e9b3b74c32ae)

`ss12`:
![image](https://github.com/be5invis/Iosevka/assets/37010132/8ed56d1f-fe3c-42bc-b7d1-ee03c23bbc85)

original Ubuntu Mono font (it does not have the small capital characters):
![image](https://github.com/be5invis/Iosevka/assets/37010132/09becf91-64b2-4dcd-b238-6902aed38564)
Note that in the original font, only capital gamma/ghe has a baseline-only serif version, not lowercase ghe.
