### PR TITLE
Some Christian Crosses

### DIFF
--- a/changes/25.0.2.md
+++ b/changes/25.0.2.md
@@ -1,3 +1,9 @@
+* Add Characters:
+  - ORTHODOX CROSS (`U+2626`).
+  - CROSS OF LORRAINE (`U+2628`).
+  - LATIN CROSS (`U+271D`) (#1841).
+  - HEAVY LATIN CROSS (`U+1F547`).
+  - CELTIC CROSS (`U+1F548`).
 * Refine shape of `U+A666` and `U+A667` (#1838).
 * Make `cv33` affect `U+0270`, `U+02AE`, and `U+02AF`.
 * Make `cv42` affect serifs of `U+027F`.

--- a/font-src/glyphs/symbol/pictograph.ptl
+++ b/font-src/glyphs/symbol/pictograph.ptl
@@ -6,6 +6,7 @@ export : define [apply] : begin
 	run-glyph-module "./pictograph/astronomy.mjs"
 	run-glyph-module "./pictograph/atom.mjs"
 	run-glyph-module "./pictograph/bolt-symbol.mjs"
+	run-glyph-module "./pictograph/christian-cross.mjs"
 	run-glyph-module "./pictograph/checking-marks.mjs"
 	run-glyph-module "./pictograph/faces.mjs"
 	run-glyph-module "./pictograph/flags.mjs"

--- a/font-src/glyphs/symbol/pictograph/christian-cross.ptl
+++ b/font-src/glyphs/symbol/pictograph/christian-cross.ptl
@@ -11,6 +11,7 @@ glyph-block Symbol-Christian-Cross : for-width-kinds WideWidth1
 	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade GeometricSizes
 
 	define Geom : GeometricDim MosaicUnitWidth MosaicWidth
+	define Size : GeometricSizes Geom
 
 	define mediumSw     : UnicodeWeightGrade 5    Geom.Scalar
 	define heavySw      : UnicodeWeightGrade 9    Geom.Scalar
@@ -19,9 +20,10 @@ glyph-block Symbol-Christian-Cross : for-width-kinds WideWidth1
 	define pShortBar 0.6
 	define pRing 0.6
 
-	define shortSize : Math.min (RightSB - SB) (Geom.TallSize * 2 / (pBottom + 1))
-	define yTop : Geom.MidY + Geom.TallSize
-	define yBot : Geom.MidY - Geom.TallSize
+	define crossHeight : Geom.Size * Size.Large.size * 2
+	define shortSize : crossHeight / (pBottom + 1)
+	define yTop : Geom.MidY + 0.5 * crossHeight
+	define yBot : Geom.MidY - 0.5 * crossHeight
 	define yCenter : yTop - shortSize
 
 	define [LatinCross sw fSecondBar] : glyph-proc

--- a/font-src/glyphs/symbol/pictograph/christian-cross.ptl
+++ b/font-src/glyphs/symbol/pictograph/christian-cross.ptl
@@ -1,0 +1,58 @@
+$$include '../../../meta/macros.ptl'
+
+import [mix linreg clamp fallback] from"../../../support/utils.mjs"
+import [DesignParameters] from"../../../meta/aesthetics.mjs"
+
+glyph-module
+
+glyph-block Symbol-Christian-Cross : for-width-kinds WideWidth1
+	glyph-block-import CommonShapes
+	glyph-block-import Common-Derivatives
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade GeometricSizes
+
+	define Geom : GeometricDim MosaicUnitWidth MosaicWidth
+
+	define mediumSw     : UnicodeWeightGrade 5    Geom.Scalar
+	define heavySw      : UnicodeWeightGrade 9    Geom.Scalar
+
+	define pBottom 2
+	define pShortBar 0.6
+	define pRing 0.6
+
+	define shortSize : Math.min (RightSB - SB) (Geom.TallSize * 2 / (pBottom + 1))
+	define yTop : Geom.MidY + Geom.TallSize
+	define yBot : Geom.MidY - Geom.TallSize
+	define yCenter : yTop - shortSize
+
+	define [LatinCross sw fSecondBar] : glyph-proc
+		include : dispiro
+			corner Geom.MidX yTop [widths.center sw]
+			corner Geom.MidX yBot
+		include : dispiro
+			corner (Geom.MidX - shortSize) yCenter [widths.center sw]
+			corner (Geom.MidX + shortSize) yCenter
+		if fSecondBar : include : dispiro
+			corner (Geom.MidX - pShortBar * shortSize) [mix yCenter yTop 0.5] [widths.center sw]
+			corner (Geom.MidX + pShortBar * shortSize) [mix yCenter yTop 0.5]
+
+	create-glyph [MangleName 'latinCross'] [MangleUnicode 0x271D] : glyph-proc
+		set-width Geom.Width
+		include : LatinCross mediumSw false
+	create-glyph [MangleName 'heavyLatinCross'] [MangleUnicode 0x1F547] : glyph-proc
+		set-width Geom.Width
+		include : LatinCross heavySw false
+
+	create-glyph [MangleName 'lorraineCross'] [MangleUnicode 0x2628] : glyph-proc
+		set-width Geom.Width
+		include : LatinCross mediumSw true
+	create-glyph [MangleName 'orthodoxCross'] [MangleUnicode 0x2626] : glyph-proc
+		set-width Geom.Width
+		include : LatinCross mediumSw true
+		include : dispiro
+			corner (Geom.MidX - pShortBar * shortSize) [mix yBot yCenter 0.45] [widths.center mediumSw]
+			corner (Geom.MidX + pShortBar * shortSize) [mix yBot yCenter 0.3]
+	create-glyph [MangleName 'celticCross'] [MangleUnicode 0x1F548] : glyph-proc
+		set-width Geom.Width
+		include : LatinCross mediumSw false
+		include : RingStrokeAt Geom.MidX yCenter (pRing * shortSize + 0.5 * mediumSw) mediumSw
+


### PR DESCRIPTION
Resolves #1841, with a few more related glyphs. Using the same approach to other Geometric mosaic characters (in particular Greek Cross), implemented like a Greek Cross but the bottom bar is longer than the other 3.

`a`, Dagger and Heavy Greek Cross for reference: 
![image](https://github.com/be5invis/Iosevka/assets/21302803/98ff582d-46ef-43c2-af0e-246d68d124ff)

The issue discussed about differentiation with Dagger, but it turns out Iosevka's Dagger is so tall anyway that it is probably different enough already.

It is Fullwidth by default though, following Greek Cross. Here's the halfwidth version:
![image](https://github.com/be5invis/Iosevka/assets/21302803/6b211862-d50e-4eda-a3d2-5df40f77580b)