### PR TITLE
Fix behavior of turned M slabs under Etoile

### DIFF
--- a/font-src/glyphs/letter/latin/lower-m.ptl
+++ b/font-src/glyphs/letter/latin/lower-m.ptl
@@ -86,12 +86,6 @@ glyph-block Letter-Latin-Lower-M : begin
 		include : SmallMBottomMiddleSerif df top mbot
 		if [not tailed] : include : SmallMBottomRightSerif df top rbot
 
-	define [SmallTurnMSerifs df top lbot mbot rbot tailed earless] : glyph-proc
-		if [not earless] : include : SmallMTopLeftSerif df top lbot
-		if [not para.isItalic] : include : SmallMBottomLeftSerif df top lbot
-		include : SmallMBottomMiddleSerif df top mbot
-		if [not tailed] : include : SmallMBottomRightSerif df top rbot
-
 	define [AutoSerifs df top lbot mbot rbot tailed earless] : begin
 		if SLAB [FullSerifs df top lbot mbot rbot tailed earless] [no-shape]
 
@@ -277,7 +271,7 @@ glyph-block Letter-Latin-Lower-M : begin
 			"toothlessRounded"   { EarlessRoundedDoubleArchSmallMShape 1 0 }
 		object
 			"serifless"          { no-shape   }
-			"serifed"            { SmallTurnMSerifs }
+			"serifed"            { FullSerifs }
 			"bottomRightSerifed" { LtSerifs }
 			"motionSerifed"      { LtRbSerifs }
 


### PR DESCRIPTION
It had just occurred to me that removing the top right slab under italics only works when the font is monospaced.
As a side note, Cyrillic Sha will now behave identically to how it does in 25.0.1.

Quasi-Proportional Slab Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/28cdc3a0-7bc3-45d5-a2df-438341cfdf3f)

Quasi-Proportional Slab Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/f4ec10e4-8a14-479c-9f9b-87d5eed018b4)

