### PR TITLE
Sort Greek letter variants in alphabetical order

### DIFF
--- a/params/variants.toml
+++ b/params/variants.toml
@@ -4148,23 +4148,6 @@ selector."grek/alpha" = "tailedBarredEarlessCorner"
 
 
 
-[prime.lower-delta]
-sampler = "δ"
-samplerExplain = "Greek lower Delta"
-tagKind = "letter"
-
-[prime.lower-delta.variants.rounded]
-rank = 1
-description = "Greek lower Delta (`δ`) with rounded top"
-selector."grek/delta" = "rounded"
-
-[prime.lower-delta.variants.flat-top]
-rank = 2
-description = "Greek lower Delta (`δ`) with flat top"
-selector."grek/delta" = "flatTop"
-
-
-
 [prime.capital-gamma]
 sampler = "Γ"
 samplerExplain = "Greek capital Gamma"
@@ -4230,6 +4213,23 @@ selector."grek/Delta" = "straight"
 rank = 2
 description = "Slightly curly Greek capital Delta (`Δ`), like Iosevka 2.x"
 selector."grek/Delta" = "curly"
+
+
+
+[prime.lower-delta]
+sampler = "δ"
+samplerExplain = "Greek lower Delta"
+tagKind = "letter"
+
+[prime.lower-delta.variants.rounded]
+rank = 1
+description = "Greek lower Delta (`δ`) with rounded top"
+selector."grek/delta" = "rounded"
+
+[prime.lower-delta.variants.flat-top]
+rank = 2
+description = "Greek lower Delta (`δ`) with flat top"
+selector."grek/delta" = "flatTop"
 
 
 
@@ -7952,12 +7952,12 @@ x = "cursive"
 y = "cursive-serifless"
 z = "cursive"
 long-s = "bent-hook-descending"
-lower-thorn = "serifed"
 eszet = "longs-s-lig-descending"
 
 [composite.ss17.slab-override.design]
 capital-u = "toothed-serifed"
 y = "straight-turn-serifed"
+lower-thorn = "serifed"
 cyrl-capital-u = "straight-turn-serifed"
 micro-sign = "tailed-serifed"
 


### PR DESCRIPTION
Alpha, Beta, Gamma, Delta, alternating capital/lowercase.

Also correct `ss17`'s thorn slab override.