### PR TITLE
Sort Cyrillic letter variants in alphabetic order

### DIFF
--- a/params/variants.toml
+++ b/params/variants.toml
@@ -4922,66 +4922,6 @@ selectorAffix."cyrl/njeKomi" = "serifedExceptBottomRight"
 
 
 
-[prime.cyrl-ef]
-sampler = "ф"
-samplerExplain = "Cyrillic Lower Ef"
-tagKind = "letter"
-
-[prime.cyrl-ef.variants.serifless]
-rank = 1
-description = "Cyrillic Lower Ef (`ф`) with standard shape and without serifs"
-selector."cyrl/ef"  = "serifless"
-
-[prime.cyrl-ef.variants.cursive]
-rank = 2
-description = "Cyrillic Lower Ef (`ф`) with cursive shape"
-selector."cyrl/ef"  = "cursive"
-
-[prime.cyrl-ef.variants.top-serifed]
-rank = 3
-description = "Cyrillic Lower Ef (`ф`) with standard shape and serif at top"
-selector."cyrl/ef"  = "topSerifed"
-
-[prime.cyrl-ef.variants.serifed]
-rank = 4
-description = "Cyrillic Lower Ef (`ф`) with standard shape and serifs at top and bottom"
-selector."cyrl/ef"  = "serifed"
-
-
-
-[prime.latn-phi]
-# Untagged -- shape change only
-[prime.latn-phi.variants.serifless]
-rank = 1
-selector."latn/phi"  = "serifless"
-
-[prime.latn-phi.variants.top-serifed]
-rank = 2
-selector."latn/phi"  = "topSerifed"
-
-[prime.latn-phi.variants.serifed]
-rank = 3
-selector."latn/phi"  = "serifed"
-
-
-
-[prime.cyrl-che]
-sampler = "ч"
-samplerExplain = "Cyrillic Lower Che"
-tagKind = "letter"
-
-[prime.cyrl-che.variants.standard]
-rank = 1
-description = "Cyrillic Lower Che (`ч`) with standard shape"
-selector."cyrl/che" = "standard"
-
-[prime.cyrl-che.variants.tailed]
-rank = 2
-description = "Cyrillic Lower Che (`ч`) with tail"
-selector."cyrl/che" = "tailed"
-
-
-
 [prime.cyrl-capital-u]
 sampler = "У"
 samplerExplain = "Cyrillic Capital U"
@@ -5044,6 +4984,178 @@ selectorAffix."cyrl/U" = "motionSerifed"
 rank = 3
 descriptionAffix = "serifs"
 selectorAffix."cyrl/U" = "serifed"
+
+
+
+[prime.cyrl-ef]
+sampler = "ф"
+samplerExplain = "Cyrillic Lower Ef"
+tagKind = "letter"
+
+[prime.cyrl-ef.variants.serifless]
+rank = 1
+description = "Cyrillic Lower Ef (`ф`) with standard shape and without serifs"
+selector."cyrl/ef"  = "serifless"
+
+[prime.cyrl-ef.variants.cursive]
+rank = 2
+description = "Cyrillic Lower Ef (`ф`) with cursive shape"
+selector."cyrl/ef"  = "cursive"
+
+[prime.cyrl-ef.variants.top-serifed]
+rank = 3
+description = "Cyrillic Lower Ef (`ф`) with standard shape and serif at top"
+selector."cyrl/ef"  = "topSerifed"
+
+[prime.cyrl-ef.variants.serifed]
+rank = 4
+description = "Cyrillic Lower Ef (`ф`) with standard shape and serifs at top and bottom"
+selector."cyrl/ef"  = "serifed"
+
+
+
+[prime.latn-phi]
+# Untagged -- shape change only
+[prime.latn-phi.variants.serifless]
+rank = 1
+selector."latn/phi"  = "serifless"
+
+[prime.latn-phi.variants.top-serifed]
+rank = 2
+selector."latn/phi"  = "topSerifed"
+
+[prime.latn-phi.variants.serifed]
+rank = 3
+selector."latn/phi"  = "serifed"
+
+
+
+[prime.cyrl-che]
+sampler = "ч"
+samplerExplain = "Cyrillic Lower Che"
+tagKind = "letter"
+
+[prime.cyrl-che.variants.standard]
+rank = 1
+description = "Cyrillic Lower Che (`ч`) with standard shape"
+selector."cyrl/che" = "standard"
+
+[prime.cyrl-che.variants.tailed]
+rank = 2
+description = "Cyrillic Lower Che (`ч`) with tail"
+selector."cyrl/che" = "tailed"
+
+
+
+[prime.cyrl-capital-yeri]
+# No tags and sampler -- for style-driven variation
+
+[prime.cyrl-capital-yeri.variants.corner]
+rank = 1
+selector."cyrl/Yer"  = "corner"
+selector."cyrl/Yeri" = "corner"
+selector."cyrl/YeriBar" = "corner"
+selector."cyrl/Yery" = "corner"
+selector."cyrl/Nje/rightHalf"  = "corner"
+selector."cyrl/Lje"  = "corner"
+
+[prime.cyrl-capital-yeri.variants.round]
+rank = 2
+selector."cyrl/Yer"  = "round"
+selector."cyrl/Yeri" = "round"
+selector."cyrl/YeriBar" = "round"
+selector."cyrl/Yery" = "round"
+selector."cyrl/Nje/rightHalf"  = "round"
+selector."cyrl/Lje"  = "round"
+
+[prime.cyrl-capital-yeri.variants.cursive]
+rank = 3
+selector."cyrl/Yer"  = "cursive"
+selector."cyrl/Yeri" = "cursive"
+selector."cyrl/YeriBar" = "cursive"
+selector."cyrl/Yery" = "cursive"
+selector."cyrl/Nje/rightHalf"  = "cursive"
+selector."cyrl/Lje"  = "cursive"
+
+
+
+[prime.cyrl-yeri]
+sampler = "ь"
+samplerExplain = "Cyrillic Lower Yeri and related letters"
+tagKind = "letter"
+
+[prime.cyrl-yeri.variants.corner]
+rank = 1
+description = "Cyrillic Lower Yeri (`ь`) with corner at bottom left"
+selector."cyrl/yer"  = "corner"
+selector."cyrl/yer.BGR"  = "round" # Bulgarian
+selector."cyrl/yeri" = "corner"
+selector."cyrl/yeri.BGR" = "round" # Bulgarian
+selector."cyrl/yeriBar" = "corner"
+selector."cyrl/nje/rightHalf"  = "corner"
+selector."cyrl/lje"  = "corner"
+selector."latn/yatSakha.upright"  = "corner"
+
+[prime.cyrl-yeri.variants.round]
+rank = 2
+description = "Cyrillic Lower Yeri (`ь`) with rounded shape"
+selector."cyrl/yer"  = "round"
+selector."cyrl/yer.BGR"  = "round"
+selector."cyrl/yeri" = "round"
+selector."cyrl/yeri.BGR" = "round"
+selector."cyrl/yeriBar" = "round"
+selector."cyrl/nje/rightHalf"  = "round"
+selector."cyrl/lje"  = "round"
+selector."latn/yatSakha.upright" = "round"
+
+[prime.cyrl-yeri.variants.cursive]
+rank = 3
+description = "Cyrillic Lower Yeri (`ь`) with cursive shape"
+selector."cyrl/yer"  = "cursive"
+selector."cyrl/yer.BGR"  = "cursive"
+selector."cyrl/yeri" = "cursive"
+selector."cyrl/yeri.BGR" = "cursive"
+selector."cyrl/yeriBar" = "cursive"
+selector."cyrl/nje/rightHalf"  = "cursive"
+selector."cyrl/lje"  = "cursive"
+selector."latn/yatSakha.upright" = "cursive"
+
+
+
+[prime.cyrl-yery]
+sampler = "ы"
+samplerExplain = "Cyrillic Lower Yery"
+tagKind = "letter"
+
+[prime.cyrl-yery.variants.corner]
+rank = 1
+description = "Cyrillic Lower Yery (`ы`) with corner at bottom left"
+selector."cyrl/yery" = "corner"
+
+[prime.cyrl-yery.variants.corner-tailed]
+rank = 2
+description = "Cyrillic Lower Yery (`ы`) with corner at bottom left and tail"
+selector."cyrl/yery" = "cornerTailed"
+
+[prime.cyrl-yery.variants.round]
+rank = 3
+description = "Cyrillic Lower Yery (`ы`) with rounded shape"
+selector."cyrl/yery" = "round"
+
+[prime.cyrl-yery.variants.round-tailed]
+rank = 4
+description = "Cyrillic Lower Yery (`ы`) with rounded shape and tail"
+selector."cyrl/yery" = "roundTailed"
+
+[prime.cyrl-yery.variants.cursive]
+rank = 5
+description = "Cyrillic Lower Yery (`ы`) with cursive shape"
+selector."cyrl/yery" = "cursive"
+
+[prime.cyrl-yery.variants.cursive-tailed]
+rank = 6
+description = "Cyrillic Lower Yery (`ы`) with cursive shape and tail"
+selector."cyrl/yery" = "cursiveTailed"
 
 
 
@@ -5170,118 +5282,6 @@ selectorAffix."cyrl/ya" = "serifless"
 rank = 2
 descriptionAffix = "serifs"
 selectorAffix."cyrl/ya" = "smallCyrl"
-
-
-
-[prime.cyrl-capital-yeri]
-# No tags and sampler -- for style-driven variation
-
-[prime.cyrl-capital-yeri.variants.corner]
-rank = 1
-selector."cyrl/Yer"  = "corner"
-selector."cyrl/Yeri" = "corner"
-selector."cyrl/YeriBar" = "corner"
-selector."cyrl/Yery" = "corner"
-selector."cyrl/Nje/rightHalf"  = "corner"
-selector."cyrl/Lje"  = "corner"
-
-[prime.cyrl-capital-yeri.variants.round]
-rank = 2
-selector."cyrl/Yer"  = "round"
-selector."cyrl/Yeri" = "round"
-selector."cyrl/YeriBar" = "round"
-selector."cyrl/Yery" = "round"
-selector."cyrl/Nje/rightHalf"  = "round"
-selector."cyrl/Lje"  = "round"
-
-[prime.cyrl-capital-yeri.variants.cursive]
-rank = 3
-selector."cyrl/Yer"  = "cursive"
-selector."cyrl/Yeri" = "cursive"
-selector."cyrl/YeriBar" = "cursive"
-selector."cyrl/Yery" = "cursive"
-selector."cyrl/Nje/rightHalf"  = "cursive"
-selector."cyrl/Lje"  = "cursive"
-
-
-
-[prime.cyrl-yeri]
-sampler = "ь"
-samplerExplain = "Cyrillic Lower Yeri and related letters"
-tagKind = "letter"
-
-[prime.cyrl-yeri.variants.corner]
-rank = 1
-description = "Cyrillic Lower Yeri (`ь`) with corner at bottom left"
-selector."cyrl/yer"  = "corner"
-selector."cyrl/yer.BGR"  = "round" # Bulgarian
-selector."cyrl/yeri" = "corner"
-selector."cyrl/yeri.BGR" = "round" # Bulgarian
-selector."cyrl/yeriBar" = "corner"
-selector."cyrl/nje/rightHalf"  = "corner"
-selector."cyrl/lje"  = "corner"
-selector."latn/yatSakha.upright"  = "corner"
-
-[prime.cyrl-yeri.variants.round]
-rank = 2
-description = "Cyrillic Lower Yeri (`ь`) with rounded shape"
-selector."cyrl/yer"  = "round"
-selector."cyrl/yer.BGR"  = "round"
-selector."cyrl/yeri" = "round"
-selector."cyrl/yeri.BGR" = "round"
-selector."cyrl/yeriBar" = "round"
-selector."cyrl/nje/rightHalf"  = "round"
-selector."cyrl/lje"  = "round"
-selector."latn/yatSakha.upright" = "round"
-
-[prime.cyrl-yeri.variants.cursive]
-rank = 3
-description = "Cyrillic Lower Yeri (`ь`) with cursive shape"
-selector."cyrl/yer"  = "cursive"
-selector."cyrl/yer.BGR"  = "cursive"
-selector."cyrl/yeri" = "cursive"
-selector."cyrl/yeri.BGR" = "cursive"
-selector."cyrl/yeriBar" = "cursive"
-selector."cyrl/nje/rightHalf"  = "cursive"
-selector."cyrl/lje"  = "cursive"
-selector."latn/yatSakha.upright" = "cursive"
-
-
-
-[prime.cyrl-yery]
-sampler = "ы"
-samplerExplain = "Cyrillic Lower Yery"
-tagKind = "letter"
-
-[prime.cyrl-yery.variants.corner]
-rank = 1
-description = "Cyrillic Lower Yery (`ы`) with corner at bottom left"
-selector."cyrl/yery" = "corner"
-
-[prime.cyrl-yery.variants.corner-tailed]
-rank = 2
-description = "Cyrillic Lower Yery (`ы`) with corner at bottom left and tail"
-selector."cyrl/yery" = "cornerTailed"
-
-[prime.cyrl-yery.variants.round]
-rank = 3
-description = "Cyrillic Lower Yery (`ы`) with rounded shape"
-selector."cyrl/yery" = "round"
-
-[prime.cyrl-yery.variants.round-tailed]
-rank = 4
-description = "Cyrillic Lower Yery (`ы`) with rounded shape and tail"
-selector."cyrl/yery" = "roundTailed"
-
-[prime.cyrl-yery.variants.cursive]
-rank = 5
-description = "Cyrillic Lower Yery (`ы`) with cursive shape"
-selector."cyrl/yery" = "cursive"
-
-[prime.cyrl-yery.variants.cursive-tailed]
-rank = 6
-description = "Cyrillic Lower Yery (`ы`) with cursive shape and tail"
-selector."cyrl/yery" = "cursiveTailed"
 
 
 


### PR DESCRIPTION
U comes before Ef, and Ya comes at the end.
Apologies if the auto diff looks messy. All I did was move U and Ya.