### PR TITLE
k with diagonal stroke

### DIFF
--- a/changes/26.0.0.md
+++ b/changes/26.0.0.md
@@ -1,4 +1,9 @@
 * \[**Breaking**\] Add separate variant selector for lowercase Thorn (#1854).
 * \[**Breaking**\] Drop `tailed-top-left-serifed` variant of `n` as it duplicates with `tailed-motion-serifed` (#1859).
 * \[**Breaking**\] Disunified the variant selector for Greek Delta and Greek Lambda, and added selectable serif variants for Lambda (#1866).
+* Add Characters:
+  - LATIN CAPITAL LETTER K WITH DIAGONAL STROKE (`U+A742`).
+  - LATIN SMALL LETTER K WITH DIAGONAL STROKE (`U+A743`).
+  - LATIN CAPITAL LETTER K WITH STROKE AND DIAGONAL STROKE (`U+A744`).
+  - LATIN SMALL LETTER K WITH STROKE AND DIAGONAL STROKE (`U+A745`).
 * Drop `<=` and `>=` as inequality for Verilog (#1864).

--- a/font-src/glyphs/letter/latin/k.ptl
+++ b/font-src/glyphs/letter/latin/k.ptl
@@ -65,7 +65,7 @@ glyph-block Letter-Latin-K : begin
 					flat [mix (kshRightTop - Ok) (kshLeft + stroke) kHookTopMix] [mix top attach kHookTopMix] [widths.rhs : mix stroke fine kHookTopMix]
 					curl (kshLeft + stroke) attach [widths.rhs fine]
 			: else : begin
-				set-base-anchor 'aluentOverlay' [mix kshLeft kshRightTop : StrokeWidthBlend 0.5 0.65] [mix attach top : StrokeWidthBlend 0.5 0.7]
+				set-base-anchor 'armOverlay' [mix kshLeft kshRightTop : StrokeWidthBlend 0.5 0.65] [mix attach top : StrokeWidthBlend 0.5 0.7]
 				include : intersection
 					TopStrokeMask 0
 					dispiro
@@ -74,6 +74,7 @@ glyph-block Letter-Latin-K : begin
 						curl (kshLeft + stroke) attach [widths 0 fine]
 
 
+			set-base-anchor 'legOverlay' [mix kshLeft kshRightBot : StrokeWidthBlend 0.5 0.65] [mix attach2 0 : StrokeWidthBlend 0.5 0.7]
 			include : intersection
 				BottomStrokeMask (-0.1)
 				spiro-outline
@@ -124,7 +125,7 @@ glyph-block Letter-Latin-K : begin
 						curl [mix (kshRightHookTop - Ok) xAttach 2] [mix top yAttach 2] [widths.rhs fine]
 			: else : begin
 				local xRef : linreg yAttach xAttach top kshRight (top * 0.75)
-				set-base-anchor 'aluentOverlay' (xRef - 0.5 * HVContrast * Stroke) (top * 0.75)
+				set-base-anchor 'armOverlay' (xRef - 0.5 * HVContrast * Stroke) (top * 0.75)
 				include : tagged 'strokeRT' : intersection
 					StrokeMask 1 top (0.5 * top) 0
 					dispiro
@@ -144,6 +145,8 @@ glyph-block Letter-Latin-K : begin
 					arcvh
 					straight.left.end (right - HookX - 0.5 * stroke * HVContrast) hookDepth
 			: else : begin
+				local xRef : linreg coYAttach xAttach 0 kshRight (top * 0.25)
+				set-base-anchor 'legOverlay' (xRef - 0.5 * HVContrast * Stroke) (top * 0.25)
 				include : tagged 'strokeRB' : intersection
 					StrokeMask 0 (0.5 * top) 0 0
 					dispiro
@@ -193,7 +196,7 @@ glyph-block Letter-Latin-K : begin
 			local xAttach2 : kshLeft + stroke * HVContrast
 			local yAttach2 : top * 0.75
 			local kDiag : mix 1 [DiagCorDs (top - yAttach1) (kshRight - kshLeft) stroke] 0.5
-			set-base-anchor 'aluentOverlay' [mix xAttach1 kshRight : StrokeWidthBlend 0.7 0.6] [mix yAttach1 top : StrokeWidthBlend 0.6 0.65]
+			set-base-anchor 'armOverlay' [mix xAttach1 kshRight : StrokeWidthBlend 0.7 0.6] [mix yAttach1 top : StrokeWidthBlend 0.6 0.65]
 			include : intersection
 				Rect top 0 kshLeft (2 * Width)
 				if fHookTop
@@ -205,6 +208,7 @@ glyph-block Letter-Latin-K : begin
 						g4.down.start (kshRight) top [widths.rhs.heading stroke Downward]
 						upperCurvature
 						g4 xAttach1 yAttach1 [widths.rhs fine]
+			set-base-anchor 'legOverlay' [mix xAttach2 kshRight : StrokeWidthBlend 0.7 0.6] [mix yAttach2 0 : StrokeWidthBlend 0.6 0.65]
 			include : difference
 				dispiro
 					g4.up.start (kshRight - O) 0 [widths.lhs.heading stroke Upward]
@@ -287,6 +291,7 @@ glyph-block Letter-Latin-K : begin
 			define [BottomStrokeMask] : Rect XH 0 0 [if slabLegs (dim.kshRight + SideJut + TanSlope * Stroke) (Width * 2)]
 
 			include : CursiveLoopT dispiro 0 left right stroke top slabLT slabLegs
+			set-base-anchor 'legOverlay' [mix dim.arcTerminalX dim.kshRight : StrokeWidthBlend 0.5 0.6] [mix dim.arcTerminalY 0 : StrokeWidthBlend 0.6 0.65]
 			include : difference
 				intersection [BottomStrokeMask] : dispiro
 					flat dim.arcTerminalX dim.arcTerminalY [widths.lhs]
@@ -312,6 +317,7 @@ glyph-block Letter-Latin-K : begin
 			define tailAngle : Math.min 85 (50 + [Math.atan2 (0.75 * swDiagTail) Hook] / Math.PI * 180)
 			define dtInnerRadius : [clamp 0.125 1 : mix 1 (Width / UPM * 2) 3] * [DiagonalTailInnerRadius]
 
+			set-base-anchor 'legOverlay' [mix xDTStart xDTEnd : StrokeWidthBlend 0.65 0.75] [mix dim.arcTerminalY 0 : StrokeWidthBlend 0.6 0.65]
 			include : difference
 				dispiro
 					flat xDTStart dim.arcTerminalY [widths.center swDiagTailAdj]
@@ -570,8 +576,12 @@ glyph-block Letter-Latin-K : begin
 	select-variant 'KHookTop' 0x198 (follow -- 'K')
 	select-variant 'kHookTop' 0x199
 
-	derive-composites 'cyrl/KaAluent' 0x51E 'cyrl/Ka' 'aluentSlashOver'
-	derive-composites 'cyrl/kaAluent' 0x51F 'cyrl/ka' 'aluentSlashOver'
+	derive-composites 'cyrl/KaAleut' 0x51E 'cyrl/Ka' 'aleutSlashOver'
+	derive-composites 'cyrl/kaAleut' 0x51F 'cyrl/ka' 'aleutSlashOver'
+	derive-composites 'KLegStroke' 0xA742 'K' 'legSlashOver'
+	derive-composites 'kLegStroke' 0xA743 'k' 'legSlashOver'
+	derive-composites 'KBarLegStroke' 0xA744 'KBar' 'legSlashOver'
+	derive-composites 'kBarLegStroke' 0xA745 'kBar' 'legSlashOver'
 
 	derive-glyphs 'kCaron' 0x1E9 'k/circumflexBase' : lambda [src gr] : glyph-proc
 		local shift : Width + SB - Middle + HalfStroke * HVContrast

--- a/font-src/glyphs/marks/overlay.ptl
+++ b/font-src/glyphs/marks/overlay.ptl
@@ -118,13 +118,21 @@ glyph-block Mark-Overlay : begin
 		set-mark-anchor 'overlay' 0 0 0 0
 		include : RingShape 0 0 tildeHalfWidth
 
-	create-glyph 'aluentSlashOver' : glyph-proc
+	create-glyph 'aleutSlashOver' : glyph-proc
 		set-width 0
-		set-mark-anchor 'aluentOverlay' 0 0 0 0
+		set-mark-anchor 'armOverlay' 0 0 0 0
 		include : dispiro
 			widths.center OverlayStroke
 			flat (-markExtend) markExtend
 			curl markExtend (-markExtend)
+
+	create-glyph 'legSlashOver' : glyph-proc
+		set-width 0
+		set-mark-anchor 'legOverlay' 0 0 0 0
+		include : dispiro
+			widths.center OverlayStroke
+			flat (-markExtend) (-markExtend)
+			curl markExtend markExtend
 
 	# Slash on entire letter on blank (bowl)
 	create-glyph 'hStrike' : glyph-proc


### PR DESCRIPTION
![image](https://github.com/be5invis/Iosevka/assets/21302803/7e0beb47-b3d6-4e97-b5d9-534f5de4e988)
Built by analogy with the Aleut Ka's. Works about as well as that I guess.

Curly/Symmetric/Connected forms:
![image](https://github.com/be5invis/Iosevka/assets/21302803/7d0569e1-56fe-4249-848a-8ff2d32d5e75)![image](https://github.com/be5invis/Iosevka/assets/21302803/eeb7d740-2d2d-4466-8a24-891f33a24c09)![image](https://github.com/be5invis/Iosevka/assets/21302803/77366ee3-a50c-4786-9114-3431be444fc3)

Cursive (this one has no upper-stroke reference)
![image](https://github.com/be5invis/Iosevka/assets/21302803/fccb8c77-56b4-4a7f-872a-df861362223d)

Plus the cursive-tailed form. I have no idea how to tune this one:
![image](https://github.com/be5invis/Iosevka/assets/21302803/ed768e95-0c6f-4da9-9a69-7ae4e91fff23)
