### PR TITLE
clean up letter(like)s, fix two variants for `ss17`, adjust/fix slabs for two IPA letters.

### DIFF
--- a/changes/26.0.0.md
+++ b/changes/26.0.0.md
@@ -7,3 +7,5 @@
   - LATIN CAPITAL LETTER K WITH STROKE AND DIAGONAL STROKE (`U+A744`).
   - LATIN SMALL LETTER K WITH STROKE AND DIAGONAL STROKE (`U+A745`).
 * Drop `<=` and `>=` as inequality for Verilog (#1864).
+* Fix variant selection for `cv27` and `cv33` for `ss17` under italics.
+* Fix slabs for `U+0257` and `U+0270`.

--- a/font-src/glyphs/auto-build/transformed.ptl
+++ b/font-src/glyphs/auto-build/transformed.ptl
@@ -667,7 +667,6 @@ glyph-block Autobuild-Transformed : begin
 			list 0xA7FB  'F'
 			list 0xA7FC  'P'
 			list 0xA7FD  'turnM'
-			list 0x1D133 'flatTone'
 			list 0x1DF01 'gScript'
 			list 0x1DF03 'k'
 			list 0x1DF07 'eng'

--- a/font-src/glyphs/letter/latin/k.ptl
+++ b/font-src/glyphs/letter/latin/k.ptl
@@ -548,7 +548,6 @@ glyph-block Letter-Latin-K : begin
 	alias-reduced-variant 'grek/Kappa/sansSerif' 'grek/Kappa' 'K/sansSerif' MathSansSerif
 	select-variant 'KBar' 0xA740 (follow -- 'K')
 	select-variant 'cyrl/KaStroke' 0x49E (shapeFrom -- 'KBar') (follow -- 'cyrl/Ka')
-	alias 'letterLike/kelvinSign' 0x212A 'K'
 	select-variant 'KDescender' 0x2C69
 	select-variant 'cyrl/Ka' 0x41A 'K' (shapeFrom -- 'K') (follow -- 'cyrl/Ka')
 	select-variant 'cyrl/KaDescender' 0x49A (shapeFrom -- 'KDescender')
@@ -556,6 +555,7 @@ glyph-block Letter-Latin-K : begin
 	select-variant 'cyrl/KaHook' 0x4C3 (shapeFrom -- 'K') (follow -- 'cyrl/KaHook')
 
 	select-variant 'k' 'k'
+	select-variant 'k/nonCursive' (shapeFrom -- 'k')
 	select-variant 'k/circumflexBase' (follow -- 'k')
 	link-reduced-variant 'k/sansSerif' 'k' MathSansSerif
 	select-variant 'kDescender' 0x2C6A
@@ -566,7 +566,7 @@ glyph-block Letter-Latin-K : begin
 	select-variant 'grek/kappa' 0x3BA
 
 	select-variant 'smcpK' 0x1D0B (follow -- 'K')
-	select-variant 'latn/kappa' 0x138 (shapeFrom -- 'smcpK')
+	select-variant 'latn/kappa' 0x138 (shapeFrom -- 'smcpK') (follow -- 'k/nonCursive')
 	select-variant 'cyrl/ka' 0x43A (shapeFrom -- 'smcpK')
 	select-variant 'cyrl/kaDescender' 0x49B (shapeFrom -- 'smcpKDescender')
 	select-variant 'cyrl/ka.BGR' (shapeFrom -- 'k') (follow -- 'cyrl/ka')

--- a/font-src/glyphs/letter/latin/lower-d.ptl
+++ b/font-src/glyphs/letter/latin/lower-d.ptl
@@ -114,6 +114,7 @@ glyph-block Letter-Latin-Lower-D : begin
 			include : df.markSet.b
 			include : Body df (Ascender - Hook - HalfStroke)
 			include : TopHook.rBarInner df.rightSB (XH / 2) Ascender
+			if bottomSerif : include : bottomSerif df Ascender
 
 		create-glyph "cyrl/djeKomi.\(suffix)" : glyph-proc
 			local df : DivFrame 1 3
@@ -169,9 +170,6 @@ glyph-block Letter-Latin-Lower-D : begin
 
 	derive-composites 'dBar' 0xA7C8 'd'
 		HBar.m (SB - OX) (RightSB + OX) (XH * 0.5) OverlayStroke
-
-	derive-composites 'currency/dongSign' 0x20AB 'dcroat' 'sbRsbUnderlineBelow'
-
 
 	define DCurlyTailConfig : object
 		toothedSerifless  { false }

--- a/font-src/glyphs/letter/latin/lower-h.ptl
+++ b/font-src/glyphs/letter/latin/lower-h.ptl
@@ -124,6 +124,7 @@ glyph-block Letter-Latin-Lower-H : begin
 
 
 	select-variant 'h' 'h'
+	select-variant 'h/tailless' (shapeFrom -- 'h')
 	select-variant 'h/circumflexBase' (follow -- 'h')
 	link-reduced-variant 'h/descBase' 'h'
 	link-reduced-variant 'h/sansSerif' 'h' MathSansSerif
@@ -138,7 +139,7 @@ glyph-block Letter-Latin-Lower-H : begin
 		include [refer-glyph "caronAbove"]
 
 	select-variant 'hBar' 0x127 (follow -- 'h')
-	turned 'turnh' 0x265 'h' Middle (XH / 2) [MarkSet.p]
+	turned 'turnh' 0x265 'h/tailless' Middle (XH / 2) [MarkSet.p]
 
 	select-variant 'hHookTop' 0x266
 	select-variant 'hengHookTop' 0x267

--- a/font-src/glyphs/letter/latin/lower-m.ptl
+++ b/font-src/glyphs/letter/latin/lower-m.ptl
@@ -220,7 +220,7 @@ glyph-block Letter-Latin-Lower-M : begin
 
 			local sf : SerifFrame.fromDf df XH Descender
 			if (SLAB && Serifs === AutoSerifs) : include sf.rb.fullSide
-			if (Serifs === LtRbSerifs || Serifs === LtSerifs) : include sf.rb.outer
+			if (Serifs !== no-shape) : include sf.rb.outer
 
 		create-glyph "mCrossedTail.\(suffix)" : glyph-proc
 			local df : DivFrame para.diversityM 4
@@ -330,8 +330,6 @@ glyph-block Letter-Latin-Lower-M : begin
 	alias 'cyrl/shcha.BGR' null 'cyrl/shcha.italic'
 
 	derive-composites 'cyrl/te.SRB' null 'cyrl/sha.italic' 'macronAbove'
-
-	derive-composites 'currency/millSign' 0x20A5 'm' 'shortSlash'
 
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarLeft
 	create-glyph 'mathbb/m' 0x1D55E : glyph-proc

--- a/font-src/glyphs/letter/latin/upper-g.ptl
+++ b/font-src/glyphs/letter/latin/upper-g.ptl
@@ -111,7 +111,6 @@ glyph-block Letter-Latin-Upper-G : begin
 	select-variant 'smcpG' 0x262 (follow -- 'G')
 	select-variant 'GHookTop' 0x193
 	select-variant 'smcpGHookTop' 0x29B (follow -- 'GHookTop')
-	turned 'turnSansSerifG' 0x2141 'G/sansSerif' Middle (CAP / 2)
 	turned 'turnSmcpG' 0x1DF02 'smcpG' Middle (XH / 2)
 
 	derive-composites 'Gbar' 0x1E4 'G' 'GBarOverlay'

--- a/font-src/glyphs/letter/latin/upper-l.ptl
+++ b/font-src/glyphs/letter/latin/upper-l.ptl
@@ -69,7 +69,6 @@ glyph-block Letter-Latin-Upper-L : begin
 	select-variant 'LHighBar' 0xA748 (follow -- 'L')
 
 	turned 'turnL' 0xA780 'L' Middle (CAP / 2)
-	turned 'turnSansSerifL' 0x2142 'L.serifless' Middle (CAP / 2)
 
 	create-glyph 'mathbb/L' 0x1D543 : glyph-proc
 		local df : DivFrame 1

--- a/font-src/glyphs/letter/latin/upper-y.ptl
+++ b/font-src/glyphs/letter/latin/upper-y.ptl
@@ -143,7 +143,6 @@ glyph-block Letter-Latin-Upper-Y : begin
 	select-variant 'smcpY' 0x28F (follow -- 'Y')
 	select-variant 'cyrl/ue' 0x4AF (follow -- 'Y')
 	select-variant 'grek/upsilonHookedSymbolShape' 0x3D2
-	turned 'turnSansSerifY' 0x2144 'Y/sansSerif' Middle (CAP / 2)
 
 	select-variant 'grek/Upsilon' 0x3A5 (follow -- 'Y')
 	link-reduced-variant 'grek/Upsilon/sansSerif' 'grek/Upsilon' MathSansSerif (follow -- 'Y/sansSerif')

--- a/font-src/glyphs/symbol/letter.ptl
+++ b/font-src/glyphs/symbol/letter.ptl
@@ -53,6 +53,8 @@ glyph-block Symbol-Currency-Letter-Derived : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 
+	derive-composites 'currency/millSign' 0x20A5 'm' 'shortSlash'
+
 	create-glyph 'currency/overlay/NS' : glyph-proc
 		define sw : Math.min OverlayStroke : AdviceStroke2 2 4 CAP
 		define gap : Math.max (CAP / 8) (sw / 2)
@@ -67,6 +69,9 @@ glyph-block Symbol-Currency-Letter-Derived : begin
 	derive-composites 'currency/nairaSign' 0x20A6 'currency/nairaSignBase' 'currency/overlay/NS'
 	derive-composites 'currency/hryvniaSign' 0x20B4 'revS' 'currency/overlay/NS'
 	derive-composites 'currency/wonSign' 0x20A9 'W' 'currency/overlay/W'
+
+	derive-composites 'currency/dongSign' 0x20AB 'dcroat' 'sbRsbUnderlineBelow'
+	derive-composites 'currency/kipSign' 0x20AD 'K' 'hStrike'
 
 	create-glyph 'currency/tugrikOverride' : let
 		l : mix (Middle - HalfStroke * HVContrast) SB       0.75
@@ -172,6 +177,7 @@ glyph-block Symbol-Letter : begin
 	alias 'Ohm' 0x2126 'grek/Omega'
 	turned 'Mho' 0x2127 'Ohm' Middle (CAP / 2)
 	turned 'turniota' 0x2129 'grek/iota' HalfAdvance (XH / 2)
+	alias 'letterLike/kelvinSign' 0x212A 'K'
 
 	create-glyph 'estimated' 0x212E : glyph-proc
 		include : MarkSet.capital
@@ -269,7 +275,11 @@ glyph-block Symbol-Letter : begin
 		include : HSerif.rb (Middle + sw / 2 * HVContrast) 0  (LongJut / 2)
 		include : DotAt Middle (XH + AccentStackOffset) (DotRadius * sw / Stroke)
 
+	turned 'turnG/sansSerif' 0x2141 'G/sansSerif' Middle (CAP / 2)
+	turned 'turnL/sansSerif' 0x2142 'L/sansSerif' Middle (CAP / 2)
 	turned 'revL/sansSerif' 0x2143 'grek/Gamma/sansSerif' Middle (CAP / 2)
+	turned 'turnY/sansSerif' 0x2144 'Y/sansSerif' Middle (CAP / 2)
+
 	turned 'turnAmpersand' 0x214B 'ampersand' Middle (CAP / 2)
 
 	do "Tironian Et"

--- a/font-src/glyphs/symbol/pictograph/musical.ptl
+++ b/font-src/glyphs/symbol/pictograph/musical.ptl
@@ -236,3 +236,7 @@ glyph-block Symbol-Pictograph-Musical : begin
 				flat l ([mix nsTop nsBot 0.7] - (Middle - l) * skew) [heading Rightward]
 				curl r ([mix nsTop nsBot 0.7] - (Middle - r) * skew) [heading Rightward]
 			include : VBar.m Middle nsBot nsTop fine
+
+		create-glyph 'qtrFlatTone' 0x1D133 : glyph-proc
+			include : FlatToneShape
+			include : FlipAround Middle SymbolMid (-1) 1

--- a/font-src/meta/unicode-knowledge.ptl
+++ b/font-src/meta/unicode-knowledge.ptl
@@ -175,8 +175,6 @@ export : define decompOverrides : object
 	0x1FE2 { 'grek/upsilon' 'dialytikaVariaAbove' }
 	0x1FE3 { 'grek/upsilon' 'dialytikaOxiaAbove' }
 
-	0x20AD { 'K' 'hStrike' }
-
 	0x2c61 { 'l' 'dblBarOver' }
 	0x2c65 { 'a' 'shortSlash' }
 	0x2c66 { 't' 'longSlash' }

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2051,6 +2051,7 @@ next = "serifs"
 rank = 1
 descriptionAffix = "straight terminal"
 selectorAffix.h = "straight"
+selectorAffix."h/tailless" = "straight"
 selectorAffix."h/descBase" = "straight"
 selectorAffix."h/sansSerif" = "straight"
 selectorAffix.hHookTop = "straight"
@@ -2063,19 +2064,21 @@ selectorAffix.turnmLeg = ""
 rank = 2
 descriptionAffix = "curly tailed terminal"
 selectorAffix.h = "tailed"
+selectorAffix."h/tailless" = "straight"
 selectorAffix."h/descBase" = "straight"
 selectorAffix."h/sansSerif" = "tailed"
 selectorAffix.hHookTop = "tailed"
 selectorAffix.hengHookTop = "straight"
 selectorAffix.heng = "straight"
 selectorAffix."cyrl/shha" = "tailed"
-selectorAffix.turnmLeg = "tailed"
+selectorAffix.turnmLeg = ""
 
 [prime.h.variants-buildup.stages.serifs.serifless]
 rank = 1
 descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix.h = "serifless"
+selectorAffix."h/tailless" = "serifless"
 selectorAffix."h/descBase" = "serifless"
 selectorAffix."h/sansSerif" = "serifless"
 selectorAffix.hHookTop = "serifless"
@@ -2089,6 +2092,7 @@ rank = 2
 disableIf = [{ tail = "NOT straight" }]
 descriptionAffix = "serif at top left"
 selectorAffix.h = "topLeftSerifed"
+selectorAffix."h/tailless" = "topLeftSerifed"
 selectorAffix."h/descBase" = "topLeftSerifed"
 selectorAffix."h/sansSerif" = "serifless"
 selectorAffix.hHookTop = "serifless"
@@ -2101,6 +2105,7 @@ selectorAffix.turnmLeg = "topLeftSerifed"
 rank = 3
 descriptionAffix = "serifs at top left and bottom right"
 selectorAffix.h = "motionSerifed"
+selectorAffix."h/tailless" = "motionSerifed"
 selectorAffix."h/descBase" = "topLeftSerifed"
 selectorAffix."h/sansSerif" = "serifless"
 selectorAffix.hHookTop = "motionSerifed"
@@ -2113,6 +2118,7 @@ selectorAffix.turnmLeg = "topLeftAndBottomRightSerifed"
 rank = 4
 descriptionAffix = "serifs"
 selectorAffix.h = "serifed"
+selectorAffix."h/tailless" = "serifed"
 selectorAffix."h/descBase" = "serifed"
 selectorAffix."h/sansSerif" = "serifless"
 selectorAffix.hHookTop = "serifed"
@@ -2314,9 +2320,9 @@ rank = 1
 descriptionAffix = "standard shape"
 selectorAffix.k = "straight"
 selectorAffix."k/sansSerif" = "straight"
+selectorAffix."k/nonCursive" = "straight"
 selectorAffix.kHookTop = "straight"
 selectorAffix.kDescender = "straight"
-selectorAffix."latn/kappa" = "straight"
 selectorAffix."grek/kappa" = "straight"
 
 [prime.k.variants-buildup.stages.body.curly]
@@ -2324,9 +2330,9 @@ rank = 2
 descriptionAffix = "curly shape"
 selectorAffix.k = "curly"
 selectorAffix."k/sansSerif" = "curly"
+selectorAffix."k/nonCursive" = "curly"
 selectorAffix.kHookTop = "curly"
 selectorAffix.kDescender = "curly"
-selectorAffix."latn/kappa" = "curly"
 selectorAffix."grek/kappa" = "curly"
 
 [prime.k.variants-buildup.stages.body.symmetric-touching]
@@ -2334,9 +2340,9 @@ rank = 3
 descriptionAffix = "symmetric legs touching the vertical bar"
 selectorAffix.k = "symmetricTouching"
 selectorAffix."k/sansSerif" = "symmetricTouching"
+selectorAffix."k/nonCursive" = "symmetricTouching"
 selectorAffix.kHookTop = "symmetricTouching"
 selectorAffix.kDescender = "symmetricTouching"
-selectorAffix."latn/kappa" = "symmetricTouching"
 selectorAffix."grek/kappa" = "symmetricTouching"
 
 [prime.k.variants-buildup.stages.body.symmetric-connected]
@@ -2344,9 +2350,9 @@ rank = 4
 descriptionAffix = "symmetric legs connected to the vertical bar"
 selectorAffix.k = "symmetricConnected"
 selectorAffix."k/sansSerif" = "symmetricConnected"
+selectorAffix."k/nonCursive" = "symmetricConnected"
 selectorAffix.kHookTop = "symmetricConnected"
 selectorAffix.kDescender = "symmetricConnected"
-selectorAffix."latn/kappa" = "symmetricConnected"
 selectorAffix."grek/kappa" = "symmetricConnected"
 
 [prime.k.variants-buildup.stages.body.cursive]
@@ -2354,9 +2360,9 @@ rank = 5
 descriptionAffix = "cursive loop"
 selectorAffix.k = "cursive"
 selectorAffix."k/sansSerif" = "cursive"
+selectorAffix."k/nonCursive" = "straight"
 selectorAffix.kHookTop = "cursive"
 selectorAffix.kDescender = "cursive"
-selectorAffix."latn/kappa" = "straight"
 selectorAffix."grek/kappa" = "straight"
 
 [prime.k.variants-buildup.stages.body.diagonal-tailed-cursive]
@@ -2364,9 +2370,9 @@ rank = 6
 descriptionAffix = "cursive loop plus diagonal tail"
 selectorAffix.k = "cursiveTailed"
 selectorAffix."k/sansSerif" = "cursiveTailed"
+selectorAffix."k/nonCursive" = "straight"
 selectorAffix.kHookTop = "cursiveTailed"
 selectorAffix.kDescender = "cursive"
-selectorAffix."latn/kappa" = "straight"
 selectorAffix."grek/kappa" = "straight"
 
 [prime.k.variants-buildup.stages.serifs.serifless]
@@ -2375,9 +2381,9 @@ descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix.k = "serifless"
 selectorAffix."k/sansSerif" = "serifless"
+selectorAffix."k/nonCursive" = "serifless"
 selectorAffix.kHookTop = "serifless"
 selectorAffix.kDescender = "serifless"
-selectorAffix."latn/kappa" = "serifless"
 selectorAffix."grek/kappa" = "serifless"
 
 [prime.k.variants-buildup.stages.serifs.top-left-serifed]
@@ -2385,9 +2391,9 @@ rank = 2
 descriptionAffix = "serifs at top left"
 selectorAffix.k = "topLeftSerifed"
 selectorAffix."k/sansSerif" = "serifless"
+selectorAffix."k/nonCursive" = "topLeftSerifed"
 selectorAffix.kHookTop = "serifless"
 selectorAffix.kDescender = "topLeftSerifed"
-selectorAffix."latn/kappa" = "topLeftSerifed"
 selectorAffix."grek/kappa" = "serifless"
 
 [prime.k.variants-buildup.stages.serifs.bottom-right-serifed]
@@ -2396,9 +2402,9 @@ disableIf = [ { body = "diagonal-tailed-cursive" } ]
 descriptionAffix = "serifs at bottom right"
 selectorAffix.k = "bottomRightSerifed"
 selectorAffix."k/sansSerif" = "serifless"
+selectorAffix."k/nonCursive" = "bottomRightSerifed"
 selectorAffix.kHookTop = "bottomRightSerifed"
 selectorAffix.kDescender = "bottomRightSerifed"
-selectorAffix."latn/kappa" = "bottomRightSerifed"
 selectorAffix."grek/kappa" = "serifless"
 
 [prime.k.variants-buildup.stages.serifs.top-left-and-bottom-right-serifed]
@@ -2407,9 +2413,9 @@ disableIf = [ { body = "diagonal-tailed-cursive" } ]
 descriptionAffix = "serifs at top left and bottom right"
 selectorAffix.k = "topLeftAndBottomRightSerifed"
 selectorAffix."k/sansSerif" = "serifless"
+selectorAffix."k/nonCursive" = "topLeftAndBottomRightSerifed"
 selectorAffix.kHookTop = "bottomRightSerifed"
 selectorAffix.kDescender = "topLeftAndBottomRightSerifed"
-selectorAffix."latn/kappa" = "topLeftAndBottomRightSerifed"
 selectorAffix."grek/kappa" = "serifless"
 
 [prime.k.variants-buildup.stages.serifs.serifed]
@@ -2418,9 +2424,9 @@ disableIf = [ { body = "diagonal-tailed-cursive" } ]
 descriptionAffix = "serifs"
 selectorAffix.k = "serifed"
 selectorAffix."k/sansSerif" = "serifless"
+selectorAffix."k/nonCursive" = "serifed"
 selectorAffix.kHookTop = "serifed"
 selectorAffix.kDescender = "serifed"
-selectorAffix."latn/kappa" = "serifed"
 selectorAffix."grek/kappa" = "serifless"
 
 
@@ -7937,9 +7943,11 @@ brace = "curly-flat-boundary"
 
 [composite.ss17.italic]
 a = "single-storey-tailed"
+b = "toothless-corner-serifless"
 e = "rounded"
 f = "tailed"
 g = "single-storey-serifless"
+h = "tailed-serifless"
 i = "serifed-flat-tailed"
 l = "serifed-flat-tailed"
 m = "tailed-serifless"
@@ -7962,7 +7970,9 @@ cyrl-capital-u = "straight-turn-serifed"
 micro-sign = "tailed-serifed"
 
 [composite.ss17.slab-override.italic]
+b = "toothless-corner-serifed"
 g = "single-storey-serifed"
+h = "tailed-motion-serifed"
 w = "cursive-serifed"
 m = "tailed-top-left-serifed"
 n = "tailed-motion-serifed"


### PR DESCRIPTION
A lot of the changed files are just stuff moved around for organizational purposes.

```
bɗ mhɰɥʮ
mɰɯ nɥu ɥʮ
```
Default Slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/51cded97-7560-4dee-9f67-9211b5fe5396)
Default Slab Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/9eb848e2-8303-40a0-978d-18c7f238a5a9)
`ss17`:
![image](https://github.com/be5invis/Iosevka/assets/37010132/85fed5e1-e4be-4947-b531-63433dfff1a3)
`ss17` Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/1047ca21-6493-4521-b4f2-872af35237c7)

Any other characters not shown here that were moved around have been tested and confirmed to be unchanged.
