### PR TITLE
Disunify variant selectors for Greek Chi and `x`.

### DIFF
--- a/changes/26.0.0.md
+++ b/changes/26.0.0.md
@@ -1,11 +1,13 @@
 * \[**Breaking**\] Add separate variant selector for lowercase Thorn (#1854).
 * \[**Breaking**\] Drop `tailed-top-left-serifed` variant of `n` as it duplicates with `tailed-motion-serifed` (#1859).
 * \[**Breaking**\] Disunified the variant selector for Greek Delta and Greek Lambda, and added selectable serif variants for Lambda (#1866).
+* \[**Breaking**\] Add a separate variant selector for lowercase Greek Chi.
 * Add Characters:
   - LATIN CAPITAL LETTER K WITH DIAGONAL STROKE (`U+A742`).
   - LATIN SMALL LETTER K WITH DIAGONAL STROKE (`U+A743`).
   - LATIN CAPITAL LETTER K WITH STROKE AND DIAGONAL STROKE (`U+A744`).
   - LATIN SMALL LETTER K WITH STROKE AND DIAGONAL STROKE (`U+A745`).
 * Drop `<=` and `>=` as inequality for Verilog (#1864).
-* Fix variant selection for `cv27` and `cv33` for `ss17` under italics.
+* Fix variant selection for `cv27`, `cv33`, `cv36`, and `cv49` for `ss17` under italics.
+* Make Greek Kappa respond to top-left serifed variants of `k`.
 * Fix slabs for `U+0257` and `U+0270`.

--- a/font-src/glyphs/letter/latin/k.ptl
+++ b/font-src/glyphs/letter/latin/k.ptl
@@ -424,12 +424,6 @@ glyph-block Letter-Latin-K : begin
 			include : KBaseShape CyrlVbSw CAP
 			include : CyrlKaVBar CAP slabLT straightBar
 
-		create-glyph "grek/kappa.\(suffix)" : glyph-proc
-			include : MarkSet.e
-			include : VBar.l (SB + [KBalance slabLT straightBar]) 0 XH
-			include : LegsImpl false SB RightSB Stroke XH slabLT false
-			if slabLT : include : HSerif.lt (SB + [KBalance slabLT straightBar]) XH SideJut
-
 		create-glyph "grek/KaiSymbol.\(suffix)" : glyph-proc
 			include [refer-glyph "K.\(suffix)"] AS_BASE ALSO_METRICS
 			include : MarkSet.capDesc
@@ -563,7 +557,8 @@ glyph-block Letter-Latin-K : begin
 	select-variant 'kBar' 0xA741 (follow -- 'k')
 	select-variant 'cyrl/kaStroke' 0x49F (shapeFrom -- 'kBar') (follow -- 'cyrl/ka')
 
-	select-variant 'grek/kappa' 0x3BA
+	select-variant 'grek/kappa' 0x3BA (shapeFrom -- 'smcpK')
+	link-reduced-variant 'grek/kappa/sansSerif' 'grek/kappa' MathSansSerif (shapeFrom -- 'smcpK')
 
 	select-variant 'smcpK' 0x1D0B (follow -- 'K')
 	select-variant 'latn/kappa' 0x138 (shapeFrom -- 'smcpK') (follow -- 'k/nonCursive')

--- a/font-src/glyphs/letter/latin/lower-m.ptl
+++ b/font-src/glyphs/letter/latin/lower-m.ptl
@@ -218,9 +218,9 @@ glyph-block Letter-Latin-Lower-M : begin
 			include : FlipAround df.middle (XH / 2)
 			include : VBar.r df.rightSB Descender XH df.mvs
 
-			local sf : SerifFrame.fromDf df XH Descender
-			if (SLAB && Serifs === AutoSerifs) : include sf.rb.fullSide
-			if (Serifs !== no-shape) : include sf.rb.outer
+			if (Serifs !== no-shape) : begin
+				local sf : SerifFrame.fromDf df XH Descender
+				include sf.rb.outer
 
 		create-glyph "mCrossedTail.\(suffix)" : glyph-proc
 			local df : DivFrame para.diversityM 4

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2324,6 +2324,7 @@ selectorAffix."k/nonCursive" = "straight"
 selectorAffix.kHookTop = "straight"
 selectorAffix.kDescender = "straight"
 selectorAffix."grek/kappa" = "straight"
+selectorAffix."grek/kappa/sansSerif" = "straight"
 
 [prime.k.variants-buildup.stages.body.curly]
 rank = 2
@@ -2334,6 +2335,7 @@ selectorAffix."k/nonCursive" = "curly"
 selectorAffix.kHookTop = "curly"
 selectorAffix.kDescender = "curly"
 selectorAffix."grek/kappa" = "curly"
+selectorAffix."grek/kappa/sansSerif" = "curly"
 
 [prime.k.variants-buildup.stages.body.symmetric-touching]
 rank = 3
@@ -2344,6 +2346,7 @@ selectorAffix."k/nonCursive" = "symmetricTouching"
 selectorAffix.kHookTop = "symmetricTouching"
 selectorAffix.kDescender = "symmetricTouching"
 selectorAffix."grek/kappa" = "symmetricTouching"
+selectorAffix."grek/kappa/sansSerif" = "symmetricTouching"
 
 [prime.k.variants-buildup.stages.body.symmetric-connected]
 rank = 4
@@ -2354,6 +2357,7 @@ selectorAffix."k/nonCursive" = "symmetricConnected"
 selectorAffix.kHookTop = "symmetricConnected"
 selectorAffix.kDescender = "symmetricConnected"
 selectorAffix."grek/kappa" = "symmetricConnected"
+selectorAffix."grek/kappa/sansSerif" = "symmetricConnected"
 
 [prime.k.variants-buildup.stages.body.cursive]
 rank = 5
@@ -2364,6 +2368,7 @@ selectorAffix."k/nonCursive" = "straight"
 selectorAffix.kHookTop = "cursive"
 selectorAffix.kDescender = "cursive"
 selectorAffix."grek/kappa" = "straight"
+selectorAffix."grek/kappa/sansSerif" = "straight"
 
 [prime.k.variants-buildup.stages.body.diagonal-tailed-cursive]
 rank = 6
@@ -2374,6 +2379,7 @@ selectorAffix."k/nonCursive" = "straight"
 selectorAffix.kHookTop = "cursiveTailed"
 selectorAffix.kDescender = "cursive"
 selectorAffix."grek/kappa" = "straight"
+selectorAffix."grek/kappa/sansSerif" = "straight"
 
 [prime.k.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -2385,6 +2391,7 @@ selectorAffix."k/nonCursive" = "serifless"
 selectorAffix.kHookTop = "serifless"
 selectorAffix.kDescender = "serifless"
 selectorAffix."grek/kappa" = "serifless"
+selectorAffix."grek/kappa/sansSerif" = "serifless"
 
 [prime.k.variants-buildup.stages.serifs.top-left-serifed]
 rank = 2
@@ -2394,7 +2401,8 @@ selectorAffix."k/sansSerif" = "serifless"
 selectorAffix."k/nonCursive" = "topLeftSerifed"
 selectorAffix.kHookTop = "serifless"
 selectorAffix.kDescender = "topLeftSerifed"
-selectorAffix."grek/kappa" = "serifless"
+selectorAffix."grek/kappa" = "topLeftSerifed"
+selectorAffix."grek/kappa/sansSerif" = "serifless"
 
 [prime.k.variants-buildup.stages.serifs.bottom-right-serifed]
 rank = 3
@@ -2406,6 +2414,7 @@ selectorAffix."k/nonCursive" = "bottomRightSerifed"
 selectorAffix.kHookTop = "bottomRightSerifed"
 selectorAffix.kDescender = "bottomRightSerifed"
 selectorAffix."grek/kappa" = "serifless"
+selectorAffix."grek/kappa/sansSerif" = "serifless"
 
 [prime.k.variants-buildup.stages.serifs.top-left-and-bottom-right-serifed]
 rank = 4
@@ -2416,7 +2425,8 @@ selectorAffix."k/sansSerif" = "serifless"
 selectorAffix."k/nonCursive" = "topLeftAndBottomRightSerifed"
 selectorAffix.kHookTop = "bottomRightSerifed"
 selectorAffix.kDescender = "topLeftAndBottomRightSerifed"
-selectorAffix."grek/kappa" = "serifless"
+selectorAffix."grek/kappa" = "topLeftSerifed"
+selectorAffix."grek/kappa/sansSerif" = "serifless"
 
 [prime.k.variants-buildup.stages.serifs.serifed]
 rank = 5
@@ -2427,7 +2437,8 @@ selectorAffix."k/sansSerif" = "serifless"
 selectorAffix."k/nonCursive" = "serifed"
 selectorAffix.kHookTop = "serifed"
 selectorAffix.kDescender = "serifed"
-selectorAffix."grek/kappa" = "serifless"
+selectorAffix."grek/kappa" = "topLeftSerifed"
+selectorAffix."grek/kappa/sansSerif" = "serifless"
 
 
 
@@ -3668,8 +3679,6 @@ rank = 1
 descriptionAffix = "straight shape"
 selectorAffix.x = "straight"
 selectorAffix."x/sansSerif" = "straight"
-selectorAffix."grek/chi" = "straight"
-selectorAffix."grek/chi/sansSerif" = "straight"
 selectorAffix."cyrl/ha" = "straight"
 
 [prime.x.variants-buildup.stages.body.curly]
@@ -3677,8 +3686,6 @@ rank = 2
 descriptionAffix = "curly shape"
 selectorAffix.x = "curly"
 selectorAffix."x/sansSerif" = "curly"
-selectorAffix."grek/chi" = "curly"
-selectorAffix."grek/chi/sansSerif" = "curly"
 selectorAffix."cyrl/ha" = "curly"
 
 [prime.x.variants-buildup.stages.body.cursive]
@@ -3687,8 +3694,6 @@ next = "END"
 descriptionAffix = "cursive shape"
 selectorAffix.x = "cursive"
 selectorAffix."x/sansSerif" = "cursive"
-selectorAffix."grek/chi" = "curlySerifless"
-selectorAffix."grek/chi/sansSerif" = "curlySerifless"
 selectorAffix."cyrl/ha" = "cursive"
 
 [prime.x.variants-buildup.stages.serifs.serifless]
@@ -3697,8 +3702,6 @@ descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix.x = "serifless"
 selectorAffix."x/sansSerif" = "serifless"
-selectorAffix."grek/chi" = "serifless"
-selectorAffix."grek/chi/sansSerif" = "serifless"
 selectorAffix."cyrl/ha" = "serifless"
 
 [prime.x.variants-buildup.stages.serifs.motion-serifed]
@@ -3707,8 +3710,6 @@ disableIf = [{ body = "cursive" }]
 descriptionAffix = "motion serifs"
 selectorAffix.x = "motionSerifed"
 selectorAffix."x/sansSerif" = "serifless"
-selectorAffix."grek/chi" = "motionSerifed"
-selectorAffix."grek/chi/sansSerif" = "serifless"
 selectorAffix."cyrl/ha" = "motionSerifed"
 
 [prime.x.variants-buildup.stages.serifs.serifed]
@@ -3717,8 +3718,6 @@ disableIf = [{ body = "cursive" }]
 descriptionAffix = "serifs"
 selectorAffix.x = "serifed"
 selectorAffix."x/sansSerif" = "serifless"
-selectorAffix."grek/chi" = "bilateralMotionSerifed"
-selectorAffix."grek/chi/sansSerif" = "serifless"
 selectorAffix."cyrl/ha" = "serifed"
 
 
@@ -4456,6 +4455,51 @@ selector."grek/xi" = "rounded"
 rank = 2
 description = "Greek lower Xi (`ξ`) with flat top"
 selector."grek/xi" = "flatTop"
+
+
+
+[prime.lower-chi]
+sampler = "χ"
+samplerExplain = "Greek lower Chi"
+tagKind = "letter"
+
+[prime.lower-chi.variants-buildup]
+entry = "body"
+descriptionLeader = "Greek lower Chi (`χ`)"
+
+[prime.lower-chi.variants-buildup.stages.body."*"]
+next = "serifs"
+
+[prime.lower-chi.variants-buildup.stages.body.straight]
+rank = 1
+descriptionAffix = "straight shape"
+selectorAffix."grek/chi" = "straight"
+selectorAffix."grek/chi/sansSerif" = "straight"
+
+[prime.lower-chi.variants-buildup.stages.body.curly]
+rank = 2
+descriptionAffix = "curly shape"
+selectorAffix."grek/chi" = "curly"
+selectorAffix."grek/chi/sansSerif" = "curly"
+
+[prime.lower-chi.variants-buildup.stages.serifs.serifless]
+rank = 1
+descriptionAffix = "serifs"
+descriptionJoiner = "without"
+selectorAffix."grek/chi" = "serifless"
+selectorAffix."grek/chi/sansSerif" = "serifless"
+
+[prime.lower-chi.variants-buildup.stages.serifs.motion-serifed]
+rank = 2
+descriptionAffix = "motion serifs"
+selectorAffix."grek/chi" = "motionSerifed"
+selectorAffix."grek/chi/sansSerif" = "serifless"
+
+[prime.lower-chi.variants-buildup.stages.serifs.serifed]
+rank = 3
+descriptionAffix = "serifs"
+selectorAffix."grek/chi" = "bilateralMotionSerifed"
+selectorAffix."grek/chi/sansSerif" = "serifless"
 
 
 
@@ -6564,6 +6608,7 @@ lower-iota = "serifed-flat-tailed"
 capital-lambda = "straight-serifless"
 lower-lambda = "straight"
 lower-xi = "flat-top"
+lower-chi = "straight-serifless"
 cyrl-capital-zhe = "symmetric-connected"
 cyrl-zhe = "symmetric-connected"
 cyrl-capital-ze = "serifless"
@@ -6703,6 +6748,7 @@ long-s = "bent-hook-bottom-serifed"
 capital-gamma = "serifed"
 capital-lambda = "straight-base-serifed"
 lower-mu = "tailed-serifed"
+lower-chi = "straight-serifed"
 cyrl-capital-ze = "unilateral-serifed"
 cyrl-ze = "unilateral-serifed"
 cyrl-em = "hanging-serifed"
@@ -7278,6 +7324,7 @@ lower-delta = "flat-top"
 capital-lambda = "curly-serifless"
 lower-lambda = "curly"
 lower-mu = "toothed-serifless"
+lower-chi = "curly-serifless"
 cyrl-capital-zhe = "curly"
 cyrl-zhe = "curly"
 cyrl-capital-ka = "curly-serifless"
@@ -7334,6 +7381,7 @@ z = "curly-serifed"
 long-s = "bent-hook-double-serifed"
 capital-lambda = "curly-base-serifed"
 lower-mu = "toothed-serifed"
+lower-chi = "curly-serifed"
 cyrl-capital-ka = "curly-serifed"
 cyrl-capital-u = "curly-serifed"
 cyrl-ka = "curly-serifed"
@@ -7949,6 +7997,7 @@ f = "tailed"
 g = "single-storey-serifless"
 h = "tailed-serifless"
 i = "serifed-flat-tailed"
+k = "cursive-bottom-right-serifed"
 l = "serifed-flat-tailed"
 m = "tailed-serifless"
 n = "tailed-serifless"
@@ -7973,9 +8022,11 @@ micro-sign = "tailed-serifed"
 b = "toothless-corner-serifed"
 g = "single-storey-serifed"
 h = "tailed-motion-serifed"
+k = "cursive-top-left-and-bottom-right-serifed"
 w = "cursive-serifed"
 m = "tailed-top-left-serifed"
 n = "tailed-motion-serifed"
+y = "cursive-motion-serifed"
 
 
 
@@ -8064,6 +8115,7 @@ z = "curly-serifless"
 capital-delta = "curly"
 capital-lambda = "curly-serifless"
 lower-lambda = "curly"
+lower-chi = "curly-serifless"
 cyrl-capital-u = "curly-serifless"
 cyrl-capital-ya = "curly-serifless"
 cyrl-ya = "curly-serifless"
@@ -8090,6 +8142,7 @@ x = "curly-serifed"
 y = "curly-serifed"
 z = "curly-serifed"
 capital-lambda = "curly-base-serifed"
+lower-chi = "curly-serifed"
 cyrl-capital-u = "curly-serifed"
 cyrl-capital-ya = "curly-serifed"
 cyrl-ya = "curly-serifed"


### PR DESCRIPTION
Also make Greek Kappa respond to top-left serifed variants for lowercase `k`.

This solves a problem that you had mentioned in the past regarding "de-cursivizing" Greek Chi, back when I made a PR for Greek Kappa.

For any stylistic set which uses a cursive form of `x`, the original font doesn't really do anything to Greek Chi. Also, for the sole stylistic set that uses a serifed `x` in non-slab mode, `ss02`, the Greek chi glyph in the original font remains sans-serif.

In other words, this variant selector is less about stylistic sets opting INTO a variant but rather being able to opt OUT of previously default configurations, which weren't really in harmony with other characters to begin with.

`Kkκ𝝹xχ𝞆`

Default:
![image](https://github.com/be5invis/Iosevka/assets/37010132/110cbeea-8f93-4582-a00a-89d1bf2664b2)

Default Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/f72d5489-6ae2-4b8f-8f15-22c24ea50bcc)

Default Slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/5f165690-6e14-43fa-a208-c092ae3ea8f5)

Default Slab Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/69987f0d-d056-44ec-b0eb-fcc984bcb674)

Curly:
![image](https://github.com/be5invis/Iosevka/assets/37010132/a0763598-40b1-4027-bd69-24dba153e06b)

Curly Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/5a37c4b6-fa6a-4022-af0a-950566d740fa)

Curly Slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/576892b0-d934-441c-9628-2236e131d8a3)

Curly Slab Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/97013547-70e2-409c-905d-6c72298f3800)

