### PR TITLE
Circular Arrows, CC-BY and SA

### DIFF
--- a/changes/26.0.0.md
+++ b/changes/26.0.0.md
@@ -3,10 +3,18 @@
 * \[**Breaking**\] Disunified the variant selector for Greek Delta and Greek Lambda, and added selectable serif variants for Lambda (#1866).
 * \[**Breaking**\] Add a separate variant selector for lowercase Greek Chi.
 * Add Characters:
+  - ANTICLOCKWISE GAPPED CIRCLE ARROW (`U+27F2`).
+  - CLOCKWISE GAPPED CIRCLE ARROW (`U+27F3`).
+  - ANTICLOCKWISE CLOSED CIRCLE ARROW (`U+2940`).
+  - CLOCKWISE CLOSED CIRCLE ARROW (`U+2941`).
+  - CLOCKWISE TRIANGLE-HEADED OPEN CIRCLE ARROW (`U+2B6E`).
+  - ANTICLOCKWISE TRIANGLE-HEADED OPEN CIRCLE ARROW (`U+2B6F`).
   - LATIN CAPITAL LETTER K WITH DIAGONAL STROKE (`U+A742`).
   - LATIN SMALL LETTER K WITH DIAGONAL STROKE (`U+A743`).
   - LATIN CAPITAL LETTER K WITH STROKE AND DIAGONAL STROKE (`U+A744`).
   - LATIN SMALL LETTER K WITH STROKE AND DIAGONAL STROKE (`U+A745`).
+  - CIRCLED ANTICLOCKWISE ARROW (`U+1F10E`).
+  - CIRCLED HUMAN FIGURE (`U+1F16F`).
 * Drop `<=` and `>=` as inequality for Verilog (#1864).
 * Fix variant selection for `cv27`, `cv33`, `cv36`, and `cv49` for `ss17` under italics.
 * Make Greek Kappa respond to top-left serifed variants of `k`.

--- a/font-src/glyphs/auto-build/composite.ptl
+++ b/font-src/glyphs/auto-build/composite.ptl
@@ -638,6 +638,8 @@ glyph-block AutoBuild-Enclosure : begin
 			list 0xA9    {'C'}                       WideWidth2
 			list 0x1F12F {'revC'}                    WideWidth2
 			list 0x2117  {'P'}                       WideWidth2
+			list 0x1F10E {'ccCcwArrow'}              WideWidth2
+			list 0x1F16F {'ccHumanFigure'}           WideWidth2
 			list 0x1F1AD {'M'}                       WideWidth2
 			list 0x24EA  {'zero.lnum'}               WideWidth1
 			list 0x1F10B {'zero.lnum'}               WideWidth1 # We don't have serifs for digit 0, so make an alias here

--- a/font-src/glyphs/symbol/arrow.ptl
+++ b/font-src/glyphs/symbol/arrow.ptl
@@ -146,7 +146,17 @@ glyph-block Symbol-Arrow : for-width-kinds WideWidth1
 			corner o (-size)
 			corner o (+width / 2)
 
-	define [TriangleArrowHead x1 y1 x2 y2 width length] : begin
+	define [ArrowHeadMaskGap x1 y1 x2 y2 width length gap] : begin
+		return : new-glyph : PointingTo x1 y1 x2 y2 : lambda [mag] : spiro-outline
+			corner length (width - o)
+			corner o 0
+			corner length (-width + o)
+			corner (length - gap) (-width + o)
+			corner (o - gap) 0
+			corner (length - gap) (width - o)
+
+	define [TriangleArrowHead x1 y1 x2 y2 width _length] : begin
+		local length : fallback _length width
 		return : new-glyph : PointingTo x1 y1 x2 y2 : lambda [mag] : spiro-outline
 			corner o 0
 			corner length (width - o)
@@ -411,64 +421,100 @@ glyph-block Symbol-Arrow : for-width-kinds WideWidth1
 		MkArrow [LoopArrowShape (-1)] [MangleName 'loopArrowRight']     [MangleUnicode 0x21AC] arrowSB SymbolMid arrowRSB SymbolMid
 
 	do "Half Circle Arrow"
-		local arcSW : Math.min arrowSw [AdviceStroke 4 MosaicWidthScalar]
+		local arcSW : Math.min arrowSw [AdviceStroke 5 MosaicWidthScalar]
 		local headSize : mix arcSW arrowHeadSize 0.5
-		local hsx0 : HVContrast * arcSW / 2
-		local hsx : hsx0 + headSize / 2
-		local hsx2 : hsx0 + (MosaicWidthScalar / 4) * headSize
-		local hsy : arcSW / 2 + headSize / 2
+		local headLength : (headSize + fine) * [Math.sqrt 0.5]
+		local l : arrowSB  + 0.5 * headSize
+		local r : arrowRSB - 0.5 * headSize
+		local t : arrowTop - 0.5 * headSize
+		local b : arrowBot + 0.5 * headSize
+		local ada : ArchDepthAOf (SmallArchDepth * (r - l) / (RightSB - SB)) (r - l)
+		local adb : ArchDepthBOf (SmallArchDepth * (r - l) / (RightSB - SB)) (r - l)
+		local gapWidth : Math.max ((t - b) * 0.05) (fine * [Math.sqrt 0.5])
 
-		define [MkHalfCircleArrow id unicode size sw z3 tween32 z2 tween21 z1 z1t]
-			create-glyph [MangleName id] [MangleUnicode unicode] : glyph-proc
-				set-width MosaicWidth
-				include : ArrowHead z1.x z1.y z1t.x z1t.y size
-				include : difference
-					dispiro [widths.center sw] z3 tween32 z2 tween21 z1 z1t
-					ArrowHeadMaskOut z1.x z1.y z1t.x z1t.y size
+		define [HalfCircleArrow headFunc fCcw fGapped] : glyph-proc
+			local arrowX : if fCcw (l + 0.5 * HVContrast * arcSW) (r - 0.5 * HVContrast * arcSW)
+			local arrowY SymbolMid
+			local arrowYS : arrowY + 0.5 * headLength
+			local arrowYE : arrowY - 0.5 * headLength
+			set-width MosaicWidth
+			include : union
+				difference
+					OShape.NoOvershoot t b l r arcSW ada adb
+					if fGapped
+						ArrowHeadMaskGap arrowX arrowYS arrowX arrowYE headSize headSize gapWidth
+						MaskBelow arrowY
+				difference
+					dispiro
+						widths.center arcSW
+						flat arrowX arrowY
+						curl arrowX arrowYE [heading Downward]
+					ArrowHeadMaskOut arrowX arrowYS arrowX arrowYE headSize
+			include : headFunc arrowX arrowYS arrowX arrowYE headSize
 
-		define [MkOpenCircleArrow id unicode size sw z4 tween43 z3 tween32 z2 tween21 z1 z1t]
-			create-glyph [MangleName id] [MangleUnicode unicode] : glyph-proc
-				set-width MosaicWidth
-				include : ArrowHead z1.x z1.y z1t.x z1t.y size
-				include : difference
-					dispiro [widths.center sw] z4 tween43 z3 tween32 z2 tween21 z1 z1t
-					ArrowHeadMaskOut z1.x z1.y z1t.x z1t.y size
+		define [ShareAlikeArrow] : glyph-proc
+			local arrowX : l + 0.5 * HVContrast * Stroke
+			local headLength : headSize * [Math.sqrt 0.5]
+			local gapSize : Math.max (2 * headLength) (CAP - 0 - ada - adb)
+			local gapTop : SymbolMid + 0.5 * gapSize
+			local gapBot : SymbolMid - 0.5 * gapSize
+			set-width MosaicWidth
+			include : union
+				difference
+					OShape.NoOvershoot CAP 0 l r Stroke ada adb
+					spiro-outline
+						corner arrowSB   gapTop
+						corner arrowMidX gapTop
+						corner arrowMidX gapBot
+						corner arrowSB   gapBot
+			include : TriangleArrowHead arrowX gapTop arrowX (gapTop - headLength) headSize
 
-		MkHalfCircleArrow 'ccwHalfCircleArrowTop' 0x21B6 headSize arcSW
-			g4 (arrowRSB - hsx) SymbolMid [heading Upward]
-			arcvh
-			g4 arrowMidX (arrowTop - hsy) [heading Leftward]
-			archv
-			flat (arrowSB + hsx) SymbolMid
-			curl (arrowSB + hsx) (SymbolMid - headSize) [heading Downward]
+		define [OpenCircleArrow headFunc fCcw fClosed] : glyph-proc
+			local arrowX : arrowMidX - CorrectionOMidX * arcSW
+			local arrowXS : arrowX + [if fCcw 0.5 (-0.5)] * headLength
+			local arrowXE : arrowX + [if fCcw (-0.5) 0.5] * headLength
+			local arrowY : t - (0.5 * arcSW)
 
-		MkHalfCircleArrow 'cwHalfCircleArrowTop'  0x21B7 headSize arcSW
-			g4 (arrowSB + hsx) SymbolMid [heading Upward]
-			arcvh
-			g4 arrowMidX (arrowTop - hsy) [heading Rightward]
-			archv
-			flat (arrowRSB - hsx) SymbolMid
-			curl (arrowRSB - hsx) (SymbolMid - headSize) [heading Downward]
+			local circle : OShape.NoOvershoot t b l r arcSW ada adb
+			set-width MosaicWidth
+			if fClosed
+				include circle
+				include : union
+					difference
+						OShape.NoOvershoot t b l r arcSW ada adb
+						intersection [MaskAbove SymbolMid] [[if fCcw MaskLeft MaskRight] arrowX]
+					difference
+						dispiro
+							widths.center arcSW
+							flat arrowX arrowY
+							curl arrowXE arrowY [heading [if fCcw Leftward Rightward]]
+						ArrowHeadMaskOut arrowXS arrowY arrowXE arrowY headSize
+			include : headFunc arrowXS arrowY arrowXE arrowY headSize
 
-		MkOpenCircleArrow 'ccwOpenCircleArrow' 0x21BA headSize arcSW
-			g4 (arrowSB + hsx2) SymbolMid [heading Downward]
-			arcvh
-			g4 arrowMidX (arrowBot + hsy) [heading Rightward]
-			archv
-			g4 (arrowRSB - hsx2) SymbolMid [heading Upward]
-			arcvh
-			flat arrowMidX (arrowTop - hsy)
-			curl (arrowMidX - headSize) (arrowTop - hsy) [heading Leftward]
+		create-glyph [MangleName 'ccwHalfCircleArrow'] [MangleUnicode 0x21B6] : glyph-proc
+			include : HalfCircleArrow ArrowHead true  false
+		create-glyph [MangleName 'cwHalfCircleArrow'] [MangleUnicode 0x21B7] : glyph-proc
+			include : HalfCircleArrow ArrowHead false false
+		create-glyph [MangleName 'ccwOpenCircleArrow'] [MangleUnicode 0x21BA] : glyph-proc
+			include : OpenCircleArrow ArrowHead true  false
+		create-glyph [MangleName 'cwOpenCircleArrow'] [MangleUnicode 0x21BB] : glyph-proc
+			include : OpenCircleArrow ArrowHead false false
+		create-glyph [MangleName 'ccwGappedCircleArrow'] [MangleUnicode 0x27F2] : glyph-proc
+			include : HalfCircleArrow ArrowHead true  true
+		create-glyph [MangleName 'cwGappedCircleArrow'] [MangleUnicode 0x27F3] : glyph-proc
+			include : HalfCircleArrow ArrowHead false true
+		create-glyph [MangleName 'ccwClosedCircleArrow'] [MangleUnicode 0x2940] : glyph-proc
+			include : OpenCircleArrow ArrowHead true  true
+		create-glyph [MangleName 'cwClosedCircleArrow'] [MangleUnicode 0x2941] : glyph-proc
+			include : OpenCircleArrow ArrowHead false true
+		create-glyph [MangleName 'ccwOpenCircleArrowTriangle'] [MangleUnicode 0x2B6E] : glyph-proc
+			include : OpenCircleArrow TriangleArrowHead true  false
+		create-glyph [MangleName 'cwOpenCircleArrowTriangle'] [MangleUnicode 0x2B6F] : glyph-proc
+			include : OpenCircleArrow TriangleArrowHead false false
 
-		MkOpenCircleArrow 'cwOpenCircleArrow'  0x21BB headSize arcSW
-			g4 (arrowRSB - hsx2) SymbolMid [heading Downward]
-			arcvh
-			g4 arrowMidX (arrowBot + hsy) [heading Leftward]
-			archv
-			g4 (arrowSB + hsx2) SymbolMid [heading Upward]
-			arcvh
-			flat arrowMidX (arrowTop - hsy)
-			curl (arrowMidX + headSize) (arrowTop - hsy) [heading Rightward]
+		if (MosaicWidthScalar == 1) : do
+			create-glyph 'ccCcwArrow' : glyph-proc
+				include : ShareAlikeArrow
 
 	do "Bend and Angle arrows"
 		define bendL : mix arrowMidX arrowSB [Math.max (bendArrowHeadSize / (arrowMidX - arrowSB)) : Math.pow 0.6 (2 /  MosaicWidthScalar)]

--- a/font-src/glyphs/symbol/pictograph/stick-figure.ptl
+++ b/font-src/glyphs/symbol/pictograph/stick-figure.ptl
@@ -149,3 +149,32 @@ glyph-block Symbol-Pictograph-Stick-Figure : begin
 				Rotate (-0.5 * Math.PI)
 				Translate (+0.5 * MosaicWidth) (+SymbolMid)
 			include : PointingHandShape vBox tfm sw
+
+	create-glyph 'ccHumanFigure' : glyph-proc
+		define yTop : mix ParenBot ParenTop 0.95
+		define yBot : mix ParenBot ParenTop 0.05
+		define cr : (yTop - yBot) * (1 / 16)
+		define rHead : (yTop - yBot) * (1 / 8)
+		define yBody : mix yBot yTop 0.7
+		define yArm : mix yBot yBody 0.5
+		define lArm : mix SB RightSB 0.1
+		define rArm : mix SB RightSB 0.9
+		define lLeg : mix lArm rArm (1 / 4)
+		define rLeg : mix lArm rArm (3 / 4)
+
+		include : DotAt Middle (yTop - rHead) rHead
+		include : spiro-outline
+			widths.center [AdviceStroke 4]
+			corner lLeg yBot
+			corner lLeg yArm
+			corner lArm yArm
+			curl lArm (yBody - cr)
+			arcvh
+			flat (lArm + cr) yBody
+			curl (rArm - cr) yBody
+			archv
+			flat rArm (yBody - cr)
+			corner rArm yArm
+			corner rLeg yArm
+			corner rLeg yBot
+			close


### PR DESCRIPTION
The remaining 2 CC Symbols (with copyleft for reference):
![image](https://github.com/be5invis/Iosevka/assets/21302803/82f652e3-7e90-4454-a336-48a5732dc5dd)![image](https://github.com/be5invis/Iosevka/assets/21302803/ce49f4dc-48ce-4f51-8e03-bb4d64cb7b9b)
* Tried my best to recreate the official CC-BY symbol human figure, and making it depend a bit on weight as well (i guess?)
* For the CC-SA arrow, [wiktionary](https://en.wiktionary.org/wiki/%F0%9F%84%8E#Translingual) claims that it is a variant of the copyleft symbol but with an arrowhead. So I did that instead of using the original CCW arrow style.
  * I suppose we *can* make the arrow fullwidth in WWID (closer to the original) but that would be kinda weird without syncing copyright and copyleft as well. I'll just leave it as is.

I suppose that completes the set, if ignoring `⊜`.

----

The circular arrows (which I did in preparation of the ShareAlike arrow. Default is Wide):
![image](https://github.com/be5invis/Iosevka/assets/21302803/5fc9b589-0530-4151-893e-4fd066ea85dc)![image](https://github.com/be5invis/Iosevka/assets/21302803/c3b55bf2-d0ff-4e04-92a7-991ff02ec593)
* Redid Semicircle Arrows (`↶↷`) and Open Circle Arrows (`↺↻`) to kinda match how Iosevka handles "Halfwidth Circular Symbols" like faces or encircled letters (or to mimic PragmataPro's style). Also so that it generalizes better to the other circular arrows.
   * Unfortunately this forced me to bump the stroke weight to `[AdviceStroke 5]` due to the halfwidth open circle arrow heads colliding with the stem.
* Triangle-Headed Open Circle Arrows (`⭮⭯`) are (probably) just the open circle arrows but with triangle head. Most font shows these (and the original Circle Arrows) with an opening above, but I'll follow the existing style for now.
* Closed Circle Arrows (`⥀⥁`) are open circle arrows with the ring closed.
* Gapped Circle Arrows (`⟲⟳`) have two common renditions: A 1/8-open circle, or a circle with a tiny gap (kinda like `∲`). I chose the latter because it's probably easier to do (considering the half-width version).



