### PR TITLE
fix variant selection for Bulgarian/Serbian de

### DIFF
--- a/font-src/glyphs/letter/latin/lower-g.ptl
+++ b/font-src/glyphs/letter/latin/lower-g.ptl
@@ -213,9 +213,8 @@ glyph-block Letter-Latin-Lower-G : begin
 	select-variant 'gPalatalHook' 0x1D83 (follow -- 'gScript')
 	select-variant 'gScriptCrossedTail' 0xAB36
 
-
-	alias 'cyrl/de.SRB' null 'gScript'
-	alias 'cyrl/de.BGR' null 'gScript'
+	select-variant 'cyrl/de.BGR' null (shapeFrom -- 'g')
+	alias 'cyrl/de.SRB' null 'cyrl/de.BGR'
 
 	derive-composites 'gScriptHookTop' 0x260 'gScript/hookTopBase'
 		TopHook.rBarOuter RightSB 0 XH

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1946,6 +1946,7 @@ selectorAffix."g/sansSerif" = ""
 selectorAffix."gScript" = ""
 selectorAffix."gScript/hookTopBase" = ""
 selectorAffix."gScriptCrossedTail" = ""
+selectorAffix."cyrl/de.BGR" = ""
 
 [prime.g.variants-buildup.stages.openness."*"]
 next = "END"
@@ -1958,6 +1959,7 @@ selectorAffix."g/sansSerif" = "doubleStorey"
 selectorAffix."gScript" = "singleStoreyScriptCut"
 selectorAffix."gScript/hookTopBase" = "singleStoreySerifless"
 selectorAffix."gScriptCrossedTail" = "singleStoreyScriptCut"
+selectorAffix."cyrl/de.BGR" = "singleStoreySerifless"
 
 [prime.g.variants-buildup.stages.openness.open]
 rank = 1
@@ -1967,6 +1969,7 @@ selectorAffix."g/sansSerif" = "openDoubleStorey"
 selectorAffix."gScript" = "singleStoreyScriptCut"
 selectorAffix."gScript/hookTopBase" = "singleStoreySerifless"
 selectorAffix."gScriptCrossedTail" = "singleStoreyScriptCut"
+selectorAffix."cyrl/de.BGR" = "singleStoreySerifless"
 
 [prime.g.variants-buildup.stages.stroey.single-storey]
 next = "hook"
@@ -1977,6 +1980,7 @@ selectorAffix."g/sansSerif" = "singleStorey"
 selectorAffix."gScript" = "singleStorey"
 selectorAffix."gScript/hookTopBase" = "singleStorey"
 selectorAffix."gScriptCrossedTail" = "singleStorey"
+selectorAffix."cyrl/de.BGR" = "singleStorey"
 
 [prime.g.variants-buildup.stages.hook."*"]
 next = "ear"
@@ -1989,6 +1993,7 @@ selectorAffix."g/sansSerif" = ""
 selectorAffix."gScript" = ""
 selectorAffix."gScript/hookTopBase" = ""
 selectorAffix."gScriptCrossedTail" = ""
+selectorAffix."cyrl/de.BGR" = ""
 
 [prime.g.variants-buildup.stages.hook.flat-hook]
 rank = 2
@@ -1998,6 +2003,7 @@ selectorAffix."g/sansSerif" = "flatHook"
 selectorAffix."gScript" = "flatHook"
 selectorAffix."gScript/hookTopBase" = "flatHook"
 selectorAffix."gScriptCrossedTail" = ""
+selectorAffix."cyrl/de.BGR" = "flatHook"
 
 [prime.g.variants-buildup.stages.ear.serifless]
 rank = 1
@@ -2006,6 +2012,7 @@ selectorAffix."g/sansSerif" = "serifless"
 selectorAffix."gScript" = "scriptCut"
 selectorAffix."gScript/hookTopBase" = "serifless"
 selectorAffix."gScriptCrossedTail" = "scriptCut"
+selectorAffix."cyrl/de.BGR" = "serifless"
 
 [prime.g.variants-buildup.stages.ear.serifed]
 rank = 2
@@ -2015,6 +2022,7 @@ selectorAffix."g/sansSerif" = "serifless"
 selectorAffix."gScript" = "scriptCut"
 selectorAffix."gScript/hookTopBase" = "serifless"
 selectorAffix."gScriptCrossedTail" = "scriptCut"
+selectorAffix."cyrl/de.BGR" = "serifed"
 
 [prime.g.variants-buildup.stages.ear.earless-corner]
 rank = 3
@@ -2024,6 +2032,7 @@ selectorAffix."g/sansSerif" = "earlessCorner"
 selectorAffix."gScript" = "scriptCut"
 selectorAffix."gScript/hookTopBase" = "serifless"
 selectorAffix."gScriptCrossedTail" = "scriptCut"
+selectorAffix."cyrl/de.BGR" = "earlessCorner"
 
 [prime.g.variants-buildup.stages.ear.earless-rounded]
 rank = 4
@@ -2033,6 +2042,7 @@ selectorAffix."g/sansSerif" = "earlessRounded"
 selectorAffix."gScript" = "scriptCut"
 selectorAffix."gScript/hookTopBase" = "serifless"
 selectorAffix."gScriptCrossedTail" = "scriptCut"
+selectorAffix."cyrl/de.BGR" = "earlessRounded"
 
 
 


### PR DESCRIPTION
`дɡg`

Default Slab under Bulgarian:
![image](https://github.com/be5invis/Iosevka/assets/37010132/76b04e14-91bd-493a-9711-1273d1515f35)

Default Slab Italic under Serbian:
![image](https://github.com/be5invis/Iosevka/assets/37010132/8b22335d-1586-4f38-b9fb-a2c3fc55df2a)

`ss03` under Bulgarian:
![image](https://github.com/be5invis/Iosevka/assets/37010132/71daa23d-5fd1-401c-82eb-aeed970c4125)

`ss03` Italic under Serbian:
![image](https://github.com/be5invis/Iosevka/assets/37010132/c2871243-7a7e-44e5-8466-28e2c4eb0d36)

`ss12` under Bulgarian:
![image](https://github.com/be5invis/Iosevka/assets/37010132/46b89127-b3e7-45a6-85f7-2c9f616e11d3)

`ss12` Italic under Serbian:
![image](https://github.com/be5invis/Iosevka/assets/37010132/e28f5031-0f95-4aba-aa96-fa9f6a62f31b)
