### PR TITLE
Volapuk Letters, and a few other fixes

### DIFF
--- a/changes/26.0.0.md
+++ b/changes/26.0.0.md
@@ -18,6 +18,7 @@
   - LATIN SMALL LETTER K WITH DIAGONAL STROKE (`U+A743`).
   - LATIN CAPITAL LETTER K WITH STROKE AND DIAGONAL STROKE (`U+A744`).
   - LATIN SMALL LETTER K WITH STROKE AND DIAGONAL STROKE (`U+A745`).
+  - LATIN CAPITAL LETTER VOLAPUK AE (`U+A79A`) ... LATIN SMALL LETTER VOLAPUK UE (`U+A79F`) (#1865).
   - CIRCLED ANTICLOCKWISE ARROW (`U+1F10E`).
   - CIRCLED HUMAN FIGURE (`U+1F16F`).
 * Drop `<=` and `>=` as inequality for Verilog (#1864).
@@ -29,3 +30,4 @@
 * Fix variant selection for `cv27`, `cv33`, `cv36`, and `cv49` for `ss17` under italics.
 * Make Greek Kappa respond to top-left serifed variants of `k`.
 * Fix slabs for `U+019C`, `U+0257`, `U+026F`, and `U+0270`.
+* Add single-storey variants support for `U+A657`.

--- a/font-src/glyphs/auto-build/transformed.ptl
+++ b/font-src/glyphs/auto-build/transformed.ptl
@@ -290,7 +290,7 @@ glyph-block Autobuild-Transformed : begin
 			list 0x107A2 'oSlash'
 			list 0x1078E 'eRev'
 			list 0x10791 'ramshorn'
-			list 0x1078F 'closeturnepsilon'
+			list 0x1078F 'epsilonRevClosed'
 			list 0x10783 'ae'
 			list 0x107A3 'smcpOE'
 			list 0x10781 'triangleColon'

--- a/font-src/glyphs/letter/cyrillic/iotified-a.ptl
+++ b/font-src/glyphs/letter/cyrillic/iotified-a.ptl
@@ -125,15 +125,9 @@ glyph-block Letter-Cyrillic-Iotified-A : begin
 						AMaskShape subDf fStraightBar CAP df.mvs
 
 	do "iotified a"
-		glyph-block-import Letter-Latin-Lower-A : DoubleStorey
-		define DoubleStoreyConfig : object
-			doubleStoreySerifless        { DoubleStorey.Serifless         }
-			doubleStoreySerifed          { DoubleStorey.Serifed           }
-			doubleStoreyTailed           { DoubleStorey.Tailed            }
-			doubleStoreyToothlessCorner  { DoubleStorey.ToothlessCorner   }
-			doubleStoreyToothlessRounded { DoubleStorey.ToothlessRounded  }
+		glyph-block-import Letter-Latin-Lower-A : DoubleStorey DoubleStoreyConfig SingleStorey SingleStoreyConfig
 
-		foreach { suffix { body } } [Object.entries DoubleStoreyConfig] : do
+		foreach { suffix { body xTrailing } } [Object.entries DoubleStoreyConfig] : do
 			create-glyph "cyrl/aIotified.\(suffix)" : glyph-proc
 				define df : DivFrame para.diversityM 3
 				set-width df.width
@@ -145,6 +139,17 @@ glyph-block Letter-Cyrillic-Iotified-A : begin
 				include : difference
 					Iotified.full df XH [mix df.leftSB df.rightSB (3 / 4)] (XH / 2)
 					WithTransform [ApparentTranslate shift 0] [DoubleStorey.GetMask body df df.mvs]
+
+		foreach { suffix { body bar } } [Object.entries SingleStoreyConfig] : do
+			create-glyph "cyrl/aIotified.\(suffix)" : glyph-proc
+				define df : DivFrame para.diversityM 3
+				set-width df.width
+				include : df.markSet.e
+
+				local { subDf shift } : SubDfAndShift 1 df
+				include : WithTransform [ApparentTranslate shift 0] [body subDf XH bar no-shape df.mvs]
+
+				include : Iotified.full df XH (shift + subDf.leftSB + 0.5 * HVContrast * df.mvs) (XH / 2)
 
 	do "iotified e"
 		glyph-block-import Letter-Latin-Lower-E : SmallEShape SmallERoundedShape
@@ -167,5 +172,5 @@ glyph-block Letter-Cyrillic-Iotified-A : begin
 				include : Iotified.full df XH df.middle (XH / 2)
 
 	select-variant 'cyrl/AIotified' 0xA656 (follow -- 'A')
-	select-variant 'cyrl/aIotified' 0xA657 (follow -- 'a/turnABase')
+	select-variant 'cyrl/aIotified' 0xA657 (follow -- 'a')
 	select-variant 'latn/eIotified' 0xAB61 (follow -- 'e')

--- a/font-src/glyphs/letter/cyrillic/orthography.ptl
+++ b/font-src/glyphs/letter/cyrillic/orthography.ptl
@@ -18,7 +18,7 @@ glyph-block Letter-Cyrillic-Orthography : begin
 	orthographic-italic 'cyrl/tse'            0x446
 	orthographic-italic 'cyrl/tetse'          0x4B5
 	orthographic-italic 'cyrl/yat'            0x463
-	orthographic-italic 'cyrl/pe'             0x43f
+	orthographic-italic 'cyrl/pe'             0x43F
 	orthographic-italic 'cyrl/peMidHook'      0x4A7
 	orthographic-italic 'cyrl/peDescender'    0x525
 	orthographic-italic 'cyrl/ghe'            0x433

--- a/font-src/glyphs/letter/greek/lower-epsilon.ptl
+++ b/font-src/glyphs/letter/greek/lower-epsilon.ptl
@@ -2,7 +2,7 @@ $$include '../../../meta/macros.ptl'
 
 extern isFinite
 
-import [mix linreg clamp fallback] from"../../../support/utils.mjs"
+import [mix linreg clamp fallback SuffixCfg] from"../../../support/utils.mjs"
 
 glyph-module
 
@@ -14,16 +14,26 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 	glyph-block-import Letter-Shared-Shapes : SerifedArcStart SerifedArcEnd SerifFrame
 	glyph-block-import Letter-Shared-Shapes : InwardSlabArcStart InwardSlabArcEnd
 	glyph-block-import Letter-Shared-Shapes : ArcStartSerif ArcEndSerif
+	glyph-block-import Letter-Shared-Shapes : OBarLeft OBarRight
 	glyph-block-import Letter-Shared-Shapes : DToothlessRise RetroflexHook CyrDescender UpwardHookShape
 
 	define SLAB-NONE       0
 	define SLAB-CLASSICAL  1
 	define SLAB-INWARD     2
 	define FLAT-CONNECTION 3
+	define OPEN-HALF       4
+	define OPEN-VERTICAL   5
+	define CLOSED-CIRCLE   6
+	define CLOSED-ROUND    7
+	define CLOSED-STEM     8
 
 	define StdBlend 0.65
+	define VolBlend 0.52
 
-	define [SmallEpsilon slabTop slabBot top bot blend hook] : namespace
+	define [SmallEpsilon] : with-params [
+			slabTop slabBot top bot blend hook
+			[ada2 SmallArchDepthA] [adb2 SmallArchDepthB]
+		] : namespace
 		export : define [Dim] : begin
 			local stroke : AdviceStroke2 2 3 (top - bot)
 			local midx : mix SB RightSB blend
@@ -33,14 +43,23 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 			local ada : topHeight - [mix (midyHeight + stroke / 2) (topHeight - O - stroke) (ArchDepthB / (ArchDepthA + ArchDepthB))] - TanSlope * HVContrast * stroke
 			local adb : [mix (stroke + O) (midyHeight - stroke / 2) (ArchDepthB / (ArchDepthA + ArchDepthB))] + TanSlope * HVContrast * stroke
 			local fine : stroke * CThin
-			return : object stroke midx midy ada adb fine
+			local stemFine : stroke * (ShoulderFine / Stroke)
+			return : object stroke midx midy ada adb fine stemFine
 
 		export : define [UpperShape] : begin
-			define [object stroke midx midy ada adb fine] : Dim
+			define [object stroke midx midy ada adb fine stemFine] : Dim
 			return : dispiro
 				match slabTop
 					[Just SLAB-CLASSICAL] : SerifedArcStart.RtlLhs RightSB Middle top stroke hook
 					[Just SLAB-INWARD] : InwardSlabArcStart.RtlLhs RightSB Middle top stroke hook
+					[Just OPEN-VERTICAL] : straight.down.start SB top [widths.lhs.heading stroke Downward]
+					([Just CLOSED-CIRCLE] || [Just CLOSED-ROUND]) : list
+						flat (RightSB - [if (slabTop === CLOSED-CIRCLE) OX 0]) midy [widths.lhs stroke]
+						curl (RightSB - [if (slabTop === CLOSED-CIRCLE) OX 0]) (top - adb2)
+						arcvh
+						g4 (Middle - CorrectionOMidX * stroke) (top - O)
+						archv
+					[Just CLOSED-STEM] : OBarRight.arcStart top SB RightSB stroke stemFine ada2 adb2 midy
 					__ : list [g4 (RightSB + O) (top - hook) [widths.lhs]] [hookstart (top - O)]
 				g4 SB [YSmoothMidL top (midy - stroke / 2)]
 				arcvh
@@ -48,15 +67,23 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 				curl midx (midy - (fine - stroke / 2)) [heading Rightward]
 
 		export : define [LowerShape] : begin
-			define [object stroke midx midy ada adb fine] : Dim
+			define [object stroke midx midy ada adb fine stemFine] : Dim
 			return : dispiro
 				flat midx (midy + (fine - stroke / 2)) [widths.heading fine 0 Leftward]
 				curl Middle (midy + (fine - stroke / 2)) [heading Leftward]
 				archv
-				g4 (SB + OX * 2) [YSmoothMidL (midy + stroke / 2) bot] [widths.lhs]
+				g4 (SB + OX * 2) [YSmoothMidL (midy + stroke / 2) bot] [widths.lhs stroke]
 				match slabBot
 					[Just SLAB-CLASSICAL] : SerifedArcEnd.LtrLhs RightSB Middle bot stroke hook
 					[Just SLAB-INWARD] : InwardSlabArcEnd.LtrLhs RightSB Middle bot stroke hook
+					[Just OPEN-VERTICAL] : straight.down.end (SB + OX * 2) bot [heading Downward]
+					([Just CLOSED-CIRCLE] || [Just CLOSED-ROUND]) : list
+						arcvh
+						g4 (Middle + CorrectionOMidX * stroke) (bot + O)
+						archv
+						flat (RightSB - [if (slabBot === CLOSED-CIRCLE) OX 0]) (bot + adb2)
+						curl (RightSB - [if (slabBot === CLOSED-CIRCLE) OX 0]) midy
+					[Just CLOSED-STEM] : OBarRight.arcEnd bot SB RightSB stroke stemFine ada2 adb2 midy
 					__ : list [hookend (bot + O)] [g4 (RightSB - O) (bot + hook)]
 
 		export : define [Shape] : union [UpperShape] [LowerShape]
@@ -76,21 +103,24 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 				__ : glyph-proc
 
 	glyph-block-export CyrZe
-	define [CyrZe slabTop slabBot top bot left right blend hook _stroke _xo _op] : namespace
-		local xo : fallback _xo OX
+	define [CyrZe] : with-params [
+		slabTop slabBot top bot left right blend hook _stroke
+		[xo OX] [op OverlayPos] [ada2 SmallArchDepthA] [adb2 SmallArchDepthB]
+		] : namespace
 		export : define [Dim] : begin
 			local stroke : fallback _stroke : AdviceStroke2 2 3 (top - bot)
 			local midx : mix right left blend
-			local midy : mix bot top [fallback _op OverlayPos]
+			local midy : mix bot top op
 			local topHeight : top - bot
 			local midyHeight : midy - bot
 			local adb : topHeight - [mix (midyHeight + stroke / 2) (topHeight - O - stroke) (ArchDepthA / (ArchDepthA + ArchDepthB))] + TanSlope * HVContrast * stroke
 			local ada : [mix (stroke + O) (midyHeight - stroke / 2) (ArchDepthA / (ArchDepthA + ArchDepthB))] - TanSlope * HVContrast * stroke
 			local fine : stroke * CThin
-			return : object stroke midx midy ada adb fine
+			local stemFine : stroke * (ShoulderFine / Stroke)
+			return : object stroke midx midy ada adb fine stemFine
 
 		define [CyrZeUpperShapeT sink] : begin
-			define [object stroke midx midy ada adb fine] : Dim
+			define [object stroke midx midy ada adb fine stemFine] : Dim
 			local middle : (left + right) / 2
 			return : sink
 				match slabTop
@@ -98,7 +128,15 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 					[Just SLAB-INWARD] : InwardSlabArcStart.LtrRhs left middle top stroke hook
 					[Just FLAT-CONNECTION] : list
 						flat (left - xo) top [widths.rhs.heading stroke Rightward]
-						curl (middle - CorrectionOMidX * stroke) top  [heading Rightward]
+						curl (middle - CorrectionOMidX * stroke) top [heading Rightward]
+					[Just OPEN-VERTICAL] : straight.down.start right top [widths.rhs.heading stroke Downward]
+					([Just CLOSED-CIRCLE] || [Just CLOSED-ROUND]) : list
+						flat (left + [if (slabTop === CLOSED-CIRCLE) xo 0]) midy [widths.rhs stroke]
+						curl (left + [if (slabTop === CLOSED-CIRCLE) xo 0]) (top - ada2)
+						arcvh
+						g4 (middle - CorrectionOMidX * stroke) (top - O)
+						archv
+					[Just CLOSED-STEM] : OBarLeft.arcStart top left right stroke stemFine ada2 adb2 midy
 					__ : list [g4 (left - xo) (top - hook) : widths.rhs stroke] [hookstart (top - O)]
 				g4 right [YSmoothMidR top (midy - stroke / 2)]
 				arcvh
@@ -106,30 +144,32 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 				curl midx (midy - (fine - stroke / 2)) [heading Leftward]
 
 		define [CyrZeLowerShapeT sink] : begin
-			define [object stroke midx midy ada adb fine] : Dim
+			define [object stroke midx midy ada adb fine stemFine] : Dim
 			local middle : (left + right) / 2
 			return : sink
-				flat midx (midy + (fine - stroke / 2)) [widths.rhs.heading fine Rightward]
+				flat midx (midy + (fine - stroke / 2)) [widths.heading 0 fine Rightward]
 				curl middle (midy + (fine - stroke / 2)) [heading Rightward]
 				archv
-				g4 (right - xo * 2) [YSmoothMidR (midy + stroke / 2) bot] [widths.rhs stroke]
+				if (slabBot === OPEN-HALF)
+					g4.down.end (right - xo * 2) [YSmoothMidR (midy + stroke / 2) bot] [widths.rhs.heading stroke Downward]
+					g4 (right - xo * 2) [YSmoothMidR (midy + stroke / 2) bot] [widths.rhs stroke]
 				match slabBot
 					[Just SLAB-CLASSICAL] : SerifedArcEnd.RtlRhs left middle bot stroke hook
 					[Just SLAB-INWARD] : InwardSlabArcEnd.RtlRhs left middle bot stroke hook
+					[Just OPEN-HALF] : list
+					[Just OPEN-VERTICAL] : straight.down.end (right - xo * 2) bot [heading Downward]
+					([Just CLOSED-CIRCLE] || [Just CLOSED-ROUND]) : list
+						arcvh
+						g4 (middle + CorrectionOMidX * stroke) (bot + O)
+						archv
+						flat (left + [if (slabBot === CLOSED-CIRCLE) xo 0]) (bot + adb2)
+						curl (left + [if (slabBot === CLOSED-CIRCLE) xo 0]) midy
+					[Just CLOSED-STEM] : OBarLeft.arcEnd bot left right stroke stemFine ada2 adb2 midy
 					__ : list [hookend (bot + O) (sw -- stroke)] [g4 (left + xo) (bot + hook)]
 
 		export : define [UpperShape] : CyrZeUpperShapeT dispiro
 
 		export : define [LowerShape] : CyrZeLowerShapeT dispiro
-
-		define [CyrZeLowerShapeHalf] : begin
-			define [object stroke midx midy ada adb fine] : Dim
-			local middle : (left + right) / 2
-			return : dispiro
-				flat midx (midy + (fine - stroke / 2)) [widths.rhs.heading fine Rightward]
-				curl middle (midy + (fine - stroke / 2)) [heading Rightward]
-				archv
-				g4.down.end (right - OX * 2) [YSmoothMidR (midy + stroke / 2) bot] [widths.rhs.heading stroke Downward]
 
 		define [CyrZeLowerShapeTailed] : begin
 			define [object stroke midx midy ada adb fine] : Dim
@@ -154,10 +194,6 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 		export : define [ShapeMask] : union
 			CyrZeUpperShapeT spiro-outline
 			CyrZeLowerShapeT spiro-outline
-
-		export : define [ShapeHalf] : union
-			CyrZeUpperShapeT dispiro
-			CyrZeLowerShapeHalf
 
 		export : define [KsiBaseShape] : union
 			CyrZeUpperShapeT dispiro
@@ -216,20 +252,16 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 
 		create-glyph "cyrl/DzjeKomi.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			local ze : CyrZe slabTop slabBot CAP 0 SB RightSB StdBlend Hook
-			define [object stroke midy] : ze.Dim
-			include : ze.ShapeHalf
-			include : ze.AutoStartSerifL slabTop CAP 0 SB RightSB StdBlend
-			include : VBar.r (RightSB - OX * 2) 0 [YSmoothMidR (midy + stroke / 2) 0] stroke
+			local ze : CyrZe slabTop OPEN-VERTICAL CAP 0 SB RightSB StdBlend Hook
+			include : ze.Shape
+			include : ze.AutoStartSerifL
 			include : CyrDescender.rSideJut (RightSB - OX * 2) 0
 
 		create-glyph "cyrl/dzjeKomi.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			local ze : CyrZe slabTop slabBot XH 0 SB RightSB StdBlend SHook
-			define [object stroke midy] : ze.Dim
-			include : ze.ShapeHalf
-			include : ze.AutoStartSerifL slabTop XH 0 SB RightSB StdBlend
-			include : VBar.r (RightSB - OX * 2) 0 [YSmoothMidR (midy + stroke / 2) 0] stroke
+			local ze : CyrZe slabTop OPEN-VERTICAL XH 0 SB RightSB StdBlend SHook
+			include : ze.Shape
+			include : ze.AutoStartSerifL
 			include : CyrDescender.rSideJut (RightSB - OX * 2) 0
 
 		create-glyph "cyrl/ZjeKomi.\(suffix)" : glyph-proc
@@ -238,9 +270,9 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 			include : df.markSet.capital
 
 			local xm : df.middle + 0.5 * df.mvs * HVContrast
-			local ze : CyrZe slabTop slabBot CAP 0 df.leftSB xm StdBlend Hook df.mvs
+			local ze : CyrZe slabTop OPEN-HALF CAP 0 df.leftSB xm StdBlend Hook df.mvs
 			define [object stroke midy] : ze.Dim
-			include : ze.ShapeHalf
+			include : ze.Shape
 			include : UpwardHookShape
 				left -- xm - OX * 2 - stroke * HVContrast
 				right -- df.rightSB
@@ -259,9 +291,9 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 			include : df.markSet.e
 
 			local xm : df.middle + 0.5 * df.mvs * HVContrast
-			local ze : CyrZe slabTop slabBot XH 0 df.leftSB xm StdBlend Hook df.mvs
+			local ze : CyrZe slabTop OPEN-HALF XH 0 df.leftSB xm StdBlend SHook df.mvs
 			define [object stroke midy] : ze.Dim
-			include : ze.ShapeHalf
+			include : ze.Shape
 			include : UpwardHookShape
 				left -- xm - OX * 2 - stroke * HVContrast
 				right -- df.rightSB
@@ -283,6 +315,156 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 			include : MarkSet.p
 			include : let [ze : CyrZe slabTop SLAB-NONE XH 0 SB RightSB StdBlend SHook]
 				union [ze.KsiBaseShape] [ze.AutoStartSerifL]
+
+	do "Closed Epsilon Shapes"
+		create-glyph 'epsilonClosed' 0x29A : glyph-proc
+			include : MarkSet.e
+			local eps : SmallEpsilon CLOSED-CIRCLE CLOSED-CIRCLE XH 0 StdBlend SHook
+				ada2 -- SmallArchDepthA
+				adb2 -- SmallArchDepthB
+			include : eps.Shape
+
+		create-glyph 'epsilonRevClosed' 0x25E : glyph-proc
+			include : MarkSet.e
+			local ze : CyrZe CLOSED-CIRCLE CLOSED-CIRCLE XH 0 SB RightSB StdBlend SHook
+				ada2 -- SmallArchDepthA
+				adb2 -- SmallArchDepthB
+			include : ze.Shape
+
+		create-glyph 'vol/Oe' 0xA79C : glyph-proc
+			include : MarkSet.capital
+			local eps : SmallEpsilon CLOSED-CIRCLE CLOSED-CIRCLE CAP 0 VolBlend Hook
+				ada2 -- ArchDepthA
+				adb2 -- ArchDepthB
+			include : eps.Shape
+
+		create-glyph 'vol/oe' 0xA79D : glyph-proc
+			include : MarkSet.e
+			local eps : SmallEpsilon CLOSED-CIRCLE CLOSED-CIRCLE XH 0 VolBlend SHook
+				ada2 -- SmallArchDepthA
+				adb2 -- SmallArchDepthB
+			include : eps.Shape
+
+	do "Volapuk AE"
+		glyph-block-import Letter-Latin-Lower-A : SingleStorey
+
+		define [FullBarBody df height bar hook ada2 adb2] : glyph-proc
+			local eps : SmallEpsilon CLOSED-STEM CLOSED-STEM height 0 VolBlend hook
+				ada2 -- ada2
+				adb2 -- adb2
+			define [object stroke] : eps.Dim
+			include : eps.Shape
+			include : bar df height no-shape stroke
+
+		define [EarlessCornerBody df height bar hook ada2 adb2] : glyph-proc
+			local eps : SmallEpsilon SLAB-INWARD CLOSED-STEM height 0 VolBlend hook
+				ada2 -- ada2
+				adb2 -- adb2
+			define [object stroke] : eps.Dim
+			include : eps.Shape
+			include : bar df (height - DToothlessRise) no-shape stroke
+
+		define [EarlessRoundedBody df height bar hook ada2 adb2] : glyph-proc
+			local eps : SmallEpsilon CLOSED-ROUND CLOSED-STEM height 0 VolBlend hook
+				ada2 -- ada2
+				adb2 -- adb2
+			define [object stroke] : eps.Dim
+			include : eps.Shape
+			include : bar df (height - adb2) no-shape stroke
+
+		define SingleStoreyConfig : SuffixCfg.weave
+			object # body
+				singleStorey                 FullBarBody
+				singleStoreyEarlessCorner    EarlessCornerBody
+				singleStoreyEarlessRounded   EarlessRoundedBody
+
+			object # bar
+				serifless  SingleStorey.SeriflessBar
+				serifed    SingleStorey.SerifedBar
+				tailed     SingleStorey.TailedBar
+
+		foreach { suffix { body bar } } [Object.entries SingleStoreyConfig] : do
+			create-glyph "vol/Ae.\(suffix)" : glyph-proc
+				include : MarkSet.capital
+				include : body [DivFrame 1] CAP bar Hook ArchDepthA ArchDepthB
+			create-glyph "vol/ae.\(suffix)" : glyph-proc
+				include : MarkSet.e
+				include : body [DivFrame 1] XH bar SHook SmallArchDepthA SmallArchDepthB
+
+	do "Volapuk UE"
+		glyph-block-import Letter-Latin-U : USerifs
+		glyph-block-import Letter-Shared-Shapes : RightwardTailedBar
+
+		define [UToothed df height slab hook ada2 adb2] : glyph-proc
+			set-base-anchor 'trailing' df.rightSB 0
+			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-STEM height 0 VolBlend hook
+				ada2 -- ada2
+				adb2 -- adb2
+			define [object stroke] : eps.Dim
+			include : eps.Shape
+			include : VBar.r df.rightSB 0 height stroke
+			include : slab df height
+
+		define [UTailed df height slab hook ada2 adb2] : glyph-proc
+			set-base-anchor 'trailing' (df.rightSB + SideJut) 0
+			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-STEM height 0 VolBlend hook
+				ada2 -- ada2
+				adb2 -- adb2
+			define [object stroke] : eps.Dim
+			include : eps.Shape
+			include : RightwardTailedBar df.rightSB 0 height stroke
+			include : slab df height
+
+		define [UToothlessRounded df height slab hook ada2 adb2] : glyph-proc
+			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-ROUND height 0 VolBlend hook
+				ada2 -- ada2
+				adb2 -- adb2
+			define [object stroke] : eps.Dim
+			include : eps.Shape
+			include : VBar.r df.rightSB ada2 height stroke
+			include : slab df height
+
+		define [UToothlessCorner df height slab hook ada2 adb2] : glyph-proc
+			local eps : SmallEpsilon OPEN-VERTICAL SLAB-INWARD height 0 VolBlend hook
+				ada2 -- ada2
+				adb2 -- adb2
+			define [object stroke] : eps.Dim
+			include : eps.Shape
+			include : VBar.r df.rightSB DToothlessRise height stroke
+			include : slab df height stroke
+
+		define SmallUConfig : SuffixCfg.weave
+			object # body
+				toothed           UToothed
+				tailed            UTailed
+				toothlessCorner   UToothlessCorner
+				toothlessRounded  UToothlessRounded
+			function [body] : object # serifs
+				serifless              no-shape
+				bottomRightSerifed     USerifs.BottomRight
+				motionSerifed : match body
+					[Just 'toothed']   USerifs.MotionToothed
+					__                 USerifs.MotionToothless
+				serifed : match body
+					[Just 'toothed']   USerifs.Toothed
+					[Just 'tailed']    USerifs.Tailed
+					__                 USerifs.SmallToothless
+
+		foreach { suffix { Base Slabs } } [Object.entries SmallUConfig] : do
+			create-glyph "vol/Ue.\(suffix)" : glyph-proc
+				local df : DivFrame 1
+				include : MarkSet.capital
+				include : Base df CAP Slabs Hook ArchDepthA ArchDepthB
+			create-glyph "vol/ue.\(suffix)" : glyph-proc
+				local df : DivFrame 1
+				include : MarkSet.e
+				include : Base df XH Slabs SHook SmallArchDepthA SmallArchDepthB
+
+
+	select-variant 'vol/Ae' 0xA79A (follow -- 'a/single')
+	select-variant 'vol/ae' 0xA79B (follow -- 'a/single')
+	select-variant 'vol/Ue' 0xA79E (follow -- 'u')
+	select-variant 'vol/ue' 0xA79F (follow -- 'u')
 
 	alias 'grek/epsilon' 0x3B5 'latn/epsilon.serifless'
 	select-variant 'latn/Epsilon' 0x190

--- a/font-src/glyphs/letter/latin/c.ptl
+++ b/font-src/glyphs/letter/latin/c.ptl
@@ -21,7 +21,7 @@ glyph-block Letter-Latin-C : begin
 	define SLAB-NONE       0
 	define SLAB-CLASSICAL  1
 	define SLAB-INWARD     2
-	define SLAB-FLAT       3
+	define FLAT-CONNECTION 3
 
 	glyph-block-export CShapeT
 	define [CShapeT sink offset df st sb top bot ada adb hook sw origBar] : sink
@@ -32,7 +32,7 @@ glyph-block Letter-Latin-C : begin
 				g4 (df.rightSB - offset) (top - DToothlessRise)
 				g4 (df.middle - CorrectionOMidX * sw) (top - O - offset)
 				archv
-			[Just SLAB-FLAT] : list
+			[Just FLAT-CONNECTION] : list
 				flat (df.rightSB - offset) (top - offset)
 				curl (df.middle - CorrectionOMidX * sw) (top - offset)
 				archv
@@ -61,7 +61,7 @@ glyph-block Letter-Latin-C : begin
 				g4 (df.leftSB + offset) (top - DToothlessRise)
 				g4 (df.middle - CorrectionOMidX * sw) (top - O - offset)
 				archv
-			[Just SLAB-FLAT] : list
+			[Just FLAT-CONNECTION] : list
 				flat (df.leftSB + offset) (top - offset)
 				curl (df.middle - CorrectionOMidX * sw) (top - offset)
 				archv

--- a/font-src/glyphs/letter/latin/lower-a.ptl
+++ b/font-src/glyphs/letter/latin/lower-a.ptl
@@ -163,7 +163,7 @@ glyph-block Letter-Latin-Lower-A : begin
 			local sw : fallback _sw df.mvs
 			local ada : df.archDepthA SmallArchDepth sw
 			local adb : df.archDepthB SmallArchDepth sw
-			include : OBarLeft.rounded 
+			include : OBarLeft.rounded
 				top   -- height
 				left  -- df.leftSB
 				right -- df.rightSB

--- a/font-src/glyphs/letter/latin/lower-a.ptl
+++ b/font-src/glyphs/letter/latin/lower-a.ptl
@@ -14,7 +14,7 @@ glyph-block Letter-Latin-Lower-A : begin
 	glyph-block-import Letter-Shared-Shapes : RightwardTailedBar InvRightwardTailedBar
 	glyph-block-import Letter-Shared-Shapes : DToothlessRise DMBlend RetroflexHook
 
-	glyph-block-export DoubleStorey
+	glyph-block-export DoubleStorey DoubleStoreyConfig
 	define DoubleStorey : namespace
 		define [ADoubleStoreyStroke df] : AdviceStroke2 2 3 XH df.div
 		define [ADoubleStoreySmoothA df] : begin
@@ -132,52 +132,82 @@ glyph-block Letter-Latin-Lower-A : begin
 			Rect XH 0 (RightSB - BBD) Width
 		include : HBar.b (RightSB - BBD) RightSB 0 BBS
 
+	glyph-block-export SingleStorey SingleStoreyConfig
 	define SingleStorey : namespace
-		export : define [FullBarBody height bar mask] : glyph-proc
-			include : OBarRight.shape (top -- height)
-			include : bar height mask
-		export : define [EarlessCornerBody height bar mask] : glyph-proc
-			include : OBarLeft.toothless (rise -- DToothlessRise) (mBlend -- DMBlend)
-			include : FlipAround Middle (XH / 2)
-			include : bar (height - DToothlessRise) mask
-		export : define [EarlessRoundedBody height bar mask] : glyph-proc
-			include : OBarLeft.rounded (yTerminal -- (XH - SmallArchDepthA))
-			include : FlipAround Middle (XH / 2)
-			include : bar (height - SmallArchDepthB) mask
+		export : define [FullBarBody df height bar mask _sw] : glyph-proc
+			local sw : fallback _sw df.mvs
+			include : OBarRight.shape
+				top   -- height
+				left  -- df.leftSB
+				right -- df.rightSB
+				sw    -- sw
+				fine  -- sw * (ShoulderFine / Stroke)
+				ada   -- [df.archDepthA SmallArchDepth sw]
+				adb   -- [df.archDepthB SmallArchDepth sw]
+			include : bar df height mask sw
+		export : define [EarlessCornerBody df height bar mask _sw] : glyph-proc
+			local sw : fallback _sw df.mvs
+			include : OBarLeft.toothless
+				top   -- height
+				left  -- df.leftSB
+				right -- df.rightSB
+				sw    -- sw
+				fine  -- sw * (ShoulderFine / Stroke)
+				ada   -- [df.archDepthA SmallArchDepth sw]
+				adb   -- [df.archDepthB SmallArchDepth sw]
+				rise  -- DToothlessRise
+				mBlend -- DMBlend
+			include : FlipAround df.middle (height / 2)
+			include : bar df (height - DToothlessRise) mask sw
+		export : define [EarlessRoundedBody df height bar mask _sw] : glyph-proc
+			local sw : fallback _sw df.mvs
+			local ada : df.archDepthA SmallArchDepth sw
+			local adb : df.archDepthB SmallArchDepth sw
+			include : OBarLeft.rounded 
+				top   -- height
+				left  -- df.leftSB
+				right -- df.rightSB
+				sw    -- sw
+				fine  -- sw * (ShoulderFine / Stroke)
+				ada   -- ada
+				adb   -- adb
+				yTerminal -- (height - ada)
+			include : FlipAround df.middle (height / 2)
+			include : bar df (height - adb) mask sw
 
-		export : define [SeriflessBar height mask] : glyph-proc
-			set-base-anchor 'trailing' RightSB 0
+		export : define [SeriflessBar df height mask sw] : glyph-proc
+			set-base-anchor 'trailing' df.rightSB 0
 			include : difference
-				VBar.r RightSB 0 height
-				mask height
-		export : define [SerifedBar height mask] : glyph-proc
-			include : SeriflessBar height mask
-			include [SerifFrame.fromDf [DivFrame 1] XH 0].rb.outer
-		export : define [TailedBar height mask] : glyph-proc
-			set-base-anchor 'trailing' (RightSB + SideJut) 0
+				VBar.r df.rightSB 0 height sw
+				mask df height sw
+		export : define [SerifedBar df height mask sw] : glyph-proc
+			include : SeriflessBar df height mask sw
+			include [SerifFrame.fromDf df height 0 (swSerif -- sw)].rb.outer
+		export : define [TailedBar df height mask sw] : glyph-proc
+			set-base-anchor 'trailing' (df.rightSB + SideJut) 0
 			include : difference
-				RightwardTailedBar RightSB 0 height
-				mask height
+				RightwardTailedBar df.rightSB 0 height sw
+				mask df height sw
 
 		set SeriflessBar.inv SeriflessBar
-		set SerifedBar.inv : function [height mask] : glyph-proc
-			include : SeriflessBar height mask
-			include [SerifFrame.fromDf [DivFrame 1] height 0].rt.outer
-		set TailedBar.inv : function [height mask] : glyph-proc
-			set-base-anchor 'trailing' (RightSB + SideJut) 0
+		set SerifedBar.inv : function [df height mask sw] : glyph-proc
+			include : SeriflessBar df height mask sw
+			include [SerifFrame.fromDf df height 0 (swSerif -- sw)].rt.outer
+		set TailedBar.inv : function [df height mask sw] : glyph-proc
+			set-base-anchor 'trailing' (df.rightSB + SideJut) 0
 			include : difference
-				InvRightwardTailedBar RightSB 0 height
-				mask height
+				InvRightwardTailedBar df.rightSB 0 height sw
+				mask df height sw
 
 
-		export : define [ScriptCut y] : spiro-outline
-			corner RightSB y
-			corner (RightSB - Stroke * HVContrast) y
-			corner (RightSB - Stroke * HVContrast) (y - Stroke / 2)
-		export : define [InvScriptCut y] : spiro-outline
-			corner RightSB 0
-			corner (RightSB - Stroke * HVContrast) 0
-			corner (RightSB - Stroke * HVContrast) (0 + Stroke / 2)
+		export : define [ScriptCut df y sw] : spiro-outline
+			corner df.rightSB y
+			corner (df.rightSB - sw * HVContrast) y
+			corner (df.rightSB - sw * HVContrast) (y - sw / 2)
+		export : define [InvScriptCut df y sw] : spiro-outline
+			corner df.rightSB 0
+			corner (df.rightSB - sw * HVContrast) 0
+			corner (df.rightSB - sw * HVContrast) (0 + sw / 2)
 
 	define SingleStoreyConfig : SuffixCfg.weave
 		object # body
@@ -193,16 +223,16 @@ glyph-block Letter-Latin-Lower-A : begin
 	foreach { suffix { body bar } } [Object.entries SingleStoreyConfig] : do
 		create-glyph "a.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			include : body XH bar no-shape
+			include : body [DivFrame 1] XH bar no-shape
 		create-glyph "largescripta.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : body CAP bar SingleStorey.ScriptCut
+			include : body [DivFrame 1] CAP bar SingleStorey.ScriptCut
 		create-glyph "scripta.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			include : body XH bar SingleStorey.ScriptCut
+			include : body [DivFrame 1] XH bar SingleStorey.ScriptCut
 		create-glyph "invscripta.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			include : body XH bar.inv SingleStorey.InvScriptCut
+			include : body [DivFrame 1] XH bar.inv SingleStorey.InvScriptCut
 
 	select-variant 'a' 'a'
 	link-reduced-variant 'a/sansSerif' 'a' MathSansSerif

--- a/font-src/glyphs/letter/latin/u.ptl
+++ b/font-src/glyphs/letter/latin/u.ptl
@@ -14,7 +14,7 @@ glyph-block Letter-Latin-U : begin
 	glyph-block-import Letter-Shared-Shapes : nShoulder RightwardTailedBar DToothlessRise SerifFrame
 	glyph-block-import Letter-Shared-Shapes : CyrTailDescender RetroflexHook VerticalHook
 
-	glyph-block-export UShape
+	glyph-block-export UShape USerifs
 
 	define [UArcT] : with-params [sink df top bottom [stroke Stroke] [ada ArchDepthA] [adb ArchDepthB] [offset 0]] : sink
 		widths.lhs stroke
@@ -84,52 +84,53 @@ glyph-block Letter-Latin-U : begin
 			curl df.rightSB 0 [heading Downward]
 		include : FlipAround df.middle (top / 2)
 
-	define [UTopLeftSerif df yTop]  : tagged 'serifLT'
-		HSerif.lt df.leftSB yTop SideJut
+	define [UTopLeftSerif df yTop _sw]  : tagged 'serifLT'
+		HSerif.lt df.leftSB yTop SideJut _sw
 
-	define [UTopRightSerif df yTop] : tagged 'serifRT'
-		HSerif.lt (df.rightSB - Stroke * HVContrast) yTop SideJut
+	define [UTopRightSerif df yTop _sw] : tagged 'serifRT'
+		HSerif.lt (df.rightSB - Stroke * HVContrast) yTop SideJut _sw
 
-	define [UBottomRightSerif df yTop] : glyph-proc
-		include : tagged 'serifRB' : HSerif.rb df.rightSB 0 SideJut
+	define [UBottomRightSerif df yTop _sw] : glyph-proc
+		include : tagged 'serifRB' : HSerif.rb df.rightSB 0 SideJut _sw
 		define trAnchor currentGlyph.baseAnchors.trailing
 		if trAnchor : begin
 			set-base-anchor 'trailing' (trAnchor.x + SideJut) trAnchor.y
 
-	define [SmallUSlabs df top] : glyph-proc
-		include : UTopLeftSerif df top
-		if [not para.isItalic] : include : UTopRightSerif df top
-		include : UBottomRightSerif df top
+	define USerifs : namespace
+		export : define [Toothed df top _sw] : glyph-proc
+			include : UTopLeftSerif df top _sw
+			if [not para.isItalic] : include : UTopRightSerif df top _sw
+			include : UBottomRightSerif df top _sw
 
-	define [UrtBaseSlabs df top] : glyph-proc
-		include : UTopLeftSerif df top
-		if [not para.isItalic] : include : UTopRightSerif df top
+		export : define [RTBase df top _sw] : glyph-proc
+			include : UTopLeftSerif df top _sw
+			if [not para.isItalic] : include : UTopRightSerif df top _sw
 
-	define [SmallUTailedSlabs df top] : glyph-proc
-		include : UTopLeftSerif df top
-		if [not para.isItalic] : include : UTopRightSerif df top
+		export : define [Tailed df top _sw] : glyph-proc
+			include : UTopLeftSerif df top _sw
+			if [not para.isItalic] : include : UTopRightSerif df top _sw
 
-	define [CapitalUMotionToothlessSlabs df top] : glyph-proc
-		include : HSerif.lt df.leftSB top SideJut
-		include : HSerif.rt df.rightSB top SideJut
+		export : define [BilateralMotion df top _sw] : glyph-proc
+			include : HSerif.lt df.leftSB top SideJut _sw
+			include : HSerif.rt df.rightSB top SideJut _sw
 
-	define [SmallUToothlessSlabs df top] : glyph-proc
-		include : UTopLeftSerif df top
-		include : UTopRightSerif df top
+		export : define [SmallToothless df top _sw] : glyph-proc
+			include : UTopLeftSerif df top _sw
+			include : UTopRightSerif df top _sw
 
-	define [SmallUMotionSlabs df top] : glyph-proc
-		include : UTopLeftSerif df top
-		include : UBottomRightSerif df top
+		export : define [MotionToothed df top _sw] : glyph-proc
+			include : UTopLeftSerif df top _sw
+			include : UBottomRightSerif df top _sw
 
-	define [SmallUBottomRightSlabs df top] : glyph-proc
-		include : UBottomRightSerif df top
+		export : define [BottomRight df top _sw] : glyph-proc
+			include : UBottomRightSerif df top _sw
 
-	define [SmallUMotionTailedSlabs df top] : glyph-proc
-		include : UTopLeftSerif df top
+		export : define [MotionToothless df top _sw] : glyph-proc
+			include : UTopLeftSerif df top _sw
 
-	define [ToothlessSlabs df top] : begin
-		local sf : SerifFrame.fromDf df top 0
-		return : composite-proc sf.lt.full sf.rt.full
+		export : define [Toothless df top _sw] : begin
+			local sf : SerifFrame.fromDf df top 0 (swSerif -- _sw)
+			return : composite-proc sf.lt.full sf.rt.full
 
 	define CapitalUConfig : SuffixCfg.weave
 		object # body
@@ -138,15 +139,15 @@ glyph-block Letter-Latin-U : begin
 			toothlessCorner   UToothlessCorner
 			toothlessRounded  UToothlessRounded
 		function [body] : object # serifs
-			serifless               { no-shape                     false }
-			bilateralMotionSerifed  { CapitalUMotionToothlessSlabs true  }
+			serifless               { no-shape                false }
+			bilateralMotionSerifed  { USerifs.BilateralMotion true  }
 			unilateralMotionSerifed : match body
-				[Just 'toothed']    { SmallUMotionSlabs            true  }
-				__                  { SmallUMotionTailedSlabs      true  }
+				[Just 'toothed']    { USerifs.MotionToothed   true  }
+				__                  { USerifs.MotionToothless true  }
 			serifed : match body
-				[Just 'toothed']    { SmallUSlabs                  true  }
-				[Just 'tailed']     { SmallUTailedSlabs            true  }
-				__                  { ToothlessSlabs               true  }
+				[Just 'toothed']    { USerifs.Toothed         true  }
+				[Just 'tailed']     { USerifs.Tailed          true  }
+				__                  { USerifs.Toothless       true  }
 
 	foreach { suffix { Base {Slabs fLTSlab} } } [Object.entries CapitalUConfig] : do
 		create-glyph "U.\(suffix)" : glyph-proc
@@ -174,15 +175,15 @@ glyph-block Letter-Latin-U : begin
 			urtBase           UToothed
 		function [body] : object # serifs
 			serifless              no-shape
-			bottomRightSerifed     SmallUBottomRightSlabs
+			bottomRightSerifed     USerifs.BottomRight
 			motionSerifed : match body
-				[Just 'toothed']   SmallUMotionSlabs
-				__                 SmallUMotionTailedSlabs
+				[Just 'toothed']   USerifs.MotionToothed
+				__                 USerifs.MotionToothless
 			serifed : match body
-				[Just 'toothed']   SmallUSlabs
-				[Just 'tailed']    SmallUTailedSlabs
-				[Just 'urtBase']   UrtBaseSlabs
-				__                 SmallUToothlessSlabs
+				[Just 'toothed']   USerifs.Toothed
+				[Just 'tailed']    USerifs.Tailed
+				[Just 'urtBase']   USerifs.RTBase
+				__                 USerifs.SmallToothless
 
 	foreach { suffix { Base Slabs } } [Object.entries SmallUConfig] : do
 		create-glyph "u.\(suffix)" : glyph-proc

--- a/font-src/glyphs/letter/latin/upper-b.ptl
+++ b/font-src/glyphs/letter/latin/upper-b.ptl
@@ -212,33 +212,7 @@ glyph-block Letter-Latin-Upper-B : begin
 			flat Middle (midy + (fine - stroke / 2)) [widths.heading fine 0 Leftward]
 			curl mid (midy + (fine - stroke / 2)) [widths.heading fine 0 Leftward]
 
-	define [ClosedEpsilonShape top] : glyph-proc
-		local stroke : AdviceStroke2 2 3 top
-		local mid : mix SB RightSB 0.65
-		local midy : top * HBarPos
-		local ada : top - [mix (midy + stroke / 2) (top - O - stroke) (ArchDepthB / (ArchDepthA + ArchDepthB))] - TanSlope * HVContrast * stroke
-		local adb : [mix (stroke + O) (midy - stroke / 2) (ArchDepthB / (ArchDepthA + ArchDepthB))] + TanSlope * HVContrast * stroke
-		local fine : stroke * CThin
-		include : dispiro
-			widths.rhs fine
-			flat mid (midy - (fine - stroke / 2)) [heading Leftward]
-			curl Middle (midy - (fine - stroke / 2)) [heading Leftward]
-			archv
-			g4   (SB + (OX - O)) (top - ada) [widths.rhs stroke]
-			arcvh
-			g4   (Middle - stroke * 0.06 - CorrectionOMidS) (top - O)
-			archv
-			flat (RightSB - O) (top - SmallArchDepthB)
-			curl (RightSB - O) SmallArchDepthA
-			arcvh
-			g4   (Middle - stroke * 0.06 + CorrectionOMidS) O
-			archv
-			g4   (SB + (OX - O) + O * 2) (adb)
-			arcvh
-			flat Middle (midy + (fine - stroke / 2)) [widths.heading 0 fine Rightward]
-			curl mid (midy + (fine - stroke / 2)) [widths.heading 0 fine Rightward]
-
-	create-glyph 'closeturnepsilon' 0x25E : glyph-proc
+	create-glyph 'cyrl/ve.italic' : glyph-proc
 		include : MarkSet.e
 		include : ItalicCyrveShape XH
 
@@ -247,11 +221,6 @@ glyph-block Letter-Latin-Upper-B : begin
 		include : ItalicCyrveShape Ascender
 
 	alias 'cyrl/ve.BGR' null 'grek/betaSymbol'
-	alias 'cyrl/ve.italic' null 'closeturnepsilon'
-
-	create-glyph 'closeepsilon' 0x29A : glyph-proc
-		include : MarkSet.e
-		include : ClosedEpsilonShape XH
 
 	create-glyph 'grek/beta' 0x3B2 : glyph-proc
 		include : MarkSet.bp

--- a/font-src/glyphs/letter/shared.ptl
+++ b/font-src/glyphs/letter/shared.ptl
@@ -226,6 +226,36 @@ glyph-block Letter-Shared-Shapes : begin
 	glyph-block-export : OBarLeft
 	define OBarLeft : namespace
 		define kSkewShift 0.5
+		export : define [arcStart] : with-params [
+				[top XH] [left SB] [right RightSB] [sw Stroke] [fine ShoulderFine]
+				[ada SmallArchDepthA] [adb SmallArchDepthB]
+				[ystart (top - ada - 0.01)]
+			] : begin
+			local skew : shoulderMidSkew fine sw
+			local mt : [mix left right 0.5] + (skew + kSkewShift * TanSlope) * sw
+			local xstart : left + (sw - fine) * HVContrast
+			return : list
+				flat xstart ystart [widths.rhs fine]
+				curl xstart (top - ada)
+				arcvh
+				g4   mt (top - O) [widths.rhs.heading sw {.y (-1) .x (-skew)}]
+				archv
+
+		export : define [arcEnd] : with-params [
+				[bot 0] [left SB] [right RightSB] [sw Stroke] [fine ShoulderFine]
+				[ada SmallArchDepthA] [adb SmallArchDepthB]
+				[yend (bot + ada + 0.01)]
+			] : begin
+			local skew : shoulderMidSkew fine sw
+			local mb : [mix left right 0.5] + (skew + kSkewShift * TanSlope) * sw
+			local xend : left + (sw - fine) * HVContrast
+			return : list
+				arcvh
+				g4   mb (bot + O) [widths.rhs.heading sw {.y (1) .x (-skew)}]
+				archv
+				flat xend (bot + adb) [widths.rhs fine]
+				curl xend yend
+
 		export : define [shape] : with-params [
 				[top XH] [left SB] [right RightSB] [sw Stroke] [fine ShoulderFine]
 				[ada SmallArchDepthA] [adb SmallArchDepthB]
@@ -334,6 +364,37 @@ glyph-block Letter-Shared-Shapes : begin
 
 	glyph-block-export : OBarRight
 	define OBarRight : namespace
+		define kSkewShift 0.5
+		export : define [arcStart] : with-params [
+				[top XH] [left SB] [right RightSB] [sw Stroke] [fine ShoulderFine]
+				[ada SmallArchDepthA] [adb SmallArchDepthB]
+				[ystart (top - ada - 0.01)]
+			] : begin
+			local skew : shoulderMidSkew fine sw
+			local mt : [mix left right 0.5] - (skew + kSkewShift * TanSlope) * sw
+			local xstart : right - (sw - fine) * HVContrast
+			return : list
+				flat xstart ystart [widths.lhs fine]
+				curl xstart (top - adb)
+				arcvh
+				g4   mt (top - O) [widths.lhs.heading sw {.y (-1) .x (skew)}]
+				archv
+
+		export : define [arcEnd] : with-params [
+				[bot 0] [left SB] [right RightSB] [sw Stroke] [fine ShoulderFine]
+				[ada SmallArchDepthA] [adb SmallArchDepthB]
+				[yend (bot + ada + 0.01)]
+			] : begin
+			local skew : shoulderMidSkew fine sw
+			local mb : [mix left right 0.5] - (skew + kSkewShift * TanSlope) * sw
+			local xend : right - (sw - fine) * HVContrast
+			return : list
+				arcvh
+				g4   mb (bot + O) [widths.lhs.heading sw {.y (1) .x (skew)}]
+				archv
+				flat xend (bot + ada) [widths.lhs fine]
+				curl xend yend
+
 		export : define [shape] : with-params [
 				[top XH] [left SB] [right RightSB] [sw Stroke] [fine ShoulderFine]
 				[ada SmallArchDepthA] [adb SmallArchDepthB]

--- a/font-src/glyphs/symbol/arrow.ptl
+++ b/font-src/glyphs/symbol/arrow.ptl
@@ -479,8 +479,8 @@ glyph-block Symbol-Arrow : for-width-kinds WideWidth1
 			local arrowX : l + 0.5 * HVContrast * Stroke
 			local headLength : headSize * [Math.sqrt 0.5]
 			local gapSize : Math.max (2 * headLength) (CAP - 0 - ada - adb)
-			local gapTop : SymbolMid + 0.5 * gapSize
-			local gapBot : SymbolMid - 0.5 * gapSize
+			local gapTop : CAP / 2 + 0.5 * gapSize
+			local gapBot : CAP / 2 - 0.5 * gapSize
 			set-width MosaicWidth
 			include : union
 				difference

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1425,6 +1425,7 @@ selectorAffix.a = "doubleStorey"
 selectorAffix."a/sansSerif" = "doubleStorey"
 selectorAffix."a/rtailBase" = "doubleStorey"
 selectorAffix."a/turnABase" = "doubleStorey"
+selectorAffix."a/single"    = "singleStorey"
 selectorAffix.scripta       = "singleStorey"
 
 [prime.a.variants-buildup.stages.storey.single-storey]
@@ -1435,6 +1436,7 @@ selectorAffix.a = "singleStorey"
 selectorAffix."a/sansSerif" = "singleStorey"
 selectorAffix."a/rtailBase" = "singleStorey"
 selectorAffix."a/turnABase" = "doubleStorey"
+selectorAffix."a/single"    = "singleStorey"
 selectorAffix.scripta       = "singleStorey"
 
 [prime.a.variants-buildup.stages.ear."*"]
@@ -1447,6 +1449,7 @@ selectorAffix.a = ""
 selectorAffix."a/sansSerif" = ""
 selectorAffix."a/rtailBase" = ""
 selectorAffix."a/turnABase" = ""
+selectorAffix."a/single"    = ""
 selectorAffix.scripta       = ""
 
 [prime.a.variants-buildup.stages.ear.earless-corner]
@@ -1456,6 +1459,7 @@ selectorAffix.a = "earlessCorner"
 selectorAffix."a/sansSerif" = "earlessCorner"
 selectorAffix."a/rtailBase" = "earlessCorner"
 selectorAffix."a/turnABase" = ""
+selectorAffix."a/single"    = "earlessCorner"
 selectorAffix.scripta       = ""
 
 [prime.a.variants-buildup.stages.ear.earless-rounded]
@@ -1465,6 +1469,7 @@ selectorAffix.a = "earlessRounded"
 selectorAffix."a/sansSerif" = "earlessRounded"
 selectorAffix."a/rtailBase" = "earlessRounded"
 selectorAffix."a/turnABase" = ""
+selectorAffix."a/single"    = "earlessRounded"
 selectorAffix.scripta       = ""
 
 [prime.a.variants-buildup.stages.terminal.serifless]
@@ -1475,6 +1480,7 @@ selectorAffix.a = "serifless"
 selectorAffix."a/sansSerif" = "serifless"
 selectorAffix."a/rtailBase" = "serifless"
 selectorAffix."a/turnABase" = "serifless"
+selectorAffix."a/single"    = "serifless"
 selectorAffix.scripta       = "serifless"
 
 [prime.a.variants-buildup.stages.terminal.tailed]
@@ -1484,6 +1490,7 @@ selectorAffix.a = "tailed"
 selectorAffix."a/sansSerif" = "tailed"
 selectorAffix."a/rtailBase" = "serifless"
 selectorAffix."a/turnABase" = "tailed"
+selectorAffix."a/single"    = "tailed"
 selectorAffix.scripta       = "tailed"
 
 [prime.a.variants-buildup.stages.terminal.toothless-corner]
@@ -1494,6 +1501,7 @@ selectorAffix.a = "toothlessCorner"
 selectorAffix."a/sansSerif" = "toothlessCorner"
 selectorAffix."a/rtailBase" = "serifless"
 selectorAffix."a/turnABase" = "toothlessCorner"
+selectorAffix."a/single"    = "serifless"
 selectorAffix.scripta       = "serifless"
 
 [prime.a.variants-buildup.stages.terminal.toothless-rounded]
@@ -1504,6 +1512,7 @@ selectorAffix.a = "toothlessRounded"
 selectorAffix."a/sansSerif" = "toothlessRounded"
 selectorAffix."a/rtailBase" = "serifless"
 selectorAffix."a/turnABase" = "toothlessRounded"
+selectorAffix."a/single"    = "serifless"
 selectorAffix.scripta       = "serifless"
 
 [prime.a.variants-buildup.stages.terminal.serifed]
@@ -1513,6 +1522,7 @@ selectorAffix.a = "serifed"
 selectorAffix."a/sansSerif" = "serifless"
 selectorAffix."a/rtailBase" = "serifless"
 selectorAffix."a/turnABase" = "serifed"
+selectorAffix."a/single"    = "serifed"
 selectorAffix.scripta       = "serifed"
 
 


### PR DESCRIPTION
* The "gap" of the share-alike arrow was a bit off-center. (`arrow.ptl`)
* Added Single-storey forms for Iotified-a, seeing how Brill and Noto (proportional) had them anyway. (`iotified-a.ptl`)
  * This meant that the SingleStorey `a` functions also had to be extended to support DivFrames and custom Stroke width (`lower-a.ptl`).
Hopefully that didn't break anything (`aąɑⱭꭤꙗ` in `cv26 = 08, 10, 12`, then italic):
![image](https://github.com/be5invis/Iosevka/assets/21302803/ac9fa7c6-9b52-4c4f-ab54-13ff79accd1c)
* Some other files have minor name/formatting fixes as I briefly went through them (`c.ptl`, `transformed.ptl`, `orthography.ptl`)

----

Volapuk Letters, closes #1865 (which should've been a separate PR, but oops)
![image](https://github.com/be5invis/Iosevka/assets/21302803/5e5fdb9b-7bfc-41a7-ac09-755bca6e5474)
Implemented by extending Epsilon code (`lower-epsilon.ptl`) by quite a lot. I kinda made a mess...

* Supports variants (see below)
* Basically divided the glyphs into possible upper-lower shape component patterns (including variants), including:
  * Parts that open vertically: ![image](https://github.com/be5invis/Iosevka/assets/21302803/c9ef4695-44b2-4e93-9948-5aecc2222cb8)
  * Parts that end up in a stem, like the OBar shapes: ![image](https://github.com/be5invis/Iosevka/assets/21302803/0cc05770-def0-4852-8f82-c5111a1293ee)
These differ a bit from the existing `SLAB-CLASSICAL` shape, which I had to add a new function in `shared.ptl` for (in OBarLeft/Right, because idk where to put them)
  * Parts that connects toothlessly(?) to a stem: ![image](https://github.com/be5invis/Iosevka/assets/21302803/8c427555-02be-47bb-a8bf-db4509dc543a)
These are identical to `SLAB-INWARD` as far as I'm aware.
  * Parts that connects rounded to a stem: ![image](https://github.com/be5invis/Iosevka/assets/21302803/43a17ae2-09c7-4b0f-905a-d2793d663add)
  * Parts that connects like into OShape, which only differs from the previous one by an `OX` on the terminal side.
* While I'm at it I also adapted Komi Dzje and Zje to this format instead of having a "Half Lower Shape", as well as the closed Epsilons in `upper-b.ptl`.
  * I don't know if I should even do the same for Beta symbol or cursive Cyrillic ve. I just left it untouched for now.
* Changes to other modules for these glyphs:
  * A new variant type `a/single` because `scripta` does not allow ear variants. (`variants.toml`)
  * Grouping, renaming and adding `sw` support for U Serifs (`u.ptl`), for better access in the epsilon module.
* This might not be super important, but since the left side of these glyphs are not actually epsilons but "dents" to the right, they are differentiated by the depth of the middle part: ![image](https://github.com/be5invis/Iosevka/assets/21302803/34f9d794-d64a-4255-8910-be991b3346ed)

AE with `cv26 = 08, 10, 12` then italic, compared to Script A:
![image](https://github.com/be5invis/Iosevka/assets/21302803/c2dee614-7e3a-4e91-abf2-7d356f510cb3)
UE with `cv45 = 03, 10, 12` then italic, compared to Lower U:
![image](https://github.com/be5invis/Iosevka/assets/21302803/1c1623f3-15fa-4808-8c1d-3a34b80a6bff)
OE compared to O, for completeness sake:
![image](https://github.com/be5invis/Iosevka/assets/21302803/bcd65f66-dd4b-4efd-a7ea-58b8bd19c38b)

----
As a final note, here's some minor bugs I'm not able to fix:
* These small bulges in the "vertical" parts, in heavier weights: ![image](https://github.com/be5invis/Iosevka/assets/21302803/abdc0b9e-0da9-4432-8bb9-e05a063e033d)
* The arc extruding the serif for inward-serif Cyrillic ze, in Heavy (exists before this PR): ![image](https://github.com/be5invis/Iosevka/assets/21302803/75618c6a-6494-408d-b928-c4aee72ea41e)

