### PR TITLE
Make lowercase wynn respond to serifs of thorn

### DIFF
--- a/changes/26.1.0.md
+++ b/changes/26.1.0.md
@@ -3,6 +3,7 @@
   - LEFT RIGHT ARROW THROUGH SMALL CIRCLE (`U+2948`) (#1900).
   - LEFT ARROW WITH SMALL CIRCLE (`U+2B30`) (#1900).
 * Make Cyrillic Abkhasian Che respond to C's serifs (#1898).
+* Make lowercase Wynn respond to thorn's serifs.
 * Drop APL form for `U+220D` as it is not used by any APL languages (#1901).
 * Add XH-height middle-serifed and dual-serifed variants for Eszet (#1904).
 * Fix `cv36`, `cv46`, `cv47`, `cv48`, `cv49`, `cv50`, `cv61`, and `cv74` under Curly Slab.

--- a/font-src/glyphs/letter/latin-ext/wynn.ptl
+++ b/font-src/glyphs/letter/latin-ext/wynn.ptl
@@ -10,6 +10,12 @@ glyph-block Letter-Latin-Wynn : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Shapes : SerifFrame SerifedArcStart
 
+	define [SerifLT top bot] : return [SerifFrame.fromDf [DivFrame 1] top bot].lt.outer
+	define [SerifLB top bot] : return [SerifFrame.fromDf [DivFrame 1] top bot].lb.fullSide
+
+	define [FullSerifs top bot] : composite-proc [SerifLT top bot] [SerifLB top bot]
+	define [MotionSerif top bot] : SerifLT top bot
+
 	define [WynnShape bot top] : glyph-proc
 		include : VBar.l SB bot top
 
@@ -23,15 +29,20 @@ glyph-block Letter-Latin-Wynn : begin
 			alsoThru 0.25 0.45 important
 			g4 (SB + [HSwToV Stroke]) bowlBottom
 
-		if SLAB : begin
-			local sf : SerifFrame.fromDf [DivFrame 1] top bot
-			include sf.lt.outer
-			include sf.lb.fullSide
+	define WynnConfig : object
+		serifless     { no-shape    false }
+		motionSerifed { MotionSerif false }
+		serifed       { FullSerifs  true  }
+
+	foreach { suffix { Serifs doBS } } [Object.entries WynnConfig] : do
+		create-glyph "wynn.\(suffix)" : glyph-proc
+			include : MarkSet.p
+			include : WynnShape Descender XH
+			include : Serifs XH Descender
+
+	select-variant 'wynn' 0x1BF
 
 	create-glyph 'Wynn' 0x1F7 : glyph-proc
 		include : MarkSet.capital
 		include : WynnShape 0 CAP
-
-	create-glyph 'wynn' 0x1BF : glyph-proc
-		include : MarkSet.p
-		include : WynnShape Descender XH
+		if SLAB : include : FullSerifs CAP 0

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -4197,16 +4197,19 @@ tagKind = "letter"
 rank = 1
 description = "Lowercase Thorn (`þ`) without serifs"
 selector.thorn = "earedSerifless"
+selector.wynn = "serifless"
 
 [prime.lower-thorn.variants.motion-serifed]
 rank = 2
 description = "Lowercase Thorn (`þ`) with motion serifs"
 selector.thorn = "earedMotionSerifed"
+selector.wynn = "motionSerifed"
 
 [prime.lower-thorn.variants.serifed]
 rank = 3
 description = "Lowercase Thorn (`þ`) with serifs"
 selector.thorn = "earedSerifed"
+selector.wynn = "serifed"
 
 
 


### PR DESCRIPTION
`ÞǷþƿ`

Default serifless:
![image](https://github.com/be5invis/Iosevka/assets/37010132/a6e5065a-2fda-4608-acfb-4c8591ff4a50)

`ss16`:
![image](https://github.com/be5invis/Iosevka/assets/37010132/681d879a-9e70-43c4-abee-555306d52419)

Default Slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/bda3bab2-6802-43b1-8e16-1138c304f22c)
