### PR TITLE
italic komi tje

### DIFF
--- a/changes/26.2.0.md
+++ b/changes/26.2.0.md
@@ -5,3 +5,4 @@
 * Fix broken hookless/tailless/asymmetric t variants in ﬅ ligature (`U+FB05`) (#1915).
 * Remove unnecessary tailed variants for Cyrillic Shha with Descender (`U+0527`) (#1916).
 * Remove unnecessary lower-right serif variants for Latin Lower K with Descender (`U+2C6A`) (#1917).
+* Add italic form of CYRILLIC SMALL LETTER KOMI TJE (`U+050F`) (#1920).

--- a/font-src/glyphs/letter/cyrillic/orthography.ptl
+++ b/font-src/glyphs/letter/cyrillic/orthography.ptl
@@ -17,6 +17,7 @@ glyph-block Letter-Cyrillic-Orthography : begin
 	orthographic-italic 'cyrl/teDescender'    0x4AD
 	orthographic-italic 'cyrl/tse'            0x446
 	orthographic-italic 'cyrl/tetse'          0x4B5
+	orthographic-italic 'cyrl/tjeKomi'        0x50F
 	orthographic-italic 'cyrl/yat'            0x463
 	orthographic-italic 'cyrl/pe'             0x43F
 	orthographic-italic 'cyrl/peMidHook'      0x4A7

--- a/font-src/glyphs/letter/latin/lower-m.ptl
+++ b/font-src/glyphs/letter/latin/lower-m.ptl
@@ -11,7 +11,7 @@ glyph-block Letter-Latin-Lower-M : begin
 	glyph-block-import Letter-Shared : CreateAccentedComposition
 	glyph-block-import Letter-Shared-Shapes : SerifFrame RightwardTailedBar DToothlessRise DMBlend
 	glyph-block-import Letter-Shared-Shapes : nShoulder nShoulderMask
-	glyph-block-import Letter-Shared-Shapes : CyrDescender PalatalHook CurlyTail
+	glyph-block-import Letter-Shared-Shapes : CyrDescender PalatalHook CurlyTail UpwardHookShape
 
 	define [SmallMSmooth df] : df.div * (0.5 * SmallArchDepth + 0.375 * Stroke)
 	define [SmallMShoulderSpiro] : with-params [left right top bottom width fine df coBottom] : glyph-proc
@@ -248,11 +248,31 @@ glyph-block Letter-Latin-Lower-M : begin
 					eject-contour 'serifMB'
 					include sf.mb.left
 
+		if (Body === SmallMArches && shortLeg == 0 && tailed == 0) : begin
+			create-glyph "cyrl/tjeKomi.italic.\(suffix)" : glyph-proc
+				local df : DivFrame para.diversityM 4
+				set-width df.width
+				include : df.markSet.e
+				local subDf : df.slice 4 3 0
+				include : Body XH 0 0 (XH / 2) subDf
+				include : UpwardHookShape
+					left -- subDf.rightSB - [HSwToV subDf.mvs]
+					right -- df.rightSB
+					ybegin -- (XH / 2)
+					yend -- (XH / 2)
+					ada -- (SmallArchDepthA * 0.6 * df.div)
+					adb -- (SmallArchDepthB * 0.6 * df.div)
+					sw -- subDf.mvs
+				include : Serifs subDf XH 0 0 (XH / 2) true false
+				local sf2 : [SerifFrame.fromDf df (XH / 2) 0].slice 2 3
+				if SLAB : include sf2.rt.full
+
 	select-variant 'm' 'm'
 	select-variant 'm/tailless' (shapeFrom -- 'm')
 	link-reduced-variant 'm/sansSerif' 'm' MathSansSerif
 
 	select-variant 'cyrl/te.italic' (shapeFrom -- 'm')
+	select-variant 'cyrl/tjeKomi.italic'
 	alias 'cyrl/te.BGR' null 'cyrl/te.italic'
 	derive-composites 'cyrl/teDescender.italic' null 'cyrl/te.italic' : do
 		local df : DivFrame para.diversityM 3

--- a/font-src/glyphs/letter/latin/upper-t.ptl
+++ b/font-src/glyphs/letter/latin/upper-t.ptl
@@ -36,8 +36,8 @@ glyph-block Letter-Latin-Upper-T : begin
 		local xTopBarLeft : df.leftSB - SideJut
 		local xTopBarRightSym : 2 * left + [HSwToV df.mvs] - xTopBarLeft
 		local xTopBarRight : Math.max xTopBarRightSym : mix left df.rightSB 0.475
-		include : tagged 'strokeLT' : HBar.t xTopBarLeft mid          top
-		include : tagged 'strokeRT' : HBar.t mid         xTopBarRight top
+		include : tagged 'strokeLT' : HBar.t xTopBarLeft mid          top df.mvs
+		include : tagged 'strokeRT' : HBar.t mid         xTopBarRight top df.mvs
 		include : UpwardHookShape
 			left -- left
 			right -- df.rightSB
@@ -145,7 +145,7 @@ glyph-block Letter-Latin-Upper-T : begin
 			include : df.markSet.capital
 			include : TjeShape df CAP doST
 
-		create-glyph "cyrl/tjeKomi.\(suffix)" : glyph-proc
+		create-glyph "cyrl/tjeKomi.upright.\(suffix)" : glyph-proc
 			local df : DivFrame div 3
 			set-width df.width
 			include : df.markSet.e
@@ -170,7 +170,7 @@ glyph-block Letter-Latin-Upper-T : begin
 	select-variant 'TRTailBR' 0x1AE (follow -- 'T/rtailBase')
 
 	select-variant 'cyrl/TjeKomi' 0x50E (follow -- 'T/rtailBase')
-	select-variant 'cyrl/tjeKomi' 0x50F (follow -- 'T/rtailBase')
+	select-variant 'cyrl/tjeKomi.upright' null (follow -- 'T/rtailBase')
 	select-variant 'cyrl/Twe' 0xA68C (follow -- 'T/rtailBase')
 	select-variant 'cyrl/twe' 0xA68D (follow -- 'T/rtailBase')
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2660,6 +2660,7 @@ selectorAffix.m = ""
 selectorAffix."m/tailless" = ""
 selectorAffix."m/sansSerif" = ""
 selectorAffix."cyrl/te.italic" = ""
+selectorAffix."cyrl/tjeKomi.italic" = ""
 selectorAffix.meng = ""
 
 [prime.m.variants-buildup.stages.body.earless-corner-double-arch]
@@ -2670,6 +2671,7 @@ selectorAffix.m = "earlessCornerDoubleArch"
 selectorAffix."m/tailless" = "earlessCornerDoubleArch"
 selectorAffix."m/sansSerif" = "earlessCornerDoubleArch"
 selectorAffix."cyrl/te.italic" = ""
+selectorAffix."cyrl/tjeKomi.italic" = ""
 selectorAffix.meng = "earlessCornerDoubleArch"
 
 [prime.m.variants-buildup.stages.body.earless-rounded-double-arch]
@@ -2680,6 +2682,7 @@ selectorAffix.m = "earlessRoundedDoubleArch"
 selectorAffix."m/tailless" = "earlessRoundedDoubleArch"
 selectorAffix."m/sansSerif" = "earlessRoundedDoubleArch"
 selectorAffix."cyrl/te.italic" = ""
+selectorAffix."cyrl/tjeKomi.italic" = ""
 selectorAffix.meng = "earlessRoundedDoubleArch"
 
 [prime.m.variants-buildup.stages.body.earless-single-arch]
@@ -2690,6 +2693,7 @@ selectorAffix.m = "earlessSingleArch"
 selectorAffix."m/tailless" = "earlessSingleArch"
 selectorAffix."m/sansSerif" = "earlessSingleArch"
 selectorAffix."cyrl/te.italic" = ""
+selectorAffix."cyrl/tjeKomi.italic" = ""
 selectorAffix.meng = "earlessSingleArch"
 
 [prime.m.variants-buildup.stages.leg."*"]
@@ -2704,6 +2708,7 @@ selectorAffix.m = ""
 selectorAffix."m/tailless" = ""
 selectorAffix."m/sansSerif" = ""
 selectorAffix."cyrl/te.italic" = ""
+selectorAffix."cyrl/tjeKomi.italic" = ""
 selectorAffix.meng = ""
 
 [prime.m.variants-buildup.stages.leg.short-leg]
@@ -2714,6 +2719,7 @@ selectorAffix.m = "shortLeg"
 selectorAffix."m/tailless" = "shortLeg"
 selectorAffix."m/sansSerif" = "shortLeg"
 selectorAffix."cyrl/te.italic" = ""
+selectorAffix."cyrl/tjeKomi.italic" = ""
 selectorAffix.meng = "shortLeg"
 
 [prime.m.variants-buildup.stages.tail."*"]
@@ -2726,6 +2732,7 @@ selectorAffix.m = ""
 selectorAffix."m/tailless" = ""
 selectorAffix."m/sansSerif" = ""
 selectorAffix."cyrl/te.italic" = ""
+selectorAffix."cyrl/tjeKomi.italic" = ""
 selectorAffix.meng = ""
 
 [prime.m.variants-buildup.stages.tail.tailed]
@@ -2735,6 +2742,7 @@ selectorAffix.m = "tailed"
 selectorAffix."m/tailless" = ""
 selectorAffix."m/sansSerif" = "tailed"
 selectorAffix."cyrl/te.italic" = "tailed"
+selectorAffix."cyrl/tjeKomi.italic" = ""
 selectorAffix.meng = ""
 
 [prime.m.variants-buildup.stages.serifs.serifless]
@@ -2745,6 +2753,7 @@ selectorAffix.m = "serifless"
 selectorAffix."m/tailless" = "serifless"
 selectorAffix."m/sansSerif" = "serifless"
 selectorAffix."cyrl/te.italic" = "serifless"
+selectorAffix."cyrl/tjeKomi.italic" = "serifless"
 selectorAffix.meng = "serifless"
 
 [prime.m.variants-buildup.stages.serifs.top-left-serifed]
@@ -2755,6 +2764,7 @@ selectorAffix.m = "topLeftSerifed"
 selectorAffix."m/tailless" = "topLeftSerifed"
 selectorAffix."m/sansSerif" = "serifless"
 selectorAffix."cyrl/te.italic" = "topLeftSerifed"
+selectorAffix."cyrl/tjeKomi.italic" = "topLeftSerifed"
 selectorAffix.meng = "topLeftSerifed"
 
 [prime.m.variants-buildup.stages.serifs.top-left-and-bottom-right-serifed]
@@ -2765,6 +2775,7 @@ selectorAffix.m = "topLeftAndBottomRightSerifed"
 selectorAffix."m/tailless" = "topLeftAndBottomRightSerifed"
 selectorAffix."m/sansSerif" = "serifless"
 selectorAffix."cyrl/te.italic" = "topLeftAndBottomRightSerifed"
+selectorAffix."cyrl/tjeKomi.italic" = "topLeftSerifed"
 selectorAffix.meng = "topLeftSerifed"
 
 [prime.m.variants-buildup.stages.serifs.serifed]
@@ -2774,6 +2785,7 @@ selectorAffix.m = "serifed"
 selectorAffix."m/tailless" = "serifed"
 selectorAffix."m/sansSerif" = "serifless"
 selectorAffix."cyrl/te.italic" = "serifed"
+selectorAffix."cyrl/tjeKomi.italic" = "serifed"
 selectorAffix.meng = "serifed"
 
 


### PR DESCRIPTION
Closes #1920.

Comparison with italic Te:
![image](https://github.com/be5invis/Iosevka/assets/21302803/d92e35bb-908d-426c-b312-a8e363385fb6)

* New variant type `cyrl/tjeKomi.italic`. Basically like `cyrl/te.italic` but no tails or bottom-right serifs exist.
  * Correspondingly, the glyph is only created with the eared form, no short middle leg, no tails to reduce the amount of unused glyphs.