### PR TITLE
Add Pi and Tau variant selectors

### DIFF
--- a/changes/26.2.0.md
+++ b/changes/26.2.0.md
@@ -1,3 +1,4 @@
+* \[**Breaking**\] Add variant selectors for lowercase Greek Pi (`π`) and Tau (`τ`) (#1924).
 * Add characters:
   - CYRILLIC SMALL LETTER ROUNDED VE (`U+1C80`).
   - CYRILLIC SMALL LETTER TALL TE (`U+1C84`) (#1911).

--- a/font-src/glyphs/letter/greek/pi.ptl
+++ b/font-src/glyphs/letter/greek/pi.ptl
@@ -57,9 +57,21 @@ glyph-block Letter-Greek-Pi : begin
 	derive-composites 'cyrl/PeDescender' 0x524 'cyrl/Pe' [CyrDescender.rSideJut RightSB 0]
 	derive-composites 'cyrl/peDescender.upright' null 'cyrl/pe.upright' [CyrDescender.rSideJut RightSB 0]
 
-	create-glyph 'grek/pi' 0x3C0 : glyph-proc
-		include : MarkSet.e
-		include : PiShape [DivFrame 1] XH 0 (doSerif -- false) (shrinkRate -- (1/6 - [HSwToV : 0.25 * Stroke] / (RightSB - SB))) (tailed -- true)
+	define SmallPiShrink : 1/6 - [HSwToV : 0.25 * Stroke] / (RightSB - SB)
+
+	define SmallPiConfig : object
+		smallCap { {0             SLAB  } false }
+		tailless { {SmallPiShrink false } false }
+		tailed   { {SmallPiShrink false } true  }
+
+	foreach { suffix { { shrink slab } tail } } [pairs-of SmallPiConfig] : do
+		create-glyph "grek/pi.\(suffix)" : glyph-proc
+			define df : DivFrame 1
+			set-width df.width
+			include : df.markSet.e
+			include : PiShape df XH 0 (shrinkRate -- shrink) (doSerif -- slab) (tailed -- tail)
+
+	select-variant 'grek/pi' 0x3C0
 
 	create-glyph 'mathbb/grek/pi' 0x213C : glyph-proc
 		include : MarkSet.e

--- a/font-src/glyphs/letter/latin/lower-t.ptl
+++ b/font-src/glyphs/letter/latin/lower-t.ptl
@@ -188,7 +188,7 @@ glyph-block Letter-Latin-Lower-T : begin
 			include : Body df sym top bot
 			include : HBar.b xLeft RightSB 0
 
-	define SmallTConfig :SuffixCfg.weave
+	define SmallTConfig : SuffixCfg.weave
 		object # body
 			bentHook                       { [DivFrame  1] BentHook           }
 			diagonalTailed                 {  dfNarrowT    DiagTail           }
@@ -198,7 +198,7 @@ glyph-block Letter-Latin-Lower-T : begin
 			""                             SYM-BALANCED
 			"asymmetric"                   SYM-LEFT
 		object # height
-			""							   Ascender
+			""                             Ascender
 			shortNeck                      yShortNeck1
 			shortNeck2                     yShortNeck2
 
@@ -301,7 +301,21 @@ glyph-block Letter-Latin-Lower-T : begin
 
 	select-variant "tHookTopRTail" 0x1DF09
 
-	# U+01BE is catually "t" and "s" combined together
+	define SmallTauConfig : object
+		tailed         { [DivFrame 1] BentHook }
+		flatTailed     {  dfNarrowT   Flat     }
+		diagonalTailed {  dfNarrowT   DiagTail }
+		tailless       {  dfNarrowT   Hookless }
+
+	foreach { suffix { df Style } } [pairs-of SmallTauConfig] : do
+		create-glyph "grek/tau.\(suffix)" : glyph-proc
+			set-width df.width
+			include : df.markSet.e
+			include : Style.Body df SYM-BALANCED XH 0
+
+	select-variant 'grek/tau' 0x3C4
+
+	# U+01BE is actually "t" and "s" combined together
 	define SLAB-NONE        0
 	define SLAB-CLASSICAL   1
 	define SLAB-INWARD      2

--- a/font-src/glyphs/letter/latin/upper-t.ptl
+++ b/font-src/glyphs/letter/latin/upper-t.ptl
@@ -53,7 +53,7 @@ glyph-block Letter-Latin-Upper-T : begin
 		local sf2 : [SerifFrame.fromDf df (top / 2) 0].slice 1 2
 		if SLAB : include sf2.rt.full
 
-	define [TauShape df top doTopSerifs] : glyph-proc
+	define [TweShape df top doTopSerifs] : glyph-proc
 		local hd : FlatHookDepth df
 		include : difference
 			TShape df top doTopSerifs false
@@ -122,12 +122,12 @@ glyph-block Letter-Latin-Upper-T : begin
 		create-glyph "cyrl/Twe.\(suffix)" : glyph-proc
 			set-width df.width
 			include : df.markSet.capital
-			include : TauShape df CAP doST doSB
+			include : TweShape df CAP doST doSB
 
 		create-glyph "cyrl/twe.\(suffix)" : glyph-proc
 			set-width df.width
 			include : df.markSet.e
-			include : TauShape df XH doST doSB
+			include : TweShape df XH doST doSB
 
 		create-glyph "currency/tengeSign.\(suffix)" : glyph-proc
 			set-width df.width
@@ -179,7 +179,6 @@ glyph-block Letter-Latin-Upper-T : begin
 	select-variant 'turnT' 0xA7B1 (follow -- 'T')
 
 	alias 'grek/Tau' 0x3A4 'T'
-	alias 'grek/tau' 0x3C4 'cyrl/twe.serifless'
 	alias-reduced-variant 'grek/Tau/sansSerif' 'grek/Tau' 'T/sansSerif' MathSansSerif
 	alias 'cyrl/Te' 0x422 'T'
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -4612,17 +4612,17 @@ description = "Greek lower Tau (`τ`) with a tailless shape"
 selector."grek/tau" = "tailless"
 
 [prime.lower-tau.variants.tailed]
-rank = 3
+rank = 2
 description = "Greek lower Tau (`τ`) with curly tail"
 selector."grek/tau" = "tailed"
 
 [prime.lower-tau.variants.flat-tailed]
-rank = 5
+rank = 3
 description = "Greek lower Tau (`τ`) with a flat tail"
 selector."grek/tau" = "flatTailed"
 
 [prime.lower-tau.variants.diagonal-tailed]
-rank = 7
+rank = 4
 description = "Greek lower Tau (`τ`) with a diagonal tail"
 selector."grek/tau" = "diagonalTailed"
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -4579,6 +4579,55 @@ selector."grek/xi" = "flatTop"
 
 
 
+[prime.lower-pi]
+sampler = "π"
+samplerExplain = "Greek lower Pi"
+tagKind = "letter"
+
+[prime.lower-pi.variants.tailless]
+rank = 1
+description = "Greek lower Pi (`π`) with a tailless shape"
+selector."grek/pi" = "tailless"
+
+[prime.lower-pi.variants.tailed]
+rank = 2
+description = "Greek lower Pi (`π`) with a tailed shape"
+selector."grek/pi" = "tailed"
+
+[prime.lower-pi.variants.small-capital]
+rank = 3
+description = "Greek lower Pi (`π`) with a small-capital shape"
+selector."grek/pi" = "smallCap"
+
+
+
+[prime.lower-tau]
+sampler = "τ"
+samplerExplain = "Greek lower Tau"
+tagKind = "letter"
+
+[prime.lower-tau.variants.tailless]
+rank = 1
+description = "Greek lower Tau (`τ`) with a tailless shape"
+selector."grek/tau" = "tailless"
+
+[prime.lower-tau.variants.tailed]
+rank = 3
+description = "Greek lower Tau (`τ`) with curly tail"
+selector."grek/tau" = "tailed"
+
+[prime.lower-tau.variants.flat-tailed]
+rank = 5
+description = "Greek lower Tau (`τ`) with a flat tail"
+selector."grek/tau" = "flatTailed"
+
+[prime.lower-tau.variants.diagonal-tailed]
+rank = 7
+description = "Greek lower Tau (`τ`) with a diagonal tail"
+selector."grek/tau" = "diagonalTailed"
+
+
+
 [prime.lower-chi]
 sampler = "χ"
 samplerExplain = "Greek lower Chi"
@@ -6739,6 +6788,8 @@ lower-iota = "serifed-flat-tailed"
 capital-lambda = "straight-serifless"
 lower-lambda = "straight"
 lower-xi = "flat-top"
+lower-pi = "tailed"
+lower-tau = "flat-tailed"
 lower-chi = "straight-serifless"
 cyrl-capital-zhe = "symmetric-connected"
 cyrl-zhe = "symmetric-connected"
@@ -6958,6 +7009,8 @@ long-s = "flat-hook-middle-serifed"
 eszet = "longs-s-lig-serifless"
 lower-lambda = "straight-turn"
 lower-iota = "flat-tailed"
+lower-pi = "tailless"
+lower-tau = "tailless"
 cyrl-capital-zhe = "straight"
 cyrl-zhe = "straight"
 cyrl-capital-ka = "straight-serifless"
@@ -7101,6 +7154,7 @@ eszet = "longs-s-lig-serifless"
 long-s = "flat-hook-serifless"
 lower-alpha = "tailed-barred"
 lower-lambda = "straight-turn"
+lower-tau = "tailed"
 cyrl-capital-zhe = "symmetric-touching"
 cyrl-zhe = "symmetric-touching"
 cyrl-capital-ka = "symmetric-touching-serifless"
@@ -7724,6 +7778,8 @@ capital-gamma = "bottom-serifed"
 lower-iota = "tailed-serifed"
 lower-lambda = "straight-turn"
 lower-mu = "toothless-corner-serifless"
+lower-pi = "small-capital"
+lower-tau = "tailed"
 cyrl-capital-zhe = "symmetric-touching"
 cyrl-zhe = "symmetric-touching"
 cyrl-capital-ka = "symmetric-touching-serifless"
@@ -7989,6 +8045,8 @@ y = "cursive-serifless"
 z = "cursive"
 long-s = "flat-hook-diagonal-tailed-middle-serifed"
 eszet = "traditional-flat-hook-middle-serifed"
+lower-iota = "serifed-diagonal-tailed"
+lower-tau = "diagonal-tailed"
 ampersand = "closed"
 
 [composite.ss15.slab-override.design]


### PR DESCRIPTION
closes #1924

`Ππ𝝿Ττt`
Default:
![image](https://github.com/be5invis/Iosevka/assets/37010132/15659565-ffe4-427e-998b-45ab838bcac3)
`ss01`:
![image](https://github.com/be5invis/Iosevka/assets/37010132/8f19162b-6a72-4a9d-9609-e6936ab83f5f)
`ss12` sans:
![image](https://github.com/be5invis/Iosevka/assets/37010132/14eeef30-926e-4fbb-835b-8e451b2955b5)
`ss12` slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/dbfdb0a8-715d-473a-8f40-9ef6917632f5)
`ss15` regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/f77b53e3-9a60-45b1-be49-9703990de65f)
`ss15` italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/2be4ac37-7e54-4ada-aa51-f5a852fa7bb9)


