### PR TITLE
Fix `VXAC` for Default Slab, `ss11`, and `ss13`.

### DIFF
--- a/changes/26.2.2.md
+++ b/changes/26.2.2.md
@@ -1,5 +1,5 @@
 * Make bowl height of Cyrillic Yat and Tall Yat (`U+0463`, `U+1C67`) consistent (#1945).
 * Make Guillemets (`«`, `»`) curly for Default Slab.
 * Fix variant selection for `cv59` and `vxAB` under `ss05` and `ss08`.
-* Fix variant selection for `vxAC` for `ss11`.
+* Fix variant selection for `vxAC` under `ss11`.
 * Fix variant selection for `cv26`, `cv34`, `cv37`, `cv59`, `cv61`, `cv62`, `vxAA`, `vxAB`, `cv81`, `vxAC`, and `vsAL` under `ss13`.

--- a/changes/26.2.2.md
+++ b/changes/26.2.2.md
@@ -1,3 +1,5 @@
 * Make bowl height of Cyrillic Yat and Tall Yat (`U+0463`, `U+1C67`) consistent (#1945).
+* Make Guillemets (`«`, `»`) curly for Default Slab.
 * Fix variant selection for `cv59` and `vxAB` under `ss05` and `ss08`.
-* Fix variant selection for `cv26`, `cv34`, `cv37`, `cv59`, `cv61`, `cv62`, `vxAA`, `vxAB`, `cv81`, and `vsAL` under `ss13`.
+* Fix variant selection for `vxAC` for `ss11`.
+* Fix variant selection for `cv26`, `cv34`, `cv37`, `cv59`, `cv61`, `cv62`, `vxAA`, `vxAB`, `cv81`, `vxAC`, and `vsAL` under `ss13`.

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -6169,6 +6169,24 @@ selector.braceRight = "curlyFlatBoundary"
 
 
 
+[prime.guillemet]
+sampler = "« »"
+samplerExplain = "Guillemets"
+nonBreakingTagForNewVariantSelector = "VXAC" # REMOVE IN NEXT MAJOR VERSION CHANGE
+tagKind = "symbol"
+
+[prime.guillemet.variants.straight]
+rank = 1
+description = "Straight Guillemets (`« »`)"
+selector."guillemet" = "straight"
+
+[prime.guillemet.variants.curly]
+rank = 2
+description = "Curly Guillemets (`« »`)"
+selector."guillemet" = "curly"
+
+
+
 [prime.number-sign]
 sampler = "#"
 tagKind = "symbol"
@@ -6569,24 +6587,6 @@ selectorAffix."micro" = "serifed"
 
 
 
-[prime.guillemet]
-sampler = "« »"
-samplerExplain = "Guillemets"
-nonBreakingTagForNewVariantSelector = "VXAC" # REMOVE IN NEXT MAJOR VERSION CHANGE
-tagKind = "symbol"
-
-[prime.guillemet.variants.straight]
-rank = 1
-description = "Straight Guillemets (`« »`)"
-selector."guillemet" = "straight"
-
-[prime.guillemet.variants.curly]
-rank = 2
-description = "Curly Guillemets (`« »`)"
-selector."guillemet" = "curly"
-
-
-
 [prime.lig-ltgteq]
 sampler = "<= >="
 samplerExplain = "Less-equal and Greater-equal ligations"
@@ -6963,7 +6963,6 @@ cyrl-capital-u = "straight-turn-serifed"
 cyrl-capital-ya = "straight-serifed"
 cyrl-ya = "straight-serifed"
 micro-sign = "toothed-serifed"
-guillemet = "straight"
 
 [composite.slab.upright-oblique]
 d = "toothed-serifed"
@@ -7781,6 +7780,7 @@ brace = "straight"
 at = "threefold"
 dollar = "through"
 percent = "rings-continuous-slash"
+guillemet = "straight"
 
 
 
@@ -7924,6 +7924,7 @@ pilcrow = "low"
 number-sign = "slanted"
 percent = "rings-continuous-slash"
 micro-sign = "toothed-serifless"
+guillemet = "straight"
 punctuation-dot = "square"
 diacritic-dot = "square"
 


### PR DESCRIPTION
also move variant selector to be next to the other opening/closing punctuation variant selectors.