### PR TITLE
Optimize shapes/variants of Barred B and R with Stroke

### DIFF
--- a/changes/26.2.2.md
+++ b/changes/26.2.2.md
@@ -3,6 +3,8 @@
 * Make Guillemets (`«`, `»`) curly for Default Slab.
 * Remove duplicate lower-right serif variants of `H` with descender (#1953).
 * Fix toothless variants of LATIN SMALL LETTER B WITH HOOK (`U+0253`) (#1952).
+* Always use closed variants for LATIN CAPITAL LETTER R WITH STROKE (`U+024C`).
+* Optimize shape of LATIN {SMALL CAPITAL|MODIFIER LETTER CAPITAL} BARRED B (`U+1D03`,`U+1D2F`).
 * Fix variant selection for `cv34` and `cv37` under `ss01`, `ss03`, `ss09`, `ss10`, and `ss13`.
 * Fix variant selection for `cv36` under `ss03`, `ss08`, `ss09`, `ss10`, `ss12`, and `ss14`.
 * Fix variant selection for `cv59` and `vxAB` under `ss01`, `ss05`, `ss08`, and `ss13`.

--- a/font-src/glyphs/letter/latin/upper-b.ptl
+++ b/font-src/glyphs/letter/latin/upper-b.ptl
@@ -103,6 +103,10 @@ glyph-block Letter-Latin-Upper-B : begin
 		return : LetterBarOverlay.l.in SB stroke (top * bp - 0.5 * stroke)
 			space -- { 0 (RightSB - [HSwToV Stroke]) }
 
+	define [BOverlayBar top bp] : begin
+		local stroke : AdviceStroke2 2 3 top
+		return : HBar.m [mix 0 SB 0.3] [mix Width RightSB 0.3] (top * bp)
+
 	define [BahtBar sw] : VBar.m [mix SB RightSB 0.48] (CAP - Descender / 2) (Descender / 2) sw
 	define [BitcoinBar sw] : begin
 		local xMid : mix SB RightSB 0.48
@@ -133,6 +137,10 @@ glyph-block Letter-Latin-Upper-B : begin
 			include [refer-glyph "B.\(suffix)"] AS_BASE ALSO_METRICS
 			include : BOverlayStroke CAP bp
 
+		create-glyph "BBar.\(suffix)" : glyph-proc
+			include [refer-glyph "B.\(suffix)"] AS_BASE ALSO_METRICS
+			include : BOverlayBar CAP bp
+
 		create-glyph "currency/baht.\(suffix)" : union
 			body CAP currencySw ts bs
 			intersection [BahtBar : AdviceStroke 5] [mask CAP : AdviceStroke2 2 3 CAP]
@@ -145,6 +153,10 @@ glyph-block Letter-Latin-Upper-B : begin
 		create-glyph "smcpB.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : body XH [AdviceStroke2 2 3 XH] ts bs
+
+		create-glyph "smcpBBar.\(suffix)" : glyph-proc
+			include [refer-glyph "smcpB.\(suffix)"] AS_BASE ALSO_METRICS
+			include : BOverlayBar XH bp
 
 		create-glyph "latn/Beta.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
@@ -167,8 +179,8 @@ glyph-block Letter-Latin-Upper-B : begin
 	select-variant 'smcpB' 0x299
 	alias 'cyrl/ve.upright' null 'smcpB'
 
-	derive-composites 'BBar' null 'B' 'hStrike'
-	derive-composites 'smcpBBar' 0x1D03 'smcpB' 'hStrike'
+	select-variant 'BBar'
+	select-variant 'smcpBBar' 0x1D03 (follow -- 'BBar')
 
 	create-glyph 'mathbb/B' 0x1D539 : glyph-proc
 		include : MarkSet.capital

--- a/font-src/glyphs/letter/latin/upper-r.ptl
+++ b/font-src/glyphs/letter/latin/upper-r.ptl
@@ -184,6 +184,10 @@ glyph-block Letter-Latin-Upper-R : begin
 			include : StrikeAnchor
 			include : RShape legShape CAP (slab -- slabs) (bp -- bpCap) (open -- fOpen)
 
+		if (!fOpen) : create-glyph "RBar.\(suffix)" : glyph-proc
+			include [refer-glyph "R.\(suffix)"] AS_BASE ALSO_METRICS
+			include : HBar.m [mix 0 SB 0.3] (SB - O) ((CAP - Stroke) * [RBarPos CAP SLAB] + Stroke * 0.25)
+
 		create-glyph "smcpR.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : StrikeAnchor
@@ -237,6 +241,9 @@ glyph-block Letter-Latin-Upper-R : begin
 
 	select-variant 'R' 'R'
 	link-reduced-variant 'R/sansSerif' 'R' MathSansSerif
+
+	select-variant 'RBar' 0x24C
+
 	select-variant 'smcpR' 0x280 (follow -- 'R')
 	turned 'turnSmapR' 0x1D1A 'smcpR' Middle (XH / 2)
 
@@ -251,10 +258,6 @@ glyph-block Letter-Latin-Upper-R : begin
 	select-variant 'Yr' 0x1A6 (follow -- 'R')
 
 	select-variant 'currency/indianRupeeSign' 0x20B9 (follow -- 'RRotunda')
-
-	derive-glyphs 'RBar' 0x24C 'R' : lambda [src gr] : glyph-proc
-		include [refer-glyph src] AS_BASE ALSO_METRICS
-		include : HBar.m [mix 0 SB 0.3] (SB - O) ((CAP - Stroke) * [RBarPos CAP SLAB] + Stroke * 0.25)
 
 	derive-glyphs 'RRTail' 0x2C64 'R' : lambda [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -72,6 +72,7 @@ descriptionAffix = "mostly symmetric shape"
 selectorAffix.B = "standard"
 selectorAffix."B/sansSerif" = "standard"
 selectorAffix.smcpB = "standard"
+selectorAffix.BBar = "standard"
 
 [prime.capital-b.variants-buildup.stages.symmetry.more-asymmetric]
 rank = 2
@@ -79,6 +80,7 @@ descriptionAffix = "more asymmetric shape"
 selectorAffix.B = "moreAsymmetric"
 selectorAffix."B/sansSerif" = "moreAsymmetric"
 selectorAffix.smcpB = "moreAsymmetric"
+selectorAffix.BBar = "moreAsymmetric"
 
 [prime.capital-b.variants-buildup.stages.openness."*"]
 next = "serifs"
@@ -89,6 +91,7 @@ keyAffix = ""
 selectorAffix.B = ""
 selectorAffix."B/sansSerif" = ""
 selectorAffix.smcpB = ""
+selectorAffix.BBar = ""
 
 [prime.capital-b.variants-buildup.stages.openness.interrupted]
 rank = 2
@@ -96,6 +99,7 @@ descriptionAffix = "interrupted middle bar"
 selectorAffix.B = "interrupted"
 selectorAffix."B/sansSerif" = "interrupted"
 selectorAffix.smcpB = "interrupted"
+selectorAffix.BBar = ""
 
 [prime.capital-b.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -104,6 +108,7 @@ descriptionJoiner = "without"
 selectorAffix.B = "serifless"
 selectorAffix."B/sansSerif" = "serifless"
 selectorAffix.smcpB = "serifless"
+selectorAffix.BBar = "serifless"
 
 [prime.capital-b.variants-buildup.stages.serifs.unilateral-serifed]
 rank = 2
@@ -111,6 +116,7 @@ descriptionAffix = "serifs at top"
 selectorAffix.B = "unilateralSerifed"
 selectorAffix."B/sansSerif" = "serifless"
 selectorAffix.smcpB = "unilateralSerifed"
+selectorAffix.BBar = "unilateralSerifed"
 
 [prime.capital-b.variants-buildup.stages.serifs.bilateral-serifed]
 rank = 3
@@ -118,6 +124,7 @@ descriptionAffix = "serifs at both top and bottom"
 selectorAffix.B = "bilateralSerifed"
 selectorAffix."B/sansSerif" = "serifless"
 selectorAffix.smcpB = "bilateralSerifed"
+selectorAffix.BBar = "bilateralSerifed"
 
 
 
@@ -867,6 +874,7 @@ rank = 1
 keyAffix = ""
 selectorAffix.R = ""
 selectorAffix."R/sansSerif" = ""
+selectorAffix.RBar = ""
 selectorAffix.RRotunda = ""
 
 [prime.capital-r.variants-buildup.stages.openness.open]
@@ -874,6 +882,7 @@ rank = 2
 descriptionAffix = "open contour"
 selectorAffix.R = "open"
 selectorAffix."R/sansSerif" = "open"
+selectorAffix.RBar = ""
 selectorAffix.RRotunda = ""
 
 [prime.capital-r.variants-buildup.stages.leg."*"]
@@ -885,6 +894,7 @@ rank = 1
 descriptionAffix = "straight leg"
 selectorAffix.R = "straight"
 selectorAffix."R/sansSerif" = "straight"
+selectorAffix.RBar = "straight"
 selectorAffix.RRotunda = "straight"
 
 [prime.capital-r.variants-buildup.stages.leg.curly]
@@ -892,6 +902,7 @@ rank = 2
 descriptionAffix = "curly leg"
 selectorAffix.R = "curly"
 selectorAffix."R/sansSerif" = "curly"
+selectorAffix.RBar = "curly"
 selectorAffix.RRotunda = "curly"
 
 [prime.capital-r.variants-buildup.stages.leg.standing]
@@ -899,6 +910,7 @@ rank = 3
 descriptionAffix = "standing leg (like Helvetica)"
 selectorAffix.R = "standing"
 selectorAffix."R/sansSerif" = "standing"
+selectorAffix.RBar = "standing"
 selectorAffix.RRotunda = "standing"
 
 [prime.capital-r.variants-buildup.stages.serifs.serifless]
@@ -907,6 +919,7 @@ descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix.R = "serifless"
 selectorAffix."R/sansSerif" = "serifless"
+selectorAffix.RBar = "serifless"
 selectorAffix.RRotunda = "serifless"
 
 [prime.capital-r.variants-buildup.stages.serifs.motion-serifed]
@@ -914,6 +927,7 @@ rank = 2
 descriptionAffix = "motion serifs"
 selectorAffix.R = "motionSerifed"
 selectorAffix."R/sansSerif" = "serifless"
+selectorAffix.RBar = "motionSerifed"
 selectorAffix.RRotunda = "serifless"
 
 [prime.capital-r.variants-buildup.stages.serifs.serifed]
@@ -921,6 +935,7 @@ rank = 3
 descriptionAffix = "serifs"
 selectorAffix.R = "serifed"
 selectorAffix."R/sansSerif" = "serifless"
+selectorAffix.RBar = "serifed"
 selectorAffix.RRotunda = "serifless"
 
 


### PR DESCRIPTION
`BᴃᴯRɌ`
Default:
![image](https://github.com/be5invis/Iosevka/assets/37010132/baf2f1af-271b-4f2e-8f69-33776ea23b9a)
Slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/f3d2639d-9187-4b77-8925-fbf425c24022)
`cv02` 10 and `cv17` 10:
![image](https://github.com/be5invis/Iosevka/assets/37010132/c2eec521-b695-453d-9a36-5e11362d5f68)
