### PR TITLE
Make MICRO SIGN (`µ`) tailed under italics by default, to match `u`.

### DIFF
--- a/build-plans.toml
+++ b/build-plans.toml
@@ -711,6 +711,7 @@ cyrl-em = "flat-bottom-serifless"
 cyrl-capital-u = "straight-serifless"
 at = "fourfold"
 percent = "rings-continuous-slash"
+micro-sign = "toothed-serifless"
 
 # Letterform control for U+1D670 ... U+1D6A3
 [buildPlans.iosevka-aile.derivingVariants.mathtt.design]
@@ -744,6 +745,7 @@ cyrl-em = "flat-bottom-serifless"
 cyrl-capital-u = "straight-serifless"
 at = "fourfold"
 percent = "rings-continuous-slash"
+micro-sign = "toothed-serifless"
 
 [buildPlans.iosevka-aile.widths.normal]
 shape = 600

--- a/changes/26.2.3.md
+++ b/changes/26.2.3.md
@@ -4,5 +4,6 @@
   - COMBINING REVERSE SOLIDUS OVERLAY (`U+20E5`).
   - COMBINING DOUBLE VERTICAL STROKE OVERLAY (`U+20E6`).
   - COMBINING LONG DOUBLE SOLIDUS OVERLAY (`U+20EB`).
+* Make MICRO SIGN (`µ`) tailed under italics by default, to match `u`.
 * Improve glyphs for COLON SIGN (`U+20A1`), GUARANI SIGN (`U+20B2`), and CEDI SIGN (`U+20B5`).
 * Generate TTFAutohint control files for better glyph display for variant glyphs (#1963).

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -6925,6 +6925,7 @@ long-s = "flat-hook-tailed"
 cyrl-ef = "cursive"
 cyrl-yeri = "round"
 cyrl-yery = "round"
+micro-sign = "tailed-serifless"
 
 ###################################################################################################
 
@@ -7022,6 +7023,7 @@ cyrl-ef = "cursive"
 cyrl-ka = "symmetric-connected-top-left-serifed"
 cyrl-yeri = "cursive"
 cyrl-yery = "cursive"
+micro-sign = "tailed-serifed"
 
 
 [composite.ss01]
@@ -7073,6 +7075,7 @@ number-sign = "slanted"
 at = "fourfold"
 percent = "rings-continuous-slash"
 lower-eth = "straight-bar"
+micro-sign = "toothed-serifless"
 guillemet = "straight"
 
 [composite.ss01.slab-override.design]
@@ -7099,6 +7102,7 @@ cyrl-ka = "straight-serifed"
 cyrl-em = "flat-bottom-serifed"
 cyrl-capital-u = "straight-turn-serifed"
 seven = "straight-serifed"
+micro-sign = "toothed-serifed"
 
 
 
@@ -7154,6 +7158,7 @@ at = "fourfold"
 percent = "rings-continuous-slash"
 partial-derivative = "straight-bar"
 lower-eth = "straight-bar"
+micro-sign = "toothed-serifless"
 punctuation-dot = "square"
 diacritic-dot = "square"
 guillemet = "straight"
@@ -7171,6 +7176,7 @@ eszet = "longs-s-lig-bottom-serifed"
 cyrl-capital-ka = "straight-serifed"
 cyrl-ka = "straight-serifed"
 cyrl-capital-u = "straight-turn-serifed"
+micro-sign = "toothed-serifed"
 
 
 
@@ -7380,6 +7386,7 @@ ampersand = "et-toothless-corner"
 at = "compact"
 cent = "open"
 percent = "rings-continuous-slash"
+micro-sign = "toothed-serifless"
 guillemet = "straight"
 lig-ltgteq = "slanted"
 lig-equal-chain = "without-notch"
@@ -7403,6 +7410,7 @@ eszet = "longs-s-lig-bottom-serifed"
 lower-mu = "toothed-serifed"
 cyrl-em = "slanted-sides-hanging-serifed"
 cyrl-capital-u = "straight-turn-serifed"
+micro-sign = "toothed-serifed"
 
 
 
@@ -7443,6 +7451,7 @@ number-sign = "slanted"
 at = "fourfold"
 percent = "rings-continuous-slash"
 bar = "force-upright"
+micro-sign = "toothed-serifless"
 punctuation-dot = "square"
 diacritic-dot = "square"
 guillemet = "straight"
@@ -7465,6 +7474,7 @@ eszet = "longs-s-lig-bottom-serifed"
 cyrl-em = "flat-bottom-serifed"
 cyrl-capital-u = "straight-turn-serifed"
 seven = "bend-serifed"
+micro-sign = "toothed-serifed"
 
 
 
@@ -7507,6 +7517,7 @@ pilcrow = "low"
 number-sign = "slanted"
 at = "fourfold"
 percent = "rings-continuous-slash"
+micro-sign = "toothed-serifless"
 guillemet = "straight"
 
 [composite.ss07.slab-override.design]
@@ -7528,6 +7539,7 @@ long-s = "flat-hook-bottom-serifed"
 eszet = "longs-s-lig-bottom-serifed"
 cyrl-capital-u = "straight-turn-serifed"
 seven = "curly-serifed"
+micro-sign = "toothed-serifed"
 
 
 
@@ -7596,6 +7608,7 @@ dollar = "open"
 cent = "open"
 percent = "dots"
 paren = "large-contour"
+micro-sign = "toothed-serifless"
 guillemet = "straight"
 lig-ltgteq = "slanted"
 lig-neq = "slightly-slanted-dotted"
@@ -7639,6 +7652,7 @@ cyrl-ka = "curly-serifed"
 cyrl-capital-ya = "curly-serifed"
 cyrl-ya = "curly-serifed"
 seven = "bend-serifed"
+micro-sign = "toothed-serifed"
 
 [composite.ss08.slab-override.italic]
 g = "single-storey-serifed"
@@ -8029,6 +8043,7 @@ number-sign = "slanted"
 ampersand = "upper-open"
 percent = "rings-continuous-slash"
 lower-eth = "straight-bar"
+micro-sign = "toothed-serifless"
 lig-ltgteq = "slanted"
 question = "corner-flat-hooked"
 guillemet = "straight"
@@ -8056,6 +8071,7 @@ y = "straight-serifed"
 z = "straight-serifed"
 long-s = "flat-hook-bottom-serifed"
 lower-mu = "toothed-serifed"
+micro-sign = "toothed-serifed"
 
 [composite.ss14.slab-override.italic]
 a = "single-storey-serifed"
@@ -8106,6 +8122,7 @@ number-sign = "slanted-open"
 ampersand = "upper-open"
 question = "corner"
 brace = "curly-flat-boundary"
+micro-sign = "toothed-serifless"
 guillemet = "straight"
 
 [composite.ss15.italic]
@@ -8137,6 +8154,7 @@ w = "straight-flat-top-serifless"
 y = "straight-turn-serifed"
 eszet = "traditional-flat-hook-dual-serifed"
 cyrl-capital-u = "straight-turn-serifed"
+micro-sign = "toothed-serifed"
 
 [composite.ss15.slab-override.italic]
 a = "single-storey-serifed"


### PR DESCRIPTION
Of all the variants that use a permanently tailed or tailless micro sign, almost all of them also use a permanently tailed or tailless `u` as well, except for Recursive Mono (`ss17`).
Fonts that add a tail to `u` under italics (example: Ubuntu Mono), also add a tail for the Latin-1 Micro Sign and/or real Greek Mu as well, as it's made to mimic the familiar ASCII lower `u` for non-Greek speakers using metric units.
Real Greek Mu is unchanged in this PR as its existing permanently-tailed behavior is probably better for Greek language text as opposed to inserting a single metric unit within a string of Latin text. I also prefer how I can currently distinguish the two and would rather not ruin that.
`uµμ`
Default:
![image](https://github.com/be5invis/Iosevka/assets/37010132/0642d9b7-167a-4bc9-a028-fb855b348037)
Slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/7de4f562-4281-40bc-8bb9-8203f4c97759)
