### PR TITLE
Clean up serifs for `u`, turn-m, micro, Greek mu.

### DIFF
--- a/font-src/glyphs/letter/latin/lower-m.ptl
+++ b/font-src/glyphs/letter/latin/lower-m.ptl
@@ -88,9 +88,6 @@ glyph-block Letter-Latin-Lower-M : begin
 	define [AutoSerifs df top lbot mbot rbot tailed earless] : begin
 		if SLAB [FullSerifs df top lbot mbot rbot tailed earless] [no-shape]
 
-	define [SmallTurnMSerifs df top lbot mbot rbot tailed earless] : begin
-		if (para.isItalic && [not earless]) [LtRbSerifs df top lbot mbot rbot tailed earless] [FullSerifs df top lbot mbot rbot tailed earless]
-
 	define [LtSerifs df top lbot mbot rbot tailed earless] : glyph-proc
 		include : SmallMTopLeftSerif df top lbot
 
@@ -296,11 +293,11 @@ glyph-block Letter-Latin-Lower-M : begin
 			"toothlessCorner"    { EarlessCornerDoubleArchSmallMShape  1 0 }
 			"toothlessRounded"   { EarlessRoundedDoubleArchSmallMShape 1 0 }
 		object
-			"serifless"          { no-shape         }
-			"serifed"            { SmallTurnMSerifs }
-			"topLeftSerifed"     { RbSerifs         } # The name-shapipng mapping is swapped by design
-			"bottomRightSerifed" { LtSerifs         } # The name-shapipng mapping is swapped by design
-			"motionSerifed"      { LtRbSerifs       }
+			"serifless"          { no-shape   }
+			"serifed"            { FullSerifs }
+			"topLeftSerifed"     { RbSerifs   } # The name-shapipng mapping is swapped by design
+			"bottomRightSerifed" { LtSerifs   } # The name-shapipng mapping is swapped by design
+			"motionSerifed"      { LtRbSerifs }
 
 	foreach { suffix { {Body toothless tailed} {Serifs} } } [pairs-of TurnMConfig] : do
 		define [turnMShapeBody df top] : glyph-proc

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -7017,13 +7017,14 @@ z = "cursive"
 eszet = "sulzbacher-tailed-serifless"
 latn-phi = "serifed"
 long-s = "flat-hook-tailed"
+lower-mu = "tailed-motion-serifed"
 cyrl-ze = "unilateral-inward-serifed"
 cyrl-en = "top-left-bottom-right-serifed"
 cyrl-ef = "cursive"
 cyrl-ka = "symmetric-connected-top-left-serifed"
 cyrl-yeri = "cursive"
 cyrl-yery = "cursive"
-micro-sign = "tailed-serifed"
+micro-sign = "tailed-motion-serifed"
 
 
 [composite.ss01]
@@ -7097,15 +7098,13 @@ z = "straight-serifed"
 long-s = "flat-hook-double-serifed"
 eszet = "longs-s-lig-bottom-serifed"
 lower-iota = "tailed-serifed"
+lower-mu = "tailed-serifed"
 cyrl-capital-ka = "straight-serifed"
 cyrl-ka = "straight-serifed"
 cyrl-em = "flat-bottom-serifed"
 cyrl-capital-u = "straight-turn-serifed"
 seven = "straight-serifed"
 micro-sign = "toothed-serifed"
-
-[composite.ss01.slab-override.italic]
-u = "toothed-motion-serifed"
 
 
 
@@ -7176,13 +7175,11 @@ w = "straight-flat-top-serifed"
 u = "toothed-serifed"
 y = "straight-turn-serifed"
 eszet = "longs-s-lig-bottom-serifed"
+lower-mu = "tailed-serifed"
 cyrl-capital-ka = "straight-serifed"
 cyrl-ka = "straight-serifed"
 cyrl-capital-u = "straight-turn-serifed"
 micro-sign = "toothed-serifed"
-
-[composite.ss02.slab-override.italic]
-u = "toothed-motion-serifed"
 
 
 
@@ -7277,6 +7274,7 @@ y = "straight-turn-motion-serifed"
 long-s = "flat-hook-descending"
 eszet = "longs-s-lig-descending-serifless"
 cyrl-ka = "symmetric-touching-top-left-serifed"
+micro-sign = "tailed-motion-serifed"
 
 
 
@@ -7342,13 +7340,11 @@ y = "straight-turn-serifed"
 z = "straight-serifed"
 long-s = "flat-hook-double-serifed"
 eszet = "longs-s-lig-bottom-serifed"
+lower-mu = "tailed-serifed"
 cyrl-capital-ka = "straight-serifed"
 cyrl-ka = "straight-serifed"
 cyrl-capital-u = "straight-turn-serifed"
 micro-sign = "tailed-serifed"
-
-[composite.ss04.slab-override.italic]
-u = "toothed-motion-serifed"
 
 
 
@@ -7422,9 +7418,6 @@ cyrl-em = "slanted-sides-hanging-serifed"
 cyrl-capital-u = "straight-turn-serifed"
 micro-sign = "toothed-serifed"
 
-[composite.ss05.slab-override.italic]
-u = "toothed-motion-serifed"
-
 
 
 [composite.ss06]
@@ -7484,13 +7477,11 @@ y = "straight-turn-serifed"
 z = "straight-serifed"
 long-s = "flat-hook-bottom-serifed"
 eszet = "longs-s-lig-bottom-serifed"
+lower-mu = "tailed-serifed"
 cyrl-em = "flat-bottom-serifed"
 cyrl-capital-u = "straight-turn-serifed"
 seven = "bend-serifed"
 micro-sign = "toothed-serifed"
-
-[composite.ss06.slab-override.italic]
-u = "toothed-motion-serifed"
 
 
 
@@ -7553,12 +7544,10 @@ y = "straight-turn-serifed"
 z = "straight-serifed"
 long-s = "flat-hook-bottom-serifed"
 eszet = "longs-s-lig-bottom-serifed"
+lower-mu = "tailed-serifed"
 cyrl-capital-u = "straight-turn-serifed"
 seven = "curly-serifed"
 micro-sign = "toothed-serifed"
-
-[composite.ss07.slab-override.italic]
-u = "toothed-motion-serifed"
 
 
 
@@ -7681,7 +7670,9 @@ v = "curly-motion-serifed"
 w = "curly-motion-serifed"
 x = "curly-motion-serifed"
 y = "curly-motion-serifed"
+lower-mu = "toothed-motion-serifed"
 cyrl-ka = "curly-top-left-serifed"
+micro-sign = "toothed-motion-serifed"
 
 
 
@@ -7766,6 +7757,7 @@ u = "toothed-motion-serifed"
 w = "straight-flat-top-motion-serifed"
 x = "straight-motion-serifed"
 y = "straight-turn-motion-serifed"
+micro-sign = "tailed-motion-serifed"
 
 
 
@@ -7825,6 +7817,7 @@ k = "symmetric-connected-top-left-serifed"
 l = "serifed-flat-tailed"
 x = "straight-motion-serifed"
 y = "cursive-flat-hook-motion-serifed"
+micro-sign = "toothless-rounded-motion-serifed"
 
 
 
@@ -7951,9 +7944,9 @@ u = "tailed-motion-serifed"
 x = "straight-motion-serifed"
 y = "straight-turn-motion-serifed"
 eszet = "longs-s-lig-tailed-serifless"
-lower-mu = "tailed-serifed"
+lower-mu = "tailed-motion-serifed"
 cyrl-ka = "symmetric-touching-top-left-serifed"
-micro-sign = "tailed-serifed"
+micro-sign = "tailed-motion-serifed"
 
 
 
@@ -8021,9 +8014,6 @@ cyrl-em = "flat-bottom-serifed"
 cyrl-capital-u = "straight-turn-serifed"
 seven = "bend-serifed"
 micro-sign = "toothed-serifed"
-
-[composite.ss13.slab-override.italic]
-u = "toothed-motion-serifed"
 
 
 
@@ -8106,6 +8096,8 @@ w = "straight-flat-top-motion-serifed"
 x = "straight-motion-serifed"
 y = "cursive-flat-hook-motion-serifed"
 long-s = "flat-hook-tailed"
+lower-mu = "toothed-motion-serifed"
+micro-sign = "toothed-motion-serifed"
 
 
 
@@ -8189,6 +8181,7 @@ u = "toothed-motion-serifed"
 w = "cursive-serifed"
 y = "cursive-motion-serifed"
 long-s = "flat-hook-diagonal-tailed-middle-serifed"
+micro-sign = "toothed-motion-serifed"
 
 
 
@@ -8251,9 +8244,6 @@ percent = "rings-continuous-slash"
 lower-eth = "straight-bar"
 micro-sign = "toothed-bottom-right-serifed"
 guillemet = "straight"
-
-[composite.ss16.italic]
-u = "toothed-motion-serifed"
 
 [composite.ss16.slab-override.design]
 capital-d = "more-rounded-bilateral-serifed"
@@ -8368,6 +8358,7 @@ m = "tailed-top-left-serifed"
 n = "tailed-motion-serifed"
 y = "cursive-motion-serifed"
 eszet = "longs-s-lig-descending-serifless"
+micro-sign = "tailed-motion-serifed"
 
 
 
@@ -8439,6 +8430,7 @@ x = "straight-motion-serifed"
 y = "straight-turn-motion-serifed"
 long-s = "flat-hook-descending-middle-serifed-xh"
 eszet = "longs-s-lig-descending-serifless"
+micro-sign = "tailed-motion-serifed"
 
 
 


### PR DESCRIPTION
Simplify turn-m slab behavior to mimic `u`,
Remove italic slab overrides for SS's whose original fonts only have oblique/faux-italic forms,
populate Greek mu and Micro Sign slab overrides to match with `u` or each other where applicable.

Slab overrides for all SS's:
![image](https://github.com/be5invis/Iosevka/assets/37010132/6c94c14a-f9da-421e-8f2e-83a85420de83)
