### PR TITLE
Make the fully-serifed form of cursive lower `y` match the serifs of lower `u`.

### DIFF
--- a/changes/26.3.0.md
+++ b/changes/26.3.0.md
@@ -6,5 +6,6 @@
   - COMBINING LONG DOUBLE SOLIDUS OVERLAY (`U+20EB`).
 * Generate TTFAutohint control files for better glyph display for variant glyphs (#1963).
 * Make the shape of motion-serifed and serifed variants of toothed/tailed `u` no longer identical under Italic. Now "serifed" `u` will always preserve all serifs (#1967).
+* Make the fully-serifed form of cursive lower `y` match the serifs of lower `u`.
 * Make MICRO SIGN (`µ`) tailed under italics by default, to match `u`.
 * Improve glyphs for COLON SIGN (`U+20A1`), GUARANI SIGN (`U+20B2`), and CEDI SIGN (`U+20B5`).

--- a/font-src/glyphs/letter/latin/lower-y.ptl
+++ b/font-src/glyphs/letter/latin/lower-y.ptl
@@ -313,10 +313,10 @@ glyph-block Letter-Latin-Lower-Y : begin
 
 		export : define [Serifs top slabType] : begin
 			local { doSlabTop doSlabBottom doSlabMotion } slabKind
-			local sf : SerifFrame.fromDf [DivFrame 1] top 0
-			return : if [not doSlabTop] [no-shape] : composite-proc
-				if doSlabMotion sf.lt.outer sf.lt.full
-				if doSlabMotion [no-shape] sf.rt.full
+			return : if [not doSlabTop] [no-shape] : glyph-proc
+				local sf : SerifFrame.fromDf [DivFrame 1] top 0
+				include sf.lt.outer
+				if [not doSlabMotion] : include sf.rt.inner
 
 	define CursiveConfig : SuffixCfg.weave
 		object # body
@@ -336,7 +336,7 @@ glyph-block Letter-Latin-Lower-Y : begin
 			include : hookShape XH Descender
 			include : Cursive.Serifs XH slabKind
 
-		create-glyph "yHookTop.\(suffix)" : glyph-proc
+		if (slabKind !== SLAB-ALL) : create-glyph "yHookTop.\(suffix)" : glyph-proc
 			include : MarkSet.p
 			include : Cursive.Arc XH 0
 			include : hookShape (XH - TailY - HalfStroke) Descender
@@ -370,7 +370,7 @@ glyph-block Letter-Latin-Lower-Y : begin
 	select-variant 'yDotBelowDot1' (follow -- 'diacriticDot')
 	CreateAccentedComposition 'yDotBelow' 0x1EF5 'y' 'yDotBelowDot1'
 
-	select-variant 'yHookTop' 0x1B4 (follow -- 'y')
+	select-variant 'yHookTop' 0x1B4
 	select-variant 'cyrl/U' 0x423 (shapeFrom -- 'yCap')
 
 	select-variant 'yLoop' 0x1EFF (shapeFrom -- 'y')

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -3834,6 +3834,7 @@ selectorAffix.y = "straight"
 selectorAffix.yLoop = "straightLoop"
 selectorAffix."y/sansSerif" = "straight"
 selectorAffix."y/nonCursive" = "straight"
+selectorAffix.yHookTop = "straight"
 
 [prime.y.variants-buildup.stages.body.curly]
 rank = 2
@@ -3842,6 +3843,7 @@ selectorAffix.y = "curly"
 selectorAffix.yLoop = "curlyLoop"
 selectorAffix."y/sansSerif" = "curly"
 selectorAffix."y/nonCursive" = "curly"
+selectorAffix.yHookTop = "curly"
 
 [prime.y.variants-buildup.stages.body.cursive]
 rank = 3
@@ -3850,6 +3852,7 @@ selectorAffix.y = "cursive"
 selectorAffix.yLoop = "straightLoop"
 selectorAffix."y/sansSerif" = "cursive"
 selectorAffix."y/nonCursive" = "straight"
+selectorAffix.yHookTop = "cursive"
 
 [prime.y.variants-buildup.stages.hook."*"]
 next = "serifs"
@@ -3861,6 +3864,7 @@ selectorAffix.y = ""
 selectorAffix.yLoop = ""
 selectorAffix."y/sansSerif" = ""
 selectorAffix."y/nonCursive" = ""
+selectorAffix.yHookTop = ""
 
 [prime.y.variants-buildup.stages.hook.turn]
 rank = 2
@@ -3870,6 +3874,7 @@ selectorAffix.y = "turn"
 selectorAffix.yLoop = ""
 selectorAffix."y/sansSerif" = ""
 selectorAffix."y/nonCursive" = "turn"
+selectorAffix.yHookTop = "turn"
 
 [prime.y.variants-buildup.stages.hook.flat-hook]
 rank = 3
@@ -3879,6 +3884,7 @@ selectorAffix.y = "flatHook"
 selectorAffix.yLoop = ""
 selectorAffix."y/sansSerif" = "flatHook"
 selectorAffix."y/nonCursive" = ""
+selectorAffix.yHookTop = "flatHook"
 
 [prime.y.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -3888,6 +3894,7 @@ selectorAffix.y = "serifless"
 selectorAffix.yLoop = "serifless"
 selectorAffix."y/sansSerif" = "serifless"
 selectorAffix."y/nonCursive" = "serifless"
+selectorAffix.yHookTop = "serifless"
 
 [prime.y.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
@@ -3896,6 +3903,7 @@ selectorAffix.y = "motionSerifed"
 selectorAffix.yLoop = "motionSerifed"
 selectorAffix."y/sansSerif" = "serifless"
 selectorAffix."y/nonCursive" = "motionSerifed"
+selectorAffix.yHookTop = "motionSerifed"
 
 [prime.y.variants-buildup.stages.serifs.serifed]
 rank = 3
@@ -3904,6 +3912,7 @@ selectorAffix.y = "serifed"
 selectorAffix.yLoop = "serifed"
 selectorAffix."y/sansSerif" = "serifless"
 selectorAffix."y/nonCursive" = "serifed"
+selectorAffix.yHookTop = { if = [{ body = "cursive" }], then = "motionSerifed", else = "serifed" }
 
 
 
@@ -7817,6 +7826,7 @@ k = "symmetric-connected-top-left-serifed"
 l = "serifed-flat-tailed"
 x = "straight-motion-serifed"
 y = "cursive-flat-hook-motion-serifed"
+cyrl-capital-u = "cursive-flat-hook-motion-serifed"
 micro-sign = "toothless-rounded-motion-serifed"
 
 


### PR DESCRIPTION
Of all serifed fonts I've seen using a cursive form of `y`, especially as a sort of "single-storey `g` analogue" `u`-like shape, I have only ever seen it match their respective serifed forms of `u`.

`Уyƴ`

`ss10` slab, the only SS that's actually affected by this:
![image](https://github.com/be5invis/Iosevka/assets/37010132/52dff392-1dd2-4ed8-ae34-915726031ac9)
Compared to `u`:
![image](https://github.com/be5invis/Iosevka/assets/37010132/ed99537c-5aeb-420d-a09e-9fc127422974)

Straight `y` is unchanged, as it should mimic `v`, which is satisfied already.

`ss03` slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/6605a79e-dd36-4392-a128-b6bae3bb3b3e)
Compared to `V`/`v`:
![image](https://github.com/be5invis/Iosevka/assets/37010132/8fa0a135-9275-4ab2-b1c2-60e837747759)

Examples of serifed fonts with cursive-upright forms of `y` from Google Fonts:
![image](https://github.com/be5invis/Iosevka/assets/37010132/0bca1436-408e-4932-a611-2112e8a6bf44)
![image](https://github.com/be5invis/Iosevka/assets/37010132/5978086c-f86e-490c-a913-8253f0d3ed0e)
![image](https://github.com/be5invis/Iosevka/assets/37010132/66251692-cb80-4bd9-bfc9-565cd4602f01)
![image](https://github.com/be5invis/Iosevka/assets/37010132/dfa9d293-c4aa-43c2-b3a9-28f6b41ae8bc)
![image](https://github.com/be5invis/Iosevka/assets/37010132/b9b12ccf-4780-4c84-85b6-8ad147627d2f)
![image](https://github.com/be5invis/Iosevka/assets/37010132/07e8e3cf-416b-44d9-a6d4-90b81d353e49)
