### PR TITLE
Add earless `m`/`n` variants with motion serifs.

### DIFF
--- a/changes/26.3.0.md
+++ b/changes/26.3.0.md
@@ -1,3 +1,4 @@
+* Add earless variants for `m` and `n` with motion serifs at bottom-right (#1974).
 * Add characters:
   - COMBINING LONG VERTICAL LINE OVERLAY (`U+20D2`).
   - COMBINING SHORT VERTICAL LINE OVERLAY (`U+20D3`).

--- a/font-src/glyphs/letter/latin/lower-m.ptl
+++ b/font-src/glyphs/letter/latin/lower-m.ptl
@@ -186,6 +186,7 @@ glyph-block Letter-Latin-Lower-M : begin
 			"serifless"                    { no-shape   }
 			"serifed"                      { FullSerifs }
 			"topLeftSerifed"               { LtSerifs   }
+			"bottomRightSerifed"           { RbSerifs   }
 			"topLeftAndBottomRightSerifed" { LtRbSerifs }
 
 	foreach { suffix { {Body earless} {shortLeg} {tailed} {Serifs} } } [pairs-of SmallMConfig] : do

--- a/font-src/glyphs/letter/latin/lower-n.ptl
+++ b/font-src/glyphs/letter/latin/lower-n.ptl
@@ -77,7 +77,13 @@ glyph-block Letter-Latin-Lower-N : begin
 		function [body tail] : object # serifs
 			serifless           { nothing        nothing  nothing }
 			topLeftSerifed      { NTopLeftSerif  nothing  nothing }
-			motionSerifed       { NTopLeftSerif  nothing  [if (tail != 'tailed') NBottomRightSerifItalic] }
+			motionSerifed : list
+				match body
+					([Just "earlessCorner"] || [Just "earlessRounded"])       nothing
+					([Just "earlessCornerHTB"] || [Just "earlessRoundedHTB"]) NHTB
+					__                                                        NTopLeftSerif
+				begin nothing
+				if (tail != 'tailed') NBottomRightSerifItalic
 			serifed : list
 				match body
 					([Just "earlessCorner"] || [Just "earlessRounded"])       nothing

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2804,6 +2804,18 @@ selectorAffix."cyrl/te.italic/descBase" = "topLeftSerifed"
 selectorAffix."cyrl/tjeKomi.italic" = "topLeftSerifed"
 selectorAffix.meng = "topLeftSerifed"
 
+[prime.m.variants-buildup.stages.serifs.bottom-right-serifed]
+rank = 3
+descriptionAffix = "serifs at bottom right"
+disableIf = [ { body = "eared" }, { tail = "tailed" } ]
+selectorAffix.m = "bottomRightSerifed"
+selectorAffix."m/descBase" = "serifless"
+selectorAffix."m/sansSerif" = "serifless"
+selectorAffix."cyrl/te.italic" = "topLeftAndBottomRightSerifed"
+selectorAffix."cyrl/te.italic/descBase" = "topLeftSerifed"
+selectorAffix."cyrl/tjeKomi.italic" = "topLeftSerifed"
+selectorAffix.meng = "serifless"
+
 [prime.m.variants-buildup.stages.serifs.serifed]
 rank = 4
 descriptionAffix = "serifs"
@@ -2934,14 +2946,14 @@ selectorAffix."cyrl/peItalicDescBase" = "motionSerifed"
 [prime.n.variants-buildup.stages.serifs.motion-serifed]
 rank = 3
 descriptionAffix = "serif at top left and bottom right"
-enableIf = [ { body = "normal" } ]
+disableIf = [ { body = "NOT normal", terminal = "tailed" } ]
 selectorAffix.n = "motionSerifed"
 selectorAffix."n/sansSerif" = "serifless"
-selectorAffix."n/descBase" = "topLeftSerifed"
-selectorAffix."n/lTailBase" = { if = [{ terminal = "straight" }], then = "motionSerifed", else = { if = [{ body = "normal" }], then = "topLeftSerifed", else = "serifless" } }
-selectorAffix.eng = "topLeftSerifed"
-selectorAffix."eng/phoneticRight" = "topLeftSerifed"
-selectorAffix."grek/eta" = "topLeftSerifed"
+selectorAffix."n/descBase" = { if = [{ body = "normal" }], then = "topLeftSerifed", else = "serifless" }
+selectorAffix."n/lTailBase" = "motionSerifed"
+selectorAffix.eng = { if = [{ body = "normal" }], then = "topLeftSerifed", else = "serifless" }
+selectorAffix."eng/phoneticRight" = { if = [{ body = "normal" }], then = "topLeftSerifed", else = "serifless" }
+selectorAffix."grek/eta" = { if = [{ body = "normal" }], then = "topLeftSerifed", else = "serifless" }
 selectorAffix."grek/eta/sansSerif" = "serifless"
 selectorAffix."cyrl/pe.italic" = "motionSerifed"
 selectorAffix."cyrl/peItalicDescBase" = "motionSerifed"
@@ -7971,6 +7983,9 @@ micro-sign = "toothless-corner-serifed"
 [composite.ss12.slab-override.italic]
 d = "tailed-serifed"
 k = "symmetric-touching-top-left-serifed"
+m = "earless-corner-double-arch-short-leg-bottom-right-serifed"
+n = "earless-corner-straight-motion-serifed"
+r = "earless-corner-serifless"
 u = "tailed-motion-serifed"
 x = "straight-motion-serifed"
 y = "straight-turn-motion-serifed"


### PR DESCRIPTION
fixes #1974

`hmnr`

`ss12` slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/eab78593-0c55-47c9-bfbc-d8429fa510fb)

`mᶆɱтҭԏ`

All `m` variants:
![image](https://github.com/be5invis/Iosevka/assets/37010132/1de479cf-bbd5-469c-8362-31fab80e0fd0)
![image](https://github.com/be5invis/Iosevka/assets/37010132/0048e979-02b4-4733-ad83-a91c1f61846a)


`nᶇɲŋʩηпԥ`

All `n` variants:
![image](https://github.com/be5invis/Iosevka/assets/37010132/44d66035-4a1a-4627-821a-bfe247f5b2ce)

