### PR TITLE
Remove duplicate variant for `n` with left hook.

### DIFF
--- a/changes/26.3.1.md
+++ b/changes/26.3.1.md
@@ -1,1 +1,2 @@
 * Fix TTFA control generator to fix broken superscript letters (#1976).
+* Remove duplicate serifed variant for LATIN SMALL LETTER N WITH LEFT HOOK (`U+0272`).

--- a/changes/26.3.1.md
+++ b/changes/26.3.1.md
@@ -1,2 +1,1 @@
 * Fix TTFA control generator to fix broken superscript letters (#1976).
-* Remove duplicate serifed variant for LATIN SMALL LETTER N WITH LEFT HOOK (`U+0272`).

--- a/changes/26.3.2.md
+++ b/changes/26.3.2.md
@@ -1,0 +1,1 @@
+* Remove duplicate serifed variant for LATIN SMALL LETTER N WITH LEFT HOOK (`U+0272`).

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2950,7 +2950,7 @@ disableIf = [ { body = "NOT normal", terminal = "tailed" } ]
 selectorAffix.n = "motionSerifed"
 selectorAffix."n/sansSerif" = "serifless"
 selectorAffix."n/descBase" = { if = [{ body = "normal" }], then = "topLeftSerifed", else = "serifless" }
-selectorAffix."n/lTailBase" = "motionSerifed"
+selectorAffix."n/lTailBase" = { if = [{ terminal = "straight" }], then = "motionSerifed", else = { if = [{ body = "normal" }], then = "topLeftSerifed", else = "serifless" } }
 selectorAffix.eng = { if = [{ body = "normal" }], then = "topLeftSerifed", else = "serifless" }
 selectorAffix."eng/phoneticRight" = { if = [{ body = "normal" }], then = "topLeftSerifed", else = "serifless" }
 selectorAffix."grek/eta" = { if = [{ body = "normal" }], then = "topLeftSerifed", else = "serifless" }


### PR DESCRIPTION
This was my fault and I know exactly why. I assumed the new predicates for enabling motion serifs were enough to suppress the duplicate serifed variants of this character, but I was wrong.