### PR TITLE
Breakup `R` motion-serifed variant into multiple variants, also add them for Cyrillic Ya

### DIFF
--- a/changes/26.3.3.md
+++ b/changes/26.3.3.md
@@ -1,7 +1,16 @@
 * \[**Breaking**\] Change of variant names:
+  - `upper-r`.`straight-motion-serifed` → `upper-r`.`straight-top-left-serifed`
+  - `upper-r`.`curly-motion-serifed` → `upper-r`.`curly-top-left-serifed`
+  - `upper-r`.`standing-motion-serifed` → `upper-r`.`standing-top-left-serifed`
+  - `upper-r`.`straight-open-motion-serifed` → `upper-r`.`straight-open-top-left-serifed`
+  - `upper-r`.`curly-open-motion-serifed` → `upper-r`.`curly-open-top-left-serifed`
+  - `upper-r`.`standing-open-motion-serifed` → `upper-r`.`standing-open-top-left-serifed`
   - `lower-alpha`.`tailed-barred` → `lower-alpha`.`barred-tailed`
   - `lower-alpha`.`tailed-barred-earless-corner` → `lower-alpha`.`barred-earless-corner-tailed`
 * Add barred-serifed and barred-earless-rounded variants for Greek Alpha (`α`).
+* Add bottom-right and top-left bottom-right serifed variants of `R`.
+* Add top-right, bottom-left, and top-right bottom-left variants of Cyrillic Ya (`Я`,`я`).
+* Allow R Rotunda (`U+A75A`, `U+A75B`) and Indian Rupee Sign (`U+20B9`) to have a bottom-right serif.
 * Remove serifs in `U+0320` (#1979).
 * Harmonize dot sizes in ellipsis shapes (#1980).
 * Make italic Cyrillic Small Pe with Middle Hook (`U+04A7`) follow variants of `n` (#1983).
@@ -14,6 +23,6 @@
 * Fix `cv28` and `cv68` for `ss02` and `ss17` under italics.
 * Fix `cv30` for `ss04` under italics.
 * Fix `cv42` for `ss13`.
-* Fix `cv69` and `cv70` for `ss17`.
+* Fix `cv69` and `cv70` for `ss15` and `ss17`.
 * Fix `cv77` and `cv78` for `ss15` under italics.
 * Fix serifs of `w` for `ss15` under upright slab.

--- a/font-src/glyphs/letter/latin/upper-r.ptl
+++ b/font-src/glyphs/letter/latin/upper-r.ptl
@@ -120,16 +120,16 @@ glyph-block Letter-Latin-Upper-R : begin
 	define [RBarPos charTop slab] : begin PShape.BarPos
 	define [RLegTop charTop sw bp] : (sw / 2) + [PBarPosY charTop sw bp]
 
-	define [RShape] : with-params [legShape top bp [mul 1] [slab null] [open false]] : glyph-proc
+	define [RShape] : with-params [legShape top bp [mul 1] [slab null] [legSlab false] [open false]] : glyph-proc
 		local right : RightSB - O - [if slab (Jut / 8) 0]
 		include : difference
 			PShape top (mul -- mul) (overshoot -- O) (slab -- slab) (bp -- bp)
 			if open [PShape.OpenGap (mul -- mul) (bp -- bp) (top -- top) (bot -- [if fSlabBot Stroke 0])] [glyph-proc]
 		include : difference
-			RLegShapes.(legShape) [RLegTop top Stroke bp] 0 Middle right top (slab === PShape.SlabSymmetric) Stroke 0
+			RLegShapes.(legShape) [RLegTop top Stroke bp] 0 Middle right top legSlab Stroke 0
 			if open [PShape.OpenGap (mul -- mul) (bp -- bp) (top -- top) (bot -- 0) ] [glyph-proc]
 
-	define [RRotundaShape] : with-params [legShape top [mul 1] [pmRotunda 0] [endX Middle] [hook Hook] [pBar 1] [slab null]] : glyph-proc
+	define [RRotundaShape] : with-params [legShape top [mul 1] [pmRotunda 0] [endX Middle] [hook Hook] [pBar 1] [slab null] [legSlab false]] : glyph-proc
 		local bp : pBar * [RBarPos top false]
 		local legTop : RLegTop top Stroke bp
 		local right (RightSB - O - [if slab (Jut / 8) 0])
@@ -137,16 +137,16 @@ glyph-block Letter-Latin-Upper-R : begin
 		local endX1 : endX - [if legShape (HalfStroke * [HSwToV cor]) HalfStroke] + [if legShape [RSlabExtraShift SLAB Stroke] 0]
 		include : PRotundaShape top (mul -- mul) (bp -- bp) (overshoot -- O) (slab -- false) (endX -- endX1) (hook -- hook)
 		include : difference
-			RLegShapes.(legShape) legTop 0 endX right top (slab === PShape.SlabSymmetric) Stroke 0
+			RLegShapes.(legShape) legTop 0 endX right top legSlab Stroke 0
 			MaskLeft endX1
 
-	define [RevRShape] : with-params [legShape top bp [slab null] [mul 1] [tailedShape false] [open false]] : glyph-proc
+	define [RevRShape] : with-params [legShape top bp [slab null] [legSlab false] [mul 1] [tailedShape false] [open false]] : glyph-proc
 		local left : SB + O + [if slab (Jut / 8) 0]
 		include : difference
 			RevPShape top (mul -- mul) (overshoot -- O) (slab -- slab) (bp -- bp)
 			if open [RevPShape.OpenGap (mul -- mul) (bp -- bp) (top -- top) (bot -- [if fSlabBot Stroke 0]) ] [glyph-proc]
 		include : difference
-			RevRLegShapes.(legShape) [RLegTop top Stroke bp] 0 left Middle top (!(!slab)) Stroke 0
+			RevRLegShapes.(legShape) [RLegTop top Stroke bp] 0 left Middle top legSlab Stroke 0
 			if open [RevPShape.OpenGap (mul -- mul) (bp -- bp) (top -- top) (bot -- 0) ] [glyph-proc]
 		if tailedShape : begin
 			eject-contour 'strokeR'
@@ -168,12 +168,14 @@ glyph-block Letter-Latin-Upper-R : begin
 			""                       false
 			tailed                   true
 		object # serifs
-			serifless                { null                           null                                                                }
-			motionSerifed            { PShape.SlabMotion              RevPShape.SlabMotion                                                }
-			serifed                  { PShape.SlabSymmetric           RevPShape.SlabSymmetric                                             }
-			smallCyrl                { PShape.SlabMotion              [if para.isItalic RevPShape.SlabCyrlItalic RevPShape.SlabSymmetric] }
+			serifless                    { null                           null                                                                false }
+			topLeftSerifed               { PShape.SlabMotion              RevPShape.SlabMotion                                                false }
+			bottomRightSerifed           { null                           null                                                                true  }
+			topLeftAndBottomRightSerifed { PShape.SlabMotion              RevPShape.SlabMotion                                                true  }
+			serifed                      { PShape.SlabSymmetric           RevPShape.SlabSymmetric                                             true  }
+			smallCyrl                    { PShape.SlabMotion              [if para.isItalic RevPShape.SlabCyrlItalic RevPShape.SlabSymmetric] true  }
 
-	foreach { suffix { legShape fOpen fTailed {slabs revSlabs} } } [Object.entries RConfig] : begin
+	foreach { suffix { legShape fOpen fTailed {slabs revSlabs doLegSlab} } } [Object.entries RConfig] : begin
 		local fMotion : slabs === PShape.SlabMotion
 		local fSlabBot : slabs && slabs !== PShape.SlabMotion
 		local bpCap : RBarPos CAP fSlabBot
@@ -182,7 +184,7 @@ glyph-block Letter-Latin-Upper-R : begin
 		create-glyph "R.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : StrikeAnchor
-			include : RShape legShape CAP (slab -- slabs) (bp -- bpCap) (open -- fOpen)
+			include : RShape legShape CAP (slab -- slabs) (legSlab -- doLegSlab) (bp -- bpCap) (open -- fOpen)
 
 		if (!fOpen) : create-glyph "RBar.\(suffix)" : glyph-proc
 			include [refer-glyph "R.\(suffix)"] AS_BASE ALSO_METRICS
@@ -191,25 +193,25 @@ glyph-block Letter-Latin-Upper-R : begin
 		create-glyph "smcpR.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : StrikeAnchor
-			include : RShape legShape XH (slab -- slabs) (bp -- bpXH) (open -- fOpen)
+			include : RShape legShape XH (slab -- slabs) (legSlab -- doLegSlab) (bp -- bpXH) (open -- fOpen)
 
-		if (!fMotion && !fOpen) : create-glyph "RRotunda.\(suffix)" : glyph-proc
+		if (!slabs && !fOpen) : create-glyph "RRotunda.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : RRotundaShape legShape CAP (hook -- Hook) (pBar -- 0.9) (slab -- slabs)
+			include : RRotundaShape legShape CAP (hook -- Hook) (pBar -- 0.9) (slab -- null) (legSlab -- doLegSlab)
 
-		if (!fMotion && !fOpen) : create-glyph "rRotunda.\(suffix)" : glyph-proc
+		if (!slabs && !fOpen) : create-glyph "rRotunda.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			include : RRotundaShape legShape XH (hook -- AHook) (pBar -- 0.9) (slab -- slabs)
+			include : RRotundaShape legShape XH (hook -- AHook) (pBar -- 0.9) (slab -- null) (legSlab -- doLegSlab)
 
 		create-glyph "cyrl/Ya.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : StrikeAnchor
-			include : RevRShape legShape CAP (slab -- revSlabs) (bp -- bpCap) (open -- fOpen)
+			include : RevRShape legShape CAP (slab -- revSlabs) (legSlab -- doLegSlab) (bp -- bpCap) (open -- fOpen)
 
 		create-glyph "cyrl/ya.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : StrikeAnchor
-			include : RevRShape legShape XH (slab -- revSlabs) (bp -- bpXH) (tailedShape -- fTailed) (open -- fOpen)
+			include : RevRShape legShape XH (slab -- revSlabs) (legSlab -- doLegSlab) (bp -- bpXH) (tailedShape -- fTailed) (open -- fOpen)
 
 		create-glyph "Yr.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
@@ -223,17 +225,17 @@ glyph-block Letter-Latin-Upper-R : begin
 				PShape top (mul -- 1) (bp -- bp) (slab -- slabs)
 				if fOpen [PShape.OpenGap (mul -- 1) (bp -- bp) (top -- top) (bot -- [if fSlabBot Stroke 0])] [glyph-proc]
 			include : difference
-				RLegShapes.(legShape) legTop Descender Middle right (top - Descender) (slabs === PShape.SlabSymmetric) Stroke 0
+				RLegShapes.(legShape) legTop Descender Middle right (top - Descender) doLegSlab Stroke 0
 				if fOpen [PShape.OpenGap (mul -- 1) (bp -- bp) (top -- top) (bot -- 0)] [glyph-proc]
 
-		create-glyph "currency/indianRupeeSign.\(suffix)" : glyph-proc
+		if (!slabs && !fOpen) : create-glyph "currency/indianRupeeSign.\(suffix)" : glyph-proc
 			define bp : RBarPos CAP 0
 			include : intersection
 				Rect CAP 0 SB Width
 				with-transform [Translate (-Width / 8) 0]
 					PShape CAP (bp -- bp) (withBar -- false)
 			local right : RightSB - O - [if legShape 0 (Width / 16)]
-			include : RLegShapes.(legShape) [RLegTop CAP Stroke bp] 0 (Width * 0.375) right CAP (slabs === PShape.SlabSymmetric) Stroke 0
+			include : RLegShapes.(legShape) [RLegTop CAP Stroke bp] 0 (Width * 0.375) right CAP doLegSlab Stroke 0
 
 			define sw : AdviceStroke2 2 4 CAP
 			include : HBar.t SB RightSB CAP sw

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -4244,7 +4244,6 @@ selectorAffix.eszet = "middleSerifed"
 
 [prime.eszet.variants-buildup.stages.serifs.middle-serifed-xh]
 rank = 3
-nonBreakingVariantAdditionPriority = 1000 # REMOVE IN NEXT MAJOR VERSION CHANGE
 enableIf = [{body = "sulzbacher"}, {body = "longs-s-lig"}]
 descriptionAffix = "serif at middle at x-height"
 selectorAffix.eszet = "middleSerifedXH"
@@ -4267,7 +4266,6 @@ enableIf = [
 	{terminal = "non-descending", body = "longs-s-lig"}
 ]
 rank = 6
-nonBreakingVariantAdditionPriority = 2000 # REMOVE IN NEXT MAJOR VERSION CHANGE
 descriptionAffix = "serif at middle (x-height) and bottom"
 selectorAffix.eszet = "dualSerifedXH"
 
@@ -4687,7 +4685,6 @@ selector."grek/xi" = "flatTop"
 [prime.lower-pi]
 sampler = "π"
 samplerExplain = "Greek lower Pi"
-nonBreakingTagForNewVariantSelector = "VXAA" # REMOVE IN NEXT MAJOR VERSION CHANGE
 tagKind = "letter"
 
 [prime.lower-pi.variants.tailless]
@@ -4710,7 +4707,6 @@ selector."grek/pi" = "smallCap"
 [prime.lower-tau]
 sampler = "τ"
 samplerExplain = "Greek lower Tau"
-nonBreakingTagForNewVariantSelector = "VXAB" # REMOVE IN NEXT MAJOR VERSION CHANGE
 tagKind = "letter"
 
 [prime.lower-tau.variants.tailless]
@@ -6308,7 +6304,6 @@ selector.braceRight = "curlyFlatBoundary"
 [prime.guillemet]
 sampler = "« »"
 samplerExplain = "Guillemets"
-nonBreakingTagForNewVariantSelector = "VXAC" # REMOVE IN NEXT MAJOR VERSION CHANGE
 tagKind = "symbol"
 
 [prime.guillemet.variants.straight]

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -8513,7 +8513,7 @@ eszet = "longs-s-lig-descending-serifless"
 lower-lambda = "straight"
 cyrl-ze = "unilateral-inward-serifed"
 cyrl-ka = "symmetric-connected-bottom-right-serifed"
-cyrl-ya = "straight-top-right-and-bottom-left-serifed"
+cyrl-ya = "straight-bottom-left-serifed"
 
 [composite.ss17.slab-override.design]
 capital-u = "toothed-serifed"

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -5636,7 +5636,7 @@ descriptionAffix = "serifs at top-right"
 selectorAffix."cyrl/ya" = "topLeftSerifed"
 
 [prime.cyrl-ya.variants-buildup.stages.serifs.bottom-left-serifed]
-rank = 2
+rank = 3
 descriptionAffix = "serifs at bottom-left"
 selectorAffix."cyrl/ya" = "bottomRightSerifed"
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -8345,6 +8345,7 @@ u = "toothed-motion-serifed"
 w = "cursive-serifed"
 y = "cursive-motion-serifed"
 long-s = "flat-hook-diagonal-tailed-middle-serifed"
+cyrl-ka = "symmetric-connected-top-left-and-bottom-right-serifed"
 micro-sign = "toothed-motion-serifed"
 
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -922,21 +922,37 @@ selectorAffix."R/sansSerif" = "serifless"
 selectorAffix.RBar = "serifless"
 selectorAffix.RRotunda = "serifless"
 
-[prime.capital-r.variants-buildup.stages.serifs.motion-serifed]
+[prime.capital-r.variants-buildup.stages.serifs.top-left-serifed]
 rank = 2
-descriptionAffix = "motion serifs"
-selectorAffix.R = "motionSerifed"
+descriptionAffix = "serifs at top-left"
+selectorAffix.R = "topLeftSerifed"
 selectorAffix."R/sansSerif" = "serifless"
-selectorAffix.RBar = "motionSerifed"
+selectorAffix.RBar = "topLeftSerifed"
 selectorAffix.RRotunda = "serifless"
 
-[prime.capital-r.variants-buildup.stages.serifs.serifed]
+[prime.capital-r.variants-buildup.stages.serifs.bottom-right-serifed]
 rank = 3
+descriptionAffix = "serifs at bottom-right"
+selectorAffix.R = "bottomRightSerifed"
+selectorAffix."R/sansSerif" = "serifless"
+selectorAffix.RBar = "bottomRightSerifed"
+selectorAffix.RRotunda = "bottomRightSerifed"
+
+[prime.capital-r.variants-buildup.stages.serifs.top-left-and-bottom-right-serifed]
+rank = 4
+descriptionAffix = "serifs at bottom-right"
+selectorAffix.R = "topLeftAndBottomRightSerifed"
+selectorAffix."R/sansSerif" = "serifless"
+selectorAffix.RBar = "topLeftAndBottomRightSerifed"
+selectorAffix.RRotunda = "bottomRightSerifed"
+
+[prime.capital-r.variants-buildup.stages.serifs.serifed]
+rank = 5
 descriptionAffix = "serifs"
 selectorAffix.R = "serifed"
 selectorAffix."R/sansSerif" = "serifless"
 selectorAffix.RBar = "serifed"
-selectorAffix.RRotunda = "serifless"
+selectorAffix.RRotunda = "bottomRightSerifed"
 
 
 
@@ -5527,8 +5543,23 @@ descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix."cyrl/Ya" = "serifless"
 
-[prime.cyrl-capital-ya.variants-buildup.stages.serifs.serifed]
+[prime.cyrl-capital-ya.variants-buildup.stages.serifs.top-right-serifed]
 rank = 2
+descriptionAffix = "serifs at top-right"
+selectorAffix."cyrl/Ya" = "topLeftSerifed"
+
+[prime.cyrl-capital-ya.variants-buildup.stages.serifs.bottom-left-serifed]
+rank = 3
+descriptionAffix = "serifs at bottom-left"
+selectorAffix."cyrl/Ya" = "bottomRightSerifed"
+
+[prime.cyrl-capital-ya.variants-buildup.stages.serifs.top-right-and-bottom-left-serifed]
+rank = 4
+descriptionAffix = "serifs at top-right and bottom-left"
+selectorAffix."cyrl/Ya" = "topLeftAndBottomRightSerifed"
+
+[prime.cyrl-capital-ya.variants-buildup.stages.serifs.serifed]
+rank = 5
 descriptionAffix = "serifs"
 selectorAffix."cyrl/Ya" = "serifed"
 
@@ -5599,8 +5630,24 @@ descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix."cyrl/ya" = "serifless"
 
-[prime.cyrl-ya.variants-buildup.stages.serifs.serifed]
+[prime.cyrl-ya.variants-buildup.stages.serifs.top-right-serifed]
 rank = 2
+descriptionAffix = "serifs at top-right"
+selectorAffix."cyrl/ya" = "topLeftSerifed"
+
+[prime.cyrl-ya.variants-buildup.stages.serifs.bottom-left-serifed]
+rank = 2
+descriptionAffix = "serifs at bottom-left"
+selectorAffix."cyrl/ya" = "bottomRightSerifed"
+
+[prime.cyrl-ya.variants-buildup.stages.serifs.top-right-and-bottom-left-serifed]
+rank = 4
+disableIf = [{ tails = "tailed" }]
+descriptionAffix = "serifs at top-right and bottom-left"
+selectorAffix."cyrl/ya" = "topLeftAndBottomRightSerifed"
+
+[prime.cyrl-ya.variants-buildup.stages.serifs.serifed]
+rank = 5
 descriptionAffix = "serifs"
 selectorAffix."cyrl/ya" = "smallCyrl"
 
@@ -8229,7 +8276,11 @@ y = "straight-turn-serifless"
 eszet = "traditional-flat-hook-middle-serifed"
 long-s = "flat-hook-double-serifed"
 lower-lambda = "straight-turn"
+cyrl-capital-ka = "symmetric-connected-bottom-right-serifed"
+cyrl-ka = "symmetric-connected-bottom-right-serifed"
 cyrl-capital-u = "straight-turn-serifless"
+cyrl-capital-ya = "straight-bottom-left-serifed"
+cyrl-ya = "straight-bottom-left-serifed"
 zero = "dotted"
 one = "base"
 two = "straight-neck"
@@ -8279,7 +8330,11 @@ u = "toothed-serifed"
 w = "straight-flat-top-serifed"
 y = "straight-turn-serifed"
 eszet = "traditional-flat-hook-dual-serifed"
+cyrl-capital-ka = "symmetric-connected-serifed"
+cyrl-ka = "symmetric-connected-serifed"
 cyrl-capital-u = "straight-turn-serifed"
+cyrl-capital-ya = "straight-serifed"
+cyrl-ya = "straight-serifed"
 micro-sign = "toothed-serifed"
 
 [composite.ss15.slab-override.italic]
@@ -8394,7 +8449,7 @@ capital-g = "toothless-corner-inward-serifed-capped"
 capital-k = "straight-bottom-right-serifed"
 capital-l = "motion-serifed"
 capital-p = "closed-motion-serifed"
-capital-r = "straight-motion-serifed"
+capital-r = "straight-top-left-and-bottom-right-serifed"
 capital-s = "unilateral-inward-serifed"
 capital-u = "toothed-serifless"
 capital-z = "straight-top-serifed"
@@ -8410,6 +8465,8 @@ lower-lambda = "straight-turn"
 cyrl-capital-ze = "unilateral-inward-serifed"
 cyrl-capital-ka = "symmetric-connected-bottom-right-serifed"
 cyrl-capital-u = "straight-turn-serifless"
+cyrl-capital-ya = "straight-top-right-and-bottom-left-serifed"
+cyrl-ya = "straight-top-right-serifed"
 one = "base"
 four = "semi-open"
 five = "oblique-upper-left-bar"
@@ -8456,6 +8513,7 @@ eszet = "longs-s-lig-descending-serifless"
 lower-lambda = "straight"
 cyrl-ze = "unilateral-inward-serifed"
 cyrl-ka = "symmetric-connected-bottom-right-serifed"
+cyrl-ya = "straight-top-right-and-bottom-left-serifed"
 
 [composite.ss17.slab-override.design]
 capital-u = "toothed-serifed"


### PR DESCRIPTION
`R₹ꝚꝛKkκКкЯя`
`ss15`:
![image](https://github.com/be5invis/Iosevka/assets/37010132/a638257b-e9af-4a77-ab11-ad7613c22fc3)
Compared to IBM Plex Mono:
![image](https://github.com/be5invis/Iosevka/assets/37010132/0f1ee4e7-c717-4f6b-a177-8ce464782171)
`ss17`:
![image](https://github.com/be5invis/Iosevka/assets/37010132/cded010c-641b-4bb2-a9fe-cb20ac823850)
Compared to Recursive Sans Mono Linear:
![image](https://github.com/be5invis/Iosevka/assets/37010132/a9710ead-f911-45cd-8bb9-07a4f2bdd81c)
![image](https://github.com/be5invis/Iosevka/assets/37010132/cd4bd309-ae96-4cd5-a159-9078597c675a)
