### PR TITLE
trying to fix mCrossTail

### DIFF
--- a/changes/27.0.0.md
+++ b/changes/27.0.0.md
@@ -8,3 +8,4 @@
   - `upper-r`.`curly-open-motion-serifed` → `upper-r`.`curly-open-top-left-serifed`
   - `upper-r`.`standing-open-motion-serifed` → `upper-r`.`standing-open-top-left-serifed`
 * Add OpenType `zero` feature (#1966).
+* Fix broken geometry of `U+AB3A` under condensed width.

--- a/font-src/glyphs/letter/cyrillic/fita.ptl
+++ b/font-src/glyphs/letter/cyrillic/fita.ptl
@@ -9,8 +9,8 @@ glyph-block Letter-Cyrillic-Fita : begin
 	glyph-block-import Common-Derivatives
 
 	define FitaWave : XH / 16
-	define [FitaLeft  sw] : SB + sw / 2 * HVContrast
-	define [FitaRight sw] : RightSB - sw / 2 * HVContrast
+	define [FitaLeft  sw] : SB      + [HSwToV : 0.5 * sw]
+	define [FitaRight sw] : RightSB - [HSwToV : 0.5 * sw]
 	define [FitaCrossbar y sw swc] : dispiro
 		widths.center swc
 		g4.right.mid [mix [FitaLeft sw] Middle (-1)] y

--- a/font-src/glyphs/letter/cyrillic/lje.ptl
+++ b/font-src/glyphs/letter/cyrillic/lje.ptl
@@ -24,13 +24,13 @@ glyph-block Letter-Cyrillic-Lje : begin
 			xb   -- xTopLeft
 			fine -- df.mvs
 		include : Yeri top
-			left -- (middle - df.mvs / 2 * HVContrast)
+			left -- (middle - [HSwToV : 0.5 * df.mvs])
 			right -- (r - O)
 			stroke -- df.mvs
 			jut -- jut
 		include : HBar.t xTopLeft middle top df.mvs
 		if SLAB : begin
-			include : HSerif.lt xTopLeft top (jut - df.mvs / 2 * HVContrast) df.mvs
+			include : HSerif.lt xTopLeft top (jut - [HSwToV : 0.5 * df.mvs]) df.mvs
 
 	define YerConfig : object
 		corner  { CyrlYeriUprightShape }

--- a/font-src/glyphs/letter/cyrillic/nje.ptl
+++ b/font-src/glyphs/letter/cyrillic/nje.ptl
@@ -36,7 +36,7 @@ glyph-block Letter-Cyrillic-Nje : begin
 
 	define [RightHalf Yeri df top] : glyph-proc
 		include : Yeri top
-			left -- (df.middle - df.mvs / 2 * HVContrast)
+			left -- (df.middle - [HSwToV : 0.5 * df.mvs])
 			right -- (df.rightSB - O)
 			stroke -- df.mvs
 		eject-contour 'serifYeriLT'

--- a/font-src/glyphs/letter/cyrillic/omega.ptl
+++ b/font-src/glyphs/letter/cyrillic/omega.ptl
@@ -16,9 +16,9 @@ glyph-block Letter-Cyrillic-Omega : begin
 		local mfine : fine * CThin
 
 		local minHookDepth : Math.min (0.625 * (df.middle - df.leftSB - [HSwToV fine])) ((1 / 3) * (df.rightSB - df.leftSB))
-		local xMidBarLeft :df.middle - fine / 2 * HVContrast
-		local xMidBarRight : df.middle + fine / 2 * HVContrast
-		local xMidBarCoLeft : df.middle - (mfine - fine / 2) * HVContrast
+		local xMidBarLeft    : df.middle - fine / 2 * HVContrast
+		local xMidBarRight   : df.middle + fine / 2 * HVContrast
+		local xMidBarCoLeft  : df.middle - (mfine - fine / 2) * HVContrast
 		local xMidBarCoRight : df.middle + (mfine - fine / 2) * HVContrast
 		local y3 : top * p1
 		local y4 : top * p2

--- a/font-src/glyphs/letter/cyrillic/yat.ptl
+++ b/font-src/glyphs/letter/cyrillic/yat.ptl
@@ -14,7 +14,7 @@ glyph-block Letter-Cyrillic-Yat : begin
 	glyph-block-import Letter-Cyrillic-Iotified-A : Iotified
 
 	define [xBarLeft df] : Math.max (df.rightSB - (RightSB - SB)) : if SLAB
-		Just ([mix df.leftSB df.rightSB 0.35] - df.mvs / 2 * HVContrast)
+		Just ([mix df.leftSB df.rightSB 0.35] - [HSwToV : 0.5 * df.mvs])
 		Just  [mix df.leftSB df.rightSB 0.2]
 
 	define [YatShape] : with-params [df top [pBar 0.5] [fLowerCase false] [sw df.mvs] [xCrossbarLeftOverride nothing] [yCrossbarOverride nothing] [YeriShape CyrlYeriUprightShape]] : glyph-proc

--- a/font-src/glyphs/letter/cyrillic/yeri.ptl
+++ b/font-src/glyphs/letter/cyrillic/yeri.ptl
@@ -37,8 +37,8 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			VBar.l left 0 yStart stroke
 
 		if SLAB : begin
-			include : tagged 'serifYeriLB' : HSerif.lb left 0 (jut - stroke / 2 * HVContrast) stroke
-			include : tagged 'serifYeriLT' : HSerif.mt (left + stroke / 2 * HVContrast) top jut stroke
+			include : tagged 'serifYeriLB' : HSerif.lb left 0 (jut - [HSwToV : 0.5 * stroke]) stroke
+			include : tagged 'serifYeriLT' : HSerif.mt (left + [HSwToV : 0.5 * stroke]) top jut stroke
 
 	glyph-block-export CyrlYeriRoundShape
 	define [CyrlYeriRoundShape] : with-params [top [left SB] [right RightSB] [stroke Stroke] [jut Jut] [pBar DefaultBarPos] [yStart top]] : glyph-proc
@@ -63,7 +63,7 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			curl (left + Stroke * 0.2) bowl [heading Leftward]
 
 		if SLAB : begin
-			include : tagged 'serifYeriLT' : HSerif.lt left top (jut - stroke / 2 * HVContrast) stroke
+			include : tagged 'serifYeriLT' : HSerif.lt left top (jut - [HSwToV : 0.5 * stroke]) stroke
 
 	glyph-block-export CyrlYeriCursiveShape
 	define [CyrlYeriCursiveShape] : with-params [top [left SB] [right RightSB] [stroke Stroke] [jut Jut] [pBar DefaultBarPos] [yStart top]] : glyph-proc
@@ -89,7 +89,7 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			g4.down.end (left + (stroke - fine) * HVContrast) yTurnBottomL [widths.lhs.heading fine Downward]
 
 		if SLAB : begin
-			include : tagged 'serifYeriLT' : HSerif.lt left top (jut - stroke / 2 * HVContrast) stroke
+			include : tagged 'serifYeriLT' : HSerif.lt left top (jut - [HSwToV : 0.5 * stroke]) stroke
 
 	define [RevCyrYeriShape] : with-params [top [left SB] [right RightSB] [stroke Stroke] [jut Jut] [pBar DefaultBarPos]] : glyph-proc
 		local bowl : top * pBar + HalfStroke
@@ -108,9 +108,9 @@ glyph-block Letter-Cyrillic-Yeri : begin
 		include : VBar.r right 0 top stroke
 		if SLAB : begin
 			include : tagged 'serifYeriRB'
-				HSerif.rb right 0 (jut - stroke / 2 * HVContrast) stroke
+				HSerif.rb right 0 (jut - [HSwToV : 0.5 * stroke]) stroke
 			include : tagged 'serifYeriRT'
-				HSerif.mt (right - stroke / 2 * HVContrast) top jut stroke
+				HSerif.mt (right - [HSwToV : 0.5 * stroke]) top jut stroke
 
 	define [RevCyrYeriRoundShape] : with-params [top [left SB] [right RightSB] [stroke Stroke] [jut Jut] [pBar DefaultBarPos] [yStart top]] : glyph-proc
 		local bowl : top * pBar + HalfStroke
@@ -170,7 +170,7 @@ glyph-block Letter-Cyrillic-Yeri : begin
 		local sw : if fBackYer [AdviceStroke 3.25 df.div] df.mvs
 
 		local jut : Math.min Jut : [Math.pow (sw / Stroke) 0.5] * Jut
-		local xm : mix (df.rightSB - [HSwToV sw]) (df.middle + sw / 2 * HVContrast) 0.75
+		local xm : mix (df.rightSB - [HSwToV sw]) (df.middle + [HSwToV : 0.5 * sw]) 0.75
 
 		include : if fBackYer
 			CyrBackYerShape Yeri
@@ -193,10 +193,10 @@ glyph-block Letter-Cyrillic-Yeri : begin
 		if SLAB : begin
 			include : tagged 'serifRT' : if (Yeri !== CyrlYeriUprightShape)
 				then : glyph-proc
-				else : HSerif.mt (df.rightSB - sw / 2 * HVContrast) top jut sw
+				else : HSerif.mt (df.rightSB - [HSwToV : 0.5 * sw]) top jut sw
 			if (!fTail) : include : tagged 'serifRB' : if (Yeri !== CyrlYeriUprightShape)
 				then : HSerif.rb df.rightSB 0 (jut - [HSwToV : 0.5 * sw]) sw
-				else : HSerif.mb (df.rightSB - sw / 2 * HVContrast) 0 jut sw
+				else : HSerif.mb (df.rightSB - [HSwToV : 0.5 * sw]) 0 jut sw
 
 	define [ZhuangToneSixShape Yeri top] : glyph-proc
 		local xLeft : [mix SB RightSB 0.20] - [HSwToV : 0.125 * Stroke]

--- a/font-src/glyphs/letter/cyrillic/yu.ptl
+++ b/font-src/glyphs/letter/cyrillic/yu.ptl
@@ -18,7 +18,7 @@ glyph-block Letter-Cyrillic-Yu : begin
 	define SLAB-OUTWARD		2
 
 	define [CyrYuShape df slabType top xtop ada adb] : glyph-proc
-		local xm : barMixL df.leftSB df.rightSB ([HSwToV df.mvs]) [StrokeWidthBlend 0.4 0.45]
+		local xm : barMixL df.leftSB df.rightSB [HSwToV df.mvs] [StrokeWidthBlend 0.4 0.45]
 		include : OShape top 0 xm df.rightSB df.mvs (ada * 0.7 * df.div) (adb * 0.7 * df.div)
 
 		include : if (slabType === SLAB-BULGARIAN)
@@ -26,7 +26,7 @@ glyph-block Letter-Cyrillic-Yu : begin
 			Iotified.full df xtop xm (top / 2) (fCapital -- (slabType === SLAB-ALL))
 
 	define [CyrRevYuShape df slabType top xtop ada adb] : glyph-proc
-		local xm : barMixL df.leftSB df.rightSB ([HSwToV df.mvs]) [StrokeWidthBlend 0.4 0.45]
+		local xm : barMixL df.leftSB df.rightSB [HSwToV df.mvs] [StrokeWidthBlend 0.4 0.45]
 		local revXm : df.leftSB + df.rightSB - xm
 		include : OShape top 0 df.leftSB revXm df.mvs (ada * 0.7 * df.div) (adb * 0.7 * df.div)
 

--- a/font-src/glyphs/letter/greek/lower-epsilon.ptl
+++ b/font-src/glyphs/letter/greek/lower-epsilon.ptl
@@ -510,4 +510,4 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 		local epsilon : SmallEpsilon SLAB-NONE SLAB-NONE (CAP - midGap) 0 blend Hook
 		local dimLower : epsilon.Dim
 		include : union [epsilon.LowerShape] [ze.UpperShape]
-			Rect (dimUpper.midy + dimUpper.stroke / 2) (dimLower.midy - dimLower.stroke / 2) (Middle - strokeV / 2 * HVContrast) (Middle + strokeV / 2 * HVContrast)
+			Rect (dimUpper.midy + dimUpper.stroke / 2) (dimLower.midy - dimLower.stroke / 2) (Middle - [HSwToV : 0.5 * strokeV]) (Middle + [HSwToV : 0.5 * strokeV])

--- a/font-src/glyphs/letter/greek/lower-omega.ptl
+++ b/font-src/glyphs/letter/greek/lower-omega.ptl
@@ -23,7 +23,7 @@ glyph-block Letter-Greek-Lower-Omega : begin
 			g4 x0 y0
 			g4 x1 (top / 2)
 			arcvh 8
-			g4 [mix x1 (df.middle + fine / 2 * HVContrast) 0.5] O [heading Rightward]
+			g4 [mix x1 (df.middle + [HSwToV : 0.5 * fine]) 0.5] O [heading Rightward]
 			archv 8
 			flat (df.middle + (mfine - fine / 2) * HVContrast) y3 [widths.heading mfine 0 Upward]
 			curl (df.middle + (mfine - fine / 2) * HVContrast) y4 [heading Upward]
@@ -32,7 +32,7 @@ glyph-block Letter-Greek-Lower-Omega : begin
 			g4 (df.width - x0) y0
 			g4 (df.width - x1) (top / 2)
 			arcvh 8
-			g4 [mix (df.width - x1) (df.middle - fine / 2 * HVContrast) 0.5] O [heading Leftward]
+			g4 [mix (df.width - x1) (df.middle - [HSwToV : 0.5 * fine]) 0.5] O [heading Leftward]
 			archv 8
 			flat (df.middle - (mfine - fine / 2) * HVContrast) y3 [widths.heading 0 mfine Upward]
 			curl (df.middle - (mfine - fine / 2) * HVContrast) y4 [heading Upward]
@@ -68,7 +68,7 @@ glyph-block Letter-Greek-Lower-Omega : begin
 			flat (df.middle + (mfine - fine / 2) * HVContrast) y4 [heading Downward]
 			curl (df.middle + (mfine - fine / 2) * HVContrast) y3 [heading Downward]
 			arcvh 8
-			g4 [mix x1 (df.middle + fine / 2 * HVContrast) 0.5] O [widths.heading 0 fine Leftward]
+			g4 [mix x1 (df.middle + [HSwToV : 0.5 * fine]) 0.5] O [widths.heading 0 fine Leftward]
 			archv 8
 			g4 x1 y1
 			arcvh
@@ -76,7 +76,7 @@ glyph-block Letter-Greek-Lower-Omega : begin
 			archv
 			g4 (df.width - x1) y1
 			arcvh 8
-			g4 [mix (df.width - x1) (df.middle - fine / 2 * HVContrast) 0.5] O [heading Leftward]
+			g4 [mix (df.width - x1) (df.middle - [HSwToV : 0.5 * fine]) 0.5] O [heading Leftward]
 			archv 8
 			flat (df.middle - (mfine - fine / 2) * HVContrast) y3 [widths.heading 0 mfine Upward]
 			curl (df.middle - (mfine - fine / 2) * HVContrast) y4 [heading Upward]

--- a/font-src/glyphs/letter/greek/lower-phi.ptl
+++ b/font-src/glyphs/letter/greek/lower-phi.ptl
@@ -26,10 +26,10 @@ glyph-block Letter-Greek-Lower-Phi : begin
 			archv
 			g4 (df.width - x1) (XH * 0.55)
 			arcvh 8
-			g4.left.mid [mix (df.width - x1) (df.middle - df.mvs / 2 * HVContrast) 0.525] XH [heading Leftward]
+			g4.left.mid [mix (df.width - x1) (df.middle - [HSwToV : 0.5 * df.mvs]) 0.525] XH [heading Leftward]
 			archv
-			flat (df.middle - df.mvs / 2 * HVContrast) y3
-			curl (df.middle - df.mvs / 2 * HVContrast) (df.mvs * 0.2) [heading Downward]
+			flat (df.middle - [HSwToV : 0.5 * df.mvs]) y3
+			curl (df.middle - [HSwToV : 0.5 * df.mvs]) (df.mvs * 0.2) [heading Downward]
 
 	create-glyph 'grek/phi' 0x3C6 : glyph-proc
 		local df : include : DivFrame para.diversityM 3

--- a/font-src/glyphs/letter/latin-ext/gha.ptl
+++ b/font-src/glyphs/letter/latin-ext/gha.ptl
@@ -11,7 +11,7 @@ glyph-block Letter-Latin-Gha : begin
 	glyph-block-import Letter-Shared-Shapes : SerifFrame
 
 	define [GhaShape df top] : glyph-proc
-		local abarRight : df.middle + df.mvs / 2 * HVContrast
+		local abarRight : df.middle + [HSwToV : 0.5 * df.mvs]
 		local ada : ArchDepthAOf [Math.max (df.mvs * 1.125) (SmallArchDepth * 0.6 * df.div)] (Width * df.div)
 		local adb : ArchDepthBOf [Math.max (df.mvs * 1.125) (SmallArchDepth * 0.6 * df.div)] (Width * df.div)
 		include : OShape top 0 df.leftSB abarRight df.mvs ada adb

--- a/font-src/glyphs/letter/latin-ext/lower-ae-oe.ptl
+++ b/font-src/glyphs/letter/latin-ext/lower-ae-oe.ptl
@@ -124,7 +124,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 			local ada : subDf.archDepthA SmallArchDepth df.mvs
 			local adb : subDf.archDepthB SmallArchDepth df.mvs
 
-			local abarRight : df.middle + df.mvs / 2 * HVContrast
+			local abarRight : df.middle + [HSwToV : 0.5 * df.mvs]
 			include : nShoulder
 				left -- abarRight
 				right -- (df.rightSB - OX)
@@ -200,7 +200,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 				local swVJut : Math.min df.mvs (0.625 * (r - m - [HSwToV : 0.5 * df.mvs]))
 				include : VSerif.dr r XH VJut swVJut
 			if doBottomSerifs : begin
-				local midJutCenter : [Math.max Jut : mix ([HSwToV : 0.5 * df.mvs]) LongJut 0.6] * (subDf.width / df.width)
+				local midJutCenter : [Math.max Jut : mix [HSwToV : 0.5 * df.mvs] LongJut 0.6] * (subDf.width / df.width)
 				include : tagged 'serifMB' : HSerif.rb m 0 midJutCenter df.mvs
 
 		define TConfig : object

--- a/font-src/glyphs/letter/latin-ext/lower-db-qp.ptl
+++ b/font-src/glyphs/letter/latin-ext/lower-db-qp.ptl
@@ -38,7 +38,7 @@ glyph-block Letter-Latin-Lower-DB-QP : begin
 		include : DbCenterShape df
 		include : VBar.m df.middle XH Ascender df.mvs
 		if SLAB : begin
-			include : HSerif.lt (df.middle - df.mvs / 2 * HVContrast) Ascender SideJut
+			include : HSerif.lt (df.middle - [HSwToV : 0.5 * df.mvs]) Ascender SideJut
 
 	create-glyph 'qp' 0x239 : glyph-proc
 		local df : include : DivFrame para.diversityM 3

--- a/font-src/glyphs/letter/latin-ext/rhotic.ptl
+++ b/font-src/glyphs/letter/latin-ext/rhotic.ptl
@@ -17,8 +17,8 @@ glyph-block Letter-Latin-Rhotic : begin
 		local sw : fallback w [AdviceStroke 5]
 		include : dispiro
 			widths.rhs sw
-			g2 (left - sw / 2 * HVContrast) (y)
-			g2 (mid - sw / 2 * HVContrast) (y + rise)
+			g2 (left - [HSwToV : 0.5 * sw]) (y)
+			g2 (mid - [HSwToV : 0.5 * sw]) (y + rise)
 		include : dispiro
 			widths.center sw
 			flat mid (y + rise) [heading Downward]

--- a/font-src/glyphs/letter/latin-ext/sakha-yat.ptl
+++ b/font-src/glyphs/letter/latin-ext/sakha-yat.ptl
@@ -14,12 +14,12 @@ glyph-block Letter-Latin-Sakha-Yat : begin
 	define [SakhaYatShape Yeri df top] : glyph-proc
 		local jut : Math.min Jut : Jut * 0.75 * df.div
 		include : Yeri top
-			left -- (df.middle - df.mvs / 2 * HVContrast)
+			left -- (df.middle - [HSwToV : 0.5 * df.mvs])
 			right -- df.rightSB
 			stroke -- df.mvs
 			jut -- jut
 
-		include : Iotified.outer df top (df.middle + df.mvs / 2 * HVContrast) (top - df.mvs * 0.5)
+		include : Iotified.outer df top (df.middle + [HSwToV : 0.5 * df.mvs]) (top - df.mvs * 0.5)
 
 	define YerConfig : object
 		corner  { CyrlYeriUprightShape }

--- a/font-src/glyphs/letter/latin-ext/upper-ae-oe.ptl
+++ b/font-src/glyphs/letter/latin-ext/upper-ae-oe.ptl
@@ -76,7 +76,7 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 		define eleft : df.middle - [HSwToV : 0.25 * sw]
 		match slabKind
 			([Just SLAB-A-BASE] || [Just SLAB-A-TRI]) : begin
-				include : HSerif.mb (df.leftSB + sw / 2 * HVContrast) 0 Jut sw
+				include : HSerif.mb (df.leftSB + [HSwToV : 0.5 * sw]) 0 Jut sw
 		match slabKind
 			[Just SLAB-A-TRI] : begin
 				include : HSerif.lt df.middle top (MidJutSide + [HSwToV : 0.25 * Stroke])

--- a/font-src/glyphs/letter/latin/c.ptl
+++ b/font-src/glyphs/letter/latin/c.ptl
@@ -48,6 +48,10 @@ glyph-block Letter-Latin-C : begin
 				arcvh
 				g4 (df.middle + CorrectionOMidX * sw) (bot + O + offset)
 				g4 (df.rightSB - offset) (bot + DToothlessRise)
+			[Just FLAT-CONNECTION] : list
+				arcvh
+				flat (df.middle + CorrectionOMidX * sw) (bot + O + offset)
+				curl (df.rightSB - offset) (bot + O + offset)
 			_ : list
 				hookend (bot + O + offset)
 				g4 (df.rightSB - offset) (bot + [fallback hook Hook])
@@ -77,6 +81,10 @@ glyph-block Letter-Latin-C : begin
 				arcvh
 				g4 (df.middle + CorrectionOMidX * sw) (bot + O + offset)
 				g4 (df.leftSB + offset) (bot + DToothlessRise)
+			[Just FLAT-CONNECTION] : list
+				arcvh
+				flat (df.middle + CorrectionOMidX * sw) (bot + O + offset)
+				curl (df.leftSB + offset) (bot + O + offset)
 			_ : list
 				hookend (bot + O + offset)
 				g4 (df.leftSB + offset) (bot + [fallback hook Hook])

--- a/font-src/glyphs/letter/latin/k.ptl
+++ b/font-src/glyphs/letter/latin/k.ptl
@@ -235,7 +235,7 @@ glyph-block Letter-Latin-K : begin
 					KAttachment attachment slabLegs top left right stroke false
 				union
 					HalfRectTriangle kshRight top xAttach1 yAttach1
-					HalfRectTriangle (kshRight - O - stroke / 2 * HVContrast) 0 xAttach2 yAttach2
+					HalfRectTriangle (kshRight - O - [HSwToV : 0.5 * stroke]) 0 xAttach2 yAttach2
 
 		define [CursiveDimen left right top stroke slabLT slabLegs] : begin
 			define kshLeft  : left + [KBalance slabLegs true]
@@ -454,7 +454,7 @@ glyph-block Letter-Latin-K : begin
 			if slabLB : include : UpperKLBSerif CAP Stroke slabLT straightBar
 
 		define [BashkirKaShape df top] : glyph-proc
-			local left : if slabLT ([mix SB RightSB 0.35] - df.mvs / 2 * HVContrast) [mix SB RightSB 0.2]
+			local left : if slabLT ([mix SB RightSB 0.35] - [HSwToV : 0.5 * df.mvs]) [mix SB RightSB 0.2]
 			local leftNB : left - [KBalance slabLT straightBar]
 			local xTopBarLeftEnd : mix 0 SB [if slabLT 0.25 0.375]
 			local sw : AdviceStroke 3

--- a/font-src/glyphs/letter/latin/lower-a.ptl
+++ b/font-src/glyphs/letter/latin/lower-a.ptl
@@ -47,7 +47,7 @@ glyph-block Letter-Latin-Lower-A : begin
 			local lowSkew  : shoulderMidSkew ShoulderFine nothing
 			local leftSlopeS : 0.1 * (df.width / HalfUPM)
 			local leftSlope  : leftSlopeS - TanSlope
-			local lowMiddle : mix (df.leftSB + OX) (df.rightSB - stroke / 2 * HVContrast) [linreg 72 0.51 126 0.58 stroke]
+			local lowMiddle : mix (df.leftSB + OX) (df.rightSB - [HSwToV : 0.5 * stroke]) [linreg 72 0.51 126 0.58 stroke]
 			local barSmooth : mix df.leftSB df.rightSB 0.55
 			include : sink
 				widths.lhs stroke

--- a/font-src/glyphs/letter/latin/lower-e.ptl
+++ b/font-src/glyphs/letter/latin/lower-e.ptl
@@ -87,7 +87,7 @@ glyph-block Letter-Latin-Lower-E : begin
 		local pBarRight : 0.475 - TanSlope * 0.5
 		local pArcRight : if para.isItalic (0.425 - TanSlope * 0.25) (ArchDepthA / (ArchDepthA + ArchDepthB))
 
-		local xStart : df.leftSB + ([HSwToV : 0.125 * stroke])
+		local xStart : df.leftSB + [HSwToV : 0.125 * stroke]
 		local pfIt : if para.isItalic 1 0
 		local path : include : dispiro
 			widths.lhs stroke
@@ -114,7 +114,7 @@ glyph-block Letter-Latin-Lower-E : begin
 		local pBarRight : 0.475 - TanSlope * 0.5
 		local pArcRight : if para.isItalic (0.425 + TanSlope * 0.25) (ArchDepthB / (ArchDepthA + ArchDepthB))
 
-		local xStart : df.rightSB - ([HSwToV : 0.125 * stroke])
+		local xStart : df.rightSB - [HSwToV : 0.125 * stroke]
 		local pfIt : if para.isItalic 1 0
 		include : dispiro
 			widths.rhs stroke

--- a/font-src/glyphs/letter/latin/lower-m.ptl
+++ b/font-src/glyphs/letter/latin/lower-m.ptl
@@ -243,17 +243,16 @@ glyph-block Letter-Latin-Lower-M : begin
 			local fine : AdviceStroke 4.5 df.div
 			local rinner : XH * 0.15 - fine * 0.75
 			local gap : (df.rightSB - df.leftSB - 3 * [HSwToV df.mvs] - [HSwToV fine]) / 3
-			local mid : df.leftSB + 1.5 * [HSwToV df.mvs] + gap
 			local m1 : df.rightSB - [HSwToV df.mvs]
 			local m2 : df.leftSB + 2 * ([HSwToV df.mvs] + gap)
 			local x2 : df.rightSB + SideJut
 			local y2 : rinner * 2 + fine - O
-			include : Body df XH 0 [if shortLeg [SmallMShortLegHeight XH df] 0] (y2 + O) mid
+			include : Body df XH 0 [if shortLeg [SmallMShortLegHeight XH df] 0] (y2 + O)
 			include : dispiro
 				straight.down.start df.rightSB (y2 + O) [widths.rhs.heading df.mvs Downward]
 				CurlyTail fine rinner m1 0 m2 x2 y2 (adj -- 0.2)
 
-			include : Serifs df XH 0 [if shortLeg [SmallMShortLegHeight XH df] 0] 0 true earless mid
+			include : Serifs df XH 0 [if shortLeg [SmallMShortLegHeight XH df] 0] 0 true earless
 
 		if (Body === SmallMArches && shortLeg == 0 && tailed == 0) : begin
 			create-glyph "cyrl/tjeKomi.italic.\(suffix)" : glyph-proc

--- a/font-src/glyphs/letter/latin/lower-m.ptl
+++ b/font-src/glyphs/letter/latin/lower-m.ptl
@@ -59,58 +59,72 @@ glyph-block Letter-Latin-Lower-M : begin
 			corner left [Math.min (top - sm - 0.1) bottom]
 			close
 
-	define [SmallMTopLeftSerif df top lbot] : begin
+
+	define [SmallMTopLeftSerif df top lbot fFull] : begin
 		local sf : SerifFrame.fromDf df top 0
 		return sf.lt.outer
 
-	define [SmallMBottomLeftSerif df top lbot] : begin
+	define [SmallMBottomLeftSerif df top lbot fFull] : begin
 		local sf : SerifFrame.fromDf df top lbot
-		return : if sf.enoughSpaceForFullSerifs sf.lb.full sf.lb.outer
+		return : if fFull sf.lb.full sf.lb.outer
 
-	define [SmallMBottomMiddleSerif df top mbot] : begin
+	define [SmallMBottomMiddleSerif df top mbot fFull mid] : begin
 		local sf : SerifFrame.fromDf df top mbot
-		return : if sf.enoughSpaceForFullSerifs sf.mb.full [no-shape]
+		return : if fFull [sf.mb.fullAt mid] [no-shape]
 
-	define [SmallMBottomRightSerif df top rbot] : begin
+	define [SmallMBottomRightSerif df top rbot fFull] : begin
 		local sf : SerifFrame.fromDf df top rbot
-		return : if sf.enoughSpaceForFullSerifs sf.rb.full sf.rb.outer
+		return : if fFull sf.rb.full sf.rb.outer
 
-	define [SmallMBottomMotionRightSerif df top rbot] : begin
+	define [SmallMBottomMotionRightSerif df top rbot fFull] : begin
 		local sf : SerifFrame.fromDf df top rbot
 		return sf.rb.outer
 
-	define [FullSerifs df top lbot mbot rbot tailed earless] : glyph-proc
-		if [not earless] : include : SmallMTopLeftSerif df top lbot
-		include : SmallMBottomLeftSerif df top lbot
-		include : SmallMBottomMiddleSerif df top mbot
-		if [not tailed] : include : SmallMBottomRightSerif df top rbot
 
-	define [AutoSerifs df top lbot mbot rbot tailed earless] : begin
-		if SLAB [FullSerifs df top lbot mbot rbot tailed earless] [no-shape]
+	define [MEnoughSpaceForFullSerifs df mid] : begin
+		local ink : HSwToV df.mvs
+		local gap : [Math.min (mid - df.leftSB) (df.rightSB - mid)] - 1.5 * ink
+		return : 0.5 * ink + 0.375 * gap > para.refJut
 
-	define [LtSerifs df top lbot mbot rbot tailed earless] : glyph-proc
-		include : SmallMTopLeftSerif df top lbot
+	define [FullSerifs df top lbot mbot rbot tailed earless _mid] : glyph-proc
+		local mid : fallback _mid df.middle
+		local fFull : MEnoughSpaceForFullSerifs df mid
+		if [not earless] : include : SmallMTopLeftSerif df top lbot fFull
+		include : SmallMBottomLeftSerif df top lbot fFull
+		include : SmallMBottomMiddleSerif df top mbot fFull mid
+		if [not tailed] : include : SmallMBottomRightSerif df top rbot fFull
 
-	define [LtRbSerifs df top lbot mbot rbot tailed earless] : glyph-proc
-		include : SmallMTopLeftSerif df top lbot
-		include : SmallMBottomMotionRightSerif df top rbot
+	define [AutoSerifs df top lbot mbot rbot tailed earless _mid] : begin
+		if SLAB [FullSerifs df top lbot mbot rbot tailed earless _mid] [no-shape]
 
-	define [RbSerifs df top lbot mbot rbot tailed earless] : glyph-proc
-		include : SmallMBottomMotionRightSerif df top rbot
+	define [LtSerifs df top lbot mbot rbot tailed earless _mid] : glyph-proc
+		local fFull : MEnoughSpaceForFullSerifs df : fallback _mid df.middle
+		include : SmallMTopLeftSerif df top lbot fFull
+
+	define [LtRbSerifs df top lbot mbot rbot tailed earless _mid] : glyph-proc
+		local fFull : MEnoughSpaceForFullSerifs df : fallback _mid df.middle
+		include : SmallMTopLeftSerif df top lbot fFull
+		include : SmallMBottomMotionRightSerif df top rbot fFull
+
+	define [RbSerifs df top lbot mbot rbot tailed earless _mid] : glyph-proc
+		local fFull : MEnoughSpaceForFullSerifs df : fallback _mid df.middle
+		include : SmallMBottomMotionRightSerif df top rbot fFull
+
 
 	define [dfM] : DivFrame para.diversityM 3
-	define [SmallMArches top lbot mbot rbot df] : glyph-proc
+	define [SmallMArches df top lbot mbot rbot _mid] : glyph-proc
+		local mid : fallback _mid df.middle
 		include : SmallMShoulderSpiro
 			df        -- df
 			left      -- (df.leftSB + [HSwToV df.mvs])
-			right     -- (df.middle + df.mvs / 2 * HVContrast)
+			right     -- (mid + [HSwToV : 0.5 * df.mvs])
 			top       -- top
 			bottom    -- mbot
 			width     -- df.mvs
 			fine      -- (df.mvs * ShoulderFine / Stroke)
 		include : SmallMShoulderSpiro
 			df        -- df
-			left      -- (df.middle + [HSwToV : 0.5 * df.mvs])
+			left      -- (mid + [HSwToV : 0.5 * df.mvs])
 			right     -- df.rightSB
 			top       -- top
 			bottom    -- rbot
@@ -121,29 +135,31 @@ glyph-block Letter-Latin-Lower-M : begin
 	define [SmallMShortLegHeight top df] : (top - df.mvs) * 0.45
 	define [SmallMSmoothHeight top df] : top - [SmallMSmooth df] - TanSlope * Stroke
 
-	define [EarlessCornerDoubleArchSmallMShape top lbot mbot rbot df] : glyph-proc
+	define [EarlessCornerDoubleArchSmallMShape df top lbot mbot rbot _mid] : glyph-proc
+		local mid : fallback _mid df.middle
 		include : dispiro
 			widths.rhs df.mvs
 			g4 df.leftSB (top - DToothlessRise)
-			g4.right.mid [mix df.leftSB (df.middle + df.mvs / 2 * HVContrast) 0.5] (top - O) [heading Rightward]
-			g4 (df.middle + df.mvs / 2 * HVContrast) (top - DToothlessRise)
+			g4.right.mid [mix df.leftSB (mid + [HSwToV : 0.5 * df.mvs]) 0.5] (top - O) [heading Rightward]
+			g4 (mid + [HSwToV : 0.5 * df.mvs]) (top - DToothlessRise)
 		include : dispiro
 			widths.rhs df.mvs
-			g4 (df.middle - df.mvs / 2 * HVContrast) (top - DToothlessRise)
-			g4.right.mid [mix df.rightSB (df.middle - df.mvs / 2 * HVContrast) 0.5] (top - O) [heading Rightward]
+			g4 (mid - [HSwToV : 0.5 * df.mvs]) (top - DToothlessRise)
+			g4.right.mid [mix df.rightSB (mid - [HSwToV : 0.5 * df.mvs]) 0.5] (top - O) [heading Rightward]
 			archv
 			flat df.rightSB (top - [SmallMSmooth df]) [heading Downward]
 			curl df.rightSB rbot [heading Downward]
 
 		include : tagged 'barL' : VBar.l df.leftSB lbot (top - DToothlessRise) df.mvs
-		include : tagged 'barM' : VBar.m df.middle mbot (top - DToothlessRise) df.mvs
+		include : tagged 'barM' : VBar.m mid mbot (top - DToothlessRise) df.mvs
 
-	define [EarlessRoundedDoubleArchSmallMShape top lbot mbot rbot df] : glyph-proc
+	define [EarlessRoundedDoubleArchSmallMShape df top lbot mbot rbot _mid] : glyph-proc
+		local mid : fallback _mid df.middle
 		include : union
 			RevSmallMShoulderSpiro
 				df        -- df
 				left      -- df.leftSB
-				right     -- (df.middle - df.mvs / 2 * HVContrast)
+				right     -- (mid - [HSwToV : 0.5 * df.mvs])
 				top       -- top
 				bottom    -- lbot
 				coBottom  -- mbot
@@ -151,7 +167,7 @@ glyph-block Letter-Latin-Lower-M : begin
 				fine      -- (df.mvs * CThin)
 			SmallMShoulderSpiro
 				df        -- df
-				left      -- (df.middle + [HSwToV : 0.5 * df.mvs])
+				left      -- (mid + [HSwToV : 0.5 * df.mvs])
 				right     -- df.rightSB
 				top       -- top
 				bottom    -- rbot
@@ -159,13 +175,14 @@ glyph-block Letter-Latin-Lower-M : begin
 				width     -- df.mvs
 				fine      -- (df.mvs * CThin)
 
-	define [EarlessSingleArchSmallMShape top lbot mbot rbot df] : glyph-proc
+	define [EarlessSingleArchSmallMShape df top lbot mbot rbot _mid] : glyph-proc
+		local mid : fallback _mid df.middle
 		include : tagged 'barL' : VBar.l df.leftSB lbot (top - DToothlessRise) df.mvs
-		include : tagged 'barM' : VBar.m df.middle mbot top df.mvs
+		include : tagged 'barM' : VBar.m mid mbot top df.mvs
 		include : dispiro
 			widths.rhs df.mvs
 			g4 df.leftSB (top - DToothlessRise)
-			g4 (df.middle - CorrectionOMidS) (top - O)
+			g4 (mid - CorrectionOMidS) (top - O)
 			archv
 			flat df.rightSB [Math.max (top - [SmallMSmooth df]) (rbot + 0.1)]
 			curl df.rightSB rbot [heading Downward]
@@ -191,7 +208,7 @@ glyph-block Letter-Latin-Lower-M : begin
 
 	foreach { suffix { {Body earless} {shortLeg} {tailed} {Serifs} } } [pairs-of SmallMConfig] : do
 		define [mShapeBody df height] : glyph-proc
-			include : Body height 0 [if shortLeg [SmallMShortLegHeight height df] 0] [if tailed ([SmallMSmoothHeight height df] + O) 0] df
+			include : Body df height 0 [if shortLeg [SmallMShortLegHeight height df] 0] [if tailed ([SmallMSmoothHeight height df] + O) 0]
 			if tailed : include : RightwardTailedBar df.rightSB 0 [SmallMSmoothHeight height df] (sw -- df.mvs)
 			include : Serifs df height 0 [if shortLeg [SmallMShortLegHeight height df] 0] 0 tailed earless
 
@@ -223,30 +240,27 @@ glyph-block Letter-Latin-Lower-M : begin
 			local df : include : DivFrame para.diversityM 4
 			include : df.markSet.e
 
-			local fine : AdviceStroke 5.5 df.div
+			local fine : AdviceStroke 4.5 df.div
 			local rinner : XH * 0.15 - fine * 0.75
+			local gap : (df.rightSB - df.leftSB - 3 * [HSwToV df.mvs] - [HSwToV fine]) / 3
+			local mid : df.leftSB + 1.5 * [HSwToV df.mvs] + gap
 			local m1 : df.rightSB - [HSwToV df.mvs]
-			local m2 : [mix (df.middle + [HSwToV : 0.5 * df.mvs]) m1 0.35] - [HSwToV : 0.5 * fine]
+			local m2 : df.leftSB + 2 * ([HSwToV df.mvs] + gap)
 			local x2 : df.rightSB + SideJut
 			local y2 : rinner * 2 + fine - O
-			include : Body XH 0 [if shortLeg [SmallMShortLegHeight XH df] 0] (y2 + O) df
+			include : Body df XH 0 [if shortLeg [SmallMShortLegHeight XH df] 0] (y2 + O) mid
 			include : dispiro
 				straight.down.start df.rightSB (y2 + O) [widths.rhs.heading df.mvs Downward]
-				CurlyTail fine rinner m1 0 m2 x2 y2 (adj -- 0)
+				CurlyTail fine rinner m1 0 m2 x2 y2 (adj -- 0.2)
 
-			include : Serifs df XH 0 [if shortLeg [SmallMShortLegHeight XH df] 0] 0 true earless
-			if (SLAB && [not shortLeg] && Serifs === FullSerifs) : begin
-				local sf : SerifFrame.fromDf df XH 0
-				if (sf.enoughSpaceForFullSerifs && m2 - (df.middle + sf.jutIn) < 0.01 * Width) : begin
-					eject-contour 'serifMB'
-					include sf.mb.left
+			include : Serifs df XH 0 [if shortLeg [SmallMShortLegHeight XH df] 0] 0 true earless mid
 
 		if (Body === SmallMArches && shortLeg == 0 && tailed == 0) : begin
 			create-glyph "cyrl/tjeKomi.italic.\(suffix)" : glyph-proc
 				local df : include : DivFrame para.diversityM 4
 				include : df.markSet.e
 				local subDf : df.slice 4 3 0
-				include : Body XH 0 0 (XH / 2) subDf
+				include : Body subDf XH 0 0 (XH / 2)
 				include : UpwardHookShape
 					left -- subDf.rightSB - [HSwToV subDf.mvs]
 					right -- df.rightSB
@@ -297,7 +311,7 @@ glyph-block Letter-Latin-Lower-M : begin
 
 	foreach { suffix { {Body toothless tailed} {Serifs} } } [pairs-of TurnMConfig] : do
 		define [turnMShapeBody df top] : glyph-proc
-			include : Body top 0 0 0 df
+			include : Body df top 0 0 0
 			include : Serifs df top 0 0 0 0 toothless
 			include : FlipAround df.middle (top / 2)
 			if tailed : begin

--- a/font-src/glyphs/letter/latin/lower-r.ptl
+++ b/font-src/glyphs/letter/latin/lower-r.ptl
@@ -39,7 +39,7 @@ glyph-block Letter-Latin-Lower-R : begin
 		local xBar : match mode
 			[Just rNarrowSerifed] : df.middle + [HSwToV : 0.5 * strokeBar] - RBalance * rBalanceMultiplier
 			__                    : SB + RBalance * rBalanceMultiplier + [HSwToV strokeBar]
-		local rSerifX : xBar - strokeBar / 2 * HVContrast
+		local rSerifX : xBar - [HSwToV : 0.5 * strokeBar]
 		local rSerifLeftJut  : SideJut + RBalance * (0.3 + rSerifLeftExtender)
 		local rSerifRightJut : rSerifLeftJut * 1.20
 		local [rBottomSerif y] : glyph-proc
@@ -59,8 +59,8 @@ glyph-block Letter-Latin-Lower-R : begin
 			[Just rSerifed]             : mix (xBar - fine) rHookX (0.59 + 2 * TanSlope * strokeBar / Width)
 			[Just rNarrow]              : mix df.width rHookX : Math.max 1.01 (5 / 4 * [mix 1 dfR.div 2])
 			[Just rNarrowSerifed]       : Math.min ([mix df.width rHookX df.div] - 0.1) : xBar + RHook * 1.25 * df.div
-			[Just rCornerHooked]        : rHookX - strokeBar / 2 * HVContrast
-			[Just rCornerHookedSerifed] : rHookX - strokeBar / 2 * HVContrast
+			[Just rCornerHooked]        : rHookX - [HSwToV : 0.5 * strokeBar]
+			[Just rCornerHookedSerifed] : rHookX - [HSwToV : 0.5 * strokeBar]
 			[Just rEarless]             : mix (xBar - [HSwToV strokeBar]) rHookX 0.5
 		local mixpin : match mode
 			([Just rSerifed] || [Just rCornerHooked] || [Just rCornerHookedSerifed]) : begin
@@ -218,12 +218,12 @@ glyph-block Letter-Latin-Lower-R : begin
 		create-glyph "fInsular.\(suffix)" : glyph-proc
 			include [refer-glyph "rLongLeg.\(suffix)"] AS_BASE ALSO_METRICS
 			define [object xBar rHookX] : RDim df mode
-			include : HBar.b xBar (rHookX - [Math.max (0.15 * (df.rightSB - df.leftSB)) ([HSwToV : 0.25 * Stroke])]) 0
+			include : HBar.b xBar (rHookX - [Math.max (0.15 * (df.rightSB - df.leftSB)) [HSwToV : 0.25 * Stroke]]) 0
 
 		create-glyph "FInsular.\(suffix)" : glyph-proc
 			include [refer-glyph "rCapLongLeg.\(suffix)"] AS_BASE ALSO_METRICS
 			define [object xBar rHookX] : RDim df mode
-			include : HBar.b xBar (rHookX - [Math.max (0.15 * (df.rightSB - df.leftSB)) ([HSwToV : 0.25 * Stroke])]) 0
+			include : HBar.b xBar (rHookX - [Math.max (0.15 * (df.rightSB - df.leftSB)) [HSwToV : 0.25 * Stroke]]) 0
 
 		create-glyph "rPalatalHook.\(suffix)" : glyph-proc
 			include [refer-glyph "r.\(suffix)"] AS_BASE ALSO_METRICS

--- a/font-src/glyphs/letter/latin/lower-t.ptl
+++ b/font-src/glyphs/letter/latin/lower-t.ptl
@@ -41,7 +41,7 @@ glyph-block Letter-Latin-Lower-T : begin
 
 		define [XHookTerminal df sym] : match sym
 			[Just SYM-LEFT]        df.rightSB
-			__                   : [BarLeftPos df sym] + [Math.max ((df.width - df.leftSB * 2) * 0.75 + [HSwToV : 0.25 * Stroke]) ([HSwToV : 2.25 * Stroke])]
+			__                   : [BarLeftPos df sym] + [Math.max ((df.width - df.leftSB * 2) * 0.75 + [HSwToV : 0.25 * Stroke]) [HSwToV : 2.25 * Stroke]]
 
 		export : define [HookShapeT sink df sym offset top bot sw] : begin
 			local xLeft : BarLeftPos df sym

--- a/font-src/glyphs/letter/latin/lower-y.ptl
+++ b/font-src/glyphs/letter/latin/lower-y.ptl
@@ -104,7 +104,7 @@ glyph-block Letter-Latin-Lower-Y : begin
 						local joinHeight1 : yJoinHeight ds ds2 top bottom false
 						local k : 1 / [Math.sin : Math.atan2 (joinX - Middle) (joinY - joinHeight1)] - 0.25
 						local joinHeight3 : [Math.abs k] * Stroke + joinHeight1
-						local deltaX : Math.max yBottomJut ([HSwToV : 1.2 * Stroke])
+						local deltaX : Math.max yBottomJut [HSwToV : 1.2 * Stroke]
 						local fine : AdviceStroke 3
 						local xLoopLeft : Math.max (SB * -0.25) [mix joinX (yrstrokel - deltaX) 2]
 						local xCenter : mix xLoopLeft joinX 0.5

--- a/font-src/glyphs/letter/latin/upper-h.ptl
+++ b/font-src/glyphs/letter/latin/upper-h.ptl
@@ -56,7 +56,7 @@ glyph-block Letter-Latin-Upper-H : begin
 	define [EnGheShape Body df top slabType vSlab] : glyph-proc
 		local sw : AdviceStroke 2.75
 		local xRightBar : Math.min (Width - df.leftSB) : if SLAB
-			[mix df.rightSB df.leftSB 0.35] + df.mvs / 2 * HVContrast
+			[mix df.rightSB df.leftSB 0.35] + [HSwToV : 0.5 * df.mvs]
 			mix df.rightSB df.leftSB 0.2
 		local xTopRight : mix df.width df.rightSB [if SLAB 0.25 0.375]
 

--- a/font-src/glyphs/letter/latin/upper-y.ptl
+++ b/font-src/glyphs/letter/latin/upper-y.ptl
@@ -58,7 +58,7 @@ glyph-block Letter-Latin-Upper-Y : begin
 			straight.right.start (SB - TailX / 3) (top - Stroke - O)
 			g4 (SB + TailX / 3) (top - TailY) [widths.lhs : AdviceStroke 2.75]
 			quadControls 0.55 0.7 32 unimportant
-			g4 (Middle - Stroke / 2 * HVContrast) cross [widths.lhs : AdviceStroke 3.5]
+			g4 (Middle - [HSwToV : 0.5 * Stroke]) cross [widths.lhs : AdviceStroke 3.5]
 
 	define [YHookRightHookedStroke top bot] : begin
 		local cross : YCrossPos top bot
@@ -67,7 +67,7 @@ glyph-block Letter-Latin-Upper-Y : begin
 			straight.left.start (RightSB + TailX / 3) (top - Stroke - O)
 			g4 (RightSB - TailX / 3) (top - TailY) [widths.rhs : AdviceStroke 2.75]
 			quadControls 0.55 0.7 32 unimportant
-			g4 (Middle + Stroke / 2 * HVContrast) cross [widths.rhs : AdviceStroke 3.5]
+			g4 (Middle + [HSwToV : 0.5 * Stroke]) cross [widths.rhs : AdviceStroke 3.5]
 
 	define [YHookTopShape bodyType slabType top bot] : glyph-proc
 		include : YShape bodyType slabType top bot
@@ -167,10 +167,10 @@ glyph-block Letter-Latin-Upper-Y : begin
 			union
 				difference
 					ExtLineCenter 1 BBS  SB         CAP (Middle - BBD / 2) yCross
-					Rect CAP 0 (Middle - BBD / 2 + BBS / 2 * HVContrast) (Width * 2)
+					Rect CAP 0 (Middle - BBD / 2 + [HSwToV : 0.5 * BBS]) (Width * 2)
 				difference
 					ExtLineCenter 1 BBS  (SB + BBD) CAP (Middle + BBD / 2) yCross
-					Rect CAP 0 (Middle + BBD / 2 + BBS / 2 * HVContrast) (Width * 2)
+					Rect CAP 0 (Middle + BBD / 2 + [HSwToV : 0.5 * BBS]) (Width * 2)
 
 		include : intersection
 			Rect CAP yCross (-Width) (2 * Width)

--- a/font-src/glyphs/letter/latin/w.ptl
+++ b/font-src/glyphs/letter/latin/w.ptl
@@ -285,7 +285,7 @@ glyph-block Letter-Latin-W : begin
 			flat x1 top [heading Downward]
 			curl x1 (fine + rInY) [heading Downward]
 			arcvh 16
-			g4 [Math.min ([mix (x1 + [HSwToV fine]) (df.middle - fine / 2 * HVContrast) 0.5] - (fine - mfine) * HVContrast) (x1 + [HSwToV fine] + rInY)] O [heading {.x (TanSlope + (0.5 * (fine - mfine) / fine)) .y 1}]
+			g4 [Math.min ([mix (x1 + [HSwToV fine]) (df.middle - [HSwToV : 0.5 * fine]) 0.5] - (fine - mfine) * HVContrast) (x1 + [HSwToV fine] + rInY)] O [heading {.x (TanSlope + (0.5 * (fine - mfine) / fine)) .y 1}]
 			archv 16
 			flat (df.middle + (mfine - fine / 2) * HVContrast) y3 [widths.heading mfine 0 Upward]
 			curl (df.middle + (mfine - fine / 2) * HVContrast) y4 [heading Upward]
@@ -298,7 +298,7 @@ glyph-block Letter-Latin-W : begin
 				flat (df.width - x1) (top - TailY - 0.5 * fine - O) [heading Downward]
 				curl (df.width - x1) y3           [heading Downward]
 				arcvh 16
-				g4 ([mix (df.width - x1) (df.middle - fine / 2 * HVContrast) 0.5] + fine * CorrectionOMidX) O
+				g4 ([mix (df.width - x1) (df.middle - [HSwToV : 0.5 * fine]) 0.5] + fine * CorrectionOMidX) O
 				archv 16
 				flat (df.middle - (mfine - fine / 2) * HVContrast) y3 [widths.heading 0 mfine Upward]
 				curl (df.middle - (mfine - fine / 2) * HVContrast) y4 [heading Upward]
@@ -308,7 +308,7 @@ glyph-block Letter-Latin-W : begin
 				g4 (df.width - x0) y0
 				g4 (df.width - x1 - OX) (top / 2)
 				arcvh 16
-				g4 ([mix (df.width - x1) (df.middle - fine / 2 * HVContrast) 0.5] + fine * CorrectionOMidX) O
+				g4 ([mix (df.width - x1) (df.middle - [HSwToV : 0.5 * fine]) 0.5] + fine * CorrectionOMidX) O
 				archv 16
 				flat (df.middle - (mfine - fine / 2) * HVContrast) y3 [widths.heading 0 mfine Upward]
 				curl (df.middle - (mfine - fine / 2) * HVContrast) y4 [heading Upward]

--- a/font-src/glyphs/letter/latin/z.ptl
+++ b/font-src/glyphs/letter/latin/z.ptl
@@ -176,7 +176,7 @@ glyph-block Letter-Latin-Z : begin
 
 	define [ZemlyaBottomStroke] : begin
 		local fine : AdviceStroke 4
-		local hx : [Math.max (0.5 * HookX) ([HSwToV : 1.25 * fine])] + ([HSwToV : 0.125 * fine])
+		local hx : [Math.max (0.5 * HookX) [HSwToV : 1.25 * fine]] + [HSwToV : 0.125 * fine]
 		return : dispiro
 			widths.lhs
 			flat SB 0 [heading Rightward]
@@ -192,7 +192,7 @@ glyph-block Letter-Latin-Z : begin
 
 	define [ZemlyaBottomStrokeCursive] : begin
 		local fine : AdviceStroke 4
-		local hx : [Math.max (0.5 * HookX) ([HSwToV : 1.25 * fine])] + ([HSwToV : 0.125 * fine])
+		local hx : [Math.max (0.5 * HookX) [HSwToV : 1.25 * fine]] + [HSwToV : 0.125 * fine]
 		return : dispiro
 			flat (RightSB - [HSwToV fine]) HalfStroke [widths.lhs.heading fine Downward]
 			curl (RightSB - [HSwToV fine]) [mix (Descender + fine) 0 0.5] [widths.lhs.heading fine Downward]

--- a/font-src/glyphs/letter/shared.ptl
+++ b/font-src/glyphs/letter/shared.ptl
@@ -163,7 +163,7 @@ glyph-block Letter-Shared-Shapes : begin
 	glyph-block-export CurlyTail
 	define [CurlyTail] : with-params [fine rinner xleft bottom right x2 y2 [adj 0.4] [adj2 0.4] [adj3 0]] : begin
 		local ltr : right > xleft
-		set right : right - fine * [if ltr 1 (-1)] * HVContrast
+		set right : right - [HSwToV fine] * [if ltr 1 (-1)]
 		local mid : mix [mix xleft right 0.5] (right - rinner * [if ltr 1 (-1)]) adj
 		local midu : mix [mix xleft right 0.5] (right - rinner * [if ltr 1 (-1)]) adj2
 		return : list
@@ -692,7 +692,7 @@ glyph-block Letter-Shared-Shapes : begin
 
 
 			local jutFS   MidJutSide
-			local jut     : mix ([HSwToV : 0.5 * swRef]) Jut [Math.min 1 : div * 2.25 / hSplit]
+			local jut     : mix [HSwToV : 0.5 * swRef] Jut [Math.min 1 : div * 2.25 / hSplit]
 			local sideJut : jut - 0.5 * ink
 
 			local jutIn     : if fForceSymmetric jut : JutIn left right jut swRef hSplit
@@ -735,6 +735,7 @@ glyph-block Letter-Shared-Shapes : begin
 
 			set this.mb : object
 				full : tagged 'serifMB' : HSerif.mbAsymmetric [mix lBarCenter rBarCenter 0.5] bot jutIn jutIn swSerif
+				[fullAt x] : tagged 'serifMB' : HSerif.mbAsymmetric x bot jutIn jutIn swSerif
 				left : tagged 'serifMB' : HSerif.mbAsymmetric [mix lBarCenter rBarCenter 0.5] bot jutIn 0 swSerif
 				right : tagged 'serifMB' : HSerif.mbAsymmetric [mix lBarCenter rBarCenter 0.5] bot 0 jutIn swSerif
 			set this.mt : object
@@ -960,7 +961,7 @@ glyph-block Letter-Shared-Shapes : begin
 					ada    -- ArchDepthA
 					adb    -- ArchDepthB
 					sw     -- df.mvs
-					xDepth -- (-[Math.max ([HSwToV df.mvs]) : Math.min HookX (0.5 * (df.rightSB - df.leftSB - [HSwToV : 2 * df.mvs]))])
+					xDepth -- (-[Math.max [HSwToV df.mvs] : Math.min HookX (0.5 * (df.rightSB - df.leftSB - [HSwToV : 2 * df.mvs]))])
 
 		# Hook for Eng shape
 		glyph-block-export EngHook

--- a/font-src/glyphs/number/2.ptl
+++ b/font-src/glyphs/number/2.ptl
@@ -74,4 +74,4 @@ glyph-block Digits-Two : begin
 		include : intersection
 			TwoArcShapeT spiro-outline 1 BBS CAP
 			VBar.r (RightSB - OX / 2 - BBD) 0 CAP BBS
-		include : HBar.b (SB + BBS / 2 * HVContrast) RightSB 0 BBS
+		include : HBar.b (SB + [HSwToV : 0.5 * BBS]) RightSB 0 BBS

--- a/font-src/glyphs/number/4.ptl
+++ b/font-src/glyphs/number/4.ptl
@@ -13,7 +13,7 @@ glyph-block Digits-Four : begin
 	define [FourStdShape] : with-params [top open crossing [fine : AdviceStroke 3] [sw Stroke] [bbd 0]] : glyph-proc
 		local yBar : top * 0.3 + 0.625 * sw
 
-		define xVertBar : [mix SB RightSB : if crossing 0.75 0.9125] - (bbd * 0.75) + [if crossing ([HSwToV : 0.375 * sw]) 0]
+		define xVertBar : [mix SB RightSB : if crossing 0.75 0.9125] - (bbd * 0.75) + [if crossing [HSwToV : 0.375 * sw] 0]
 		define yVertBarTop : [mix (yBar - sw) top : if open 0.5 1] - [if open (0.3 * sw) 0]
 		define xHBarTerminal : if crossing RightSB xVertBar
 		define xSlopeTop : xVertBar - [HSwToV sw] - [if open 0.25 1] * [HSwToV fine] * [if crossing 0.25 0.5]

--- a/font-src/glyphs/symbol/geometric/masked.ptl
+++ b/font-src/glyphs/symbol/geometric/masked.ptl
@@ -199,7 +199,7 @@ glyph-block Symbol-Geometric-Masked : for-width-kinds WideWidth1
 			list 0x25F7 'whiteCircle' 1 0 0 1
 		foreach { u frame T L B R } [items-of quarterLineParts] : begin
 			create-glyph [MangleName : NameUni u] [MangleUnicode u] : glyph-proc
-				local hh : GeometryStroke / 2 * HVContrast
+				local hh : HSwToV : 0.5 * GeometryStroke
 				local hv : GeometryStroke / 2
 				local s    GeometryStroke
 				set-width Geom.Width

--- a/font-src/glyphs/symbol/letter.ptl
+++ b/font-src/glyphs/symbol/letter.ptl
@@ -247,9 +247,9 @@ glyph-block Symbol-Letter : begin
 		include : MarkSet.b
 		local sw : UnicodeWeightGrade 9 1
 		include : VBar.m Middle 0 XH sw
-		include : HSerif.lt (Middle - sw / 2 * HVContrast) XH (LongJut / 2)
-		include : HSerif.lb (Middle - sw / 2 * HVContrast) 0  (LongJut / 2)
-		include : HSerif.rb (Middle + sw / 2 * HVContrast) 0  (LongJut / 2)
+		include : HSerif.lt (Middle - [HSwToV : 0.5 * sw]) XH (LongJut / 2)
+		include : HSerif.lb (Middle - [HSwToV : 0.5 * sw]) 0  (LongJut / 2)
+		include : HSerif.rb (Middle + [HSwToV : 0.5 * sw]) 0  (LongJut / 2)
 		include : DotAt Middle (XH + AccentStackOffset) (DotRadius * sw / Stroke)
 
 	turned 'turnG/sansSerif' 0x2141 'G/sansSerif' Middle (CAP / 2)

--- a/font-src/glyphs/symbol/math/integrals.ptl
+++ b/font-src/glyphs/symbol/math/integrals.ptl
@@ -77,7 +77,7 @@ glyph-block Symbol-Math-Integrals : begin
 			IntegrateRingMask 1
 		intersection
 			IntegrateRing 1 RingIntFine
-			MaskRight (Middle - OperatorStroke / 2 * HVContrast)
+			MaskRight (Middle - [HSwToV : 0.5 * OperatorStroke])
 		DrawAt Middle SymbolMid (RingIntDotSize * kdr - ov)
 
 	WithDotVariants 'shiftedRightHalfRingDotIntegrate' 0x2A14 : function [DrawAt kdr ov] : union
@@ -86,7 +86,7 @@ glyph-block Symbol-Math-Integrals : begin
 			with-transform [Translate RingIntSideShift 0] : IntegrateRingMask 1
 		intersection
 			with-transform [Translate RingIntSideShift 0] : IntegrateRing 1 RingIntFine
-			MaskRight (Middle - OperatorStroke / 2 * HVContrast)
+			MaskRight (Middle - [HSwToV : 0.5 * OperatorStroke])
 		DrawAt (Middle + RingIntSideShift) SymbolMid (RingIntDotSize * kdr - ov)
 
 	define RingIntArrowSize : Hook / 2
@@ -158,7 +158,7 @@ glyph-block Symbol-Math-Integrals : begin
 		difference
 			intersection
 				IntegrateBox 1 0
-				MaskRight (Middle - OperatorStroke / 2 * HVContrast)
+				MaskRight (Middle - [HSwToV : 0.5 * OperatorStroke])
 			IntegrateBox 1 RingIntFine
 		DrawAt Middle SymbolMid (RingIntDotSize * kdr - ov)
 

--- a/font-src/glyphs/symbol/math/v-and-cup.ptl
+++ b/font-src/glyphs/symbol/math/v-and-cup.ptl
@@ -51,12 +51,12 @@ glyph-block Symbol-Math-VAndCup : begin
 		local fine : CThin * OperatorStroke
 		include : dispiro
 			g4 SB OperTop [widths.center OperatorStroke]
-			straight.down.end (Middle - OperatorStroke / 2 * HVContrast) OperBot [widths.heading fine 0 Downward]
+			straight.down.end (Middle - [HSwToV : 0.5 * OperatorStroke]) OperBot [widths.heading fine 0 Downward]
 
 		include : dispiro
 			widths.center OperatorStroke
 			g4 RightSB OperTop [widths.center OperatorStroke]
-			straight.down.end (Middle + OperatorStroke / 2 * HVContrast) OperBot [widths.heading 0 fine Downward]
+			straight.down.end (Middle + [HSwToV : 0.5 * OperatorStroke]) OperBot [widths.heading 0 fine Downward]
 
 	turned 'curlyWedge' 0x22CF 'curlyVee' Middle SymbolMid
 

--- a/font-src/glyphs/symbol/pictograph/clock.ptl
+++ b/font-src/glyphs/symbol/pictograph/clock.ptl
@@ -37,6 +37,6 @@ glyph-block Symbol-Geometric-Clock : for-width-kinds WideWidth1
 					corner
 						Geom.MidX + (Geom.Size - mediumSw) * pHour * [Math.sin hrAngle]
 						Geom.MidY + (Geom.Size - mediumSw) * pHour * [Math.cos hrAngle]
-	
+
 	patterns 0 0x1F550
 	patterns 30 0x1F55C

--- a/font-src/glyphs/symbol/pictograph/flags.ptl
+++ b/font-src/glyphs/symbol/pictograph/flags.ptl
@@ -31,7 +31,7 @@ glyph-block Symbol-Pictograph-Flags : begin
 			flat (SB + delta) SymbolMid
 			corner SB SymbolMid
 			close
-		include : Translate (sw / 2 * HVContrast) 0
+		include : Translate [HSwToV : 0.5 * sw] 0
 		include : FlagBar
 
 	create-glyph 'whiteflag' 0x2690 : glyph-proc
@@ -54,5 +54,5 @@ glyph-block Symbol-Pictograph-Flags : begin
 			alsoThru 0.5 curliness
 			flat (SB + delta) (SymbolMid - sw / 2) [heading Leftward]
 			curl SB (SymbolMid - sw / 2) [heading Leftward]
-		include : Translate (sw / 2 * HVContrast) 0
+		include : Translate [HSwToV : 0.5 * sw] 0
 		include : FlagBar

--- a/font-src/glyphs/symbol/pictograph/i-ching.ptl
+++ b/font-src/glyphs/symbol/pictograph/i-ching.ptl
@@ -12,8 +12,8 @@ glyph-block Symbol-Pictograph-I-Ching : begin
 	create-glyph 'iChing/barYin' : glyph-proc
 		local bar : AdviceStroke 3
 		local gap : Math.max (Width / 8) [AdviceStroke 5]
-		include : HBar.m SB (Middle - gap / 2 * HVContrast) 0 bar
-		include : HBar.m (Middle + gap / 2 * HVContrast) RightSB 0 bar
+		include : HBar.m SB (Middle - [HSwToV : 0.5 * gap]) 0 bar
+		include : HBar.m (Middle + [HSwToV : 0.5 * gap]) RightSB 0 bar
 
 	create-glyph 'iChing/barYang' : glyph-proc
 		local bar : AdviceStroke 3

--- a/font-src/glyphs/symbol/pictograph/iec-power-and-playback.ptl
+++ b/font-src/glyphs/symbol/pictograph/iec-power-and-playback.ptl
@@ -26,8 +26,8 @@ glyph-block Symbol-Pictograph-IEC-Power-And-Playback : for-width-kinds WideWidth
 		include : Rect
 			SymbolMid + squareRadiusFW
 			SymbolMid - squareRadiusFW
-			df.middle - GeometryStroke / 2 * HVContrast
-			df.middle + GeometryStroke / 2 * HVContrast
+			df.middle - [HSwToV : 0.5 * GeometryStroke]
+			df.middle + [HSwToV : 0.5 * GeometryStroke]
 
 	create-glyph [MangleName 'powerOnOff'] [MangleUnicode 0x23FC] : glyph-proc
 		set-width df.width
@@ -35,8 +35,8 @@ glyph-block Symbol-Pictograph-IEC-Power-And-Playback : for-width-kinds WideWidth
 		include : Rect
 			SymbolMid + squareRadiusFW - GeometryStroke - gap
 			SymbolMid - squareRadiusFW + GeometryStroke + gap
-			df.middle - GeometryStroke / 2 * HVContrast
-			df.middle + GeometryStroke / 2 * HVContrast
+			df.middle - [HSwToV : 0.5 * GeometryStroke]
+			df.middle + [HSwToV : 0.5 * GeometryStroke]
 
 	create-glyph [MangleName 'powerStandby'] [MangleUnicode 0x23FB] : glyph-proc
 		set-width df.width
@@ -50,8 +50,8 @@ glyph-block Symbol-Pictograph-IEC-Power-And-Playback : for-width-kinds WideWidth
 			Rect
 				SymbolMid + 1.5 * squareRadiusFW
 				SymbolMid - 0.0 * squareRadiusFW
-				df.middle - GeometryStroke / 2 * HVContrast
-				df.middle + GeometryStroke / 2 * HVContrast
+				df.middle - [HSwToV : 0.5 * GeometryStroke]
+				df.middle + [HSwToV : 0.5 * GeometryStroke]
 
 	create-glyph [MangleName 'powerSleep'] [MangleUnicode 0x23FE] : glyph-proc
 		set-width df.width

--- a/font-src/glyphs/symbol/pictograph/musical.ptl
+++ b/font-src/glyphs/symbol/pictograph/musical.ptl
@@ -30,7 +30,7 @@ glyph-block Symbol-Pictograph-Musical : begin
 		include : Regizmo
 
 	create-glyph 'crotchet' 0x2669 : union
-		MusicalNoteAt noteSize (Middle + noteSize / 6 + fine / 2 * HVContrast) commonNoteBottom
+		MusicalNoteAt noteSize (Middle + noteSize / 6 + [HSwToV : 0.5 * fine]) commonNoteBottom
 		VBar.m (Middle + noteSize / 6) commonNoteBottom PictTop fine
 
 	create-glyph 'quaver' 0x266A : glyph-proc

--- a/font-src/glyphs/symbol/pictograph/powerline-and-gui.ptl
+++ b/font-src/glyphs/symbol/pictograph/powerline-and-gui.ptl
@@ -344,7 +344,7 @@ glyph-block Symbol-Pictograph-Powerline-And-GUI : begin
 			create-glyph [MangleName "upPointingHouse"] [MangleUnicode 0x2302] : glyph-proc
 				set-width MosaicWidth
 				include : ChevronUpperHalf true
-				include : HBar.b scaffold.xLeft scaffold.xRight scaffold.stroke
+				include : HBar.b scaffold.xLeft scaffold.xRight scaffold.bot scaffold.stroke
 
 		do "Segmented digits"
 			define scaffold : object

--- a/font-src/glyphs/symbol/punctuation/at.ptl
+++ b/font-src/glyphs/symbol/punctuation/at.ptl
@@ -88,7 +88,7 @@ glyph-block Symbol-Punctuation-At : begin
 					curl m1 (obot + adbInner)
 					arcvh
 				flat df.middle obot
-				curl (df.rightSB - [Math.max ((m2 - m1) / 2) ([HSwToV : 1.5 * sw])]) obot
+				curl (df.rightSB - [Math.max ((m2 - m1) / 2) [HSwToV : 1.5 * sw]]) obot
 				archv
 				flat df.rightSB (obot + [Math.max adaInner (sw * 1.5)])
 				curl df.rightSB (top - adb)

--- a/font-src/glyphs/symbol/punctuation/slashes-and-number-sign.ptl
+++ b/font-src/glyphs/symbol/punctuation/slashes-and-number-sign.ptl
@@ -115,7 +115,7 @@ glyph-block Symbol-Punctuation-Slashes-And-Number-Sign : begin
 
 		define [SlantedDim l r] : begin
 			define hsp : HspT l r
-			define x : hsp + fine / 2 * HVContrast
+			define x : hsp + [HSwToV : 0.5 * fine]
 			define w : (r - l) * 0.15
 			define shift : w / 3
 			return : object hsp x w shift

--- a/font-src/meta/aesthetics.ptl
+++ b/font-src/meta/aesthetics.ptl
@@ -95,8 +95,8 @@ export : define [calculateMetrics para] : begin
 	define Jut para.jut
 	define LongJut para.longjut
 	define VJut para.vjut
-	define MidJutSide   : Math.max Jut : mix ([HSwToV : 0.5 * Stroke]) LongJut 0.5
-	define MidJutCenter : Math.max Jut : mix ([HSwToV : 0.5 * Stroke]) LongJut 0.6
+	define MidJutSide   : Math.max Jut : mix [HSwToV : 0.5 * Stroke] LongJut 0.5
+	define MidJutCenter : Math.max Jut : mix [HSwToV : 0.5 * Stroke] LongJut 0.6
 	define AccentStackOffset para.accentStackOffset
 	define AccentWidth       para.accentWidth
 	define AccentClearance   para.accentClearance


### PR DESCRIPTION
- Replaced some more `HVContrast` code to use `HSwToV`
- Some leftover code in `c.ptl` as I looked into https://github.com/be5invis/Iosevka/issues/1287#issuecomment-1708637055. No actual changes are made.
- Fixed a minor error with `upPointingHouse`
- Tried to fix `mCrossedTail` as proposed in #1882
	- Added a `_mid` parameter to a lot of `m`'s functions to control where the middle stem goes.
	- The 3 legs and the tail loop are spaced equally for now.

The result, tested with UltraCondensed and UltraExtended, Thin and Heavy:
Etoile
![image](https://github.com/be5invis/Iosevka/assets/21302803/e953d98f-d386-4303-9b66-35960473208f)
Slab
![image](https://github.com/be5invis/Iosevka/assets/21302803/cab60a77-828b-4044-816f-d1ddbec8dd7b)

* It should build in all (permitted) weight and width settings now.
* However, it may make the glyph a bit awkward in ultra-extended + thin. I need some feedback on this:
    * Should I shift the middle leg back to the center on some variants only? or depending on stroke/width?
    * Should I just fix the leg to the center and let the tail overlap with it?
    * Or should I leave it as is?
* Other variants are also supported:
![image](https://github.com/be5invis/Iosevka/assets/21302803/99f2c057-d896-4296-946c-bcb55df67322)
However, `m` breaks in some variants under ultracondensed. I think it exists before this PR, though I'm not sure.
