### PR TITLE
Optimize shape of Latin Phi, fix doc.

### DIFF
--- a/changes/27.0.0.md
+++ b/changes/27.0.0.md
@@ -7,5 +7,9 @@
   - `upper-r`.`straight-open-motion-serifed` → `upper-r`.`straight-open-top-left-serifed`
   - `upper-r`.`curly-open-motion-serifed` → `upper-r`.`curly-open-top-left-serifed`
   - `upper-r`.`standing-open-motion-serifed` → `upper-r`.`standing-open-top-left-serifed`
+* Add bottom-right and top-left bottom-right serifed variants of `R`.
+* Add top-right, bottom-left, and top-right bottom-left variants of Cyrillic Ya (`Я`,`я`).
+* Allow R Rotunda (`U+A75A`, `U+A75B`) and Indian Rupee Sign (`U+20B9`) to have a bottom-right serif.
 * Add OpenType `zero` feature (#1966).
 * Fix broken geometry of `U+AB3A` under condensed width.
+* Improve bowl shape of Latin Phi (`U+0278`).

--- a/changes/archives/26.x/26.3.3.md
+++ b/changes/archives/26.x/26.3.3.md
@@ -2,9 +2,6 @@
   - `lower-alpha`.`tailed-barred` → `lower-alpha`.`barred-tailed`
   - `lower-alpha`.`tailed-barred-earless-corner` → `lower-alpha`.`barred-earless-corner-tailed`
 * Add barred-serifed and barred-earless-rounded variants for Greek Alpha (`α`).
-* Add bottom-right and top-left bottom-right serifed variants of `R`.
-* Add top-right, bottom-left, and top-right bottom-left variants of Cyrillic Ya (`Я`,`я`).
-* Allow R Rotunda (`U+A75A`, `U+A75B`) and Indian Rupee Sign (`U+20B9`) to have a bottom-right serif.
 * Remove serifs in `U+0320` (#1979).
 * Harmonize dot sizes in ellipsis shapes (#1980).
 * Make italic Cyrillic Small Pe with Middle Hook (`U+04A7`) follow variants of `n` (#1983).
@@ -18,6 +15,6 @@
 * Fix `cv28` and `cv68` for `ss02` and `ss17` under italics.
 * Fix `cv30` for `ss04` under italics.
 * Fix `cv42` for `ss13`.
-* Fix `cv69` and `cv70` for `ss15` and `ss17`.
+* Fix `cv69` and `cv70` for `ss17`.
 * Fix `cv77` and `cv78` for `ss15` under italics.
 * Fix serifs of `w` for `ss15` under upright slab.

--- a/font-src/glyphs/letter/greek/upper-phi.ptl
+++ b/font-src/glyphs/letter/greek/upper-phi.ptl
@@ -46,6 +46,14 @@ glyph-block Letter-Greek-Upper-Phi : begin
 		include : VBar.m df.middle Descender HalfStroke
 		include : VBar.m df.middle (XH - HalfStroke) Ascender
 
+	create-glyph 'latn/phi' 0x278 : glyph-proc
+		local df : include : DivFrame para.diversityM 3
+		include [refer-glyph 'grek/varphi'] AS_BASE ALSO_METRICS
+
+		if SLAB : begin
+			include : tagged 'serifMT' : HSerif.lt df.middle Ascender Jut
+			include : tagged 'serifMB' : HSerif.mb df.middle Descender Jut
+
 	create-glyph 'cyrl/ef.serifless' : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.bp
@@ -93,4 +101,3 @@ glyph-block Letter-Greek-Upper-Phi : begin
 			curl xBarRight (0 - O)
 
 	select-variant 'cyrl/ef' 0x444
-	select-variant 'latn/phi' 0x278 (shapeFrom -- 'cyrl/ef')

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -5347,22 +5347,6 @@ selector."cyrl/ef"  = "serifed"
 
 
 
-[prime.latn-phi]
-# Untagged -- shape change only
-[prime.latn-phi.variants.serifless]
-rank = 1
-selector."latn/phi"  = "serifless"
-
-[prime.latn-phi.variants.top-serifed]
-rank = 2
-selector."latn/phi"  = "topSerifed"
-
-[prime.latn-phi.variants.serifed]
-rank = 3
-selector."latn/phi"  = "serifed"
-
-
-
 [prime.cyrl-che]
 sampler = "ч"
 samplerExplain = "Cyrillic Lower Che"
@@ -6928,7 +6912,6 @@ x = "straight-serifless"
 z = "straight-serifless"
 # Non-latin
 long-s = "bent-hook-serifless"
-latn-phi = "serifless"
 lower-thorn = "serifless"
 lower-alpha = "crossing"
 lower-delta = "rounded"
@@ -7077,7 +7060,6 @@ x = "straight-serifed"
 z = "straight-serifed"
 one = "base"
 seven = "straight-serifed"
-latn-phi = "serifed"
 lower-thorn = "serifed"
 long-s = "bent-hook-bottom-serifed"
 capital-gamma = "serifed"
@@ -7127,7 +7109,6 @@ x = "cursive"
 y = "cursive-motion-serifed"
 z = "cursive"
 eszet = "sulzbacher-tailed-serifless"
-latn-phi = "serifed"
 long-s = "flat-hook-tailed"
 lower-mu = "tailed-motion-serifed"
 cyrl-ze = "unilateral-inward-serifed"


### PR DESCRIPTION
Latin Phi should be based on the straight Greek Phi Symbol but with serifs when under slab.
This also solves the problem with the orphaned Latin Phi variant selector which didn't get used in the customizer but selected serif variants at compile time.

Additionally, correct the change log of 26.3.3 which was erroneously edited after its release and before the file was archived.

Latin Phi vs. Greek Phi Symbol vs. Cyrillic Ef:
`ɸϕф`
Sans Upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/2f2da4ff-584d-43a6-85d5-74037bdc7eec)
Sans Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/0ae8a67c-8db9-4456-9a89-a5beff051d4a)
Slab Upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/d125c4e3-3a44-4780-bd0a-3fea1b37cba7)
Slab Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/64aa7198-7987-4048-934f-2aab93682012)
