### PR TITLE
Fix dot radius for combining ellipsis above/below, add combining ring overlay.

### DIFF
--- a/changes/27.0.0.md
+++ b/changes/27.0.0.md
@@ -7,9 +7,12 @@
   - `upper-r`.`straight-open-motion-serifed` → `upper-r`.`straight-open-top-left-serifed`
   - `upper-r`.`curly-open-motion-serifed` → `upper-r`.`curly-open-top-left-serifed`
   - `upper-r`.`standing-open-motion-serifed` → `upper-r`.`standing-open-top-left-serifed`
+* Add characters:
+  - COMBINING RING OVERLAY (`U+20D8`).
 * Add bottom-right and top-left bottom-right serifed variants of `R`.
 * Add top-right, bottom-left, and top-right bottom-left variants of Cyrillic Ya (`Я`,`я`).
 * Allow R Rotunda (`U+A75A`, `U+A75B`) and Indian Rupee Sign (`U+20B9`) to have a bottom-right serif.
 * Add OpenType `zero` feature (#1966).
 * Fix broken geometry of `U+AB3A` under condensed width.
 * Improve bowl shape of Latin Phi (`U+0278`).
+* Fix dot radius of COMBINING THREE DOTS ABOVE (`U+20DB`), COMBINING FOUR DOTS ABOVE (`U+20DC`), and COMBINING TRIPLE UNDERDOT (`U+20D8`).

--- a/font-src/glyphs/marks/above.ptl
+++ b/font-src/glyphs/marks/above.ptl
@@ -84,18 +84,22 @@ glyph-block Mark-Above : begin
 
 		create-glyph "elipsisAbove.\(suffix)" : glyph-proc
 			set-width 0
-			include : StdAnchors.impl 'above' 0 1.5
-			include : DrawAt (markMiddle - markExtend * 1.5) aboveMarkMid (markDotsRadius * kdr)
-			include : DrawAt  markMiddle                     aboveMarkMid (markDotsRadius * kdr)
-			include : DrawAt (markMiddle + markExtend * 1.5) aboveMarkMid (markDotsRadius * kdr)
+			include : StdAnchors.wide
+			local fine : Math.min (markDotsRadius * kdr) (markExtend * 0.375)
+			local coFine : markExtend * 1.5 - fine
+			include : DrawAt (markMiddle - coFine) aboveMarkMid fine
+			include : DrawAt  markMiddle           aboveMarkMid fine
+			include : DrawAt (markMiddle + coFine) aboveMarkMid fine
 
 		create-glyph "fourDotsAbove.\(suffix)" : glyph-proc
 			set-width 0
-			include : StdAnchors.impl 'above' 0 2
-			include : DrawAt (markMiddle - markExtend * 2)     aboveMarkMid (markDotsRadius * kdr)
-			include : DrawAt (markMiddle - markExtend * 2 / 3) aboveMarkMid (markDotsRadius * kdr)
-			include : DrawAt (markMiddle + markExtend * 2 / 3) aboveMarkMid (markDotsRadius * kdr)
-			include : DrawAt (markMiddle + markExtend * 2)     aboveMarkMid (markDotsRadius * kdr)
+			include : StdAnchors.extraWide
+			local fine : Math.min (markDotsRadius * kdr) (markExtend * 0.3125)
+			local coFine : markExtend * 2 - fine
+			include : DrawAt (markMiddle - coFine)     aboveMarkMid fine
+			include : DrawAt (markMiddle - coFine / 3) aboveMarkMid fine
+			include : DrawAt (markMiddle + coFine / 3) aboveMarkMid fine
+			include : DrawAt (markMiddle + coFine)     aboveMarkMid fine
 
 	select-variant 'dotAbove'             0x307 (follow -- 'diacriticDot')
 	select-variant 'dieresisAbove'        0x308 (follow -- 'diacriticDot')

--- a/font-src/glyphs/marks/overlay.ptl
+++ b/font-src/glyphs/marks/overlay.ptl
@@ -112,7 +112,7 @@ glyph-block Mark-Overlay : begin
 			set-mark-anchor 'overlay' markMiddle (XH / 2) markMiddle (XH / 2)
 			include : FlatSlashShape markMiddle (XH / 2) (0.5 * OverlayStroke) (0.75) (-0.3)
 
-		create-glyph 'ringOver' : glyph-proc
+		create-glyph 'ringOver' 0x20D8 : glyph-proc
 			set-width 0
 			set-mark-anchor 'overlay' 0 0 0 0
 			include : RingShape 0 0 tildeHalfWidth


### PR DESCRIPTION
Credit to @Logo121 for actually implementing the combining ring overlay, all I did was formally assign it to the real Unicode character.
```
◌̇ ◌̈ ◌⃛ ◌⃜ ◌̣ ◌̤ ◌⃨
◌̇᪻ ◌̈᪻ ◌⃛᪻ ◌⃜᪻ ◌̣᪽ ◌̤᪽ ◌⃨᪽
◌̊◌⃘◌̥
```
Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/5507f904-5b80-4753-a7a4-38630a330077)
Heavy:
![image](https://github.com/be5invis/Iosevka/assets/37010132/30f17bdb-530b-46b5-bf38-6dd27e90eea8)
Thin:
![image](https://github.com/be5invis/Iosevka/assets/37010132/891d51e9-1105-4f64-a9ea-178cf3ba3ec7)
