### PR TITLE
Add cursive Zhe variant, scale back Ya variants

### DIFF
--- a/changes/27.0.0.md
+++ b/changes/27.0.0.md
@@ -10,7 +10,8 @@
 * Add characters:
   - COMBINING RING OVERLAY (`U+20D8`).
 * Add bottom-right and top-left bottom-right serifed variants of `R`.
-* Add top-right, bottom-left, and top-right bottom-left variants of Cyrillic Ya (`Я`,`я`).
+* Add bottom-left motion serifed variants of Cyrillic Ya (`Я`,`я`).
+* Add cursive variants for Cyrillic Capital/Small Zhe (`Ж`,`ж`) (#1762).
 * Allow R Rotunda (`U+A75A`, `U+A75B`) and Indian Rupee Sign (`U+20B9`) to have a bottom-right serif.
 * Add OpenType `zero` feature (#1966).
 * Fix broken geometry of `U+AB3A` under condensed width.

--- a/font-src/glyphs/letter/cyrillic/dzzhe-zhwe.ptl
+++ b/font-src/glyphs/letter/cyrillic/dzzhe-zhwe.ptl
@@ -84,9 +84,9 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 
 	do "zhe subglyphs"
 		glyph-block-import Letter-Cyrillic-Zhe : Zhe
-		define [CyrRightZheShape legShape fSlab df top barLeft] : glyph-proc
+		define [CyrRightZheShape legShape fSlab fMidSlab df top barLeft] : glyph-proc
 			local [object subDf shift sw] : SubDfDim 1 3 df OX
-			include : with-transform [ApparentTranslate shift 0] : Zhe.HalfShape legShape fSlab subDf 0 top top
+			include : with-transform [ApparentTranslate shift 0] : Zhe.HalfShape legShape fSlab fMidSlab subDf 0 top top
 			include : HBar.m barLeft (shift + subDf.middle) (0.5 * top) sw
 
 		define [DzzheLeft df] : begin
@@ -94,51 +94,52 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 			local swInner : sw * [AdviceStroke 2.75] / Stroke
 			return : [mix subDf.leftSB subDf.rightSB : StrokeWidthBlend 0.95 0.96] - [HSwToV : 0.5 * swInner]
 
-		define [ZhweZheShape legShape fSlab df top hook] : glyph-proc
+		define [ZhweZheShape legShape fSlab fMidSlab df top hook] : glyph-proc
 			local [object subDf sw] : SubDfDim 0 2 df OX
 			local ze : CyrZe 0 0 top 0 subDf.leftSB subDf.rightSB 0.65 hook (0.5 * sw)
-			include : difference [CyrRightZheShape legShape fSlab df top subDf.middle] [ze.ShapeMask]
+			include : difference [CyrRightZheShape legShape fSlab fMidSlab df top subDf.middle] [ze.ShapeMask]
 
 		glyph-block-import Letter-Cyrillic-De : CyrDeItalicShapeT
-		define [DzzheZheItalicShape legShape fSlab df] : glyph-proc
+		define [DzzheZheItalicShape legShape fSlab fMidSlab df top] : glyph-proc
 			local [object subDf sw] : SubDfDim 0 2 df OX
 			include : difference
-				CyrRightZheShape legShape fSlab df XH subDf.middle
+				CyrRightZheShape legShape fSlab fMidSlab df top subDf.middle
 				CyrDeItalicShapeT spiro-outline subDf sw
 
 		define ZheConfig : object
-			straight            { Zhe.StraightLegs   SLAB }
-			curly               { Zhe.CurlyLegs      SLAB }
-			symmetricTouching   { Zhe.TouchingLegs   SLAB }
-			symmetricConnected  { Zhe.ConnectingLegs SLAB }
+			straight            { Zhe.StraightLegs   SLAB  SLAB }
+			curly               { Zhe.CurlyLegs      SLAB  SLAB }
+			symmetricTouching   { Zhe.TouchingLegs   SLAB  SLAB }
+			symmetricConnected  { Zhe.ConnectingLegs SLAB  SLAB }
+			cursive             { Zhe.CursiveLegs    false SLAB }
 
-		foreach { suffix { legShape fSlab } } [Object.entries ZheConfig] : do
+		foreach { suffix { legShape fSlab fMidSlab } } [Object.entries ZheConfig] : do
 			create-glyph "cyrl/Dzzhe/right.\(suffix)" : glyph-proc
 				define df : include : DivFrame para.diversityM 3.5
 				include : df.markSet.capital
-				include : CyrRightZheShape legShape fSlab df CAP : DzzheLeft df
+				include : CyrRightZheShape legShape fSlab fMidSlab df CAP : DzzheLeft df
 
 			create-glyph "cyrl/dzzhe.upright/right.\(suffix)" : glyph-proc
 				define df : include : DivFrame para.diversityM 3.5
 				include : df.markSet.e
-				include : CyrRightZheShape legShape fSlab df XH : DzzheLeft df
+				include : CyrRightZheShape legShape fSlab fMidSlab df XH : DzzheLeft df
 
 			create-glyph "cyrl/dzzhe.italic/right.\(suffix)" : glyph-proc
 				define df : include : DivFrame para.diversityM 3.5
 				include : df.markSet.e
-				include : DzzheZheItalicShape legShape fSlab df
+				include : DzzheZheItalicShape legShape fSlab fMidSlab df XH
 
 			create-glyph "cyrl/Zhwe/right.\(suffix)" : glyph-proc
 				define df : include : DivFrame para.diversityM 3.5
 				include : df.markSet.capital
 				set-base-anchor 'cvDecompose' 0 0
-				include : ZhweZheShape legShape fSlab df CAP Hook
+				include : ZhweZheShape legShape fSlab fMidSlab df CAP Hook
 
 			create-glyph "cyrl/zhwe/right.\(suffix)" : glyph-proc
 				define df : include : DivFrame para.diversityM 3.5
 				include : df.markSet.e
 				set-base-anchor 'cvDecompose' 0 0
-				include : ZhweZheShape legShape fSlab df XH SHook
+				include : ZhweZheShape legShape fSlab fMidSlab df XH SHook
 
 	select-variant "cyrl/Dzzhe/right" (follow -- "cyrl/Zhe")
 	select-variant "cyrl/dzzhe.upright/right" (follow -- "cyrl/zhe")

--- a/font-src/glyphs/letter/cyrillic/zhe.ptl
+++ b/font-src/glyphs/letter/cyrillic/zhe.ptl
@@ -140,27 +140,51 @@ glyph-block Letter-Cyrillic-Zhe : begin
 
 			return : union fullShape : HBar.m [if fHalf df.middle midX] (df.width - midX) midY fine
 
-		export : define [Shape Legs fSlab df bot top midTop] : glyph-proc
-			include : CenterBar fSlab df bot midTop
+		export : define [CursiveLegs fSlab fHalf df bot top] : begin
+			define fine : ZheSw df
+			define midX : mix df.leftSB (df.middle - [HSwToV : 0.5 * fine]) 0.4
+			define midY : mix bot top 0.5
+			define overshoot : Overshoot fSlab df
+
+			local rightShape : dispiro
+					g4.left.start (df.rightSB - overshoot) (top - fine) [widths.rhs.heading fine Leftward]
+					archv
+					g4.down.mid (df.width - midX + OX) midY [heading Downward]
+					arcvh
+					g4.right.end (df.rightSB - overshoot) (bot + fine) [heading Rightward]
+
+			local fullShape : if fHalf rightShape : union rightShape
+				dispiro
+					g4.right.start (df.leftSB + overshoot) (top - fine) [widths.lhs.heading fine Rightward]
+					archv
+					g4.down.mid (midX - OX) midY [heading Downward]
+					arcvh
+					g4.left.end (df.leftSB + overshoot) (bot + fine) [heading Leftward]
+
+			return : union fullShape : HBar.m [if fHalf df.middle (midX + 0.5 * fine)] (df.width - (midX + 0.5 * fine)) midY fine
+
+		export : define [Shape Legs fSlab fMidSlab df bot top midTop] : glyph-proc
+			include : CenterBar fMidSlab    df bot midTop
 			include : Legs      fSlab false df bot top
 			include : LegSerifs fSlab false df bot top
 
-		export : define [HalfShape Legs fSlab df bot top] : glyph-proc
-			include : CenterBar fSlab df bot top
+		export : define [HalfShape Legs fSlab fMidSlab df bot top midTop] : glyph-proc
+			include : CenterBar fMidSlab   df bot midTop
 			include : Legs      fSlab true df bot top
 			include : LegSerifs fSlab true df bot top
 
 	define ZheConfig : object
-		straight            { Zhe.StraightLegs   SLAB }
-		curly               { Zhe.CurlyLegs      SLAB }
-		symmetricTouching   { Zhe.TouchingLegs   SLAB }
-		symmetricConnected  { Zhe.ConnectingLegs SLAB }
+		straight            { Zhe.StraightLegs   SLAB  SLAB }
+		curly               { Zhe.CurlyLegs      SLAB  SLAB }
+		symmetricTouching   { Zhe.TouchingLegs   SLAB  SLAB }
+		symmetricConnected  { Zhe.ConnectingLegs SLAB  SLAB }
+		cursive             { Zhe.CursiveLegs    false SLAB }
 
-	foreach { suffix { legShape fSlab } } [Object.entries ZheConfig] : do
+	foreach { suffix { legShape fSlab fMidSlab } } [Object.entries ZheConfig] : do
 		create-glyph "cyrl/Zhe.\(suffix)" : glyph-proc
 			define df : include : DivFrame para.diversityM 3
 			include : df.markSet.capital
-			include : Zhe.Shape legShape fSlab df 0 CAP CAP
+			include : Zhe.Shape legShape fSlab fMidSlab df 0 CAP CAP
 
 		create-glyph "cyrl/ZheDescender.\(suffix)" : glyph-proc
 			local df : DivFrame para.diversityM 3
@@ -170,7 +194,7 @@ glyph-block Letter-Cyrillic-Zhe : begin
 		create-glyph "cyrl/zhe.\(suffix)" : glyph-proc
 			define df : include : DivFrame para.diversityM 3
 			include : df.markSet.e
-			include : Zhe.Shape legShape fSlab df 0 XH XH
+			include : Zhe.Shape legShape fSlab fMidSlab df 0 XH XH
 
 		create-glyph "cyrl/zheDescender.\(suffix)" : glyph-proc
 			local df : DivFrame para.diversityM 3
@@ -180,7 +204,7 @@ glyph-block Letter-Cyrillic-Zhe : begin
 		create-glyph "cyrl/zhe.BGR.\(suffix)" : glyph-proc
 			define df : include : DivFrame para.diversityM 3
 			include : df.markSet.b
-			include : Zhe.Shape legShape fSlab df 0 XH Ascender
+			include : Zhe.Shape legShape fSlab fMidSlab df 0 XH Ascender
 
 	select-variant 'cyrl/Zhe'          0x416
 	select-variant 'cyrl/ZheDescender' 0x496 (follow -- 'cyrl/Zhe')

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -4783,23 +4783,28 @@ tagKind = "letter"
 
 [prime.cyrl-capital-zhe.variants.straight]
 rank = 1
-description = "Cyrillic Capital Lower Zhe (`Ж`) with straight legs"
+description = "Cyrillic Capital Zhe (`Ж`) with straight legs"
 selector."cyrl/Zhe" = "straight"
 
 [prime.cyrl-capital-zhe.variants.curly]
 rank = 2
-description = "Cyrillic Capital Lower Zhe (`Ж`) with curly legs"
+description = "Cyrillic Capital Zhe (`Ж`) with curly legs"
 selector."cyrl/Zhe" = "curly"
 
 [prime.cyrl-capital-zhe.variants.symmetric-touching]
 rank = 3
-description = "Cyrillic Capital Lower Zhe (`Ж`) with symmetric legs touching the vertical bar"
+description = "Cyrillic Capital Zhe (`Ж`) with symmetric legs touching the vertical bar"
 selector."cyrl/Zhe" = "symmetricTouching"
 
 [prime.cyrl-capital-zhe.variants.symmetric-connected]
 rank = 4
-description = "Cyrillic Capital Lower Zhe (`Ж`) with symmetric legs connected to the vertical bar"
+description = "Cyrillic Capital Zhe (`Ж`) with symmetric legs connected to the vertical bar"
 selector."cyrl/Zhe" = "symmetricConnected"
+
+[prime.cyrl-capital-zhe.variants.cursive]
+rank = 5
+description = "Cyrillic Capital Zhe (`Ж`) with cursive legs"
+selector."cyrl/Zhe" = "cursive"
 
 
 
@@ -4827,6 +4832,11 @@ selector."cyrl/zhe" = "symmetricTouching"
 rank = 4
 description = "Cyrillic Lower Zhe (`ж`) with symmetric legs connected to the vertical bar"
 selector."cyrl/zhe" = "symmetricConnected"
+
+[prime.cyrl-zhe.variants.cursive]
+rank = 5
+description = "Cyrillic Lower Zhe (`ж`) with cursive legs"
+selector."cyrl/zhe" = "cursive"
 
 
 
@@ -5523,23 +5533,13 @@ descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix."cyrl/Ya" = "serifless"
 
-[prime.cyrl-capital-ya.variants-buildup.stages.serifs.top-right-serifed]
+[prime.cyrl-capital-ya.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
-descriptionAffix = "serifs at top-right"
-selectorAffix."cyrl/Ya" = "topLeftSerifed"
-
-[prime.cyrl-capital-ya.variants-buildup.stages.serifs.bottom-left-serifed]
-rank = 3
-descriptionAffix = "serifs at bottom-left"
+descriptionAffix = "motion serifs at bottom-left"
 selectorAffix."cyrl/Ya" = "bottomRightSerifed"
 
-[prime.cyrl-capital-ya.variants-buildup.stages.serifs.top-right-and-bottom-left-serifed]
-rank = 4
-descriptionAffix = "serifs at top-right and bottom-left"
-selectorAffix."cyrl/Ya" = "topLeftAndBottomRightSerifed"
-
 [prime.cyrl-capital-ya.variants-buildup.stages.serifs.serifed]
-rank = 5
+rank = 3
 descriptionAffix = "serifs"
 selectorAffix."cyrl/Ya" = "serifed"
 
@@ -5610,24 +5610,13 @@ descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix."cyrl/ya" = "serifless"
 
-[prime.cyrl-ya.variants-buildup.stages.serifs.top-right-serifed]
+[prime.cyrl-ya.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
-descriptionAffix = "serifs at top-right"
-selectorAffix."cyrl/ya" = "topLeftSerifed"
-
-[prime.cyrl-ya.variants-buildup.stages.serifs.bottom-left-serifed]
-rank = 3
-descriptionAffix = "serifs at bottom-left"
+descriptionAffix = "motion serifs at bottom-left"
 selectorAffix."cyrl/ya" = "bottomRightSerifed"
 
-[prime.cyrl-ya.variants-buildup.stages.serifs.top-right-and-bottom-left-serifed]
-rank = 4
-disableIf = [{ tails = "tailed" }]
-descriptionAffix = "serifs at top-right and bottom-left"
-selectorAffix."cyrl/ya" = "topLeftAndBottomRightSerifed"
-
 [prime.cyrl-ya.variants-buildup.stages.serifs.serifed]
-rank = 5
+rank = 3
 descriptionAffix = "serifs"
 selectorAffix."cyrl/ya" = "smallCyrl"
 
@@ -8028,6 +8017,7 @@ eszet = "longs-s-lig-tailed-serifless"
 lower-alpha = "barred-earless-corner-tailed"
 lower-mu = "tailed-serifless"
 micro-sign = "tailed-serifless"
+cyrl-zhe = "cursive"
 
 [composite.ss12.slab-override.design]
 capital-d = "more-rounded-bilateral-serifed"
@@ -8255,8 +8245,8 @@ lower-lambda = "straight-turn"
 cyrl-capital-ka = "symmetric-connected-bottom-right-serifed"
 cyrl-ka = "symmetric-connected-bottom-right-serifed"
 cyrl-capital-u = "straight-turn-serifless"
-cyrl-capital-ya = "straight-bottom-left-serifed"
-cyrl-ya = "straight-bottom-left-serifed"
+cyrl-capital-ya = "straight-motion-serifed"
+cyrl-ya = "straight-motion-serifed"
 zero = "dotted"
 one = "base"
 two = "straight-neck"
@@ -8295,6 +8285,7 @@ long-s = "flat-hook-diagonal-tailed-middle-serifed"
 lower-iota = "serifed-diagonal-tailed"
 lower-lambda = "straight"
 lower-tau = "diagonal-tailed"
+cyrl-zhe = "cursive"
 cyrl-yeri = "cursive"
 cyrl-yery = "cursive"
 ampersand = "closed"
@@ -8442,8 +8433,7 @@ lower-lambda = "straight-turn"
 cyrl-capital-ze = "unilateral-inward-serifed"
 cyrl-capital-ka = "symmetric-connected-bottom-right-serifed"
 cyrl-capital-u = "straight-turn-serifless"
-cyrl-capital-ya = "straight-top-right-and-bottom-left-serifed"
-cyrl-ya = "straight-top-right-serifed"
+cyrl-capital-ya = "straight-motion-serifed"
 one = "base"
 four = "semi-open"
 five = "oblique-upper-left-bar"
@@ -8490,7 +8480,7 @@ eszet = "longs-s-lig-descending-serifless"
 lower-lambda = "straight"
 cyrl-ze = "unilateral-inward-serifed"
 cyrl-ka = "symmetric-connected-bottom-right-serifed"
-cyrl-ya = "straight-bottom-left-serifed"
+cyrl-ya = "straight-motion-serifed"
 
 [composite.ss17.slab-override.design]
 capital-u = "toothed-serifed"


### PR DESCRIPTION
Closes #1762

I don't know if there's any further optimization that can be done but I got it to behave under the upper and lower weight extremes.

`ЖжԪԫꚄꚅ`
Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/41e9b2df-29c1-4008-8132-a6f7c5bc0ee7)
Heavy:
![image](https://github.com/be5invis/Iosevka/assets/37010132/f540cb65-5240-4c5b-b7d0-4c1983c86d32)
Thin:
![image](https://github.com/be5invis/Iosevka/assets/37010132/b10989f4-6bd5-4801-a35c-c0a672a23f2f)
Additionally, I feel like my top-right serifed variants were a bit frivolous for Cyrillic Ya, especially since Italic and Bulgarian fonts delete that serif, so I reduced them to only those that I've actually seen to exist, and before 27.0.0 comes out and it will be too late to back out:
![image](https://github.com/be5invis/Iosevka/assets/37010132/f75ad6e1-4e1b-4a22-beba-f19806530a88)
![image](https://github.com/be5invis/Iosevka/assets/37010132/ce73baac-126f-495a-98b2-26d614af17f5)
