### PR TITLE
Yr fix, R with long right leg

### DIFF
--- a/changes/27.0.2.md
+++ b/changes/27.0.2.md
@@ -1,3 +1,4 @@
 * Add Characters
   - LATIN LETTER SMALL CAPITAL R WITH RIGHT LEG (`U+AB46`).
 * Fix serifs in `U+01A6`.
+* Optimize geometry for `U+A65A` and `U+A65B` under extended width.

--- a/changes/27.0.2.md
+++ b/changes/27.0.2.md
@@ -1,0 +1,3 @@
+* Add Characters
+  - LATIN LETTER SMALL CAPITAL R WITH RIGHT LEG (`U+AB46`).
+* Fix serifs in `U+01A6`.

--- a/font-src/glyphs/letter/cyrillic/big-yus.ptl
+++ b/font-src/glyphs/letter/cyrillic/big-yus.ptl
@@ -93,7 +93,7 @@ glyph-block Letter-Cyrillic-BigYus : begin
 	create-glyph 'cyrl/blendedYus' 0xA65B : glyph-proc
 		local df : include : DivFrame 1 3
 		include : df.markSet.e
-		include : CyrBlendedYusShape df XH 0.6 (0.6 * 0.65)
+		include : CyrBlendedYusShape df XH 0.625 (0.625 * 0.65)
 
 	define [CyrIotifiedBigYusShape fCapital df top yp] : glyph-proc
 		local gap : (df.width - 2 * df.leftSB - 4 * df.mvs) / 3

--- a/font-src/glyphs/letter/cyrillic/big-yus.ptl
+++ b/font-src/glyphs/letter/cyrillic/big-yus.ptl
@@ -88,12 +88,12 @@ glyph-block Letter-Cyrillic-BigYus : begin
 	create-glyph 'cyrl/BlendedYus' 0xA65A : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.capital
-		include : CyrBlendedYusShape df CAP 0.575 (0.575 * 0.65)
+		include : CyrBlendedYusShape df CAP 0.65 (0.65 * 0.65)
 
 	create-glyph 'cyrl/blendedYus' 0xA65B : glyph-proc
 		local df : include : DivFrame 1 3
 		include : df.markSet.e
-		include : CyrBlendedYusShape df XH 0.55 (0.55 * 0.65)
+		include : CyrBlendedYusShape df XH 0.6 (0.6 * 0.65)
 
 	define [CyrIotifiedBigYusShape fCapital df top yp] : glyph-proc
 		local gap : (df.width - 2 * df.leftSB - 4 * df.mvs) / 3

--- a/font-src/glyphs/letter/latin/upper-p.ptl
+++ b/font-src/glyphs/letter/latin/upper-p.ptl
@@ -97,6 +97,9 @@ glyph-block Letter-Latin-Upper-P : begin
 
 	set PShape.SlabMotion : function [top sw mul] : glyph-proc
 		include : tagged 'serifLT' : HSerif.lt (SB * mul) top SideJut sw
+	set PShape.SlabFullSymmetric : function [top sw mul] : glyph-proc
+		include : tagged 'serifLT' : HSerif.mt (SB * mul + [HSwToV : 0.5 * sw]) top Jut sw
+		include : tagged 'serifLB' : HSerif.mb (SB * mul + [HSwToV : 0.5 * sw]) 0 Jut sw
 	set PShape.SlabSymmetric : function [top sw mul] : glyph-proc
 		include : PShape.SlabMotion top sw mul
 		include : tagged 'serifLB' : HSerif.mb (SB * mul + [HSwToV : 0.5 * sw]) 0 Jut sw

--- a/font-src/glyphs/letter/latin/upper-r.ptl
+++ b/font-src/glyphs/letter/latin/upper-r.ptl
@@ -120,13 +120,13 @@ glyph-block Letter-Latin-Upper-R : begin
 	define [RBarPos charTop slab] : begin PShape.BarPos
 	define [RLegTop charTop sw bp] : (sw / 2) + [PBarPosY charTop sw bp]
 
-	define [RShape] : with-params [legShape top bp [mul 1] [slab null] [legSlab false] [open false]] : glyph-proc
+	define [RShape] : with-params [legShape top bp [mul 1] [slab null] [legSlab false] [open false] [legBottom 0]] : glyph-proc
 		local right : RightSB - O - [if slab (Jut / 8) 0]
 		include : difference
 			PShape top (mul -- mul) (overshoot -- O) (slab -- slab) (bp -- bp)
 			if open [PShape.OpenGap (mul -- mul) (bp -- bp) (top -- top) (bot -- [if fSlabBot Stroke 0])] [glyph-proc]
 		include : difference
-			RLegShapes.(legShape) [RLegTop top Stroke bp] 0 Middle right top legSlab Stroke 0
+			RLegShapes.(legShape) [RLegTop top Stroke bp] legBottom Middle right top legSlab Stroke 0
 			if open [PShape.OpenGap (mul -- mul) (bp -- bp) (top -- top) (bot -- 0) ] [glyph-proc]
 
 	define [RRotundaShape] : with-params [legShape top [mul 1] [pmRotunda 0] [endX Middle] [hook Hook] [pBar 1] [slab null] [legSlab false]] : glyph-proc
@@ -221,12 +221,16 @@ glyph-block Letter-Latin-Upper-R : begin
 			local right (RightSB - O - [if SLAB (Jut / 8) 0])
 
 			include : VBar.l SB (top - 1) CAP
-			include : difference
-				PShape top (mul -- 1) (bp -- bp) (slab -- slabs)
-				if fOpen [PShape.OpenGap (mul -- 1) (bp -- bp) (top -- top) (bot -- [if fSlabBot Stroke 0])] [glyph-proc]
-			include : difference
-				RLegShapes.(legShape) legTop Descender Middle right (top - Descender) doLegSlab Stroke 0
-				if fOpen [PShape.OpenGap (mul -- 1) (bp -- bp) (top -- top) (bot -- 0)] [glyph-proc]
+			include : RShape legShape top (legSlab -- doLegSlab) (bp -- bp) (open -- fOpen) (legBottom -- Descender)
+			include : match slabs
+				[Just PShape.SlabSymmetric] : PShape.SlabFullSymmetric CAP Stroke 1
+				[Just PShape.SlabMotion]    : PShape.SlabMotion        CAP Stroke 1
+				__                          : glyph-proc
+
+		create-glyph "smcpRLongRightLeg.\(suffix)" : glyph-proc
+			include : MarkSet.p
+			include : StrikeAnchor
+			include : RShape legShape XH (slab -- slabs) (legSlab -- doLegSlab) (bp -- bpXH) (open -- fOpen) (legBottom -- Descender)
 
 		if (!slabs && !fOpen) : create-glyph "currency/indianRupeeSign.\(suffix)" : glyph-proc
 			define bp : RBarPos CAP 0
@@ -258,6 +262,7 @@ glyph-block Letter-Latin-Upper-R : begin
 	turned 'invSmcpR' 0x281 'revSmcpR' Middle (XH / 2)
 
 	select-variant 'Yr' 0x1A6 (follow -- 'R')
+	select-variant 'smcpRLongRightLeg' 0xAB46 (follow -- 'R')
 
 	select-variant 'currency/indianRupeeSign' 0x20B9 (follow -- 'RRotunda')
 


### PR DESCRIPTION
![image](https://github.com/be5invis/Iosevka/assets/21302803/af71915c-8880-4937-ad92-76ab9eaff0e3)

* The top-left serif of Yr should be on top of the stem: (chart) ![image](https://github.com/be5invis/Iosevka/assets/21302803/0e8d3e2d-6996-4732-b2e5-e96c0f138ad5)
  * Made some adaptation for Motion variants.
* `U+AB46` is implemented as just a small capital R with long right leg. Other fonts render it with an up-pointing tailed leg, but from the source given by the proposal that seems to just be a consequence of the letter `R` in the same font:
![image](https://github.com/be5invis/Iosevka/assets/21302803/356d218f-86ac-4e51-98b9-e82bee4d7460)
   * (`LATIN LETTER SMALL CAPITAL R WITH RIGHT LEG` seems like a typo in the Unicode standard anyway:) ![image](https://github.com/be5invis/Iosevka/assets/21302803/bbf3debe-8fda-4594-90ab-b162b14d218d)
* Changed Blended Yus a bit so that the horizontal strokes don't stick together in extended width.
