### PR TITLE
Add variants for Cyrillic Ef with split bowl.

### DIFF
--- a/changes/27.0.2.md
+++ b/changes/27.0.2.md
@@ -1,5 +1,6 @@
 * Add Characters
   - LATIN LETTER SMALL CAPITAL R WITH RIGHT LEG (`U+AB46`).
+* Add variants for Cyrillic Ef (`ф`) with a split bowl (#1992).
 * Fix serifs in `U+01A6`.
 * Improve serifs of Turn M (`U+019C`, `U+026F`) under quasi-proportional.
 * Make Turn h (`U+0265`) and Turn M with Long Leg (`U+0270`) follow serif variants of `u`.

--- a/font-src/glyphs/letter/greek/upper-phi.ptl
+++ b/font-src/glyphs/letter/greek/upper-phi.ptl
@@ -1,6 +1,6 @@
 $$include '../../../meta/macros.ptl'
 
-import [mix linreg clamp fallback] from"../../../support/utils.mjs"
+import [mix linreg clamp fallback SuffixCfg] from"../../../support/utils.mjs"
 import [DesignParameters] from"../../../meta/aesthetics.mjs"
 
 glyph-module
@@ -8,7 +8,8 @@ glyph-module
 glyph-block Letter-Greek-Upper-Phi : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : FlatHookDepth
+	glyph-block-import Letter-Shared-Shapes : FlatHookDepth OBarLeft OBarRight
+	glyph-block-import Letter-Latin-Lower-AE-OE : SubDfAndShift
 
 	define [VarPhiRing fFlatTB df y1 y2] : glyph-proc
 		local gap : Math.max df.mvs : 0.25 * (df.rightSB - df.leftSB)
@@ -17,12 +18,63 @@ glyph-block Letter-Greek-Upper-Phi : begin
 			OShapeFlatTB y2 y1 df.leftSB df.rightSB df.mvs (ArchDepthA * df.div) (ArchDepthB * df.div) gap
 			OShape y2 y1 df.leftSB df.rightSB df.mvs (ArchDepthA * df.div) (ArchDepthB * df.div)
 
+	define [CyrlEfSplitRing fFlatTB df y1 y2] : glyph-proc
+		local { subDf } : SubDfAndShift 0 df OX
+		local ada : subDf.archDepthA SmallArchDepth df.mvs
+		local adb : subDf.archDepthB SmallArchDepth df.mvs
+
+		include : VBar.m df.middle y1 y2 df.mvs
+		include : with-transform [ApparentTranslate 0 y1] : union
+			OBarRight.shape
+				top       -- (y2 - y1)
+				left      -- df.leftSB
+				right     -- df.middle + [HSwToV : 0.5 * df.mvs]
+				sw        -- df.mvs
+				ada       -- ada
+				adb       -- adb
+			OBarLeft.shape
+				top       -- (y2 - y1)
+				left      -- df.middle - [HSwToV : 0.5 * df.mvs]
+				right     -- df.rightSB
+				sw        -- df.mvs
+				ada       -- ada
+				adb       -- adb
+
+	define [StraightBar df bot y1 y2 top] : glyph-proc
+		include : VBar.m df.middle bot (y1 + HalfStroke)
+		include : VBar.m df.middle (y2 - HalfStroke) top
+
+	define [CursiveBar df bot y1 y2 top] : glyph-proc
+		local hd : FlatHookDepth df
+
+		local xCrossLeft  : mix 0         df.leftSB   [mix 1 df.div 2]
+		local xCrossRight : mix df.width  df.rightSB  [mix 1 df.div 2]
+
+		local xBarLeft    : df.middle - [HSwToV HalfStroke]
+		local xBarRight   : df.middle + [HSwToV HalfStroke]
+
+		include : dispiro
+			flat xCrossRight top [widths.lhs]
+			curl [Math.min (xBarLeft + hd.x) (xCrossRight - 0.1)] top
+			archv
+			flat xBarLeft [Math.max y2 (top - hd.y)]
+			curl xBarLeft (y2 + O)
+
+		include : dispiro
+			flat xCrossLeft bot [widths.lhs]
+			curl [Math.max (xBarRight - hd.x) (xCrossLeft + 0.1)] bot
+			archv
+			flat xBarRight [Math.min y1 (bot + hd.y)]
+			curl xBarRight (y1 - O)
+
+	define [MtSerif df y] : tagged 'serifMT' : HSerif.lt df.middle y Jut
+	define [MbSerif df y] : tagged 'serifMB' : HSerif.mb df.middle y Jut
+
 	define [GrekCapitalPhiImpl fFlatTB df] : glyph-proc
 		local y1 : mix [if SLAB Stroke 0] [if SLAB (CAP - Stroke) CAP] 0.125
 		local y2 : mix [if SLAB Stroke 0] [if SLAB (CAP - Stroke) CAP] 0.875
 		include : VarPhiRing fFlatTB df y1 y2
-		include : VBar.m df.middle 0 (y1 + HalfStroke)
-		include : VBar.m df.middle (y2 - HalfStroke) CAP
+		include : StraightBar df 0 y1 y2 CAP
 
 		if SLAB : begin
 			include : tagged 'serifMT' : HSerif.mt df.middle CAP MidJutSide
@@ -43,61 +95,41 @@ glyph-block Letter-Greek-Upper-Phi : begin
 		include : df.markSet.bp
 
 		include : VarPhiRing 0 df 0 XH
-		include : VBar.m df.middle Descender HalfStroke
-		include : VBar.m df.middle (XH - HalfStroke) Ascender
+		include : StraightBar df Descender 0 XH Ascender
 
 	create-glyph 'latn/phi' 0x278 : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include [refer-glyph 'grek/varphi'] AS_BASE ALSO_METRICS
 
 		if SLAB : begin
-			include : tagged 'serifMT' : HSerif.lt df.middle Ascender Jut
+			include : tagged 'serifMT' : HSerif.mt df.middle Ascender Jut
 			include : tagged 'serifMB' : HSerif.mb df.middle Descender Jut
 
-	create-glyph 'cyrl/ef.serifless' : glyph-proc
-		local df : include : DivFrame para.diversityM 3
-		include : df.markSet.bp
+	define CyrlEfConfig : SuffixCfg.weave
+		object # bowl
+			""                  VarPhiRing
+			splitBowl           CyrlEfSplitRing
+		object # bar
+			serifless          { StraightBar nothing nothing }
+			topSerifed         { StraightBar MtSerif nothing }
+			serifed            { StraightBar MtSerif MbSerif }
+			cursive            { CursiveBar  nothing nothing }
 
-		include : VarPhiRing 1 df 0 XH
-		include : VBar.m df.middle Descender HalfStroke
-		include : VBar.m df.middle (XH - HalfStroke) Ascender
-
-	create-glyph 'cyrl/ef.topSerifed' : glyph-proc
-		local df : DivFrame para.diversityM 3
-		include [refer-glyph 'cyrl/ef.serifless'] AS_BASE ALSO_METRICS
-		include : tagged 'serifMT' : HSerif.lt df.middle Ascender Jut
-
-	create-glyph 'cyrl/ef.serifed' : glyph-proc
-		local df : DivFrame para.diversityM 3
-		include [refer-glyph 'cyrl/ef.serifless'] AS_BASE ALSO_METRICS
-		include : tagged 'serifMT' : HSerif.lt df.middle Ascender Jut
-		include : tagged 'serifMB' : HSerif.mb df.middle Descender Jut
-
-	create-glyph 'cyrl/ef.cursive' : glyph-proc
-		local df : include : DivFrame para.diversityM 3
-		include : df.markSet.bp
-
-		include : VarPhiRing 1 df 0 XH
-		local hd : FlatHookDepth df
-
-		local xCrossLeft  : mix 0         df.leftSB   [mix 1 df.div 2]
-		local xCrossRight : mix df.width  df.rightSB  [mix 1 df.div 2]
-
-		local xBarLeft    : df.middle - [HSwToV HalfStroke]
-		local xBarRight   : df.middle + [HSwToV HalfStroke]
-
-		include : dispiro
-			flat xCrossRight Ascender [widths.lhs]
-			curl [Math.min (xBarLeft + hd.x) (xCrossRight - 0.1)] Ascender
-			archv
-			flat xBarLeft [Math.max XH (Ascender - hd.y)]
-			curl xBarLeft (XH + O)
-
-		include : dispiro
-			flat xCrossLeft Descender [widths.lhs]
-			curl [Math.max (xBarRight - hd.x) (xCrossLeft + 0.1)] Descender
-			archv
-			flat xBarRight [Math.min 0 (Descender + hd.y)]
-			curl xBarRight (0 - O)
+	foreach { suffix { Bowl { Bar sMT sMB } } } [Object.entries CyrlEfConfig] : do
+		create-glyph "cyrl/ef.\(suffix)" : glyph-proc
+			local df : include : DivFrame para.diversityM 3
+			include : df.markSet.bp
+			include : Bowl 1 df 0 XH
+			include : Bar df Descender 0 XH Ascender
+			if sMT : include : sMT df Ascender
+			if sMB : include : sMB df Descender
+		create-glyph "cyrl/ef.BGR.\(suffix)" : glyph-proc
+			local df : include : DivFrame para.diversityM 3
+			include : df.markSet.bp
+			include : VarPhiRing 0 df 0 XH
+			include : Bar df Descender 0 XH Ascender
+			if sMT : include : sMT df Ascender
+			if sMB : include : sMB df Descender
 
 	select-variant 'cyrl/ef' 0x444
+	select-variant 'cyrl/ef.BGR'

--- a/font-src/otl/gsub-locl.ptl
+++ b/font-src/otl/gsub-locl.ptl
@@ -53,6 +53,7 @@ export : define [buildLOCL sink para glyphStore] : begin
 			'cyrl/en'      : glyphStore.ensureExists 'cyrl/en.BGR'
 			'cyrl/pe'      : glyphStore.ensureExists 'cyrl/pe.BGR'
 			'cyrl/te'      : glyphStore.ensureExists 'cyrl/te.BGR'
+			'cyrl/ef'      : glyphStore.ensureExists 'cyrl/ef.BGR'
 			'cyrl/che'     : glyphStore.ensureExists 'cyrl/che.BGR'
 			'cyrl/sha'     : glyphStore.ensureExists 'cyrl/sha.BGR'
 			'cyrl/shcha'   : glyphStore.ensureExists 'cyrl/shcha.BGR'

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -5355,25 +5355,60 @@ sampler = "ф"
 samplerExplain = "Cyrillic Lower Ef"
 tagKind = "letter"
 
-[prime.cyrl-ef.variants.serifless]
+[prime.cyrl-ef.variants-buildup]
+entry = "bowl"
+descriptionLeader = "Cyrillic Lower Ef (`ф`)"
+
+[prime.cyrl-ef.variants-buildup.stages.bowl."*"]
+next = "bar"
+
+[prime.cyrl-ef.variants-buildup.stages.bowl.standard]
 rank = 1
-description = "Cyrillic Lower Ef (`ф`) with standard shape and without serifs"
-selector."cyrl/ef"  = "serifless"
+keyAffix = ""
+selectorAffix."cyrl/ef" = ""
+selectorAffix."cyrl/ef.BGR" = ""
 
-[prime.cyrl-ef.variants.cursive]
+[prime.cyrl-ef.variants-buildup.stages.bowl.split]
 rank = 2
-description = "Cyrillic Lower Ef (`ф`) with cursive shape"
-selector."cyrl/ef"  = "cursive"
+descriptionAffix = "split bowl"
+selectorAffix."cyrl/ef" = "splitBowl"
+selectorAffix."cyrl/ef.BGR" = ""
 
-[prime.cyrl-ef.variants.top-serifed]
+[prime.cyrl-ef.variants-buildup.stages.bar."*"]
+next = "serifs"
+
+[prime.cyrl-ef.variants-buildup.stages.bar.straight]
+rank = 1
+keyAffix = ""
+descriptionAffix = "straight bar"
+selectorAffix."cyrl/ef" = ""
+selectorAffix."cyrl/ef.BGR" = ""
+
+[prime.cyrl-ef.variants-buildup.stages.bar.cursive]
+rank = 2
+next = "END"
+descriptionAffix = "cursive bar"
+selectorAffix."cyrl/ef" = "cursive"
+selectorAffix."cyrl/ef.BGR" = "cursive"
+
+[prime.cyrl-ef.variants-buildup.stages.serifs.serifless]
+rank = 1
+descriptionAffix = "serifs"
+descriptionJoiner = "without"
+selectorAffix."cyrl/ef" = "serifless"
+selectorAffix."cyrl/ef.BGR" = "serifless"
+
+[prime.cyrl-ef.variants-buildup.stages.serifs.top-serifed]
+rank = 2
+descriptionAffix = "serif at top"
+selectorAffix."cyrl/ef" = "topSerifed"
+selectorAffix."cyrl/ef.BGR" = "topSerifed"
+
+[prime.cyrl-ef.variants-buildup.stages.serifs.serifed]
 rank = 3
-description = "Cyrillic Lower Ef (`ф`) with standard shape and serif at top"
-selector."cyrl/ef"  = "topSerifed"
-
-[prime.cyrl-ef.variants.serifed]
-rank = 4
-description = "Cyrillic Lower Ef (`ф`) with standard shape and serifs at top and bottom"
-selector."cyrl/ef"  = "serifed"
+descriptionAffix = "serifs at top and bottom"
+selectorAffix."cyrl/ef" = "serifed"
+selectorAffix."cyrl/ef.BGR" = "serifed"
 
 
 
@@ -7162,6 +7197,7 @@ cyrl-capital-ka = "straight-serifless"
 cyrl-ka = "straight-serifless"
 cyrl-em = "flat-bottom-serifless"
 cyrl-capital-u = "straight-turn-serifless"
+cyrl-ef = "split-serifless"
 zero = "dotted"
 one = "base"
 two = "straight-neck"
@@ -7209,6 +7245,7 @@ cyrl-capital-ka = "straight-serifed"
 cyrl-ka = "straight-serifed"
 cyrl-em = "flat-bottom-serifed"
 cyrl-capital-u = "straight-turn-serifed"
+cyrl-ef = "split-serifed"
 seven = "straight-serifed"
 micro-sign = "toothed-serifed"
 
@@ -7253,6 +7290,7 @@ cyrl-capital-ze = "unilateral-serifed"
 cyrl-capital-ka = "straight-serifless"
 cyrl-ka = "straight-serifless"
 cyrl-capital-u = "straight-turn-serifless"
+cyrl-ef = "split-serifless"
 one = "base"
 two = "straight-neck"
 four = "closed"
@@ -7290,6 +7328,7 @@ cyrl-ze = "unilateral-serifed"
 cyrl-capital-ka = "straight-serifed"
 cyrl-ka = "straight-serifed"
 cyrl-capital-u = "straight-turn-serifed"
+cyrl-ef = "split-serifed"
 micro-sign = "toothed-serifed"
 
 
@@ -7493,6 +7532,7 @@ lower-mu = "toothed-serifless"
 lower-tau = "tailed"
 cyrl-em = "slanted-sides-hanging-serifless"
 cyrl-capital-u = "straight-turn-serifless"
+cyrl-ef = "split-serifless"
 zero = "oval-dotted"
 one = "base"
 two = "straight-neck"
@@ -7535,6 +7575,7 @@ eszet = "longs-s-lig-bottom-serifed"
 lower-mu = "toothed-serifed"
 cyrl-em = "slanted-sides-hanging-serifed"
 cyrl-capital-u = "straight-turn-serifed"
+cyrl-ef = "split-serifed"
 micro-sign = "toothed-serifed"
 
 
@@ -7828,6 +7869,7 @@ lower-alpha = "barred-tailed"
 lower-lambda = "straight-turn"
 cyrl-em = "flat-bottom-serifless"
 cyrl-capital-u = "straight-turn-serifless"
+cyrl-ef = "split-serifless"
 zero = "oval-dotted"
 one = "base-flat-top-serif"
 two = "straight-neck"
@@ -7869,6 +7911,7 @@ long-s = "flat-hook-double-serifed"
 eszet = "longs-s-lig-bottom-serifed"
 cyrl-em = "flat-bottom-serifed"
 cyrl-capital-u = "straight-turn-serifed"
+cyrl-ef = "split-serifed"
 seven = "bend-serifed"
 micro-sign = "tailed-serifed"
 
@@ -8266,6 +8309,7 @@ lower-lambda = "straight-turn"
 cyrl-capital-ka = "symmetric-connected-bottom-right-serifed"
 cyrl-ka = "symmetric-connected-bottom-right-serifed"
 cyrl-capital-u = "straight-turn-serifless"
+cyrl-ef = "split-serifless"
 cyrl-capital-ya = "straight-motion-serifed"
 cyrl-ya = "straight-motion-serifed"
 zero = "dotted"
@@ -8307,6 +8351,7 @@ lower-iota = "serifed-diagonal-tailed"
 lower-lambda = "straight"
 lower-tau = "diagonal-tailed"
 cyrl-zhe = "cursive"
+cyrl-ef = "split-cursive"
 cyrl-yeri = "cursive"
 cyrl-yery = "cursive"
 ampersand = "closed"
@@ -8321,6 +8366,7 @@ eszet = "traditional-flat-hook-dual-serifed"
 cyrl-capital-ka = "symmetric-connected-serifed"
 cyrl-ka = "symmetric-connected-serifed"
 cyrl-capital-u = "straight-turn-serifed"
+cyrl-ef = "split-serifed"
 cyrl-capital-ya = "straight-serifed"
 cyrl-ya = "straight-serifed"
 micro-sign = "toothed-serifed"
@@ -8334,6 +8380,7 @@ w = "cursive-serifed"
 y = "cursive-motion-serifed"
 long-s = "flat-hook-diagonal-tailed-middle-serifed"
 cyrl-ka = "symmetric-connected-top-left-and-bottom-right-serifed"
+cyrl-ef = "split-cursive"
 micro-sign = "toothed-motion-serifed"
 
 
@@ -8378,8 +8425,8 @@ lower-mu = "toothed-bottom-right-serifed"
 cyrl-capital-ze = "bilateral-inward-serifed"
 cyrl-ze = "unilateral-inward-serifed"
 cyrl-ka = "symmetric-connected-bottom-right-serifed"
-cyrl-ef = "top-serifed"
 cyrl-capital-u = "straight-turn-serifless"
+cyrl-ef = "split-top-serifed"
 zero = "slashed"
 one = "base"
 two = "straight-neck"
@@ -8418,8 +8465,8 @@ eszet = "longs-s-lig-dual-serifed"
 lower-thorn = "serifed"
 lower-mu = "toothed-serifed"
 cyrl-ka = "symmetric-connected-serifed"
-cyrl-ef = "serifed"
 cyrl-capital-u = "straight-turn-serifed"
+cyrl-ef = "split-serifed"
 micro-sign = "toothed-serifed"
 
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -5394,7 +5394,6 @@ selectorAffix."cyrl/ef.BGR" = "cursive"
 
 [prime.cyrl-ef.variants-buildup.stages.serifs.serifless]
 rank = 1
-keyAffix = ""
 descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix."cyrl/ef" = "serifless"

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -5370,6 +5370,7 @@ selectorAffix."cyrl/ef.BGR" = ""
 
 [prime.cyrl-ef.variants-buildup.stages.bowl.split]
 rank = 2
+nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "split bowl"
 selectorAffix."cyrl/ef" = "splitBowl"
 selectorAffix."cyrl/ef.BGR" = ""
@@ -5393,6 +5394,7 @@ selectorAffix."cyrl/ef.BGR" = "cursive"
 
 [prime.cyrl-ef.variants-buildup.stages.serifs.serifless]
 rank = 1
+keyAffix = ""
 descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix."cyrl/ef" = "serifless"
@@ -5400,12 +5402,16 @@ selectorAffix."cyrl/ef.BGR" = "serifless"
 
 [prime.cyrl-ef.variants-buildup.stages.serifs.top-serifed]
 rank = 2
+nonBreakingVariantAdditionPriority = 10
+disableIf = [{ bar = "cursive" }]
 descriptionAffix = "serif at top"
 selectorAffix."cyrl/ef" = "topSerifed"
 selectorAffix."cyrl/ef.BGR" = "topSerifed"
 
 [prime.cyrl-ef.variants-buildup.stages.serifs.serifed]
 rank = 3
+nonBreakingVariantAdditionPriority = 20
+disableIf = [{ bar = "cursive" }]
 descriptionAffix = "serifs at top and bottom"
 selectorAffix."cyrl/ef" = "serifed"
 selectorAffix."cyrl/ef.BGR" = "serifed"


### PR DESCRIPTION
Closes #1992 .
Below is Greek Phi Symbol compared with Latin Phi (under slab), Cyrillic Ef, and Cyrillic Ef under a Bulgarian locale:
`ϕɸфф`
![image](https://github.com/be5invis/Iosevka/assets/37010132/8108be9c-3c4b-4901-a228-d9d5fad1e1b3)
below is just Cyrillic Ef, under both default and Bulgarian locales, plus italics:

All SSs under Sans:
![image](https://github.com/be5invis/Iosevka/assets/37010132/58275ff7-7bba-44e6-8711-058ca484d963)
All SSs under Slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/34e09acb-bb67-4baa-b9c0-d78470ad0df9)
