### PR TITLE
Add Bulgarian override for Cyrillic Capital Ef.

### DIFF
--- a/changes/27.0.2.md
+++ b/changes/27.0.2.md
@@ -1,6 +1,7 @@
 * Add Characters
   - LATIN LETTER SMALL CAPITAL R WITH RIGHT LEG (`U+AB46`).
-* Add variants for Cyrillic Ef (`ф`) with a split bowl (#1992).
+* Add variants for Cyrillic lower Ef (`ф`) with a split bowl (#1992).
+* Add Bulgarian local variants for Cyrillic Ef (`Ф`,`ф`).
 * Fix serifs in `U+01A6`.
 * Improve serifs of Turn M (`U+019C`, `U+026F`) under quasi-proportional.
 * Make Turn h (`U+0265`) and Turn M with Long Leg (`U+0270`) follow serif variants of `u`.

--- a/font-src/glyphs/letter/greek/upper-phi.ptl
+++ b/font-src/glyphs/letter/greek/upper-phi.ptl
@@ -8,6 +8,7 @@ glyph-module
 glyph-block Letter-Greek-Upper-Phi : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
+	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors ExtendBelowBaseAnchors
 	glyph-block-import Letter-Shared-Shapes : FlatHookDepth OBarLeft OBarRight
 	glyph-block-import Letter-Latin-Lower-AE-OE : SubDfAndShift
 
@@ -89,6 +90,23 @@ glyph-block Letter-Greek-Upper-Phi : begin
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.capital
 		include : GrekCapitalPhiImpl 1 df
+
+	create-glyph 'cyrl/Ef.BGR' : glyph-proc
+		local df : include : DivFrame para.diversityM 3
+		include : df.markSet.capital
+
+		local top : CAP + Ascender - XH
+		local bot   Descender
+
+		include : ExtendAboveBaseAnchors top
+		include : ExtendBelowBaseAnchors bot
+
+		include : VarPhiRing 0 df 0 CAP
+		include : StraightBar df bot 0 CAP top
+
+		if SLAB : begin
+			include : tagged 'serifMT' : HSerif.mt df.middle top MidJutSide
+			include : tagged 'serifMB' : HSerif.mb df.middle bot MidJutSide
 
 	create-glyph 'grek/varphi' 0x3D5 : glyph-proc
 		local df : include : DivFrame para.diversityM 3

--- a/font-src/glyphs/letter/greek/upper-phi.ptl
+++ b/font-src/glyphs/letter/greek/upper-phi.ptl
@@ -95,8 +95,8 @@ glyph-block Letter-Greek-Upper-Phi : begin
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.capital
 
-		local top : CAP + Ascender - XH
-		local bot   Descender
+		local top : CAP + LongJut - HalfStroke
+		local bot : 0   - LongJut + HalfStroke
 
 		include : ExtendAboveBaseAnchors top
 		include : ExtendBelowBaseAnchors bot

--- a/font-src/otl/gsub-locl.ptl
+++ b/font-src/otl/gsub-locl.ptl
@@ -53,6 +53,7 @@ export : define [buildLOCL sink para glyphStore] : begin
 			'cyrl/en'      : glyphStore.ensureExists 'cyrl/en.BGR'
 			'cyrl/pe'      : glyphStore.ensureExists 'cyrl/pe.BGR'
 			'cyrl/te'      : glyphStore.ensureExists 'cyrl/te.BGR'
+			'cyrl/Ef'      : glyphStore.ensureExists 'cyrl/Ef.BGR'
 			'cyrl/ef'      : glyphStore.ensureExists 'cyrl/ef.BGR'
 			'cyrl/che'     : glyphStore.ensureExists 'cyrl/che.BGR'
 			'cyrl/sha'     : glyphStore.ensureExists 'cyrl/sha.BGR'

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -5402,7 +5402,6 @@ selectorAffix."cyrl/ef.BGR" = "serifless"
 [prime.cyrl-ef.variants-buildup.stages.serifs.top-serifed]
 rank = 2
 nonBreakingVariantAdditionPriority = 10
-disableIf = [{ bar = "cursive" }]
 descriptionAffix = "serif at top"
 selectorAffix."cyrl/ef" = "topSerifed"
 selectorAffix."cyrl/ef.BGR" = "topSerifed"
@@ -5410,7 +5409,6 @@ selectorAffix."cyrl/ef.BGR" = "topSerifed"
 [prime.cyrl-ef.variants-buildup.stages.serifs.serifed]
 rank = 3
 nonBreakingVariantAdditionPriority = 10
-disableIf = [{ bar = "cursive" }]
 descriptionAffix = "serifs at top and bottom"
 selectorAffix."cyrl/ef" = "serifed"
 selectorAffix."cyrl/ef.BGR" = "serifed"


### PR DESCRIPTION
continuation of #2003 .

May be fine tuned later if needed. The important part is that the bowl should be cap height and rest on the baseline. How long the bar should be is not clear.

`OФoф bg:OФoф`

![image](https://github.com/be5invis/Iosevka/assets/37010132/974f8e82-f4f7-4860-b61b-6a42e60d0309)

Example:
![image](https://github.com/be5invis/Iosevka/assets/37010132/c89212b7-4843-442c-8cf1-1cf56cf360c1)


Also remove `disableIf = [{ bar = "cursive"}]` in `prime.cyrl-ef` because it's never used, for the same reason that `serifless` and `cursive` never mix.

The names and order are unchanged:
![image](https://github.com/be5invis/Iosevka/assets/37010132/d3f6e86e-d74e-46e8-9717-b277bfbdf515)

