### PR TITLE
 Add separate variant selector for Cyrillic Lower Er

### DIFF
--- a/changes/27.1.0.md
+++ b/changes/27.1.0.md
@@ -1,4 +1,5 @@
 * Add characters:
   - CYRILLIC CAPITAL LETTER DCHE (`U+052C`) (#1897).
   - CYRILLIC SMALL LETTER DCHE (`U+052D`) (#1897).
-* Add separate variant selector `VXAA` for Cyrillic Lower U (`у`) (#2006).
+* Add separate variant selector `VXAA` for Cyrillic Lower Er (`р`) (#2006).
+* Add separate variant selector `VXAB` for Cyrillic Lower U (`у`) (#2006).

--- a/font-src/glyphs/letter/latin/lower-p.ptl
+++ b/font-src/glyphs/letter/latin/lower-p.ptl
@@ -79,7 +79,7 @@ glyph-block Letter-Latin-Lower-P : begin
 	select-variant 'p' 'p'
 	link-reduced-variant 'p/sansSerif' 'p' MathSansSerif
 	link-reduced-variant 'p/hookTopBase' 'p'
-	select-variant 'cyrl/er' 0x440 (shapeFrom -- 'p') (follow -- 'p')
+	select-variant 'cyrl/er' 0x440 (shapeFrom -- 'p')
 	select-variant "pPalatalHook" 0x1D88 (follow -- 'p')
 
 	select-variant 'thorn' 0xFE

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -5285,6 +5285,62 @@ selectorAffix."cyrl/njeKomi" = "serifedExceptBottomRight"
 
 
 
+[prime.cyrl-er]
+sampler = "р"
+samplerExplain = "Cyrillic Lower Er"
+nonBreakingTagForNewVariantSelector = "VXAA" # REMOVE IN NEXT MAJOR VERSION CHANGE
+tagKind = "letter"
+
+[prime.cyrl-er.variants-buildup]
+entry = "body"
+descriptionLeader = "Cyrillic Lower Er (`р`)"
+
+[prime.cyrl-er.variants-buildup.stages.body."*"]
+next = "serifs"
+
+[prime.cyrl-er.variants-buildup.stages.body.eared]
+rank = 1
+descriptionAffix = "eared shape"
+selectorAffix."cyrl/er" = "eared"
+
+[prime.cyrl-er.variants-buildup.stages.body.earless-corner]
+rank = 2
+descriptionAffix = "earless (cornered) shape"
+selectorAffix."cyrl/er" = "earlessCorner"
+
+[prime.cyrl-er.variants-buildup.stages.body.earless-rounded]
+rank = 3
+descriptionAffix = "earless (rounded) shape"
+selectorAffix."cyrl/er" = "earlessRounded"
+
+[prime.cyrl-er.variants-buildup.stages.serifs.serifless]
+rank = 1
+descriptionAffix = "serifs"
+descriptionJoiner = "without"
+selectorAffix."cyrl/er" = "serifless"
+
+[prime.cyrl-er.variants-buildup.stages.serifs.motion-serifed]
+rank = 2
+enableIf = [{ body = "eared" }]
+descriptionAffix = "motion serifs"
+selectorAffix."cyrl/er" = "motionSerifed"
+
+[prime.cyrl-er.variants-buildup.stages.serifs.serifed__eared]
+rank = 3
+enableIf = [{ body = "eared" }]
+keyAffix = "serifed"
+descriptionAffix = "serifs"
+selectorAffix."cyrl/er" = "serifed"
+
+[prime.cyrl-er.variants-buildup.stages.serifs.serifed__earless]
+rank = 3
+enableIf = [{ body = "NOT eared" }]
+keyAffix = "serifed"
+descriptionAffix = "serifs"
+selectorAffix."cyrl/er" = "bottomSerifed"
+
+
+
 [prime.cyrl-capital-u]
 sampler = "У"
 samplerExplain = "Cyrillic Capital U"
@@ -5353,7 +5409,7 @@ selectorAffix."cyrl/U" = "serifed"
 [prime.cyrl-u]
 sampler = "у"
 samplerExplain = "Cyrillic Lower U"
-nonBreakingTagForNewVariantSelector = "VXAA" # REMOVE IN NEXT MAJOR VERSION CHANGE
+nonBreakingTagForNewVariantSelector = "VXAB" # REMOVE IN NEXT MAJOR VERSION CHANGE
 tagKind = "letter"
 
 [prime.cyrl-u.variants-buildup]
@@ -7048,6 +7104,7 @@ cyrl-ka = "symmetric-connected-serifless"
 cyrl-el = "straight"
 cyrl-em = "hanging-serifless"
 cyrl-en = "serifless"
+cyrl-er = "eared-serifless"
 cyrl-capital-u = "straight-serifless"
 cyrl-u = "straight-serifless"
 cyrl-ef = "serifless"
@@ -7187,6 +7244,7 @@ cyrl-capital-ka = "symmetric-connected-serifed"
 cyrl-ka = "symmetric-connected-serifed"
 cyrl-em = "hanging-serifed"
 cyrl-en = "serifed"
+cyrl-er = "eared-serifed"
 cyrl-capital-u = "straight-turn-serifed"
 cyrl-u = "straight-turn-serifed"
 cyrl-ef = "serifed"
@@ -8533,6 +8591,7 @@ lower-mu = "toothed-bottom-right-serifed"
 cyrl-capital-ze = "bilateral-inward-serifed"
 cyrl-ze = "unilateral-inward-serifed"
 cyrl-ka = "symmetric-connected-bottom-right-serifed"
+cyrl-er = "eared-motion-serifed"
 cyrl-capital-u = "straight-turn-serifless"
 cyrl-u = "straight-turn-serifless"
 cyrl-ef = "split-top-serifed"
@@ -8574,6 +8633,7 @@ eszet = "longs-s-lig-dual-serifed"
 lower-thorn = "serifed"
 lower-mu = "toothed-serifed"
 cyrl-ka = "symmetric-connected-serifed"
+cyrl-er = "eared-serifed"
 cyrl-capital-u = "straight-turn-serifed"
 cyrl-u = "straight-turn-serifed"
 cyrl-ef = "split-serifed"


### PR DESCRIPTION
In the time between the issues #769 and #1426 , Cyrillic Er was already (partially) disunified from `p` to be in harmony with italic pe/te. Adding a separate variant selector satisfies both issues at once by letting the user opt in to (or out of) forcing an eared/earless er against the selected `p` variant.

Below is Cyrillic Lower Er compared with Latin `p` and Greek Rho.

`рpρ`

All SSs under sans-serif:
![image](https://github.com/be5invis/Iosevka/assets/37010132/b1d4779a-84e1-41b4-bea7-31de388dbb41)
All SSs under slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/35547041-bbcd-45b5-9a45-b27b2716278d)
