### PR TITLE
Fix variant selection for Cyrillic Digraph Uk

### DIFF
--- a/font-src/glyphs/auto-build/composite.ptl
+++ b/font-src/glyphs/auto-build/composite.ptl
@@ -1208,8 +1208,8 @@ glyph-block Autobuild-Ligatures : begin
 		list 0x1F1 { 'D' 'Z' }
 		list 0x1F2 { 'D' 'z' }
 		list 0x1F3 { 'd' 'z' }
-		list 0x478 { 'O' 'y' }
-		list 0x479 { 'o' 'y' }
+		list 0x478 { 'cyrl/O' 'cyrl/u' }
+		list 0x479 { 'cyrl/o' 'cyrl/u' }
 		list 0x20A7 { 'P' 't' }
 		list 0x20A8 { 'R' 's' }
 		list 0x20AF { 'D' 'grek/rho' }


### PR DESCRIPTION
Cyrillic U and `y` are no longer interchangeable.
