### PR TITLE
fix(utility): correct the format of generated hash values and file names

### DIFF
--- a/utility/create-sha-file.mjs
+++ b/utility/create-sha-file.mjs
@@ -24,7 +24,7 @@ export default (async function (out, archiveFiles) {
 	const filesToAnalyze = Array.from(new Set(archiveFiles.map(f => f.full))).sort();
 	let s = "";
 	for (const file of filesToAnalyze) {
-		s += `${file.base}\t${await hashFile(file)}\n`;
+		s += `${await hashFile(file)}\t${file.name}\n`;
 	}
 	await fs.promises.writeFile(out, s);
 });


### PR DESCRIPTION
Fix a bug in the utility/create-sha-file.mjs module that caused the generated hash values to have an incorrect format and the file names to be undefined. Use the file.name property instead of the file.base property to get the correct file name. Append the hash value before the file name, separated by a tab character, to match the expected format.