### PR TITLE
Fix toothedness of Serbian Cyrillic Pe to match Te.

### DIFF
--- a/changes/27.1.0.md
+++ b/changes/27.1.0.md
@@ -7,3 +7,4 @@
 * Add separate variant selector `VXAA` for Cyrillic Lower Er (`р`) (#2006).
 * Add separate variant selector `VXAB` for Cyrillic Lower U (`у`) (#2006).
 * Add flat middle stroke variant for `5` (#1995).
+* Fix variants for Serbian Cyrillic Lower Pe (`п`).

--- a/font-src/glyphs/letter/greek/pi.ptl
+++ b/font-src/glyphs/letter/greek/pi.ptl
@@ -50,10 +50,6 @@ glyph-block Letter-Greek-Pi : begin
 		include : MarkSet.e
 		include : PiShape [DivFrame 1] XH 0 (shrinkRate -- 0) (doSerif -- SLAB)
 
-	derive-glyphs 'cyrl/pe.SRB' null 'u' : lambda [src gr] : glyph-proc
-		include [refer-glyph src] AS_BASE
-		include : refer-glyph "macronAbove"
-
 	derive-composites 'cyrl/PeDescender' 0x524 'cyrl/Pe' [CyrDescender.rSideJut RightSB 0]
 	derive-composites 'cyrl/peDescender.upright' null 'cyrl/pe.upright' [CyrDescender.rSideJut RightSB 0]
 

--- a/font-src/glyphs/letter/latin/u.ptl
+++ b/font-src/glyphs/letter/latin/u.ptl
@@ -251,6 +251,10 @@ glyph-block Letter-Latin-U : begin
 		refer-glyph 'breveAbove'
 		CyrTailDescender.rSideJut RightSB 0
 
+	derive-glyphs 'cyrl/pe.SRB' null 'cyrl/i.italic' : lambda [src gr] : glyph-proc
+		include [refer-glyph src] AS_BASE ALSO_METRICS
+		include [refer-glyph 'macronAbove']
+
 	derive-composites 'uRTailBR' 0x1D99 'u/uRTailBase'
 		RetroflexHook.rSideJut RightSB 0 (yOverflow -- Stroke)
 

--- a/utility/generate-samples/templates/languages.mjs
+++ b/utility/generate-samples/templates/languages.mjs
@@ -23,7 +23,7 @@ const languages = [
     { lang: 'Kurdish', sample: 'Cem vî Feqoyê pîs zêdetir ji çar gulên xweşik hebûn.' },
     { lang: 'Latvian', sample: 'Muļķa hipiji mēģina brīvi nogaršot celofāna žņaudzējčūsku.' },
     { lang: 'Lithuanian', sample: 'Įlinkdama fechtuotojo špaga sublykčiojusi pragręžė apvalų arbūzą.' },
-    { lang: 'Macedonian', sample: 'Ѕидарски пејзаж: шугав билмез со чудење џвака ќофте и кељ на туѓ цех.' },
+    { lang: 'Macedonian', sample: 'Ѕидарски пејзаж: шугав билмез со чудење џвака ќофте и кељ на туѓ цех.', localeId :'mk' },
     { lang: 'Maltese', sample: 'Kien liebes gozz ħwejjeġ u ċraret vera qodma u m’għażluhx fil-pront.' },
     { lang: 'Norwegian', sample: 'Jeg begynte å fortære en sandwich mens jeg kjørte taxi på vei til quiz' },
     { lang: 'Polish', sample: 'Pchnąć w tę łódź jeża lub ośm skrzyń fig.' },


### PR DESCRIPTION
Also fix Macedonian localeId in language samples.