### PR TITLE
add exe files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ node_modules
 # Special
 *.ttf
 *.7z
+*.exe
 test/
 preview/
 .build/


### PR DESCRIPTION
This allows users/contributors to simply place the ttfautohint exe file into the Iosevka directory without modifying their global path variable on the OS level.