### PR TITLE
Use previous customizer preview as package sample

### DIFF
--- a/utility/generate-samples/templates/package-sample.mjs
+++ b/utility/generate-samples/templates/package-sample.mjs
@@ -3,9 +3,9 @@ import * as themes from "../themes/index.mjs";
 // prettier-ignore
 export const ssStrings = [
 	["ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ", "abc.def.ghi.jkl.mno.pqrs.tuv.wxyz"],
-	["¢ſßðþ ΓΛΔαδιλμξ КУЗЯЖэльфязычникж", "float il1[]={1-2/3.4,5+6=7/8%90};"],
-	["1234567890 ,._-+= >< ¯-¬_ >~–÷+×<", "{*}[]()<>`+-=$/#_%^@\\&|~?'\" !,.;:"],
-	["!iIlL17|¦ coO08BbDQ $5SZ2zsz 96G&", [..."E3CGQ g9q¶ uvw  ", "__", " ", "<=", " ", "!="," ","==", " ", ">=", " ", "->"]]
+	["!iIlL17|¦ coO08BbDQ $5SZ2zsz 96µm", "float il1[]={1-2/3.4,5+6=7/8%90};"],
+	["1234567890 ,._-+= >« ¯-¬_ »~–÷+×<", "{*}[]()<>`+-=$/#_%^@\\&|~?'\" !,.;:"],
+	["E3CGQ g9q¶ uvw ¢ſßðþ ΓΔΛαδιλμξπτχ", [..."ЖЗКУЯжзклмнруфчьыя ", "<=", " ", "!="," ","==", " ", "=>", " ", "->"]]
 ];
 
 function* makeSample(lbm, hotChars) {


### PR DESCRIPTION
Now that they are properly synced up, it makes perfect sense to use the previous website version for both to show as many customized characters as possible