### PR TITLE
Make the fully tailed shapes of `i`/`l` consistent with `t`/etc. regardless of italicization.

### DIFF
--- a/changes/27.2.2.md
+++ b/changes/27.2.2.md
@@ -1,3 +1,4 @@
+* Make the tailed variants of `i` and `l` use the fully-tailed shape even when upright, as is consistent with `t = bent-hook` (#1692).
 * Fix `cv44` and `cv99` for `ss13`.
 * Fix `cv48` and `cv54` for `ss17`.
 * Fix `cv52` and `cv58` for `ss15`.

--- a/font-src/glyphs/letter/latin/lower-il.ptl
+++ b/font-src/glyphs/letter/latin/lower-il.ptl
@@ -29,10 +29,10 @@ glyph-block Letter-Latin-Lower-I : begin
 		set-base-anchor 'topRight' (xMiddle + df.rightSB - df.middle) yTop
 
 	# Support shapes
-	define [TailedDotlessXMiddle df addTopSerif] : df.middle - [if addTopSerif 0 : IBalance2 df]
-	define [ItalicDotlessIShift df] : (1 - df.div) * 0.2
-	define [ItalicDotlessIXMiddle df] : begin
-		return : mix df.leftSB df.rightSB ([StrokeWidthBlend 0.42 0.46] - [ItalicDotlessIShift df])
+	define [FlatTailedDotlessIXMiddle df addTopSerif] : df.middle - [if addTopSerif 0 : IBalance2 df]
+	define [TailedDotlessIShift df] : (1 - df.div) * 0.2
+	define [TailedDotlessIXMiddle df addTopSerif] : begin
+		return : mix df.leftSB df.rightSB ([StrokeWidthBlend 0.42 0.46] - [TailedDotlessIShift df])
 
 	###########################################################################################
 	# Implementations
@@ -42,14 +42,10 @@ glyph-block Letter-Latin-Lower-I : begin
 		export : define [Hooky df] : df.middle + [IBalance2 df]
 		export : define [HookyBottom df] : df.middle - [IBalance2 df]
 		export : define [Serifed df] : df.middle + [IBalance df]
-		export : define [Tailed df] : if para.isItalic
-			ItalicDotlessIXMiddle df
-			TailedDotlessXMiddle df false
-		export : define [TailedSerifed df] : if para.isItalic
-			ItalicDotlessIXMiddle df
-			TailedDotlessXMiddle df true
-		export : define [FlatTailed df] : TailedDotlessXMiddle df false
-		export : define [SerifedFlatTailed df] : TailedDotlessXMiddle df true
+		export : define [Tailed df] : TailedDotlessIXMiddle df false
+		export : define [TailedSerifed df] : TailedDotlessIXMiddle df true
+		export : define [FlatTailed df] : FlatTailedDotlessIXMiddle df false
+		export : define [SerifedFlatTailed df] : FlatTailedDotlessIXMiddle df true
 		export : define [PhoneticLeft df] : df.leftSB + [HSwToV Stroke]
 
 	define Body : namespace
@@ -70,9 +66,9 @@ glyph-block Letter-Latin-Lower-I : begin
 				HSerif.mb df.middle 0 (LongJut * df.div)
 			set-base-anchor 'trailing' (df.middle + LongJut * df.div) 0
 
-		define [IalicTailed df top xMiddle] : glyph-proc
+		export : define [Tailed df top xMiddle] : glyph-proc
 			local fine : AdviceStroke 3
-			local shift : ItalicDotlessIShift df
+			local shift : TailedDotlessIShift df
 			local left : xMiddle - [HSwToV : 0.5 * df.mvs]
 			local right : mix df.leftSB df.rightSB (1.1 - shift)
 			local rightTerm : Math.max right (left + HookX + df.mvs)
@@ -89,28 +85,6 @@ glyph-block Letter-Latin-Lower-I : begin
 			include : OverrideILMarks df xDot top
 			set-base-anchor 'trailing' [mix left rightTerm 0.5] 0
 			set-base-anchor 'palatalHookMask' [mix left rightTerm 0.5] (HalfStroke + O)
-
-		define [UprightTailed df top xMiddle] : glyph-proc
-			local tailLength : LongJut * 1.05 * [mix 1 df.div 0.75]
-			local hookScaleX  : mix 1 df.div 0.5
-			local hookScaleY  : mix 1 df.div 1.25
-			local x0 : mix (0.5 * df.mvs) (0.5 * df.mvs + (Hook - df.mvs + 1) * 0.85 * df.div + [IBalance2 df]) hookScaleX
-			local x1 : mix (0.5 * df.mvs) ([Math.max (Hook - 0.5 * df.mvs + 1) tailLength] + [IBalance2 df]) hookScaleX
-			include : dispiro
-				widths.center df.mvs
-				flat xMiddle top [heading Downward]
-				curl xMiddle [Math.max (df.mvs * 1.1) : mix df.mvs Hook hookScaleY]
-				arcvh 16
-				g2.right.mid (xMiddle + x0) (0.5 * df.mvs + O) [heading Rightward]
-				g4 (xMiddle + x1) (0.5 * df.mvs + (1 - 2 * hookScaleY) * O) [heading Rightward]
-
-			include : OverrideILMarks df xMiddle top
-			set-base-anchor 'trailing' (xMiddle + x0) 0
-			set-base-anchor 'palatalHookMask' (xMiddle + x0) (HalfStroke + O)
-
-		export : define [Tailed df top xMiddle] : if para.isItalic
-			IalicTailed df top xMiddle
-			UprightTailed df top xMiddle
 
 		export : define [FlatTailed df top xMiddle] : glyph-proc
 			local tailLength : LongJut * 1.05 * [mix 1 df.div 0.75]


### PR DESCRIPTION
Closes #1692 

Note that the appearance of the font's defaults are completely unchanged because the fully tailed `i`/`l` variants are only used under italics.

Also note that none of the SS's need adjustment for their upright forms because all of the original fonts that use a full tail when upright would still end up using the fully tailed variants here anyway:

`jiιltτ`

Andale Mono:
![image](https://github.com/be5invis/Iosevka/assets/37010132/5ab92b1d-5ab6-4ea8-b5ec-fdb5c38dea31)

Consolas:
![image](https://github.com/be5invis/Iosevka/assets/37010132/6f0bec32-93ba-43ee-9283-b5debefa5756)

Fira Mono:
![image](https://github.com/be5invis/Iosevka/assets/37010132/c2d5a625-214a-44f7-b4a0-5dd1a8d51b3b)

Liberation Mono:
![image](https://github.com/be5invis/Iosevka/assets/37010132/0547396a-79be-41d6-9342-5f81cbfc1685)

Pragmata Pro:
![image](https://github.com/be5invis/Iosevka/assets/37010132/2b1191ce-c369-4d12-9958-96d8a2842a43)

Source Code Pro:
![image](https://github.com/be5invis/Iosevka/assets/37010132/7f6e9027-2583-40bb-94ab-eb8fcfb461c8)

Ubuntu Mono:
![image](https://github.com/be5invis/Iosevka/assets/37010132/fb62ceb2-1049-4761-876d-ac4334e20048)

Lucida Console:
![image](https://github.com/be5invis/Iosevka/assets/37010132/199b14f4-2201-4590-927d-056361469dca)

PT Mono:
![image](https://github.com/be5invis/Iosevka/assets/37010132/c4c65dd7-c63f-428c-8828-71a0ae074fa3)

Input Mono:
![image](https://github.com/be5invis/Iosevka/assets/37010132/ffc7c978-9e05-464a-ad23-ed7bddba0cc9)

All SS's:
![image](https://github.com/be5invis/Iosevka/assets/37010132/11d575f8-42e5-4d9e-b164-368b9e4cb148)
