### PR TITLE
Fit partial derivative into sampler specimen.

### DIFF
--- a/utility/generate-samples/templates/package-sample.mjs
+++ b/utility/generate-samples/templates/package-sample.mjs
@@ -3,7 +3,7 @@ import * as themes from "../themes/index.mjs";
 // prettier-ignore
 export const ssStrings = [
 	["ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ", "abc.def.ghi.jkl.mno.pqrs.tuv.wxyz"],
-	["!iIlL17|¦ ¢coO08BDQ $5SZ2zsz 96µm", "float il1[]={1-2/3.4,5+6=7/8%90};"],
+	["!iIlL17|¦ ¢coO08BbDQ $5SZ2zs 96µm", "float il1[]={1-2/3.4,5+6=7/8%90};"],
 	["1234567890 ,._-+= >« ¯-¬_ »~–÷+×<", "{*}[]()<>`+-=$/#_%^@\\&|~?'\" !,.;:"],
 	["E3CGQ g9q¶ uvw ſßðþ ΓΔΛαδιλμξπτχ∂", [..."ЖЗКУЯжзклмнруфчьыя ", "<=", " ", "!="," ","==", " ", "=>", " ", "->"]]
 ];

--- a/utility/generate-samples/templates/package-sample.mjs
+++ b/utility/generate-samples/templates/package-sample.mjs
@@ -3,9 +3,9 @@ import * as themes from "../themes/index.mjs";
 // prettier-ignore
 export const ssStrings = [
 	["ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ", "abc.def.ghi.jkl.mno.pqrs.tuv.wxyz"],
-	["!iIlL17|¦ coO08BbDQ $5SZ2zsz 96µm", "float il1[]={1-2/3.4,5+6=7/8%90};"],
+	["!iIlL17|¦ ¢coO08BDQ $5SZ2zsz 96µm", "float il1[]={1-2/3.4,5+6=7/8%90};"],
 	["1234567890 ,._-+= >« ¯-¬_ »~–÷+×<", "{*}[]()<>`+-=$/#_%^@\\&|~?'\" !,.;:"],
-	["E3CGQ g9q¶ uvw ¢ſßðþ ΓΔΛαδιλμξπτχ", [..."ЖЗКУЯжзклмнруфчьыя ", "<=", " ", "!="," ","==", " ", "=>", " ", "->"]]
+	["E3CGQ g9q¶ uvw ſßðþ ΓΔΛαδιλμξπτχ∂", [..."ЖЗКУЯжзклмнруфчьыя ", "<=", " ", "!="," ","==", " ", "=>", " ", "->"]]
 ];
 
 function* makeSample(lbm, hotChars) {

--- a/utility/generate-samples/templates/package-sample.mjs
+++ b/utility/generate-samples/templates/package-sample.mjs
@@ -3,7 +3,7 @@ import * as themes from "../themes/index.mjs";
 // prettier-ignore
 export const ssStrings = [
 	["ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ", "abc.def.ghi.jkl.mno.pqrs.tuv.wxyz"],
-	["!iIlL17|¦ ¢coO08BbDQ $5SZ2sz 96µm", "float il1[]={1-2/3.4,5+6=7/8%90};"],
+	["!iIlL17|¦ ¢coO08BbDQ $5SZ2zs 96µm", "float il1[]={1-2/3.4,5+6=7/8%90};"],
 	["1234567890 ,._-+= >« ¯-¬_ »~–÷+×<", "{*}[]()<>`+-=$/#_%^@\\&|~?'\" !,.;:"],
 	["E3CGQ g9q¶ uvw ſßðþ ΓΔΛαδιλμξπτχ∂", [..."ЖЗКУЯжзклмнруфчьыя ", "<=", " ", "!="," ","==", " ", "=>", " ", "->"]]
 ];

--- a/utility/generate-samples/templates/package-sample.mjs
+++ b/utility/generate-samples/templates/package-sample.mjs
@@ -3,7 +3,7 @@ import * as themes from "../themes/index.mjs";
 // prettier-ignore
 export const ssStrings = [
 	["ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ", "abc.def.ghi.jkl.mno.pqrs.tuv.wxyz"],
-	["!iIlL17|¦ ¢coO08BbDQ $5SZ2zs 96µm", "float il1[]={1-2/3.4,5+6=7/8%90};"],
+	["!iIlL17|¦ ¢coO08BbDQ $5SZ2sz 96µm", "float il1[]={1-2/3.4,5+6=7/8%90};"],
 	["1234567890 ,._-+= >« ¯-¬_ »~–÷+×<", "{*}[]()<>`+-=$/#_%^@\\&|~?'\" !,.;:"],
 	["E3CGQ g9q¶ uvw ſßðþ ΓΔΛαδιλμξπτχ∂", [..."ЖЗКУЯжзклмнруфчьыя ", "<=", " ", "!="," ","==", " ", "=>", " ", "->"]]
 ];

--- a/utility/generate-samples/templates/stylistic-set.mjs
+++ b/utility/generate-samples/templates/stylistic-set.mjs
@@ -3,7 +3,7 @@ import * as themes from "../themes/index.mjs";
 // prettier-ignore
 const ssStrings = [
 	["ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ", "abc.def.ghi.jkl.mno.pqrs.tuv.wxyz"],
-	["!iIlL17|¦ ¢coO08BbDQ $5SZ2sz 96µm", "float il1[]={1-2/3.4,5+6=7/8%90};"],
+	["!iIlL17|¦ ¢coO08BbDQ $5SZ2zs 96µm", "float il1[]={1-2/3.4,5+6=7/8%90};"],
 	["1234567890 ,._-+= >« ¯-¬_ »~–÷+×<", "{*}[]()<>`+-=$/#_%^@\\&|~?'\" !,.;:"],
 	["E3CGQ g9q¶ uvw ſßðþ ΓΔΛαδιλμξπτχ∂", [..."ЖЗКУЯжзклмнруфчьыя ", "<=", " ", "!="," ","==", " ", "=>", " ", "->"]]
 ];

--- a/utility/generate-samples/templates/stylistic-set.mjs
+++ b/utility/generate-samples/templates/stylistic-set.mjs
@@ -3,7 +3,7 @@ import * as themes from "../themes/index.mjs";
 // prettier-ignore
 const ssStrings = [
 	["ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ", "abc.def.ghi.jkl.mno.pqrs.tuv.wxyz"],
-	["!iIlL17|¦ ¢coO08BDQ $5SZ2zsz 96µm", "float il1[]={1-2/3.4,5+6=7/8%90};"],
+	["!iIlL17|¦ ¢coO08BbDQ $5SZ2zs 96µm", "float il1[]={1-2/3.4,5+6=7/8%90};"],
 	["1234567890 ,._-+= >« ¯-¬_ »~–÷+×<", "{*}[]()<>`+-=$/#_%^@\\&|~?'\" !,.;:"],
 	["E3CGQ g9q¶ uvw ſßðþ ΓΔΛαδιλμξπτχ∂", [..."ЖЗКУЯжзклмнруфчьыя ", "<=", " ", "!="," ","==", " ", "=>", " ", "->"]]
 ];

--- a/utility/generate-samples/templates/stylistic-set.mjs
+++ b/utility/generate-samples/templates/stylistic-set.mjs
@@ -3,7 +3,7 @@ import * as themes from "../themes/index.mjs";
 // prettier-ignore
 const ssStrings = [
 	["ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ", "abc.def.ghi.jkl.mno.pqrs.tuv.wxyz"],
-	["!iIlL17|¦ ¢coO08BbDQ $5SZ2zs 96µm", "float il1[]={1-2/3.4,5+6=7/8%90};"],
+	["!iIlL17|¦ ¢coO08BbDQ $5SZ2sz 96µm", "float il1[]={1-2/3.4,5+6=7/8%90};"],
 	["1234567890 ,._-+= >« ¯-¬_ »~–÷+×<", "{*}[]()<>`+-=$/#_%^@\\&|~?'\" !,.;:"],
 	["E3CGQ g9q¶ uvw ſßðþ ΓΔΛαδιλμξπτχ∂", [..."ЖЗКУЯжзклмнруфчьыя ", "<=", " ", "!="," ","==", " ", "=>", " ", "->"]]
 ];

--- a/utility/generate-samples/templates/stylistic-set.mjs
+++ b/utility/generate-samples/templates/stylistic-set.mjs
@@ -3,9 +3,9 @@ import * as themes from "../themes/index.mjs";
 // prettier-ignore
 const ssStrings = [
 	["ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ", "abc.def.ghi.jkl.mno.pqrs.tuv.wxyz"],
-	["!iIlL17|¦ coO08BbDQ $5SZ2zsz 96G&", "float il1[]={1-2/3.4,5+6=7/8%90};"],
+	["!iIlL17|¦ ¢coO08BDQ $5SZ2zsz 96µm", "float il1[]={1-2/3.4,5+6=7/8%90};"],
 	["1234567890 ,._-+= >« ¯-¬_ »~–÷+×<", "{*}[]()<>`+-=$/#_%^@\\&|~?'\" !,.;:"],
-	["E3C g9qCGQ uvw ¢ſßðþ ΓΔΛαδιλμξπτχ", [..."ЖЗКУЯжзклмнруфчьыя ", "<=", " ", "!="," ","==", " ", "=>", " ", "->"]]
+	["E3CGQ g9q¶ uvw ſßðþ ΓΔΛαδιλμξπτχ∂", [..."ЖЗКУЯжзклмнруфчьыя ", "<=", " ", "!="," ","==", " ", "=>", " ", "->"]]
 ];
 
 function* makeSample(theme, lbm, features, hotChars) {


### PR DESCRIPTION
Cent sign is moved to be next to a lowercase `c` similar to the nearby `$5S`; A duplicate lowercase `z` later on is removed:
`coO08BbDQ $5SZ2zsz`…`¢ſßðþ` ⇒ `¢coO08BbDQ $5SZ2zs`…`ſßðþ`

Partial derivative (`∂`) is added to the end of Greek section:
`ΓΔΛαδιλμξπτχ` ⇒ `ΓΔΛαδιλμξπτχ∂`