### PR TITLE
Fix tailed variants for LATIN SMALL LETTER Q WITH HOOK (`U+02A0`).

### DIFF
--- a/changes/27.3.0.md
+++ b/changes/27.3.0.md
@@ -2,6 +2,7 @@
   - The old, slightly-curly variants for `i`, `l`, iota (`ι`) and tau (`τ`) are moved to `semi-tailed` variants.
   - Corresponded SSes are changed to keep the shape identical to the old version.
 * Add short-tailed lowercase tau (`τ`) (#2050).
+* Fix tailed variants for `U+02A0`.
 * Stylistic set fixes:
   * Fix `cv44` and `cv99` for `ss13`.
   * Fix `cv48` and `cv54` for `ss17`.

--- a/font-src/glyphs/letter/latin/lower-q.ptl
+++ b/font-src/glyphs/letter/latin/lower-q.ptl
@@ -102,7 +102,7 @@ glyph-block Letter-Latin-Lower-Q : begin
 	derive-glyphs 'qHookTop' 0x2A0 "q/hookTopBase" : function [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
 		include : VBar.r RightSB 0 XH
-		include : TopHook.rBarOuter RightSB Descender XH
+		include : TopHook.rBarOuter RightSB 0 XH
 
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarRight
 	create-glyph 'mathbb/q' 0x1D562 : glyph-proc


### PR DESCRIPTION
`ʠ`

`'cv41'4`:

Before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/d1a19427-5586-4b98-af77-45b4981a5427)
After:
![image](https://github.com/be5invis/Iosevka/assets/37010132/1e3686ad-8aa9-4753-9724-1a5c82984a68)

`'cv41'6`:

Before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/f4c3ffb9-90c6-4e35-90d9-f71f78173f58)
After:
![image](https://github.com/be5invis/Iosevka/assets/37010132/5999da1e-5b0c-4be2-92d4-0027d4dd17be)

