### PR TITLE
Fix earedness of italic Cyrillic Yat to match the other italic Cyrillic letter forms.

### DIFF
--- a/changes/27.3.1.md
+++ b/changes/27.3.1.md
@@ -1,0 +1,1 @@
+* Fix application of `cv39` on italic Cyrillic Yat.

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2933,7 +2933,7 @@ selectorAffix."grek/eta" = "earlessCorner"
 selectorAffix."grek/eta/sansSerif" = "earlessCorner"
 selectorAffix."cyrl/pe.italic" = ""
 selectorAffix."cyrl/peItalicDescBase" = ""
-selectorAffix."cyrl/yat.italic/base" = "earlessCorner"
+selectorAffix."cyrl/yat.italic/base" = ""
 
 [prime.n.variants-buildup.stages.body.earless-rounded]
 rank = 3
@@ -2949,7 +2949,7 @@ selectorAffix."grek/eta" = "earlessRounded"
 selectorAffix."grek/eta/sansSerif" = "earlessRounded"
 selectorAffix."cyrl/pe.italic" = ""
 selectorAffix."cyrl/peItalicDescBase" = ""
-selectorAffix."cyrl/yat.italic/base" = "earlessRounded"
+selectorAffix."cyrl/yat.italic/base" = ""
 
 [prime.n.variants-buildup.stages.terminal."*"]
 next = "serifs"
@@ -3017,7 +3017,7 @@ selectorAffix."eng/lTailBase" = "topLeftSerifed"
 selectorAffix."grek/eta" = "topLeftSerifed"
 selectorAffix."grek/eta/sansSerif" = "serifless"
 selectorAffix."cyrl/pe.italic" = "topLeftSerifed"
-selectorAffix."cyrl/peItalicDescBase" = "motionSerifed"
+selectorAffix."cyrl/peItalicDescBase" = "topLeftSerifed"
 selectorAffix."cyrl/yat.italic/base" = "topLeftSerifed"
 
 [prime.n.variants-buildup.stages.serifs.motion-serifed]
@@ -3034,8 +3034,8 @@ selectorAffix."eng/lTailBase" = { if = [{ body = "normal" }], then = "topLeftSer
 selectorAffix."grek/eta" = { if = [{ body = "normal" }], then = "topLeftSerifed", else = "serifless" }
 selectorAffix."grek/eta/sansSerif" = "serifless"
 selectorAffix."cyrl/pe.italic" = "motionSerifed"
-selectorAffix."cyrl/peItalicDescBase" = "motionSerifed"
-selectorAffix."cyrl/yat.italic/base" = { if = [{ body = "normal" }], then = "topLeftSerifed", else = "serifless" }
+selectorAffix."cyrl/peItalicDescBase" = "topLeftSerifed"
+selectorAffix."cyrl/yat.italic/base" = "topLeftSerifed"
 
 [prime.n.variants-buildup.stages.serifs.serifed]
 rank = 4


### PR DESCRIPTION
`mтҭnпԥѣ`

`ss12` sans italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/91888c8a-55d4-47fa-9293-0f5d1416cb62)
`ss12` slab italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/bb241096-014d-40ae-a0fd-03bda69091c6)
