### PR TITLE
Fix strikethrough mark anchor for LATIN SMALL LETTER Y WITH STROKE (`U+024F`) when cursive.

### DIFF
--- a/changes/27.3.1.md
+++ b/changes/27.3.1.md
@@ -1,1 +1,2 @@
 * Fix application of `cv39` on italic Cyrillic Yat.
+* Fix mark placement for `U+024F`.

--- a/font-src/glyphs/letter/latin/lower-y.ptl
+++ b/font-src/glyphs/letter/latin/lower-y.ptl
@@ -388,7 +388,7 @@ glyph-block Letter-Latin-Lower-Y : begin
 	foreach { suffix { hookShape slabKind } } [Object.entries CursiveConfig] : do
 		create-glyph "y.\(suffix)" : glyph-proc
 			include : MarkSet.p
-			set-base-anchor 'overlay' Middle (XH / 2)
+			set-base-anchor 'strike' Middle (XH / 2)
 			set-base-anchor 'yBelowDot' Middle Descender
 			include : Cursive.Arc XH 0
 			include : hookShape XH Descender


### PR DESCRIPTION
Before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/a0a576f2-a8fc-4b17-b3c4-ac0085c62bf7)
After:
![image](https://github.com/be5invis/Iosevka/assets/37010132/ed98fde2-096e-44e7-977c-3dfcb4843345)

