### PR TITLE
Fix width of VERY MUCH GREATER-THAN (`U+22D9`).

### DIFF
--- a/changes/27.3.2.md
+++ b/changes/27.3.2.md
@@ -1,1 +1,2 @@
 * Fix overlapping serifs of italic Yat (#2061).
+* Fix width of VERY MUCH GREATER-THAN (`U+22D9`).

--- a/font-src/glyphs/symbol/math/relation.ptl
+++ b/font-src/glyphs/symbol/math/relation.ptl
@@ -593,7 +593,7 @@ glyph-block Symbol-Math-Relation-Inequality : begin
 		include : LessShape (SymbolMid + dH) (SymbolMid - dH) [mix df.leftSB df.rightSB (1/3)] [mix df.leftSB df.rightSB (2/3)] muchLessSW
 		include : LessShape (SymbolMid + dH) (SymbolMid - dH) [mix df.leftSB df.rightSB (2/3)] [mix df.leftSB df.rightSB (3/3)] muchLessSW
 	create-glyph 'muchGreater' 0x22D9 : glyph-proc
-		local df : include : DivFrame para.diversityM
+		local df : include : DivFrame para.diversityM 3
 		include : GreaterShape (SymbolMid + dH) (SymbolMid - dH) [mix df.leftSB df.rightSB (0/3)] [mix df.leftSB df.rightSB (1/3)] muchLessSW
 		include : GreaterShape (SymbolMid + dH) (SymbolMid - dH) [mix df.leftSB df.rightSB (1/3)] [mix df.leftSB df.rightSB (2/3)] muchLessSW
 		include : GreaterShape (SymbolMid + dH) (SymbolMid - dH) [mix df.leftSB df.rightSB (2/3)] [mix df.leftSB df.rightSB (3/3)] muchLessSW


### PR DESCRIPTION
`⋘⋙`
Before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/1e662c0f-1a10-42cb-a631-4405fbb99f1b)
After:
![image](https://github.com/be5invis/Iosevka/assets/37010132/9b1353df-46ba-4a09-8f2f-189fcc1e4087)
