### PR TITLE
Remove duplicate variants of capital `B`, `D`, and `P` with hook and capital `R` with tail.

### DIFF
--- a/changes/27.3.2.md
+++ b/changes/27.3.2.md
@@ -1,2 +1,3 @@
 * Fix overlapping serifs of italic Yat (#2061).
 * Fix width of VERY MUCH GREATER-THAN (`U+22D9`).
+* Remove duplicate variants for `U+0181`, `U+018A`, `U+01A4`, and `U+2C64`.

--- a/font-src/glyphs/letter/latin/upper-b.ptl
+++ b/font-src/glyphs/letter/latin/upper-b.ptl
@@ -141,6 +141,11 @@ glyph-block Letter-Latin-Upper-B : begin
 			include [refer-glyph "B.\(suffix)"] AS_BASE ALSO_METRICS
 			include : BOverlayBar CAP bp
 
+		create-glyph "Bhookleft.\(suffix)" : glyph-proc
+			include [refer-glyph "B.\(suffix)"] AS_BASE ALSO_METRICS
+			eject-contour "serifLT"
+			include : LeftHook SB CAP
+
 		create-glyph "currency/baht.\(suffix)" : union
 			body CAP currencySw ts bs
 			intersection [BahtBar : AdviceStroke 5] [mask CAP : AdviceStroke2 2 3 CAP]
@@ -182,6 +187,8 @@ glyph-block Letter-Latin-Upper-B : begin
 	select-variant 'BBar'
 	select-variant 'smcpBBar' 0x1D03 (follow -- 'BBar')
 
+	select-variant 'Bhookleft' 0x181
+
 	create-glyph 'mathbb/B' 0x1D539 : glyph-proc
 		include : MarkSet.capital
 		include : union
@@ -192,11 +199,6 @@ glyph-block Letter-Latin-Upper-B : begin
 					VBar.r (RightSB - BBD - OX * 2) 0 (CAP * BBarPos) BBS
 					VBar.r ([mix SB RightSB BArcMix] - BBD - OX * 2) (CAP * BBarPos) CAP BBS
 					VBar.l (SB + BBD) 0 CAP BBS
-
-	derive-glyphs 'Bhookleft' 0x181 'B' : lambda [src gr] : glyph-proc
-		include [refer-glyph src] AS_BASE ALSO_METRICS
-		eject-contour "serifLT"
-		include : LeftHook SB CAP
 
 	define [ItalicCyrveShape top] : glyph-proc
 		local stroke : AdviceStroke2 2 3 top

--- a/font-src/glyphs/letter/latin/upper-d.ptl
+++ b/font-src/glyphs/letter/latin/upper-d.ptl
@@ -56,18 +56,28 @@ glyph-block Letter-Latin-Upper-D : begin
 			bilateralSerifed  { true  true  }
 
 	foreach { suffix { fRound {fSlabTop fSlabBot} } } [Object.entries DConfig] : do
+		local fMotion : fSlabTop && !fSlabBot
+
 		create-glyph "D.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : DShape [DivFrame 1] CAP RightSB fRound fSlabTop fSlabBot
+
+		if (!fMotion) : create-glyph "Dhookleft.\(suffix)" : glyph-proc
+			include [refer-glyph "D.\(suffix)"] AS_BASE ALSO_METRICS
+			eject-contour 'serifLT'
+			include : LeftHook SB CAP
+
 		create-glyph "smcpD.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : DShape [DivFrame 1] XH RightSB fRound fSlabTop fSlabBot
+
 		create-glyph "romanFiveThousand.\(suffix)" : glyph-proc
 			local df : DivFrame 1 3
 			include : MarkSet.capital
 			include : DShape df CAP df.rightSB fRound fSlabTop fSlabBot
 			include : with-transform [ApparentTranslate 0 (CAP * 0.2)]
 				DShape df (CAP * 0.6) (df.middle + [HSwToV : 0.5 * df.mvs]) fRound
+
 		create-glyph "romanFiftyThousand.\(suffix)" : glyph-proc
 			local df : DivFrame 1 4
 			local innerDist : df.rightSB - df.leftSB - [HSwToV : 4 * df.mvs]
@@ -91,6 +101,7 @@ glyph-block Letter-Latin-Upper-D : begin
 			space -- { 0 (RightSB - [HSwToV Stroke]) }
 	alias 'Dcroat' 0x110 'Eth'
 	alias 'arficanD' 0x189 'Eth'
+	select-variant 'Dhookleft' 0x18A
 
 	derive-composites 'Dbar' 0xA7C7 'D'
 		HBar.m (SB - OX) (RightSB + OX) (CAP * 0.5) OverlayStroke
@@ -100,11 +111,6 @@ glyph-block Letter-Latin-Upper-D : begin
 		include [refer-glyph src] AS_BASE ALSO_METRICS
 		include : LetterBarOverlay.l.in SB Stroke (XH - Stroke)
 			space -- { 0 (RightSB - [HSwToV Stroke]) }
-
-	derive-glyphs 'Dhookleft' 0x18a 'D' : lambda [src gr] : glyph-proc
-		include [refer-glyph src] AS_BASE ALSO_METRICS
-		eject-contour 'serifLT'
-		include : LeftHook SB CAP
 
 	glyph-block-import Letter-Blackboard : BBS BBD
 	create-glyph 'mathbb/D' 0x1D53B : glyph-proc

--- a/font-src/glyphs/letter/latin/upper-p.ptl
+++ b/font-src/glyphs/letter/latin/upper-p.ptl
@@ -141,6 +141,7 @@ glyph-block Letter-Latin-Upper-P : begin
 		openSerifed           { true   PShape.SlabAsymmetric           RevPShape.SlabAsymmetric           }
 
 	foreach { suffix { fGap slabs revSlabs } } [Object.entries PConfig] : do
+		local fMotion : slabs === PShape.SlabMotion
 		local fSlabBot : slabs && slabs !== PShape.SlabMotion
 
 		create-glyph "P.\(suffix)" : glyph-proc
@@ -154,6 +155,11 @@ glyph-block Letter-Latin-Upper-P : begin
 			include [refer-glyph "P.\(suffix)"] AS_BASE ALSO_METRICS
 			include : SetGrekUpperTonos [if slabs (-SideJut) 0]
 
+		if (!fMotion) : create-glyph "PHookLeft.\(suffix)" : glyph-proc
+			include [refer-glyph "P.\(suffix)"] AS_BASE
+			eject-contour "serifLT"
+			include : LeftHook (SB * 1.25) CAP
+
 		create-glyph "smcpP.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : LeaningAnchor.Below.VBar.l (SB * PShape.defaultMul)
@@ -161,7 +167,7 @@ glyph-block Letter-Latin-Upper-P : begin
 				PShape XH (slab -- slabs)
 				if fGap [PShape.OpenGap (top -- XH) (bot -- [if fSlabBot Stroke 0])] [glyph-proc]
 
-		create-glyph "currency/rubleSign.\(suffix)" : glyph-proc
+		if (!fGap) : create-glyph "currency/rubleSign.\(suffix)" : glyph-proc
 			include [refer-glyph "P.\(suffix)"] AS_BASE ALSO_METRICS
 			define bar1pos : [PBarPosY CAP Stroke PShape.BarPos] + HalfStroke
 
@@ -175,11 +181,6 @@ glyph-block Letter-Latin-Upper-P : begin
 			include : HOverlayBar xCrossBarLeft xPLeft bar1pos Stroke
 			include : HOverlayBar xCrossBarLeft xCrossBarRight yCrossbar
 
-		create-glyph "PHookLeft.\(suffix)" : glyph-proc
-			include [refer-glyph "P.\(suffix)"] AS_BASE
-			eject-contour "serifLT"
-			include : LeftHook (SB * 1.25) CAP
-
 		create-glyph "currency/pesoSign.\(suffix)" : glyph-proc
 			include [refer-glyph "P.\(suffix)"] AS_BASE ALSO_METRICS
 			define bar1pos : PBarPosY CAP Stroke PShape.BarPos
@@ -190,16 +191,19 @@ glyph-block Letter-Latin-Upper-P : begin
 
 	select-variant 'P' 'P'
 	link-reduced-variant 'P/sansSerif' 'P' MathSansSerif
-	select-variant 'smcpP' 0x1D18 (follow -- 'P')
-	alias 'grek/smcpRho' 0x1D29 'smcpP'
 
 	select-variant 'grek/Rho' 0x3A1 (follow -- 'P')
 	link-reduced-variant 'grek/Rho/sansSerif' 'grek/Rho' MathSansSerif (follow -- 'P/sansSerif')
+
+	select-variant 'smcpP' 0x1D18 (follow -- 'P')
+	alias 'grek/smcpRho' 0x1D29 'smcpP'
+
 	alias 'cyrl/Er' 0x420 'P'
+
+	select-variant 'PHookLeft' 0x1A4
 
 	select-variant 'currency/rubleSign' 0x20BD
 	select-variant 'currency/pesoSign' 0x20B1 (follow -- 'P')
-	select-variant 'PHookLeft' 0x1A4
 
 	derive-glyphs 'cyrl/ErTick' 0x48E 'cyrl/Er' : lambda [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS

--- a/font-src/glyphs/letter/latin/upper-r.ptl
+++ b/font-src/glyphs/letter/latin/upper-r.ptl
@@ -190,6 +190,11 @@ glyph-block Letter-Latin-Upper-R : begin
 			include [refer-glyph "R.\(suffix)"] AS_BASE ALSO_METRICS
 			include : HBar.m [mix 0 SB 0.3] (SB - O) ((CAP - Stroke) * [RBarPos CAP SLAB] + Stroke * 0.25)
 
+		if (!fSlabBot) : create-glyph "RRTail.\(suffix)" : glyph-proc
+			include [refer-glyph "R.\(suffix)"] AS_BASE ALSO_METRICS
+			eject-contour 'serifLB'
+			include : RetroflexHook.lExt SB 0
+
 		create-glyph "smcpR.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : StrikeAnchor
@@ -249,6 +254,7 @@ glyph-block Letter-Latin-Upper-R : begin
 	link-reduced-variant 'R/sansSerif' 'R' MathSansSerif
 
 	select-variant 'RBar' 0x24C
+	select-variant 'RRTail' 0x2C64
 
 	select-variant 'smcpR' 0x280 (follow -- 'R')
 	turned 'turnSmapR' 0x1D1A 'smcpR' Middle (XH / 2)
@@ -265,11 +271,6 @@ glyph-block Letter-Latin-Upper-R : begin
 	select-variant 'smcpRLongRightLeg' 0xAB46 (follow -- 'R')
 
 	select-variant 'currency/indianRupeeSign' 0x20B9 (follow -- 'RRotunda')
-
-	derive-glyphs 'RRTail' 0x2C64 'R' : lambda [src gr] : glyph-proc
-		include [refer-glyph src] AS_BASE ALSO_METRICS
-		eject-contour 'serifLB'
-		include : RetroflexHook.lExt SB 0
 
 	create-glyph 'mathbb/R' 0x211D : glyph-proc
 		define [SingleLeg] : RLegShape-Straight ((CAP - BBS) * HBarPos) 0 Middle (RightSB - O) CAP false BBS (BBD / 2)

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -73,6 +73,7 @@ selectorAffix.B = "standard"
 selectorAffix."B/sansSerif" = "standard"
 selectorAffix.smcpB = "standard"
 selectorAffix.BBar = "standard"
+selectorAffix.Bhookleft = "standard"
 
 [prime.capital-b.variants-buildup.stages.symmetry.more-asymmetric]
 rank = 2
@@ -81,6 +82,7 @@ selectorAffix.B = "moreAsymmetric"
 selectorAffix."B/sansSerif" = "moreAsymmetric"
 selectorAffix.smcpB = "moreAsymmetric"
 selectorAffix.BBar = "moreAsymmetric"
+selectorAffix.Bhookleft = "moreAsymmetric"
 
 [prime.capital-b.variants-buildup.stages.openness."*"]
 next = "serifs"
@@ -92,6 +94,7 @@ selectorAffix.B = ""
 selectorAffix."B/sansSerif" = ""
 selectorAffix.smcpB = ""
 selectorAffix.BBar = ""
+selectorAffix.Bhookleft = ""
 
 [prime.capital-b.variants-buildup.stages.openness.interrupted]
 rank = 2
@@ -100,6 +103,7 @@ selectorAffix.B = "interrupted"
 selectorAffix."B/sansSerif" = "interrupted"
 selectorAffix.smcpB = "interrupted"
 selectorAffix.BBar = ""
+selectorAffix.Bhookleft = "interrupted"
 
 [prime.capital-b.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -109,6 +113,7 @@ selectorAffix.B = "serifless"
 selectorAffix."B/sansSerif" = "serifless"
 selectorAffix.smcpB = "serifless"
 selectorAffix.BBar = "serifless"
+selectorAffix.Bhookleft = "serifless"
 
 [prime.capital-b.variants-buildup.stages.serifs.unilateral-serifed]
 rank = 2
@@ -117,6 +122,7 @@ selectorAffix.B = "unilateralSerifed"
 selectorAffix."B/sansSerif" = "serifless"
 selectorAffix.smcpB = "unilateralSerifed"
 selectorAffix.BBar = "unilateralSerifed"
+selectorAffix.Bhookleft = "serifless"
 
 [prime.capital-b.variants-buildup.stages.serifs.bilateral-serifed]
 rank = 3
@@ -125,6 +131,7 @@ selectorAffix.B = "bilateralSerifed"
 selectorAffix."B/sansSerif" = "serifless"
 selectorAffix.smcpB = "bilateralSerifed"
 selectorAffix.BBar = "bilateralSerifed"
+selectorAffix.Bhookleft = "bilateralSerifed"
 
 
 
@@ -199,12 +206,14 @@ rank = 1
 descriptionAffix = "standard shape"
 selectorAffix.D = "standard"
 selectorAffix."D/sansSerif" = "standard"
+selectorAffix.Dhookleft = "standard"
 
 [prime.capital-d.variants-buildup.stages.body.more-rounded]
 rank = 2
 descriptionAffix = "more rounded shape"
 selectorAffix.D = "moreRounded"
 selectorAffix."D/sansSerif" = "moreRounded"
+selectorAffix.Dhookleft = "moreRounded"
 
 [prime.capital-d.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -212,18 +221,21 @@ descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix.D = "serifless"
 selectorAffix."D/sansSerif" = "serifless"
+selectorAffix.Dhookleft = "serifless"
 
 [prime.capital-d.variants-buildup.stages.serifs.unilateral-serifed]
 rank = 2
 descriptionAffix = "serifs at top"
 selectorAffix.D = "unilateralSerifed"
 selectorAffix."D/sansSerif" = "serifless"
+selectorAffix.Dhookleft = "serifless"
 
 [prime.capital-d.variants-buildup.stages.serifs.bilateral-serifed]
 rank = 3
 descriptionAffix = "serifs at both top and bottom"
 selectorAffix.D = "bilateralSerifed"
 selectorAffix."D/sansSerif" = "serifless"
+selectorAffix.Dhookleft = "bilateralSerifed"
 
 
 
@@ -779,7 +791,7 @@ rank = 2
 descriptionAffix = "motion serifs"
 selectorAffix.P = "motionSerifed"
 selectorAffix."P/sansSerif" = "serifless"
-selectorAffix.PHookLeft = "motionSerifed"
+selectorAffix.PHookLeft = "serifless"
 selectorAffix."currency/rubleSign" = "motionSerifed"
 
 [prime.capital-p.variants-buildup.stages.serifs.serifed]
@@ -876,6 +888,7 @@ keyAffix = ""
 selectorAffix.R = ""
 selectorAffix."R/sansSerif" = ""
 selectorAffix.RBar = ""
+selectorAffix.RRTail = ""
 selectorAffix.RRotunda = ""
 
 [prime.capital-r.variants-buildup.stages.openness.open]
@@ -885,6 +898,7 @@ descriptionAffix = "open contour"
 selectorAffix.R = "open"
 selectorAffix."R/sansSerif" = "open"
 selectorAffix.RBar = ""
+selectorAffix.RRTail = "open"
 selectorAffix.RRotunda = ""
 
 [prime.capital-r.variants-buildup.stages.leg."*"]
@@ -898,6 +912,7 @@ descriptionAffix = "straight leg"
 selectorAffix.R = "straight"
 selectorAffix."R/sansSerif" = "straight"
 selectorAffix.RBar = "straight"
+selectorAffix.RRTail = "straight"
 selectorAffix.RRotunda = "straight"
 
 [prime.capital-r.variants-buildup.stages.leg.curly]
@@ -907,6 +922,7 @@ descriptionAffix = "curly leg"
 selectorAffix.R = "curly"
 selectorAffix."R/sansSerif" = "curly"
 selectorAffix.RBar = "curly"
+selectorAffix.RRTail = "curly"
 selectorAffix.RRotunda = "curly"
 
 [prime.capital-r.variants-buildup.stages.leg.standing]
@@ -916,6 +932,7 @@ descriptionAffix = "standing leg (like Helvetica)"
 selectorAffix.R = "standing"
 selectorAffix."R/sansSerif" = "standing"
 selectorAffix.RBar = "standing"
+selectorAffix.RRTail = "standing"
 selectorAffix.RRotunda = "standing"
 
 [prime.capital-r.variants-buildup.stages.serifs.serifless]
@@ -925,6 +942,7 @@ descriptionJoiner = "without"
 selectorAffix.R = "serifless"
 selectorAffix."R/sansSerif" = "serifless"
 selectorAffix.RBar = "serifless"
+selectorAffix.RRTail = "serifless"
 selectorAffix.RRotunda = "serifless"
 
 [prime.capital-r.variants-buildup.stages.serifs.top-left-serifed]
@@ -933,6 +951,7 @@ descriptionAffix = "serifs at top-left"
 selectorAffix.R = "topLeftSerifed"
 selectorAffix."R/sansSerif" = "serifless"
 selectorAffix.RBar = "topLeftSerifed"
+selectorAffix.RRTail = "topLeftSerifed"
 selectorAffix.RRotunda = "serifless"
 
 [prime.capital-r.variants-buildup.stages.serifs.bottom-right-serifed]
@@ -941,6 +960,7 @@ descriptionAffix = "serifs at bottom-right"
 selectorAffix.R = "bottomRightSerifed"
 selectorAffix."R/sansSerif" = "serifless"
 selectorAffix.RBar = "bottomRightSerifed"
+selectorAffix.RRTail = "bottomRightSerifed"
 selectorAffix.RRotunda = "bottomRightSerifed"
 
 [prime.capital-r.variants-buildup.stages.serifs.top-left-and-bottom-right-serifed]
@@ -949,6 +969,7 @@ descriptionAffix = "serifs at bottom-right"
 selectorAffix.R = "topLeftAndBottomRightSerifed"
 selectorAffix."R/sansSerif" = "serifless"
 selectorAffix.RBar = "topLeftAndBottomRightSerifed"
+selectorAffix.RRTail = "topLeftAndBottomRightSerifed"
 selectorAffix.RRotunda = "bottomRightSerifed"
 
 [prime.capital-r.variants-buildup.stages.serifs.serifed]
@@ -957,6 +978,7 @@ descriptionAffix = "serifs"
 selectorAffix.R = "serifed"
 selectorAffix."R/sansSerif" = "serifless"
 selectorAffix.RBar = "serifed"
+selectorAffix.RRTail = "topLeftAndBottomRightSerifed"
 selectorAffix.RRotunda = "bottomRightSerifed"
 
 


### PR DESCRIPTION
Also make an attempt at somewhat reducing the number of glyphs surrounding these characters.