### PR TITLE
Remove asymmetric variants for Small Capital `B` and Cyrillic Lower Ve.

### DIFF
--- a/changes/27.3.2.md
+++ b/changes/27.3.2.md
@@ -1,3 +1,4 @@
 * Fix overlapping serifs of italic Yat (#2061).
 * Fix width of VERY MUCH GREATER-THAN (`U+22D9`).
 * Remove duplicate variants for `U+0181`, `U+018A`, `U+01A4`, and `U+2C64`.
+* Remove asymmetric variants for small capital `B` (`U+0299`, `U+1D03`) and Cyrillic Lower Ve (`U+0432`).

--- a/font-src/glyphs/letter/latin/upper-b.ptl
+++ b/font-src/glyphs/letter/latin/upper-b.ptl
@@ -117,16 +117,18 @@ glyph-block Letter-Latin-Upper-B : begin
 
 	define BConfig : SuffixCfg.weave
 		object # body
-			standard                  { StdShape                   StdMask        BBarPos           }
-			moreAsymmetric            { AsymmetricShape            AsymmetricMask AsymmetricBBarPos }
-			standardInterrupted       { StdShapeInterrupted        StdMask        BBarPos           }
-			moreAsymmetricInterrupted { AsymmetricShapeInterrupted AsymmetricMask AsymmetricBBarPos }
+			standard                  { StdShape                   StdMask        BBarPos           false }
+			moreAsymmetric            { AsymmetricShape            AsymmetricMask AsymmetricBBarPos false }
+			standardInterrupted       { StdShapeInterrupted        StdMask        BBarPos           true  }
+			moreAsymmetricInterrupted { AsymmetricShapeInterrupted AsymmetricMask AsymmetricBBarPos true  }
 		object # serifs
 			serifless         { false false }
 			unilateralSerifed { true  false }
 			bilateralSerifed  { true  true  }
 
-	foreach { suffix { {body mask bp} {ts bs} } } [Object.entries BConfig] : do
+	foreach { suffix { {body mask bp fGap} {ts bs} } } [Object.entries BConfig] : do
+		local fMotion : ts && !bs
+		local fAsymmetric : mask === AsymmetricMask
 		local currencySw : AdviceStroke2 3.5 3 CAP
 
 		create-glyph "B.\(suffix)" : glyph-proc
@@ -137,14 +139,22 @@ glyph-block Letter-Latin-Upper-B : begin
 			include [refer-glyph "B.\(suffix)"] AS_BASE ALSO_METRICS
 			include : BOverlayStroke CAP bp
 
-		create-glyph "BBar.\(suffix)" : glyph-proc
-			include [refer-glyph "B.\(suffix)"] AS_BASE ALSO_METRICS
-			include : BOverlayBar CAP bp
-
-		create-glyph "Bhookleft.\(suffix)" : glyph-proc
+		if (!fMotion) : create-glyph "Bhookleft.\(suffix)" : glyph-proc
 			include [refer-glyph "B.\(suffix)"] AS_BASE ALSO_METRICS
 			eject-contour "serifLT"
 			include : LeftHook SB CAP
+
+		if (!fGap) : create-glyph "BBar.\(suffix)" : glyph-proc
+			include [refer-glyph "B.\(suffix)"] AS_BASE ALSO_METRICS
+			include : BOverlayBar CAP bp
+
+		if (!fAsymmetric) : create-glyph "smcpB.\(suffix)" : glyph-proc
+			include : MarkSet.e
+			include : body XH [AdviceStroke2 2 3 XH] ts bs
+
+		if (!fGap && !fAsymmetric) : create-glyph "smcpBBar.\(suffix)" : glyph-proc
+			include [refer-glyph "smcpB.\(suffix)"] AS_BASE ALSO_METRICS
+			include : BOverlayBar XH bp
 
 		create-glyph "currency/baht.\(suffix)" : union
 			body CAP currencySw ts bs
@@ -154,14 +164,6 @@ glyph-block Letter-Latin-Upper-B : begin
 		create-glyph "currency/bitcoin.\(suffix)" : union
 			body CAP currencySw ts bs
 			difference [BitcoinBar : AdviceStroke 5] [mask CAP : AdviceStroke2 2 3 CAP]
-
-		create-glyph "smcpB.\(suffix)" : glyph-proc
-			include : MarkSet.e
-			include : body XH [AdviceStroke2 2 3 XH] ts bs
-
-		create-glyph "smcpBBar.\(suffix)" : glyph-proc
-			include [refer-glyph "smcpB.\(suffix)"] AS_BASE ALSO_METRICS
-			include : BOverlayBar XH bp
 
 		create-glyph "latn/Beta.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
@@ -185,7 +187,7 @@ glyph-block Letter-Latin-Upper-B : begin
 	alias 'cyrl/ve.upright' null 'smcpB'
 
 	select-variant 'BBar'
-	select-variant 'smcpBBar' 0x1D03 (follow -- 'BBar')
+	select-variant 'smcpBBar' 0x1D03
 
 	select-variant 'Bhookleft' 0x181
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -71,18 +71,20 @@ rank = 1
 descriptionAffix = "mostly symmetric shape"
 selectorAffix.B = "standard"
 selectorAffix."B/sansSerif" = "standard"
-selectorAffix.smcpB = "standard"
-selectorAffix.BBar = "standard"
 selectorAffix.Bhookleft = "standard"
+selectorAffix.BBar = "standard"
+selectorAffix.smcpB = "standard"
+selectorAffix.smcpBBar = "standard"
 
 [prime.capital-b.variants-buildup.stages.symmetry.more-asymmetric]
 rank = 2
 descriptionAffix = "more asymmetric shape"
 selectorAffix.B = "moreAsymmetric"
 selectorAffix."B/sansSerif" = "moreAsymmetric"
-selectorAffix.smcpB = "moreAsymmetric"
-selectorAffix.BBar = "moreAsymmetric"
 selectorAffix.Bhookleft = "moreAsymmetric"
+selectorAffix.BBar = "moreAsymmetric"
+selectorAffix.smcpB = "standard"
+selectorAffix.smcpBBar = "standard"
 
 [prime.capital-b.variants-buildup.stages.openness."*"]
 next = "serifs"
@@ -92,18 +94,20 @@ rank = 1
 keyAffix = ""
 selectorAffix.B = ""
 selectorAffix."B/sansSerif" = ""
-selectorAffix.smcpB = ""
-selectorAffix.BBar = ""
 selectorAffix.Bhookleft = ""
+selectorAffix.BBar = ""
+selectorAffix.smcpB = ""
+selectorAffix.smcpBBar = ""
 
 [prime.capital-b.variants-buildup.stages.openness.interrupted]
 rank = 2
 descriptionAffix = "interrupted middle bar"
 selectorAffix.B = "interrupted"
 selectorAffix."B/sansSerif" = "interrupted"
-selectorAffix.smcpB = "interrupted"
-selectorAffix.BBar = ""
 selectorAffix.Bhookleft = "interrupted"
+selectorAffix.BBar = ""
+selectorAffix.smcpB = "interrupted"
+selectorAffix.smcpBBar = ""
 
 [prime.capital-b.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -111,27 +115,30 @@ descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix.B = "serifless"
 selectorAffix."B/sansSerif" = "serifless"
-selectorAffix.smcpB = "serifless"
-selectorAffix.BBar = "serifless"
 selectorAffix.Bhookleft = "serifless"
+selectorAffix.BBar = "serifless"
+selectorAffix.smcpB = "serifless"
+selectorAffix.smcpBBar = "serifless"
 
 [prime.capital-b.variants-buildup.stages.serifs.unilateral-serifed]
 rank = 2
 descriptionAffix = "serifs at top"
 selectorAffix.B = "unilateralSerifed"
 selectorAffix."B/sansSerif" = "serifless"
-selectorAffix.smcpB = "unilateralSerifed"
-selectorAffix.BBar = "unilateralSerifed"
 selectorAffix.Bhookleft = "serifless"
+selectorAffix.BBar = "unilateralSerifed"
+selectorAffix.smcpB = "unilateralSerifed"
+selectorAffix.smcpBBar = "unilateralSerifed"
 
 [prime.capital-b.variants-buildup.stages.serifs.bilateral-serifed]
 rank = 3
 descriptionAffix = "serifs at both top and bottom"
 selectorAffix.B = "bilateralSerifed"
 selectorAffix."B/sansSerif" = "serifless"
-selectorAffix.smcpB = "bilateralSerifed"
-selectorAffix.BBar = "bilateralSerifed"
 selectorAffix.Bhookleft = "bilateralSerifed"
+selectorAffix.BBar = "bilateralSerifed"
+selectorAffix.smcpB = "bilateralSerifed"
+selectorAffix.smcpBBar = "bilateralSerifed"
 
 
 


### PR DESCRIPTION
This appears to have been the font's original behavior up until 2fce3d1 when an attempt to refactor some of the variant groups/names for the website seemed to have accidentally allowed smcpB to inherit all `B` variants.

Additionally, this PR attempts to further reduce the number of unused glyphs surrounding the adjacent `B` characters.

`BƁʙвᴃᴯ`

`'cv02'11`:
![image](https://github.com/be5invis/Iosevka/assets/37010132/d68b4f17-7a89-4905-a6b6-a115a7577984)
