### PR TITLE
Disunify anonymous untagged variant selectors for Cyrillic Capital Yeri/Yery, for consistency.

### DIFF
--- a/changes/27.3.4.md
+++ b/changes/27.3.4.md
@@ -1,0 +1,1 @@
+* Disunify anonymous untagged variant selectors for Cyrillic Capital Yeri/Yery for consistency in style-driven configurations.

--- a/font-src/glyphs/letter/cyrillic/yat.ptl
+++ b/font-src/glyphs/letter/cyrillic/yat.ptl
@@ -112,14 +112,14 @@ glyph-block Letter-Cyrillic-Yat : begin
 
 			DependentSelector.set currentGlyph : if (suffix === "corner") 'full' 'reduced'
 
-	select-variant 'cyrl/Yat' 0x462 (follow -- 'cyrl/YeriBar')
-	select-variant 'cyrl/yat.upright' (follow -- 'cyrl/yeriBar')
-	select-variant 'cyrl/yatTall' 0x1C87 (follow -- 'cyrl/yeriBar')
+	select-variant 'cyrl/Yat' 0x462 (follow -- 'cyrl/Yeri')
+	select-variant 'cyrl/yat.upright' (follow -- 'cyrl/yeri')
+	select-variant 'cyrl/yatTall' 0x1C87 (follow -- 'cyrl/yeri')
 
-	select-variant 'cyrl/YatIotified' 0xA652 (follow -- 'cyrl/YeriBar')
-	select-variant 'cyrl/yatIotified' 0xA653 (follow -- 'cyrl/yeriBar')
+	select-variant 'cyrl/YatIotified' 0xA652 (follow -- 'cyrl/Yeri')
+	select-variant 'cyrl/yatIotified' 0xA653 (follow -- 'cyrl/yeri')
 
-	select-variant 'cyrl/yat.italic/yeri' (follow -- 'cyrl/yeriBar')
+	select-variant 'cyrl/yat.italic/yeri' (follow -- 'cyrl/yeri')
 	CreateDependentComposite 'cyrl/yat.italic' null 'cyrl/yat.italic/yeri' : object
 		full    'cyrl/yat.italic/base/corner'
 		reduced 'cyrl/yat.italic/base/cursive'

--- a/font-src/glyphs/letter/cyrillic/yeri.ptl
+++ b/font-src/glyphs/letter/cyrillic/yeri.ptl
@@ -301,8 +301,8 @@ glyph-block Letter-Cyrillic-Yeri : begin
 	select-variant 'cyrl/Yeri' 0x42C
 	select-variant 'cyrl/yeri' 0x44C
 	select-variant 'cyrl/yeri.BGR' (shapeFrom -- 'cyrl/yeri')
-	select-variant 'cyrl/YeriBar' 0x48C
-	select-variant 'cyrl/yeriBar' 0x48D
+	select-variant 'cyrl/YeriBar' 0x48C (follow -- 'cyrl/Yeri')
+	select-variant 'cyrl/yeriBar' 0x48D (follow -- 'cyrl/yeri')
 	select-variant 'cyrl/YerNeutral' 0xA64E (follow -- 'cyrl/Yer')
 	select-variant 'cyrl/yerNeutral' 0xA64F (follow -- 'cyrl/yer')
 	select-variant 'cyrl/YeryBack' 0xA650 (follow -- 'cyrl/Yery')
@@ -318,9 +318,9 @@ glyph-block Letter-Cyrillic-Yeri : begin
 		if SLAB : begin
 			include : VSerif.dr [mix SB RightSB 0.9] CAP VJut
 
-	alias 'latinBe' 0x182 'cyrl/Be'
+	alias 'latn/Be' 0x182 'cyrl/Be'
 
-	create-glyph 'latinDe' 0x18B : glyph-proc
+	create-glyph 'latn/De' 0x18B : glyph-proc
 		include : MarkSet.capital
 		include : RevCyrYeriShape CAP
 		include : HBar.t [mix RightSB SB 0.9] (RightSB + O) CAP

--- a/font-src/glyphs/letter/latin-ext/sakha-yat.ptl
+++ b/font-src/glyphs/letter/latin-ext/sakha-yat.ptl
@@ -27,4 +27,4 @@ glyph-block Letter-Latin-Sakha-Yat : begin
 			include : df.markSet.e
 			include : SakhaYatShape Yeri df XH
 
-	select-variant 'latn/yatSakha.upright'
+	select-variant 'latn/yatSakha.upright' (follow -- 'cyrl/yeri')

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -5754,8 +5754,6 @@ selector."cyrl/che" = "tailed"
 rank = 1
 selector."cyrl/Yer"  = "corner"
 selector."cyrl/Yeri" = "corner"
-selector."cyrl/YeriBar" = "corner"
-selector."cyrl/Yery" = "corner"
 selector."cyrl/Nje/rightHalf"  = "corner"
 selector."cyrl/Lje"  = "corner"
 
@@ -5763,8 +5761,6 @@ selector."cyrl/Lje"  = "corner"
 rank = 2
 selector."cyrl/Yer"  = "round"
 selector."cyrl/Yeri" = "round"
-selector."cyrl/YeriBar" = "round"
-selector."cyrl/Yery" = "round"
 selector."cyrl/Nje/rightHalf"  = "round"
 selector."cyrl/Lje"  = "round"
 
@@ -5772,8 +5768,6 @@ selector."cyrl/Lje"  = "round"
 rank = 3
 selector."cyrl/Yer"  = "cursive"
 selector."cyrl/Yeri" = "cursive"
-selector."cyrl/YeriBar" = "cursive"
-selector."cyrl/Yery" = "cursive"
 selector."cyrl/Nje/rightHalf"  = "cursive"
 selector."cyrl/Lje"  = "cursive"
 
@@ -5791,10 +5785,8 @@ selector."cyrl/yer"  = "corner"
 selector."cyrl/yer.BGR"  = "round" # Bulgarian
 selector."cyrl/yeri" = "corner"
 selector."cyrl/yeri.BGR" = "round" # Bulgarian
-selector."cyrl/yeriBar" = "corner"
 selector."cyrl/nje/rightHalf"  = "corner"
 selector."cyrl/lje"  = "corner"
-selector."latn/yatSakha.upright"  = "corner"
 
 [prime.cyrl-yeri.variants.round]
 rank = 2
@@ -5803,10 +5795,8 @@ selector."cyrl/yer"  = "round"
 selector."cyrl/yer.BGR"  = "round"
 selector."cyrl/yeri" = "round"
 selector."cyrl/yeri.BGR" = "round"
-selector."cyrl/yeriBar" = "round"
 selector."cyrl/nje/rightHalf"  = "round"
 selector."cyrl/lje"  = "round"
-selector."latn/yatSakha.upright" = "round"
 
 [prime.cyrl-yeri.variants.cursive]
 rank = 3
@@ -5815,10 +5805,25 @@ selector."cyrl/yer"  = "cursive"
 selector."cyrl/yer.BGR"  = "cursive"
 selector."cyrl/yeri" = "cursive"
 selector."cyrl/yeri.BGR" = "cursive"
-selector."cyrl/yeriBar" = "cursive"
 selector."cyrl/nje/rightHalf"  = "cursive"
 selector."cyrl/lje"  = "cursive"
-selector."latn/yatSakha.upright" = "cursive"
+
+
+
+[prime.cyrl-capital-yery]
+# No tags and sampler -- for style-driven variation
+
+[prime.cyrl-capital-yery.variants.corner]
+rank = 1
+selector."cyrl/Yery" = "corner"
+
+[prime.cyrl-capital-yery.variants.round]
+rank = 2
+selector."cyrl/Yery" = "round"
+
+[prime.cyrl-capital-yery.variants.cursive]
+rank = 3
+selector."cyrl/Yery" = "cursive"
 
 
 
@@ -7350,6 +7355,7 @@ cyrl-ef = "serifless"
 cyrl-che = "standard"
 cyrl-capital-yeri = "corner"
 cyrl-yeri = "corner"
+cyrl-capital-yery = "corner"
 cyrl-yery = "corner"
 cyrl-capital-ya = "straight-serifless"
 cyrl-ya = "straight-serifless"


### PR DESCRIPTION
With this PR, capital Yery will have an additional (untagged) variant selector, making both the tagged lower yeri/yery selectors have respective untagged capital counterparts. As a result, this would be a possible user style configuration via a custom build:
`ЫыЬь`
![image](https://github.com/be5invis/Iosevka/assets/37010132/6641e93d-9c14-49e6-a794-d53afa37b03f)
Whereas before, it would have required capital Yery to be rounded as well, despite the cornered lowercase.

Additionally, some extended Cyrillic characters have been cleaned up to directly follow their respective yer* variants.