### PR TITLE
Make LATIN CAPITAL LETTER Y WITH LOOP (`U+1EFE`) follow variants of capital `Y` (`cv24`) for more appropriate response to italics.

### DIFF
--- a/changes/27.3.4.md
+++ b/changes/27.3.4.md
@@ -1,1 +1,2 @@
 * Disunify anonymous untagged variant selectors for Cyrillic Capital Yeri/Yery for consistency in style-driven configurations.
+* Make LATIN CAPITAL LETTER Y WITH LOOP (`U+1EFE`) follow variants of capital `Y` (`cv24`) for a more balanced slab-italic form like that of Cyrillic Capital U.

--- a/font-src/glyphs/letter/latin/lower-y.ptl
+++ b/font-src/glyphs/letter/latin/lower-y.ptl
@@ -430,8 +430,8 @@ glyph-block Letter-Latin-Lower-Y : begin
 	select-variant 'yHookTop' 0x1B4
 	select-variant 'cyrl/U' 0x423 (shapeFrom -- 'yCap')
 
+	select-variant 'YLoop' 0x1EFE (shapeFrom -- 'yCap')
 	select-variant 'yLoop' 0x1EFF (shapeFrom -- 'y')
-	select-variant 'YLoop' 0x1EFE (follow -- 'yLoop') (shapeFrom -- 'yCap')
 
 	select-variant 'grek/lambda' 0x3BB
 	select-variant 'lambdaSlash' 0x19B (follow -- 'grek/lambda')

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1324,44 +1324,50 @@ next = "serifs"
 rank = 1
 descriptionAffix = "straight shape"
 selectorAffix.Y = "straight"
-selectorAffix."grek/upsilonHookedSymbolShape" = "straight"
 selectorAffix."Y/sansSerif" = "straight"
+selectorAffix.YLoop = "straightLoop"
+selectorAffix."grek/upsilonHookedSymbolShape" = "straight"
 
 [prime.capital-y.variants-buildup.stages.body.curly]
 rank = 2
 descriptionAffix = "curly shape"
 selectorAffix.Y = "curly"
-selectorAffix."grek/upsilonHookedSymbolShape" = "straight"
 selectorAffix."Y/sansSerif" = "curly"
+selectorAffix.YLoop = "curlyLoop"
+selectorAffix."grek/upsilonHookedSymbolShape" = "straight"
 
 [prime.capital-y.variants-buildup.stages.serifs.serifless]
 rank = 1
 descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix.Y = "serifless"
-selectorAffix."grek/upsilonHookedSymbolShape" = "serifless"
 selectorAffix."Y/sansSerif" = "serifless"
+selectorAffix.YLoop = "serifless"
+selectorAffix."grek/upsilonHookedSymbolShape" = "serifless"
 
 [prime.capital-y.variants-buildup.stages.serifs.base-serifed]
 rank = 2
 descriptionAffix = "serifs at bottom"
 selectorAffix.Y = "baseSerifed"
-selectorAffix."grek/upsilonHookedSymbolShape" = "BaseSerifed"
 selectorAffix."Y/sansSerif" = "serifless"
+selectorAffix.YLoop = "serifless"
+selectorAffix."grek/upsilonHookedSymbolShape" = "BaseSerifed"
 
 [prime.capital-y.variants-buildup.stages.serifs.motion-serifed]
 rank = 3
 descriptionAffix = "motion serifs"
 selectorAffix.Y = "motionSerifed"
-selectorAffix."grek/upsilonHookedSymbolShape" = "serifless"
 selectorAffix."Y/sansSerif" = "serifless"
+selectorAffix.YLoop = "motionSerifed"
+selectorAffix."grek/upsilonHookedSymbolShape" = "serifless"
 
 [prime.capital-y.variants-buildup.stages.serifs.serifed]
 rank = 4
 descriptionAffix = "serifs"
 selectorAffix.Y = "serifed"
-selectorAffix."grek/upsilonHookedSymbolShape" = "BaseSerifed"
 selectorAffix."Y/sansSerif" = "serifless"
+selectorAffix.YLoop = "serifed"
+selectorAffix."grek/upsilonHookedSymbolShape" = "BaseSerifed"
 
 
 


### PR DESCRIPTION
`YỾyỿ`
Default Slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/2122f1da-14d3-4d27-92f3-c4cf1d07934f)
Default Slab Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/f23f0bad-c2ad-4f0c-acea-b524716aef7b)
