### PR TITLE
Remove `base-serifed`-only variants for Cyrillic Lower Ue.

### DIFF
--- a/changes/27.3.4.md
+++ b/changes/27.3.4.md
@@ -1,2 +1,3 @@
 * Disunify anonymous untagged variant selectors for Cyrillic Capital Yeri/Yery for consistency in style-driven configurations.
 * Make LATIN CAPITAL LETTER Y WITH LOOP (`U+1EFE`) follow variants of capital `Y` (`cv24`) for a more balanced slab-italic form like that of Cyrillic Capital U.
+* Remove `base-serifed`-only variants for CYRILLIC SMALL LETTER STRAIGHT U (`U+04AF`, `U+04B1`).

--- a/font-src/glyphs/letter/latin/upper-y.ptl
+++ b/font-src/glyphs/letter/latin/upper-y.ptl
@@ -113,25 +113,20 @@ glyph-block Letter-Latin-Upper-Y : begin
 			include : YSlabs slabType CAP 0
 			eject-contour 'serifRT'
 
-		create-glyph "cyrl/ue.\(suffix)" : glyph-proc
-			include : MarkSet.p
-			include : YShape bodyType slabType XH Descender
-			include : YSlabs slabType XH Descender
+		if (slabType !== SLAB-BASE) : begin
+			create-glyph "cyrl/ue.\(suffix)" : glyph-proc
+				include : MarkSet.p
+				include : YShape bodyType slabType XH Descender
+				include : YSlabs slabType XH Descender
 
-		create-glyph "grek/upsilonHookedSymbolShape.\(suffix)" : glyph-proc
-			include : MarkSet.capital
-			include : UpsilonHookedSymbolShape CAP 0
-			include : YSlabs slabType CAP 0
-			eject-contour 'serifLT'
-			eject-contour 'serifRT'
-			include : SetGrekUpperTonos (OX - TailX / 3)
-
-		create-glyph "YStroke.\(suffix)" : glyph-proc
-			include [refer-glyph "Y.\(suffix)"] AS_BASE ALSO_METRICS
-			local b : YCrossPos CAP 0
-			local t : CAP - [if (slabType === SLAB-ALL || slabType === SLAB-MOTION) Stroke 0]
-			include : HOverlayBar [mix 0 SB 0.5] [mix Width RightSB 0.5] [mix b t 0.5]
-				Math.min OverlayStroke ((t - b) * 0.625)
+		if ((slabType === SLAB-NONE || slabType === SLAB-BASE) && bodyType === BODY-STRAIGHT) : begin
+			create-glyph "grek/UpsilonHookTop.\(suffix)" : glyph-proc
+				include : MarkSet.capital
+				include : UpsilonHookedSymbolShape CAP 0
+				include : YSlabs slabType CAP 0
+				eject-contour 'serifLT'
+				eject-contour 'serifRT'
+				include : SetGrekUpperTonos (OX - TailX / 3)
 
 		create-glyph "currency/yenSign.\(suffix)" : glyph-proc
 			include [refer-glyph "Y.\(suffix)"] AS_BASE ALSO_METRICS
@@ -139,21 +134,22 @@ glyph-block Letter-Latin-Upper-Y : begin
 
 	select-variant 'Y' 'Y'
 	link-reduced-variant 'Y/sansSerif' 'Y' MathSansSerif
-	select-variant 'YHookTop' 0x1B3 (follow -- 'Y')
 	select-variant 'smcpY' 0x28F (follow -- 'Y')
-	select-variant 'cyrl/ue' 0x4AF (follow -- 'Y')
-	select-variant 'grek/upsilonHookedSymbolShape' 0x3D2
+	select-variant 'YHookTop' 0x1B3 (follow -- 'Y')
 
 	select-variant 'grek/Upsilon' 0x3A5 (follow -- 'Y')
 	link-reduced-variant 'grek/Upsilon/sansSerif' 'grek/Upsilon' MathSansSerif (follow -- 'Y/sansSerif')
+	select-variant 'grek/UpsilonHookTop' 0x3D2
+
 	alias 'cyrl/Ue' 0x4AE 'Y'
-	select-variant 'currency/yenSign' 0xA5 (follow -- 'Y')
+	select-variant 'cyrl/ue' 0x4AF
+	CreateAccentedComposition 'cyrl/KazakhShortU' 0x4B0 'cyrl/Ue' 'barOver'
+	CreateAccentedComposition 'cyrl/KazakhShortu' 0x4B1 'cyrl/ue' 'barOver'
 
 	create-glyph 'YStrokeOverlay' : HOverlayBar ([mix 0 SB 0.5]) ([mix Width RightSB 0.5]) [mix 0 CAP 0.75]
 	derive-composites 'YStroke' 0x24E 'Y' 'YStrokeOverlay'
 
-	CreateAccentedComposition 'cyrl/KazakhShortU' 0x4B0 'cyrl/Ue' 'barOver'
-	CreateAccentedComposition 'cyrl/KazakhShortu' 0x4B1 'cyrl/ue' 'barOver'
+	select-variant 'currency/yenSign' 0xA5 (follow -- 'Y')
 
 	# Blackboard
 	glyph-block-import Letter-Blackboard : BBS BBD

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1326,7 +1326,8 @@ descriptionAffix = "straight shape"
 selectorAffix.Y = "straight"
 selectorAffix."Y/sansSerif" = "straight"
 selectorAffix.YLoop = "straightLoop"
-selectorAffix."grek/upsilonHookedSymbolShape" = "straight"
+selectorAffix."grek/UpsilonHookTop" = "straight"
+selectorAffix."cyrl/ue" = "straight"
 
 [prime.capital-y.variants-buildup.stages.body.curly]
 rank = 2
@@ -1334,7 +1335,8 @@ descriptionAffix = "curly shape"
 selectorAffix.Y = "curly"
 selectorAffix."Y/sansSerif" = "curly"
 selectorAffix.YLoop = "curlyLoop"
-selectorAffix."grek/upsilonHookedSymbolShape" = "straight"
+selectorAffix."grek/UpsilonHookTop" = "straight"
+selectorAffix."cyrl/ue" = "curly"
 
 [prime.capital-y.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -1343,7 +1345,8 @@ descriptionJoiner = "without"
 selectorAffix.Y = "serifless"
 selectorAffix."Y/sansSerif" = "serifless"
 selectorAffix.YLoop = "serifless"
-selectorAffix."grek/upsilonHookedSymbolShape" = "serifless"
+selectorAffix."grek/UpsilonHookTop" = "serifless"
+selectorAffix."cyrl/ue" = "serifless"
 
 [prime.capital-y.variants-buildup.stages.serifs.base-serifed]
 rank = 2
@@ -1351,7 +1354,8 @@ descriptionAffix = "serifs at bottom"
 selectorAffix.Y = "baseSerifed"
 selectorAffix."Y/sansSerif" = "serifless"
 selectorAffix.YLoop = "serifless"
-selectorAffix."grek/upsilonHookedSymbolShape" = "BaseSerifed"
+selectorAffix."grek/UpsilonHookTop" = "BaseSerifed"
+selectorAffix."cyrl/ue" = "serifless"
 
 [prime.capital-y.variants-buildup.stages.serifs.motion-serifed]
 rank = 3
@@ -1359,7 +1363,8 @@ descriptionAffix = "motion serifs"
 selectorAffix.Y = "motionSerifed"
 selectorAffix."Y/sansSerif" = "serifless"
 selectorAffix.YLoop = "motionSerifed"
-selectorAffix."grek/upsilonHookedSymbolShape" = "serifless"
+selectorAffix."grek/UpsilonHookTop" = "serifless"
+selectorAffix."cyrl/ue" = "motionSerifed"
 
 [prime.capital-y.variants-buildup.stages.serifs.serifed]
 rank = 4
@@ -1367,7 +1372,8 @@ descriptionAffix = "serifs"
 selectorAffix.Y = "serifed"
 selectorAffix."Y/sansSerif" = "serifless"
 selectorAffix.YLoop = "serifed"
-selectorAffix."grek/upsilonHookedSymbolShape" = "BaseSerifed"
+selectorAffix."grek/UpsilonHookTop" = "BaseSerifed"
+selectorAffix."cyrl/ue" = "serifed"
 
 
 
@@ -1907,7 +1913,6 @@ selectorAffix."f/phoneticLeft" = ""
 selectorAffix."f/tailless" = ""
 selectorAffix.fLenis = ""
 selectorAffix.fLTail = ""
-selectorAffix.dotlessjWithStrokeAndHook = ""
 
 [prime.f.variants-buildup.stages.hook.flat-hook]
 rank = 2
@@ -1921,7 +1926,6 @@ selectorAffix."f/phoneticLeft" = "flatHook"
 selectorAffix."f/tailless" = "flatHook"
 selectorAffix.fLenis = "flatHook"
 selectorAffix.fLTail = "flatHook"
-selectorAffix.dotlessjWithStrokeAndHook = "flatHook"
 
 [prime.f.variants-buildup.stages.tail."*"]
 next = "hook"
@@ -1939,7 +1943,6 @@ selectorAffix."f/phoneticLeft" = "serifless"
 selectorAffix."f/tailless" = "serifless"
 selectorAffix.fLenis = "serifless"
 selectorAffix.fLTail = "tailed"
-selectorAffix.dotlessjWithStrokeAndHook = "tailed"
 
 [prime.f.variants-buildup.stages.tail.serifed]
 rank = 2
@@ -1953,7 +1956,6 @@ selectorAffix."f/phoneticLeft" = "serifed"
 selectorAffix."f/tailless" = "serifed"
 selectorAffix.fLenis = "serifless"
 selectorAffix.fLTail = "tailed"
-selectorAffix.dotlessjWithStrokeAndHook = "tailed"
 
 [prime.f.variants-buildup.stages.tail.extended]
 rank = 3
@@ -1967,7 +1969,6 @@ selectorAffix."f/phoneticLeft" = "extended"
 selectorAffix."f/tailless" = "serifless"
 selectorAffix.fLenis = "serifless"
 selectorAffix.fLTail = "tailed"
-selectorAffix.dotlessjWithStrokeAndHook = "tailed"
 
 [prime.f.variants-buildup.stages.tail.tailed]
 rank = 4
@@ -1981,7 +1982,6 @@ selectorAffix."f/phoneticLeft" = "tailed"
 selectorAffix."f/tailless" = "serifless"
 selectorAffix.fLenis = "serifless"
 selectorAffix.fLTail = "tailed"
-selectorAffix.dotlessjWithStrokeAndHook = "tailed"
 
 [prime.f.variants-buildup.stages.tail.diagonal-tailed]
 rank = 5
@@ -1995,7 +1995,6 @@ selectorAffix."f/phoneticLeft" = "diagonalTailed"
 selectorAffix."f/tailless" = "serifless"
 selectorAffix.fLenis = "serifless"
 selectorAffix.fLTail = "tailed"
-selectorAffix.dotlessjWithStrokeAndHook = "tailed"
 
 [prime.f.variants-buildup.stages.crossbar.standard]
 rank = 1
@@ -2009,7 +2008,6 @@ selectorAffix."f/phoneticLeft" = "crossbarAtXHeight"
 selectorAffix."f/tailless" = ""
 selectorAffix.fLenis = ""
 selectorAffix.fLTail = ""
-selectorAffix.dotlessjWithStrokeAndHook = ""
 
 [prime.f.variants-buildup.stages.crossbar.crossbar-at-x-height]
 rank = 1
@@ -2023,7 +2021,6 @@ selectorAffix."f/phoneticLeft" = "crossbarAtXHeight"
 selectorAffix."f/tailless" = "crossbarAtXHeight"
 selectorAffix.fLenis = "crossbarAtXHeight"
 selectorAffix.fLTail = "crossbarAtXHeight"
-selectorAffix.dotlessjWithStrokeAndHook = "crossbarAtXHeight"
 
 
 
@@ -2032,10 +2029,10 @@ sampler = "g"
 tagKind = "letter"
 
 [prime.g.variants-buildup]
-entry = "stroey"
+entry = "storey"
 descriptionLeader = "`g`"
 
-[prime.g.variants-buildup.stages.stroey.double-storey]
+[prime.g.variants-buildup.stages.storey.double-storey]
 next = "openness"
 rank = 1
 descriptionAffix = "double-storey shape"
@@ -2069,7 +2066,7 @@ selectorAffix."gScript/hookTopBase" = "singleStoreySerifless"
 selectorAffix."gScriptCrossedTail" = "singleStoreyScriptCut"
 selectorAffix."g/single" = "singleStoreyAutoSerifed"
 
-[prime.g.variants-buildup.stages.stroey.single-storey]
+[prime.g.variants-buildup.stages.storey.single-storey]
 next = "hook"
 rank = 2
 descriptionAffix = "single-storey shape"


### PR DESCRIPTION
This matches other lowercase letters' behavior when they are derived from capital letters (other than literal small capitals) such as with Cyrillic Lower Ge.

Additionally, having a "pedestal-like" base serif looks unbalanced when it's on the descender — I've not seen any fonts that use only a base serif for the lowercase; I've only seen them either commit to full serifs or just delete the bottom serif.

`ҮүҰұ`

`'cv24'2`:
![image](https://github.com/be5invis/Iosevka/assets/37010132/70944c2e-180d-4d0f-a4e7-a7fceb3f8d84)

`'cv24'4`:
![image](https://github.com/be5invis/Iosevka/assets/37010132/29f6d9f0-1bd7-46e2-ad3a-e619680c008c)

-----

Also rename of `grek/upsilonHookedSymbolShape` to `grek/UpsilonHookTop`.

Also remove duplicate `"YStroke.(suffix)"` configuration introduced in a611171 but never used.

Also remove orphaned `selectorAffix.dotlessjWithStrokeAndHook` leftover from a611171 .

Also correct typo in `prime.g.variants-buildup` from `stroey` to `storey`.