### PR TITLE
Make Etoile use `flat-bottom-serifed` for `M` and Cyrillic Lower Em.

### DIFF
--- a/build-plans.toml
+++ b/build-plans.toml
@@ -773,6 +773,7 @@ snapshotFeature = {"NWID" = 0}
 export-glyph-names = true
 
 [buildPlans.iosevka-etoile.variants.design]
+capital-m = "flat-bottom-serifed"
 capital-w = "straight-flat-top-serifed"
 f = "flat-hook-serifed"
 i = "serifed"
@@ -784,6 +785,7 @@ long-s = "flat-hook-bottom-serifed"
 eszet = "longs-s-lig-bottom-serifed"
 lower-iota = "serifed-flat-tailed"
 lower-tau = "flat-tailed"
+cyrl-em = "flat-bottom-serifed"
 at = "fourfold"
 percent = "rings-continuous-slash"
 

--- a/changes/27.3.4.md
+++ b/changes/27.3.4.md
@@ -1,3 +1,4 @@
 * Disunify anonymous untagged variant selectors for Cyrillic Capital Yeri/Yery for consistency in style-driven configurations.
 * Make LATIN CAPITAL LETTER Y WITH LOOP (`U+1EFE`) follow variants of capital `Y` (`cv24`) for a more balanced slab-italic form like that of Cyrillic Capital U.
 * Remove `base-serifed`-only variants for CYRILLIC SMALL LETTER STRAIGHT U (`U+04AF`, `U+04B1`).
+* Make Etoile use `flat-bottom-serifed` for `M` and Cyrillic Lower Em (`cv13`, `cv74`).


### PR DESCRIPTION
It looks more balanced to fill the negative space when there is plenty of room available to do so.
This is also what other font families seem to do when they include both a proportional and monospace version (and a serif version of at least one), like Liberation, DejaVu, etc.

Etoile:
![image](https://github.com/be5invis/Iosevka/assets/37010132/6bc37bec-1835-447f-92c6-b3b2404f8533)
compared with Aile:
![image](https://github.com/be5invis/Iosevka/assets/37010132/338c9a1d-a0b2-42c0-a870-1b9fce1a067d)
