### PR TITLE
Improve fully serifed form for CYRILLIC SMALL LETTER TALL TE (`U+1C84`).

### DIFF
--- a/changes/27.3.5.md
+++ b/changes/27.3.5.md
@@ -1,1 +1,2 @@
 * Add italic form of CYRILLIC SMALL LETTER THREE-LEGGED TE (`U+1C85`).
+* Add top-right serif to fully serifed form for CYRILLIC SMALL LETTER TALL TE (`U+1C84`).

--- a/font-src/glyphs/letter/latin/upper-t.ptl
+++ b/font-src/glyphs/letter/latin/upper-t.ptl
@@ -76,8 +76,9 @@ glyph-block Letter-Latin-Upper-T : begin
 		if doTopSerifs : begin
 			include : tagged 'serifLT' : VSerif.dl xLeft top VJut
 		if doBottomSerifs : begin
-			include : tagged 'serifMB' : HSerif.rb (xRight - [HSwToV HalfStroke]) 0 MidJutCenter
-			include : tagged 'serifMB' : HSerif.lb (xRight - [HSwToV HalfStroke]) 0 MidJutCenter
+			include : tagged 'serifMB' : HSerif.rb (xRight - [HSwToV HalfStroke]) 0 Jut
+			include : tagged 'serifMB' : HSerif.lb (xRight - [HSwToV HalfStroke]) 0 MidJutSide
+			include : tagged 'serifRT' : HSerif.rt xRight top SideJut
 
 	define TConfig : object
 		serifless     { 1                           false false }


### PR DESCRIPTION
Addition of top-right serif and adjustment of balance of bottom serif based on metrics from Greek Gamma.

ref #1911 : 
![image](https://github.com/be5invis/Iosevka/assets/37010132/576f55da-5614-4141-9d57-bf7205a86c4f)

`ᲄ`
Before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/cfb2ad4b-b453-40da-837d-afb523a55432)
After:
![image](https://github.com/be5invis/Iosevka/assets/37010132/90637422-1d94-4d92-814a-177fe09b764a)
