### PR TITLE
Some cosmetic enhancements/optimizations for Upper and Lower Greek Digamma.

### DIFF
--- a/changes/27.3.5.md
+++ b/changes/27.3.5.md
@@ -1,4 +1,4 @@
 * Add italic form of CYRILLIC SMALL LETTER THREE-LEGGED TE (`U+1C85`).
 * Add top-right serif to fully serifed form for CYRILLIC SMALL LETTER TALL TE (`U+1C84`).
-* Fix serifs of GREEK CAPITAL LETTER DIGAMMA (`U+03DC`) under `ss12`.
+* Fix serifs of GREEK LETTER DIGAMMA (`U+03DC`) under `ss12`.
 * Improve glyph shape of GREEK SMALL LETTER DIGAMMA (`U+03DD`) with the addition of a tailed terminal, higher crossbar, and a middle serif under slab.

--- a/changes/27.3.5.md
+++ b/changes/27.3.5.md
@@ -1,2 +1,4 @@
 * Add italic form of CYRILLIC SMALL LETTER THREE-LEGGED TE (`U+1C85`).
 * Add top-right serif to fully serifed form for CYRILLIC SMALL LETTER TALL TE (`U+1C84`).
+* Fix serifs of GREEK CAPITAL LETTER DIGAMMA (`U+03DC`) under `ss12`.
+* Improve glyph shape of GREEK SMALL LETTER DIGAMMA (`U+03DD`) with the addition of a tailed terminal, higher crossbar, and a middle serif under slab.

--- a/font-src/glyphs/letter/greek/upper-gamma.ptl
+++ b/font-src/glyphs/letter/greek/upper-gamma.ptl
@@ -43,11 +43,11 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 	define GammaConfig : object
 		serifless       { SLAB-NONE   false }
 		topLeftSerifed  { SLAB-LT     false }
-		topRightSerifed { SLAB-TR     false }
-		bottomSerifed   { SLAB-BOTTOM false }
+		topRightSerifed { SLAB-TR     true  }
+		bottomSerifed   { SLAB-BOTTOM SLAB  }
 		serifed         { SLAB-ALL    true  }
 
-	foreach { suffix { slabType doSB } } [Object.entries GammaConfig] : do
+	foreach { suffix { slabType doSM } } [Object.entries GammaConfig] : do
 		create-glyph "grek/Gamma.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : GammaShape CAP slabType
@@ -57,9 +57,9 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 			include : GammaShape CAP slabType
 
 			local yBar : CAP * DesignParameters.upperEBarPos
-			include : HBar.m GammaBarLeft (RightSB - [xMidBarShrink slabType]) yBar
-			if slabType : include : tagged 'serifRM'
-				VSerif.dr (RightSB - [xMidBarShrink slabType]) (yBar + HalfStroke) [mix Stroke VJut 0.5]
+			include : HBar.m GammaBarLeft (RightSB - [xMidBarShrink doSM]) yBar
+			if doSM : include : tagged 'serifRM'
+				VSerif.dr (RightSB - [xMidBarShrink doSM]) (yBar + HalfStroke) [mix Stroke VJut 0.5]
 
 		create-glyph "cyrl/GheDescender.\(suffix)" : glyph-proc
 			include [refer-glyph "grek/Gamma.\(suffix)"] AS_BASE ALSO_METRICS
@@ -163,9 +163,11 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 		include : BBBarLeft GammaBarLeft 0 CAP
 		include : HBar.t GammaBarLeft RightSB CAP BBS
 
-	create-glyph 'digamma' 0x3DD : glyph-proc
+	create-glyph 'grek/digamma' 0x3DD : glyph-proc
 		include : MarkSet.p
-		include : GammaShape (XH - Descender) SLAB-NONE
-		include : ApparentTranslate 0 Descender
-		local yBar : mix Descender XH DesignParameters.upperEBarPos
+		include : GammaShape XH SLAB-NONE
+		include : PalatalHook.lExt GammaBarLeft 0
+		local yBar : mix 0 XH DesignParameters.upperEBarPos
 		include : HBar.m GammaBarLeft (RightSB - [xMidBarShrink SLAB]) yBar
+		if SLAB : include : tagged 'serifRM'
+			VSerif.dr (RightSB - [xMidBarShrink SLAB]) (yBar + HalfStroke) [mix Stroke VJut 0.5]

--- a/font-src/glyphs/letter/greek/upper-gamma.ptl
+++ b/font-src/glyphs/letter/greek/upper-gamma.ptl
@@ -41,11 +41,11 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 				include : tagged 'serifRT' : VSerif.dr (RightSB - OX) top VJut
 
 	define GammaConfig : object
-		serifless       { SLAB-NONE   false }
-		topLeftSerifed  { SLAB-LT     false }
-		topRightSerifed { SLAB-TR     true  }
-		bottomSerifed   { SLAB-BOTTOM SLAB  }
-		serifed         { SLAB-ALL    true  }
+		serifless       { SLAB-NONE   SLAB }
+		topLeftSerifed  { SLAB-LT     SLAB }
+		topRightSerifed { SLAB-TR     true }
+		bottomSerifed   { SLAB-BOTTOM SLAB }
+		serifed         { SLAB-ALL    true }
 
 	foreach { suffix { slabType doSM } } [Object.entries GammaConfig] : do
 		create-glyph "grek/Gamma.\(suffix)" : glyph-proc


### PR DESCRIPTION
For lowercase Digamma, the crossbar should be placed based on the distance from the baseline, as the letter is functionally an x-height letter with a descender. To make it look more balanced, I made the descender into a tail, which is a common form of the letter which often shows up when you search for examples of digamma on [wikimedia](https://commons.wikimedia.org/wiki/Category:Digamma_(letter)). Additionally, a middle serif is often present for the lowercase letter in other fonts, but usually not accompanied with other serifs as the lowercase Greek alphabet tends to be very light on serifs.

For capital Digamma, the middle serif may not be present when gamma is only bottom-serifed, as it's essentially a convergence based on the literal name "di-gamma"; However, I allowed it display anyway when the font is slab, for harmony with the lowercase.

`Ϝϝ`
Sans:
![image](https://github.com/be5invis/Iosevka/assets/37010132/5934592a-5e7f-4010-b99b-08420a67f796)
Slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/37d8a4c1-0d46-4000-8f6e-d345e3a32a09)
