### PR TITLE
Further tweaks for Greek Lower Digamma.

### DIFF
--- a/changes/27.3.5.md
+++ b/changes/27.3.5.md
@@ -1,4 +1,4 @@
 * Add italic form of CYRILLIC SMALL LETTER THREE-LEGGED TE (`U+1C85`).
 * Add top-right serif to fully serifed form for CYRILLIC SMALL LETTER TALL TE (`U+1C84`).
 * Fix serifs of GREEK LETTER DIGAMMA (`U+03DC`) under `ss12`.
-* Improve glyph shape of GREEK SMALL LETTER DIGAMMA (`U+03DD`) with the addition of a tailed terminal, higher crossbar, and a middle serif under slab.
+* Improve crossbar position of GREEK SMALL LETTER DIGAMMA (`U+03DD`) and add a middle serif under slab.

--- a/font-src/glyphs/letter/greek/upper-gamma.ptl
+++ b/font-src/glyphs/letter/greek/upper-gamma.ptl
@@ -22,19 +22,19 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 	define SLAB-ALL    4
 
 	define GammaBarLeft (SB * 1.5)
-	define [GammaShape top slabType] : glyph-proc
+	define [GammaShape top bot slabType] : glyph-proc
 		include : LeaningAnchor.Below.VBar.l GammaBarLeft
-		include : VBar.l GammaBarLeft 0 top
+		include : VBar.l GammaBarLeft bot top
 		include : HBar.t (GammaBarLeft - O) (RightSB - OX) top
 		match slabType
 			[Just SLAB-ALL] : begin
 				include : HSerif.lt GammaBarLeft top SideJut
-				include : HSerif.lb (GammaBarLeft + [HSwToV HalfStroke]) 0 Jut
-				include : HSerif.rb (GammaBarLeft + [HSwToV HalfStroke]) 0 MidJutSide
+				include : HSerif.lb (GammaBarLeft + [HSwToV HalfStroke]) bot Jut
+				include : HSerif.rb (GammaBarLeft + [HSwToV HalfStroke]) bot MidJutSide
 				include : tagged 'serifRT' : VSerif.dr (RightSB - OX) top VJut
 			[Just SLAB-BOTTOM] : begin
-				include : HSerif.lb (GammaBarLeft + [HSwToV HalfStroke]) 0 Jut
-				include : HSerif.rb (GammaBarLeft + [HSwToV HalfStroke]) 0 MidJutSide
+				include : HSerif.lb (GammaBarLeft + [HSwToV HalfStroke]) bot Jut
+				include : HSerif.rb (GammaBarLeft + [HSwToV HalfStroke]) bot MidJutSide
 			[Just SLAB-LT] : begin
 				include : HSerif.lt GammaBarLeft top SideJut
 			[Just SLAB-TR] : begin
@@ -50,11 +50,11 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 	foreach { suffix { slabType doSM } } [Object.entries GammaConfig] : do
 		create-glyph "grek/Gamma.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : GammaShape CAP slabType
+			include : GammaShape CAP 0 slabType
 
 		create-glyph "grek/Digamma.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : GammaShape CAP slabType
+			include : GammaShape CAP 0 slabType
 
 			local yBar : CAP * DesignParameters.upperEBarPos
 			include : HBar.m GammaBarLeft (RightSB - [xMidBarShrink doSM]) yBar
@@ -77,7 +77,7 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 
 		create-glyph "cyrl/ghe.upright.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			include : GammaShape XH slabType
+			include : GammaShape XH 0 slabType
 
 		create-glyph "cyrl/gheDescender.upright.\(suffix)" : glyph-proc
 			include [refer-glyph "cyrl/ghe.upright.\(suffix)"] AS_BASE ALSO_METRICS
@@ -96,21 +96,21 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 		create-glyph "cyrl/Ge.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : ExtendAboveBaseAnchors (CAP + LongJut - 0.5 * Stroke)
-			include : GammaShape CAP slabType
+			include : GammaShape CAP 0 slabType
 			eject-contour 'serifRT'
 			include : VBar.r (RightSB - OX) CAP (CAP + LongJut - 0.5 * Stroke)
 
 		create-glyph "cyrl/ge.upright.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : ExtendAboveBaseAnchors (XH + LongJut - 0.5 * Stroke)
-			include : GammaShape XH slabType
+			include : GammaShape XH 0 slabType
 			eject-contour 'serifRT'
 			include : VBar.r (RightSB - OX) XH (XH + LongJut - 0.5 * Stroke)
 
 		create-glyph "cyrl/ge.italic.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : ExtendAboveBaseAnchors (XH + LongJut - 0.5 * Stroke)
-			include : GammaShape XH slabType
+			include : GammaShape XH 0 slabType
 			eject-contour 'serifRT'
 			include : VBar.r (RightSB - OX) XH (XH + LongJut - 0.5 * Stroke)
 
@@ -165,8 +165,7 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 
 	create-glyph 'grek/digamma' 0x3DD : glyph-proc
 		include : MarkSet.p
-		include : GammaShape XH SLAB-NONE
-		include : PalatalHook.lExt GammaBarLeft 0
+		include : GammaShape XH Descender SLAB-NONE
 		local yBar : mix 0 XH DesignParameters.upperEBarPos
 		include : HBar.m GammaBarLeft (RightSB - [xMidBarShrink SLAB]) yBar
 		if SLAB : include : tagged 'serifRM'


### PR DESCRIPTION
The addition of the tail in #2078 was probably unnecessary as I have come to realize that fonts with a serif on the crossbar for the lowercase appear to be mutually exclusive with fonts with a tailed descender, so to be on the safe side I settled for the straight descender form as the least disruptive change.

Additionally, the gamma shape function now takes a bottom height argument.

`Ϝϝ`
Sans:
![image](https://github.com/be5invis/Iosevka/assets/37010132/6c90e3ee-06ba-46cb-a6b5-ee90eb02cebd)
Slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/bf286dc2-ac2c-4539-99a3-d02046f7ccd6)
Comparison to Arial:
![image](https://github.com/be5invis/Iosevka/assets/37010132/e4f122a1-03f5-43b4-8c21-2fbe678e822a)
