### PR TITLE
Reorder some variants and variant selectors.

### DIFF
--- a/changes/28.0.0-alpha.1.md
+++ b/changes/28.0.0-alpha.1.md
@@ -12,7 +12,7 @@
    - `webfont-formats` → `webfontFormats`
  * \[**BREAKING**\] The "SGr" TTC packages for Iosevka Aile and Etoile will no longer be generated, as they are duplicates to the non-SGr TTC packages.
  * \[**BREAKING**\] Reorder of glyph variants:
-   - Influenced characters: `M`, `R`, `f`, `t`, `x`, Long S (`ſ`), Lower Lambda (`λ`), Lower Tau (`τ`), Lower Chi (`χ`), Cyrillic Lower Em (`м`), Cyrillic Lowen Ef (`ф`), Cyrillic Ya (`Я`, `я`), `5`.
+   - Influenced characters: `M`, `R`, `f`, `t`, `x`, Long S (`ſ`), Lower Lambda (`λ`), Lower Tau (`τ`), Lower Chi (`χ`), Cyrillic Lower Em (`м`), Cyrillic Lower Ef (`ф`), Cyrillic Ya (`Я`, `я`), `5`.
  * \[**BREAKING**\] Tags for variant features for Cyrillic lowercase Er and U are changed to `cv76` and `cv78`.
      - Various other glyph variant tags are also changed to reflect this insertion.
  * Add hook-inward-serifed variants for `a` (#2085).

--- a/changes/28.0.0-alpha.1.md
+++ b/changes/28.0.0-alpha.1.md
@@ -12,7 +12,7 @@
    - `webfont-formats` → `webfontFormats`
  * \[**BREAKING**\] The "SGr" TTC packages for Iosevka Aile and Etoile will no longer be generated, as they are duplicates to the non-SGr TTC packages.
  * \[**BREAKING**\] Reorder of glyph variants:
-   - Influenced characters: `M`, `R`, `f`, `t`, `x`, Long S (`ſ`), Lower Chi (`χ`), Cyrillic Lower Em (`м`), Cyrillic Ya (`Я`, `я`), `5`.
+   - Influenced characters: `M`, `R`, `f`, `t`, `x`, Long S (`ſ`), Lower Lambda (`λ`), Lower Tau (`τ`), Lower Chi (`χ`), Cyrillic Lower Em (`м`), Cyrillic Lowen Ef (`ф`), Cyrillic Ya (`Я`, `я`), `5`.
  * \[**BREAKING**\] Tags for variant features for Cyrillic lowercase Er and U are changed to `cv76` and `cv78`.
      - Various other glyph variant tags are also changed to reflect this insertion.
  * Add hook-inward-serifed variants for `a` (#2085).

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -6854,6 +6854,7 @@ description = "Ampersand (`&`) drawn like a ligature of Ɛ and t with tail"
 selector.ampersand = "etTailed"
 
 
+
 [prime.at]
 sampler = "@"
 tagKind = "symbol"

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -197,6 +197,7 @@ selector.CTopSerifOnly = "unilateralInwardSerifed"
 selector.CBottomSerifOnly = "bilateralInwardSerifed"
 
 
+
 [prime.capital-d]
 sampler = "D"
 tagKind = "letter"
@@ -1647,6 +1648,7 @@ selectorAffix."a/single"    = "serifed"
 selectorAffix.scripta       = "serifed"
 
 
+
 [prime.b]
 sampler = "b"
 tagKind = "letter"
@@ -2255,6 +2257,7 @@ selectorAffix.heng = "serifed"
 selectorAffix."cyrl/shha" = "serifed"
 
 
+
 [prime.i]
 sampler = "i"
 tagKind = "letter"
@@ -2786,6 +2789,7 @@ selector."l/reduced/rtailDec" = "hookyRTailDec"
 selector."l/phoneticLeft" = "hookyPL"
 selector.lCurlyTail = "hooky"
 selector.lyogh = "hooky"
+
 
 
 [prime.m]
@@ -4794,20 +4798,20 @@ rank = 2
 description = "Greek small Lambda (`λ`) with straight upper and a tail turns leftward"
 selector."grek/lambda" = "straightTurnSerifless"
 
-[prime.lower-lambda.variants.curly]
+[prime.lower-lambda.variants.tailed-turn]
 rank = 3
+description = "More curly Greek small Lambda (`λ`), with a tail turns leftward at top and a tail turns right at bottom-right"
+selector."grek/lambda" = "tailedTurnSerifless"
+
+[prime.lower-lambda.variants.curly]
+rank = 4
 description = "More curly Greek small Lambda (`λ`), like Iosevka 2.x"
 selector."grek/lambda" = "curlySerifless"
 
 [prime.lower-lambda.variants.curly-turn]
-rank = 4
+rank = 5
 description = "More curly Greek small Lambda (`λ`), like Iosevka 2.x, with a tail turns leftward"
 selector."grek/lambda" = "curlyTurnSerifless"
-
-[prime.lower-lambda.variants.tailed-turn]
-rank = 5
-description = "More curly Greek small Lambda (`λ`), with a tail turns leftward at top and a tail turns right at bottom-right"
-selector."grek/lambda" = "tailedTurnSerifless"
 
 [prime.lower-lambda.variants.curly-tailed-turn]
 rank = 6
@@ -4929,30 +4933,30 @@ rank = 1
 description = "Greek lower Tau (`τ`) with a tailless shape"
 selector."grek/tau" = "tau/tailless"
 
-[prime.lower-tau.variants.tailed]
+[prime.lower-tau.variants.short-tailed]
 rank = 2
+description = "Greek lower Tau (`τ`) with a very short tail"
+selector."grek/tau" = "tau/shortTailed"
+
+[prime.lower-tau.variants.tailed]
+rank = 3
 description = "Greek lower Tau (`τ`) with curly tail"
 selector."grek/tau" = "tau/tailed"
 
 [prime.lower-tau.variants.flat-tailed]
-rank = 3
+rank = 4
 description = "Greek lower Tau (`τ`) with a flat tail"
 selector."grek/tau" = "tau/flatTailed"
 
 [prime.lower-tau.variants.diagonal-tailed]
-rank = 4
+rank = 5
 description = "Greek lower Tau (`τ`) with a diagonal tail"
 selector."grek/tau" = "tau/diagonalTailed"
 
 [prime.lower-tau.variants.semi-tailed]
-rank = 5
+rank = 6
 description = "Greek lower Tau (`τ`) with a slightly curly tail"
 selector."grek/tau" = "tau/semiTailed"
-
-[prime.lower-tau.variants.short-tailed]
-rank = 6
-description = "Greek lower Tau (`τ`) with a very short tail"
-selector."grek/tau" = "tau/shortTailed"
 
 
 
@@ -5000,7 +5004,6 @@ next = "END"
 descriptionAffix = "Chancery shape"
 selectorAffix."grek/chi" = "chancery"
 selectorAffix."grek/chi/sansSerif" = "chancery"
-
 
 [prime.lower-chi.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -5981,7 +5984,7 @@ descriptionAffix = "standing leg (like Helvetica)"
 selectorAffix."cyrl/ya" = "standing"
 
 [prime.cyrl-ya.variants-buildup.stages.openness."*"]
-next = "serifs"
+next = "tails"
 
 [prime.cyrl-ya.variants-buildup.stages.openness.closed]
 rank = 1
@@ -6658,6 +6661,43 @@ selector.asciiCaret = "low"
 
 
 
+[prime.ascii-grave]
+sampler = "`"
+tagKind = "symbol"
+
+[prime.ascii-grave.variants.straight]
+rank = 1
+description = "Show ASCII grave (`` ` ``) as short diagonal straight bar."
+selector.asciiGrave = "straight"
+
+[prime.ascii-grave.variants.raised-inverse-comma]
+rank = 2
+description = "Show ASCII grave (`` ` ``) as raised comma."
+selector.asciiGrave = "raisedInverseComma"
+
+[prime.ascii-grave.variants.raised-turn-comma]
+rank = 3
+description = "Show ASCII grave (`` ` ``) as raised turned comma, identical to curly open single quote symbols (U+2018)."
+selector.asciiGrave = "raisedTurnComma"
+
+
+
+[prime.ascii-single-quote]
+sampler = "'"
+tagKind = "symbol"
+
+[prime.ascii-single-quote.variants.straight]
+rank = 1
+description = 'Show ASCII quote (`"`) as short vertical straight bar.'
+selector.asciiSingleQuote = "straight"
+
+[prime.ascii-single-quote.variants.raised-comma]
+rank = 2
+description = 'Show ASCII quote (`"`) as raised comma.'
+selector.asciiSingleQuote = "raisedComma"
+
+
+
 [prime.paren]
 sampler = "( )"
 tagKind = "symbol"
@@ -6902,6 +6942,42 @@ selector.dollar = "interruptedCap"
 
 
 
+[prime.cent]
+sampler = "¢"
+tagKind = "symbol"
+
+[prime.cent.variants.open]
+rank = 1
+description = "Cent sign (`¢`) with open contour"
+selector.cent = "open"
+
+[prime.cent.variants.through]
+rank = 2
+description = "Cent sign (`¢`) with vertical bar all through the `c` part"
+selector.cent = "through"
+
+[prime.cent.variants.bar-interrupted]
+rank = 3
+description = "Cent sign (`¢`) with vertical bar breaks at center"
+selector.cent = "interrupted"
+
+[prime.cent.variants.open-cap]
+rank = 4
+description = "Cent sign (`¢`) with open contour, sized not exceeding baseline and ascender"
+selector.cent = "openCap"
+
+[prime.cent.variants.through-cap]
+rank = 5
+description = "Cent sign (`¢`) with vertical bar all through the `c` part, sized not exceeding baseline and ascender"
+selector.cent = "throughCap"
+
+[prime.cent.variants.bar-interrupted-cap]
+rank = 6
+description = "Cent sign (`¢`) with vertical bar breaks at center, sized not exceeding baseline and ascender"
+selector.cent = "interruptedCap"
+
+
+
 [prime.percent]
 sampler = "%"
 tagKind = "symbol"
@@ -6953,43 +7029,6 @@ selector."bar.slanted" = "forceUpright"
 
 
 
-[prime.ascii-single-quote]
-sampler = "'"
-tagKind = "symbol"
-
-[prime.ascii-single-quote.variants.straight]
-rank = 1
-description = 'Show ASCII quote (`"`) as short vertical straight bar.'
-selector.asciiSingleQuote = "straight"
-
-[prime.ascii-single-quote.variants.raised-comma]
-rank = 2
-description = 'Show ASCII quote (`"`) as raised comma.'
-selector.asciiSingleQuote = "raisedComma"
-
-
-
-[prime.ascii-grave]
-sampler = "`"
-tagKind = "symbol"
-
-[prime.ascii-grave.variants.straight]
-rank = 1
-description = "Show ASCII grave (`` ` ``) as short diagonal straight bar."
-selector.asciiGrave = "straight"
-
-[prime.ascii-grave.variants.raised-inverse-comma]
-rank = 2
-description = "Show ASCII grave (`` ` ``) as raised comma."
-selector.asciiGrave = "raisedInverseComma"
-
-[prime.ascii-grave.variants.raised-turn-comma]
-rank = 3
-description = "Show ASCII grave (`` ` ``) as raised turned comma, identical to curly open single quote symbols (U+2018)."
-selector.asciiGrave = "raisedTurnComma"
-
-
-
 [prime.question]
 sampler = "?"
 tagKind = "symbol"
@@ -7026,42 +7065,6 @@ rank = 2
 description = "Lower pilcrow sign `¶`"
 selector.pilcrow = "low"
 selector.revPilcrow = "low"
-
-
-
-[prime.cent]
-sampler = "¢"
-tagKind = "symbol"
-
-[prime.cent.variants.open]
-rank = 1
-description = "Cent sign (`¢`) with open contour"
-selector.cent = "open"
-
-[prime.cent.variants.through]
-rank = 2
-description = "Cent sign (`¢`) with vertical bar all through the `c` part"
-selector.cent = "through"
-
-[prime.cent.variants.bar-interrupted]
-rank = 3
-description = "Cent sign (`¢`) with vertical bar breaks at center"
-selector.cent = "interrupted"
-
-[prime.cent.variants.open-cap]
-rank = 4
-description = "Cent sign (`¢`) with open contour, sized not exceeding baseline and ascender"
-selector.cent = "openCap"
-
-[prime.cent.variants.through-cap]
-rank = 5
-description = "Cent sign (`¢`) with vertical bar all through the `c` part, sized not exceeding baseline and ascender"
-selector.cent = "throughCap"
-
-[prime.cent.variants.bar-interrupted-cap]
-rank = 6
-description = "Cent sign (`¢`) with vertical bar breaks at center, sized not exceeding baseline and ascender"
-selector.cent = "interruptedCap"
 
 
 


### PR DESCRIPTION
Specifically:
- move tailed lambda variants to the end of either the straight or curly sections so they follow a loose order of e.g. plain → top tail → double tailed.
- move short tailed tau variant to the second place position so that the first two tau variants mirror the first two pi variants.
- document existing effects on Cyrillic Ef.
- fix anomaly where Cyrillic Lower Ya had its tail variants skipped.
- Move ASCII grave/quote variant selectors to be between section of ASCII marks and section of enclosing punctuation.
- Move Cent sign variant selector to be after Dollar Sign variant selector.