### PR TITLE
Mordvin Letters

### DIFF
--- a/font-src/glyphs/letter/cyrillic/dzzhe-zhwe.ptl
+++ b/font-src/glyphs/letter/cyrillic/dzzhe-zhwe.ptl
@@ -9,24 +9,25 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Greek-Lower-Epsilon : CyrZe
 
-	define [SubDfDim pShift keeps df _o] : begin
+	glyph-block-export SubDfDimBy4
+	define [SubDfDimBy4 pShift keeps df _o] : begin
 		local subDf : df.slice 4 keeps _o
 		local subDfFullShift : (df.rightSB - subDf.rightSB) / (4 - keeps)
 		local shift : pShift * subDfFullShift
 		local sw : AdviceStroke 3.3 [df.slice 4 3 _o].div
 		return : object subDf shift sw
 
-	do "d subglyph"
+	do "de subglyph"
 		glyph-block-import Mark-Adjustment : ExtendBelowBaseAnchors
 		glyph-block-import Letter-Cyrillic-De : CyrDeShape CyrDeItalicShapeT
 
 		define [CyrDzzheDeShape df top] : glyph-proc
-			local [object subDf sw] : SubDfDim 0 2 df OX
+			local [object subDf sw] : SubDfDimBy4 0 2 df OX
 			local left : if SLAB (subDf.leftSB + 0.5 * SideJut) subDf.leftSB
 			include : CyrDeShape top left subDf.rightSB sw
 
 		define [CyrDzzheDeItalicShape df] : glyph-proc
-			local [object subDf sw] : SubDfDim 0 2 df OX
+			local [object subDf sw] : SubDfDimBy4 0 2 df OX
 			include : CyrDeItalicShapeT dispiro subDf sw
 
 		create-glyph "cyrl/Dzzhe/left" : glyph-proc
@@ -62,7 +63,7 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 			bilateralInwardSerifed  { SLAB-INWARD    SLAB-INWARD    }
 
 		define [CyrZhweZeShape slabTop slabBot df top hook] : glyph-proc
-			local [object subDf sw] : SubDfDim 0 2 df OX
+			local [object subDf sw] : SubDfDimBy4 0 2 df OX
 			local ze : CyrZe slabTop slabBot top 0 subDf.leftSB subDf.rightSB 0.65 hook sw
 			include : ze.Shape
 			include : ze.AutoStartSerifL
@@ -84,23 +85,23 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 	do "zhe subglyphs"
 		glyph-block-import Letter-Cyrillic-Zhe : Zhe
 		define [CyrRightZheShape legShape fSlab fMidSlab df top barLeft] : glyph-proc
-			local [object subDf shift sw] : SubDfDim 1 3 df OX
+			local [object subDf shift sw] : SubDfDimBy4 1 3 df OX
 			include : with-transform [ApparentTranslate shift 0] : Zhe.HalfShape legShape fSlab fMidSlab subDf 0 top top
 			include : HBar.m barLeft (shift + subDf.middle) (0.5 * top) sw
 
 		define [DzzheLeft df] : begin
-			local [object subDf sw] : SubDfDim 0 2 df OX
+			local [object subDf sw] : SubDfDimBy4 0 2 df OX
 			local swInner : sw * [AdviceStroke 2.75] / Stroke
 			return : [mix subDf.leftSB subDf.rightSB : StrokeWidthBlend 0.95 0.96] - [HSwToV : 0.5 * swInner]
 
 		define [ZhweZheShape legShape fSlab fMidSlab df top hook] : glyph-proc
-			local [object subDf sw] : SubDfDim 0 2 df OX
+			local [object subDf sw] : SubDfDimBy4 0 2 df OX
 			local ze : CyrZe 0 0 top 0 subDf.leftSB subDf.rightSB 0.65 hook (0.5 * sw)
 			include : difference [CyrRightZheShape legShape fSlab fMidSlab df top subDf.middle] [ze.ShapeMask]
 
 		glyph-block-import Letter-Cyrillic-De : CyrDeItalicShapeT
 		define [DzzheZheItalicShape legShape fSlab fMidSlab df top] : glyph-proc
-			local [object subDf sw] : SubDfDim 0 2 df OX
+			local [object subDf sw] : SubDfDimBy4 0 2 df OX
 			include : difference
 				CyrRightZheShape legShape fSlab fMidSlab df top subDf.middle
 				CyrDeItalicShapeT spiro-outline subDf sw

--- a/font-src/glyphs/letter/cyrillic/el.ptl
+++ b/font-src/glyphs/letter/cyrillic/el.ptl
@@ -11,9 +11,9 @@ glyph-block Letter-Cyrillic-El : begin
 	glyph-block-import Letter-Shared-Shapes : SerifFrame LegShape RightwardTailedBar
 	glyph-block-import Letter-Shared-Shapes : CyrDescender CyrTailDescender PalatalHook MidHook UpwardHookShape
 
-	define BODY-STRAIGHT 0
-	define BODY-TAILED   1
-	define BODY-NONE     2
+	define BODY-NONE     0
+	define BODY-STRAIGHT 1
+	define BODY-TAILED   2
 
 	define SLAB-NONE     0
 	define SLAB-ALL      1

--- a/font-src/glyphs/letter/latin-ext/lower-ae-oe.ptl
+++ b/font-src/glyphs/letter/latin-ext/lower-ae-oe.ptl
@@ -8,6 +8,7 @@ glyph-module
 glyph-block Letter-Latin-Lower-AE-OE : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
+	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared-Shapes : nShoulder OBarLeft
 
 	glyph-block-export SubDfAndShift
@@ -191,7 +192,96 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 				set-base-anchor 'cvDecompose' 0 0
 				include : EsTeLeftShape df styBot
 
+	do "P/R subglyphs"
+		glyph-block-import Letter-Latin-Upper-P : PShape PBarPosY
+		glyph-block-import Letter-Latin-Upper-R : RevRShape RConfig RBarPos
+
+		# Ya
+		foreach { suffix { legShape fOpen fTailed {slabs revSlabs doLegSlab} } } [Object.entries RConfig] : begin
+			local fSlabBot : slabs && slabs !== PShape.SlabMotion
+
+			if [not fTailed] : begin
+				create-glyph "cyrl/yae/left.\(suffix)" : glyph-proc
+					local df : include : DivFrame para.diversityM 3
+					include : df.markSet.e
+					set-base-anchor 'cvDecompose' 0 0
+
+					local { subDf } : SubDfAndShift 0 df
+					local bp : RBarPos XH fSlabBot
+
+					include : RevRShape legShape XH (df -- subDf) (slab -- revSlabs) (legSlab -- doLegSlab) (bp -- bp) (open -- fOpen) (sw -- df.mvs)
+
+					eject-contour 'strokeR'
+					eject-contour 'serifRB'
+					eject-contour 'serifRT'
+					include : VBar.r subDf.rightSB [PBarPosY XH df.mvs bp] XH df.mvs
+
+		# P
+		glyph-block-import Letter-Latin-Lower-P : PConfig
+		foreach { suffix { Body {Serifs doBS} }} [Object.entries PConfig] : do
+			create-glyph "cyrl/rha/left.\(suffix)" : glyph-proc
+				local df : include : DivFrame para.diversityM 3
+				include : df.markSet.p
+				local { subDf } : SubDfAndShift 0 df
+				set-base-anchor 'cvDecompose' 0 0
+
+				include : Body
+					left  -- subDf.leftSB
+					right -- subDf.rightSB
+					sw    -- df.mvs
+				include : Serifs subDf XH df.mvs
+				include : LeaningAnchor.Below.VBar.l SB
+
+	do "X subglyphs"
+		glyph-block-import Letter-Shared-Shapes : SerifFrame WithSerifOverflowMask
+		glyph-block-import Letter-Latin-X : XConfig XLetterForm XSerifs
+
+		foreach { suffix {stroke1 stroke2 serifShape fMaskBase} } [Object.entries XConfig] : do
+			define [halfLetterShape df top bot turn tension] : glyph-proc
+				local lf : XLetterForm df top bot stroke1 stroke2 turn tension
+				include : WithSerifOverflowMask fMaskBase top bot df.leftSB df.rightSB : lf.rightHalf fMaskBase
+				if serifShape : begin
+					local sf : SerifFrame.fromDf df top bot
+					include : match serifShape
+						[Just XSerifs.Full] : composite-proc sf.rt.full sf.rb.full
+						[Just XSerifs.BilateralMotion] : composite-proc sf.rb.outer
+						__ : glyph-proc
+
+			define [letterShape df top bot turn tension] : glyph-proc
+				local stroke1f : if (stroke1 == 3) 4 stroke1
+				local lf : XLetterForm df top bot stroke1f stroke2 turn tension
+				include : WithSerifOverflowMask fMaskBase top bot df.leftSB df.rightSB : lf.base fMaskBase
+				if serifShape : begin
+					local sf : SerifFrame.fromDf df top bot
+					include : match serifShape
+						[Just XSerifs.Full] : composite-proc sf.rt.full sf.lb.full sf.rb.full
+						[Just XSerifs.BilateralMotion] : composite-proc sf.rb.outer
+						__ : glyph-proc
+
+			create-glyph "cyrl/rha/right.\(suffix)" : glyph-proc
+				local df : DivFrame para.diversityM 3
+				set-width 0
+				set-mark-anchor 'cvDecompose' 0 0
+				include : halfLetterShape df XH 0 0.1 0.20
+
+			create-glyph "cyrl/lha/right.\(suffix)" : glyph-proc
+				local df : DivFrame para.diversityM 3
+				set-width 0
+				set-mark-anchor 'cvDecompose' 0 0
+
+				local { subDf shift } : SubDfAndShift 1 df
+				include : with-transform [ApparentTranslate shift 0] : letterShape subDf XH 0 0.1 0.20
+
+			create-glyph "cyrl/Lha/right.\(suffix)" : glyph-proc
+				local df : DivFrame para.diversityM 3
+				set-width 0
+				set-mark-anchor 'cvDecompose' 0 0
+
+				local { subDf shift } : SubDfAndShift 1 df
+				include : with-transform [ApparentTranslate shift 0] : letterShape subDf CAP 0 0.1 0.28
+
 	do "other subglyphs"
+		# Te
 		define [EsTeRightShape df doTopSerifs doBottomSerifs] : new-glyph : glyph-proc
 			local subDf : df.sliceFine 3 2 (1/3)
 			# local shift : df.rightSB - subDf.rightSB
@@ -220,6 +310,22 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
 				include : EsTeRightShape df doST doSB
+
+		# El
+		glyph-block-import Letter-Cyrillic-El : CyrElShape
+		create-glyph 'cyrl/Lha/left' : glyph-proc
+			local df : include : DivFrame para.diversityM 3
+			include : df.markSet.capital
+			local { subDf } : SubDfAndShift 0 df
+			set-base-anchor 'cvDecompose' 0 0
+			include : CyrElShape subDf.leftSB (subDf.rightSB - [HSwToV : 0.5 * df.mvs]) CAP 0 [if SLAB 4 0] df.mvs
+
+		create-glyph 'cyrl/lha/left' : glyph-proc
+			local df : include : DivFrame para.diversityM 3
+			include : df.markSet.e
+			local { subDf } : SubDfAndShift 0 df
+			set-base-anchor 'cvDecompose' 0 0
+			include : CyrElShape subDf.leftSB (subDf.rightSB - [HSwToV : 0.5 * df.mvs]) XH 0 [if SLAB 4 0] df.mvs
 
 	do "subglyph diacritics"
 		glyph-block-import Mark-Overlay : InnerDot
@@ -262,6 +368,11 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 	select-variant "aeInvE/right" (follow -- 'e')
 	select-variant "ue/u"
 	select-variant "oeOpenO/left" (follow -- 'c')
+	select-variant "cyrl/yae/left"
+	select-variant "cyrl/rha/left" (follow -- 'cyrl/er')
+	select-variant "cyrl/rha/right"
+	select-variant "cyrl/Lha/right" (follow -- 'cyrl/Rha/right')
+	select-variant "cyrl/lha/right" (follow -- 'cyrl/rha/right')
 
 	derive-composites 'ae' 0xE6   'ae/a' 'ae/e'
 	derive-composites 'oe' 0x153  'oe/o' 'ae/e'
@@ -272,6 +383,10 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 	derive-composites 'oeOpenO' 0xAB62 'oeOpenO/left' 'ae/e'
 	derive-composites 'aeInvE' 0xAB31 'ae/a' 'aeInvE/right'
 	derive-composites 'oeInv' 0xAB40 'oe/o' 'aeInvE/right'
+	derive-composites 'cyrl/lha' 0x515 'cyrl/lha/left' 'cyrl/lha/right'
+	derive-composites 'cyrl/Lha' 0x514 'cyrl/Lha/left' 'cyrl/Lha/right'
+	derive-composites 'cyrl/rha' 0x517 'cyrl/rha/left' 'cyrl/rha/right'
+	derive-composites 'cyrl/yae' 0x519 'cyrl/yae/left' 'ae/e'
 
 	alias 'cyrl/ae' 0x4D5  'ae'
 	alias 'cyrl/oo' 0xA699 'oo'

--- a/font-src/glyphs/letter/latin-ext/upper-aa-ao.ptl
+++ b/font-src/glyphs/letter/latin-ext/upper-aa-ao.ptl
@@ -1,95 +1,130 @@
 $$include '../../../meta/macros.ptl'
 
 import [mix linreg clamp fallback] from"../../../support/utils.mjs"
-import [bitOr] from"../../../support/util/mask-bit.mjs"
+import [maskOffBits] from"../../../support/util/mask-bit.mjs"
 
 glyph-module
 
 glyph-block Letter-Latin-Upper-AA-AO : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Latin-Upper-F : EFVJutLength
-	glyph-block-import Letter-Latin-Upper-A : AMaskShape ALetterShape
 	glyph-block-import Letter-Latin-Lower-AE-OE : SubDfAndShift
 
-	define [AHalfShape pShift df top fStraightBar slabKind] : begin
-		local { subDf shift } : SubDfAndShift pShift df
-		return : with-transform [ApparentTranslate shift 0]
-			ALetterShape subDf fStraightBar slabKind top df.mvs
+	do "A glyphs"
+		glyph-block-import Letter-Latin-Upper-A : AConfig AMaskShape ALetterShape
 
-	define [AHalfShapeMask pShift df top fStraightBar slabKind] : begin
-		local { subDf shift } : SubDfAndShift pShift df
-		return : with-transform [ApparentTranslate shift 0]
-			AMaskShape subDf fStraightBar top df.mvs
+		define [AHalfShape pShift df top fStraightBar slabKind] : begin
+			local { subDf shift } : SubDfAndShift pShift df
+			return : with-transform [ApparentTranslate shift 0]
+				ALetterShape subDf fStraightBar slabKind top df.mvs
 
-	define SLAB-NONE    0
-	define SLAB-TOP     1
-	define SLAB-LEFT    2
-	define SLAB-RIGHT   4
+		define [AHalfShapeMask pShift df top fStraightBar slabKind] : begin
+			local { subDf shift } : SubDfAndShift pShift df
+			return : with-transform [ApparentTranslate shift 0]
+				AMaskShape subDf fStraightBar top df.mvs
 
-	define ALetters : object
-		AA     { 0xA732 'capital' CAP }
-		smcpAA { null   'e'       XH  }
+		define SLAB-NONE    0
+		define SLAB-TOP     1
+		define SLAB-LEFT    2
+		define SLAB-RIGHT   4
 
-	define AConfig : object
-		straightSerifless     { true   SLAB-NONE                   SLAB-NONE                   }
-		curlySerifless        { false  SLAB-NONE                   SLAB-NONE                   }
-		straightTopSerifed    { true          SLAB-TOP                    SLAB-TOP             }
-		curlyTopSerifed       { false         SLAB-TOP                    SLAB-TOP             }
-		straightBaseSerifed   { true                   SLAB-LEFT                   SLAB-RIGHT  }
-		curlyBaseSerifed      { false                  SLAB-LEFT                   SLAB-RIGHT  }
-		straightTriSerifed    { true   [bitOr SLAB-TOP SLAB-LEFT]  [bitOr SLAB-TOP SLAB-RIGHT] }
-		curlyTriSerifed       { false  [bitOr SLAB-TOP SLAB-LEFT]  [bitOr SLAB-TOP SLAB-RIGHT] }
+		define ALetters : object
+			AA     { 0xA732 'capital' CAP }
+			smcpAA { null   'e'       XH  }
 
-	foreach { prefix { code mk height } } [Object.entries ALetters] : do
-		foreach { suffix { fStraightBar skLeft skRight } } [Object.entries AConfig] : do
-			create-glyph "\(prefix)/Left.\(suffix)" : glyph-proc
-				define df : include : DivFrame para.diversityM 3.5
-				include : df.markSet.(mk)
+		foreach { prefix { code mk height } } [Object.entries ALetters] : do
+			foreach { suffix { fStraightBar slabKind } } [Object.entries AConfig] : do
+				define skLeft  : maskOffBits slabKind SLAB-RIGHT
+				define skRight : maskOffBits slabKind SLAB-LEFT
+
+				create-glyph "\(prefix)/Left.\(suffix)" : glyph-proc
+					define df : include : DivFrame para.diversityM 3.5
+					include : df.markSet.(mk)
+					set-base-anchor 'cvDecompose' 0 0
+					include : AHalfShape 0 df height fStraightBar skLeft
+
+				create-glyph "\(prefix)/LeftMask.\(suffix)" : glyph-proc
+					define df : include : DivFrame para.diversityM 3.5
+					include : df.markSet.(mk)
+					set-base-anchor 'cvDecompose' 0 0
+					include : AHalfShapeMask 0 df height fStraightBar skLeft
+
+				create-glyph "\(prefix)/Right.\(suffix)" : glyph-proc
+					define df : DivFrame para.diversityM 3.5
+					set-width 0
+					include : df.markSet.(mk)
+					set-mark-anchor 'cvDecompose' 0 0 0 0
+					include : AHalfShape 1 df height fStraightBar skRight
+
+				create-glyph "\(prefix)/RightMask.\(suffix)" : glyph-proc
+					define df : DivFrame para.diversityM 3.5
+					set-width 0
+					include : df.markSet.(mk)
+					set-mark-anchor 'cvDecompose' 0 0 0 0
+					include : AHalfShapeMask 1 df height fStraightBar skRight
+
+			select-variant "\(prefix)/Left"      (follow -- 'A')
+			select-variant "\(prefix)/LeftMask"  (follow -- 'A')
+			select-variant "\(prefix)/Right"     (follow -- 'A')
+			select-variant "\(prefix)/RightMask" (follow -- 'A')
+
+			derive-multi-part-glyphs prefix code
+				list "\(prefix)/Left" "\(prefix)/LeftMask" "\(prefix)/Right" "\(prefix)/RightMask"
+				function [srcs gr] : glyph-proc
+					define df : DivFrame para.diversityM 3.5
+					define topSerifGap : Math.max (0.1 * (df.rightSB - df.leftSB)) [AdviceStroke 6]
+					define { left leftMask right rightMask } srcs
+
+					include [refer-glyph left] AS_BASE ALSO_METRICS
+					include : difference
+						refer-glyph right
+						refer-glyph leftMask
+						difference
+							intersection
+								MaskAbove (height - Stroke)
+								with-transform [ApparentTranslate topSerifGap 0] [refer-glyph leftMask]
+							with-transform [ApparentTranslate (OX - 0.1) 0] [refer-glyph rightMask]
+
+	do "RHA"
+		glyph-block-import Letter-Shared-Shapes : SerifFrame WithSerifOverflowMask
+		glyph-block-import Letter-Latin-Upper-P : PShape PConfig
+		glyph-block-import Letter-Latin-X : XConfig XLetterForm XSerifs
+
+		foreach { suffix { fGap slabs revSlabs } } [Object.entries PConfig] : do
+			local fMotion : slabs === PShape.SlabMotion
+			local fSlabBot : slabs && slabs !== PShape.SlabMotion
+
+			create-glyph "cyrl/Rha/left.\(suffix)" : glyph-proc
+				local df : include : DivFrame para.diversityM 3
+				include : df.markSet.capital
 				set-base-anchor 'cvDecompose' 0 0
-				include : AHalfShape 0 df height fStraightBar skLeft
+				local subDf : df.sliceFine 3 2 0.575
 
-			create-glyph "\(prefix)/LeftMask.\(suffix)" : glyph-proc
-				define df : include : DivFrame para.diversityM 3.5
-				include : df.markSet.(mk)
-				set-base-anchor 'cvDecompose' 0 0
-				include : AHalfShapeMask 0 df height fStraightBar skLeft
-
-			create-glyph "\(prefix)/Right.\(suffix)" : glyph-proc
-				define df : DivFrame para.diversityM 3.5
-				set-width 0
-				include : df.markSet.(mk)
-				set-mark-anchor 'cvDecompose' 0 0 0 0
-				include : AHalfShape 1 df height fStraightBar skRight
-
-			create-glyph "\(prefix)/RightMask.\(suffix)" : glyph-proc
-				define df : DivFrame para.diversityM 3.5
-				set-width 0
-				include : df.markSet.(mk)
-				set-mark-anchor 'cvDecompose' 0 0 0 0
-				include : AHalfShapeMask 1 df height fStraightBar skRight
-
-		select-variant "\(prefix)/Left"      (follow -- 'A')
-		select-variant "\(prefix)/LeftMask"  (follow -- 'A')
-		select-variant "\(prefix)/Right"     (follow -- 'A')
-		select-variant "\(prefix)/RightMask" (follow -- 'A')
-
-		derive-multi-part-glyphs prefix code
-			list "\(prefix)/Left" "\(prefix)/LeftMask" "\(prefix)/Right" "\(prefix)/RightMask"
-			function [srcs gr] : glyph-proc
-				define df : DivFrame para.diversityM 3.5
-				define topSerifGap : Math.max (0.1 * (df.rightSB - df.leftSB)) [AdviceStroke 6]
-				define { left leftMask right rightMask } srcs
-
-				include [refer-glyph left] AS_BASE ALSO_METRICS
 				include : difference
-					refer-glyph right
-					refer-glyph leftMask
-					difference
-						intersection
-							MaskAbove (height - Stroke)
-							with-transform [ApparentTranslate topSerifGap 0] [refer-glyph leftMask]
-						with-transform [ApparentTranslate (OX - 0.1) 0] [refer-glyph rightMask]
+					PShape CAP (df -- subDf) (slab -- slabs)
+					if fGap [PShape.OpenGap (df -- subDf) (top -- CAP) (bot -- [if fSlabBot df.mvs 0])] [glyph-proc]
+
+		foreach { suffix {stroke1 stroke2 serifShape fMaskBase} } [Object.entries XConfig] : do
+			define [letterShape df top bot turn tension] : glyph-proc
+				local lf : XLetterForm df top bot stroke1 stroke2 turn tension
+				include : WithSerifOverflowMask fMaskBase top bot df.leftSB df.rightSB : lf.rightHalf fMaskBase
+				if serifShape : begin
+					local sf : SerifFrame.fromDf df top bot
+					include : match serifShape
+						[Just XSerifs.Full] : composite-proc sf.rt.full sf.rb.full
+						[Just XSerifs.BilateralMotion] : composite-proc sf.rb.outer
+						__ : glyph-proc
+
+			create-glyph "cyrl/Rha/right.\(suffix)" : glyph-proc
+				local df : DivFrame para.diversityM 3
+				set-width 0
+				set-mark-anchor 'cvDecompose' 0 0
+				include : letterShape df CAP 0 0.1 0.28
+
+		select-variant "cyrl/Rha/left" (follow -- 'P')
+		select-variant "cyrl/Rha/right"
+
+		derive-composites "cyrl/Rha" 0x516 'cyrl/Rha/left' 'cyrl/Rha/right'
 
 	derive-multi-part-glyphs 'AO' 0xA734 {"AA/Left" "AA/LeftMask" "OO/right"} : function [srcs gr] : glyph-proc
 		define df : DivFrame para.diversityM 3.5

--- a/font-src/glyphs/letter/latin-ext/upper-ae-oe.ptl
+++ b/font-src/glyphs/letter/latin-ext/upper-ae-oe.ptl
@@ -7,6 +7,7 @@ glyph-module
 glyph-block Letter-Latin-Upper-AE-OE : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
+	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Latin-Upper-F : EFVJutLength
 
 	define SLAB-A-NONE    0
@@ -39,7 +40,7 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 				corner df.leftSB 0 [heading Upward]
 				curl   df.leftSB (top * 0.1) [heading Upward]
 				quadControls 0 0.3 6 unimportant
-				corner   (eleft - HalfStroke) top [widths.rhs fine]
+				corner (eleft - HalfStroke) top [widths.rhs fine]
 				corner eleft top
 				corner eleft 0
 			HBar.t 0 eleft (XH / 2) sw
@@ -107,6 +108,27 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 				include : VSerif.dr df.rightSB top jutTop swVJut
 				include : VSerif.ur df.rightSB 0 jutBot swVJut
 
+	do "P/Ya Half"
+		glyph-block-import Letter-Latin-Upper-P : PShape PBarPosY
+		glyph-block-import Letter-Latin-Upper-R : RevRShape RConfig RBarPos
+
+		foreach { suffix { legShape fOpen fTailed {slabs revSlabs doLegSlab} } } [Object.entries RConfig] : begin
+			local fSlabBot : slabs && slabs !== PShape.SlabMotion
+
+			if [not fTailed] : begin
+				create-glyph "cyrl/Yae/left.\(suffix)" : glyph-proc
+					local df : include : DivFrame para.diversityM 3
+					include : df.markSet.capital
+					local sw : AESW df CAP
+					local bp : RBarPos CAP fSlabBot
+					local subDf : df.sliceFine 3 2 0.5 [HSwToV : 0.25 * sw]
+					set-base-anchor 'cvDecompose' 0 0
+
+					include : RevRShape legShape CAP (df -- subDf) (slab -- revSlabs) (legSlab -- doLegSlab) (bp -- bp) (open -- fOpen) (sw -- sw)
+
+					eject-contour 'strokeR'
+					eject-contour 'serifRT'
+
 	define AConfig : object
 		straightSerifless     { true   SLAB-A-NONE }
 		curlySerifless        { false  SLAB-A-NONE }
@@ -149,9 +171,11 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 	select-variant 'AE/EHalf' (follow -- 'AE/EHalf')
 	select-variant 'smcpAE/AHalf' (follow -- 'A')
 	select-variant 'smcpAE/EHalf' (follow -- 'AE/EHalf')
+	select-variant 'cyrl/Yae/left'
 
 	derive-composites "AE" 0xC6 'AE/AHalf' 'AE/EHalf'
 	derive-composites "smcpAE" 0x1D01 'smcpAE/AHalf' 'smcpAE/EHalf'
+	derive-composites "cyrl/Yae" 0x518 'cyrl/Yae/left' 'AE/EHalf'
 	alias 'cyrl/AE' 0x4D4 'AE'
 
 	define [OEShape top df slabKind] : glyph-proc

--- a/font-src/glyphs/letter/latin/lower-p.ptl
+++ b/font-src/glyphs/letter/latin/lower-p.ptl
@@ -14,24 +14,41 @@ glyph-block Letter-Latin-Lower-P : begin
 	glyph-block-import Letter-Shared-Shapes : TopHook PalatalHook SerifFrame
 
 
-	define [EaredBody top] : glyph-proc
+	define [SmallThornEaredBody] : glyph-proc
 		include : tagged 'bowl' : OBarLeft.shape
-		include : tagged 'stemLeft' : VBar.l SB Descender top
+		include : tagged 'stemLeft' : VBar.l SB Descender Ascender
 
-	define [EarlessCornerBody] : glyph-proc
+	define [EaredBody] : with-params [[left SB] [right RightSB] [sw Stroke]] : glyph-proc
+		include : tagged 'bowl' : OBarLeft.shape
+			left  -- left
+			right -- right
+			sw    -- sw
+			fine  -- (ShoulderFine * sw / Stroke)
+		include : tagged 'stemLeft' : VBar.l left Descender XH sw
+
+	define [EarlessCornerBody] : with-params [[left SB] [right RightSB] [sw Stroke]] : glyph-proc
 		include : tagged 'bowl' : OBarLeft.toothlessTop (rise -- DToothlessRise) (mBlend -- DMBlend)
-		include : tagged 'stemLeft' : VBar.l SB Descender (XH - DToothlessRise)
+			left  -- left
+			right -- right
+			sw    -- sw
+			fine  -- (ShoulderFine * sw / Stroke)
+		include : tagged 'stemLeft' : VBar.l left Descender (XH - DToothlessRise) sw
 
-	define [EarlessRoundedBody] : glyph-proc
+	define [EarlessRoundedBody] : with-params [[left SB] [right RightSB] [sw Stroke]] : glyph-proc
 		include : tagged 'bowl' : OBarLeft.roundedTop (yTerminal -- Descender)
+			left  -- left
+			right -- right
+			sw    -- sw
+			fine  -- (ShoulderFine * sw / Stroke)
 
-	define [SmallPSerifLT top] : return [SerifFrame.fromDf [DivFrame 1] top Descender].lt.outer
-	define [SmallPSerifLB top] : return [SerifFrame.fromDf [DivFrame 1] top Descender].lb.fullSide
+	define [SmallPSerifLT df top _sw] : return [SerifFrame.fromDf df top Descender (swRef -- _sw)].lt.outer
+	define [SmallPSerifLB df top _sw] : return [SerifFrame.fromDf df top Descender (swRef -- _sw)].lb.fullSide
 
-	define [FullSerifs top] : composite-proc [SmallPSerifLT top] [SmallPSerifLB top]
-	define [MotionSerif top] : SmallPSerifLT top
-	define [BottomSerif top] : SmallPSerifLB top
+	define [FullSerifs  df top _sw] : composite-proc [SmallPSerifLT df top _sw] [SmallPSerifLB df top _sw]
+	define [MotionSerif df top _sw] : SmallPSerifLT df top _sw
+	define [BottomSerif df top _sw] : SmallPSerifLB df top _sw
 
+	glyph-block-export : PConfig
 	define PConfig : SuffixCfg.weave
 		object # body
 			eared                EaredBody
@@ -45,18 +62,20 @@ glyph-block Letter-Latin-Lower-P : begin
 
 	foreach { suffix { Body {Serifs doBS} }} [Object.entries PConfig] : do
 		local yOverlay : mix 0 (Descender + [if doBS Stroke 0]) 0.5
+		local df : DivFrame 1
+
 		create-glyph "p.\(suffix)" : glyph-proc
 			include : MarkSet.p
-			include : Body XH
-			include : Serifs XH
+			include : Body
+			include : Serifs df XH
 			include : LeaningAnchor.Below.VBar.l SB
 			set-base-anchor 'overlayOnExtension' (SB + [HSwToV : 0.5 * Stroke]) yOverlay
 			set-base-anchor 'strike' Middle (XH / 2)
 
 		create-glyph "thorn.\(suffix)" : glyph-proc
 			include : MarkSet.bp
-			include : Body Ascender
-			include : Serifs Ascender
+			include : SmallThornEaredBody
+			include : Serifs df Ascender
 			include : LeaningAnchor.Above.VBar.l SB
 			include : LeaningAnchor.Below.VBar.l SB
 			set-base-anchor 'overlayOnExtension' (SB + [HSwToV : 0.5 * Stroke]) yOverlay

--- a/font-src/glyphs/letter/latin/upper-p.ptl
+++ b/font-src/glyphs/letter/latin/upper-p.ptl
@@ -13,124 +13,142 @@ glyph-block Letter-Latin-Upper-P : begin
 	glyph-block-import Letter-Shared-Metrics : BowlXDepth
 	glyph-block-import Letter-Shared-Shapes : LetterBarOverlay LeftHook
 	glyph-block-import Letter-Blackboard : BBS BBD
-	glyph-block-export PShape PShapeOutline RevPShape PBarPosY PRotundaShape BBPShape
+	glyph-block-export PConfig PShape PShapeOutline RevPShape PBarPosY PRotundaShape BBPShape
 
 	define [PBarPosY top sw bp] : (top - sw) * bp - sw * PShape.SwBelowBar
 
-	define [PRotundaOutlineKnots top mul bp overshoot sw offset endX hook] : begin
+	define [PRotundaOutlineKnots top df mul bp overshoot sw offset endX hook] : begin
 		local bowlTop (top * 1 - offset)
 		local bowlBottom : [PBarPosY top sw bp] + offset
-		local turnRadius : BowlXDepth bowlTop bowlBottom SB RightSB sw
-		local ada : ArchDepthAOf (ArchDepth * 0.9) Width
-		local adb : ArchDepthBOf (ArchDepth * 0.9) Width
-		local right : RightSB - offset
+		local turnRadius : BowlXDepth bowlTop bowlBottom df.leftSB df.rightSB sw
+		local ada : ArchDepthAOf (ArchDepth * 0.9) df.width
+		local adb : ArchDepthBOf (ArchDepth * 0.9) df.width
+		local left : df.leftSB * mul
+		local right : df.rightSB - offset
 		local turn : YSmoothMidR bowlTop bowlBottom ada adb
 		return : list
-			g4 (SB * mul - O) (bowlTop - hook)
+			g4 (left - O) (bowlTop - hook)
 			hookstart (bowlTop - O)
 			g4 (right - overshoot) turn
 			arcvh
-			flat ([Math.max (endX + 0.01 + sw / 2 * TanSlope) Middle] + CorrectionOMidX * sw * 0.5) bowlBottom
+			flat ([Math.max (endX + 0.01 + sw / 2 * TanSlope) df.middle] + CorrectionOMidX * sw * 0.5) bowlBottom
 			curl endX bowlBottom [heading Leftward]
 
-	define [PShapeOutlineKnots top mul bp overshoot sw offset] : begin
+	define [PShapeOutlineKnots top df mul bp overshoot sw offset] : begin
 		local bowlTop (top * 1 - offset)
 		local bowlBottom : [PBarPosY top sw bp] + offset
-		local turnRadius : BowlXDepth bowlTop bowlBottom SB RightSB sw
-		local ada : ArchDepthAOf (ArchDepth * 0.9) Width
-		local adb : ArchDepthBOf (ArchDepth * 0.9) Width
-		local right : RightSB - offset
+		local turnRadius : BowlXDepth bowlTop bowlBottom df.leftSB df.rightSB sw
+		local ada : ArchDepthAOf (ArchDepth * 0.9) df.width
+		local adb : ArchDepthBOf (ArchDepth * 0.9) df.width
+		local left : df.leftSB * mul
+		local right : df.rightSB - offset
 		local turn : YSmoothMidR bowlTop bowlBottom ada adb
 		return : list
-			flat (SB * mul - O) bowlTop [heading Rightward]
+			flat (left - O) bowlTop [heading Rightward]
 			curl (right - turnRadius - CorrectionOMidX * sw) bowlTop
 			archv
 			g4 (right - overshoot) turn
 			arcvh
 			flat (right - turnRadius + CorrectionOMidX * sw) bowlBottom
-			curl (SB * mul - O) bowlBottom [heading Leftward]
+			curl (left - O) bowlBottom [heading Leftward]
 
-	define [RevPshapeOutlineKnots top mul bp overshoot sw offset] : begin
+	define [RevPshapeOutlineKnots top df mul bp overshoot sw offset] : begin
 		local bowlTop (top * 1 - offset)
-		local bowlBottom ((top - sw) * bp - sw * PShape.SwBelowBar + offset)
-		local turnRadius : BowlXDepth bowlTop bowlBottom SB RightSB sw
-		local ada : ArchDepthAOf (ArchDepth * 0.9) Width
-		local adb : ArchDepthBOf (ArchDepth * 0.9) Width
-		local left : SB + offset
+		local bowlBottom : [PBarPosY top sw bp] + offset
+		local turnRadius : BowlXDepth bowlTop bowlBottom df.leftSB df.rightSB sw
+		local ada : ArchDepthAOf (ArchDepth * 0.9) df.width
+		local adb : ArchDepthBOf (ArchDepth * 0.9) df.width
+		local left : df.leftSB + offset
+		local right : df.width - df.leftSB * mul
 		local turn : YSmoothMidL bowlTop bowlBottom ada adb
 		return : list
-			flat (Width - SB * mul + O) bowlTop [heading Leftward]
+			flat (right + O) bowlTop [heading Leftward]
 			curl (left + turnRadius - CorrectionOMidX * sw) bowlTop
 			archv
 			g4 (left + overshoot) turn
 			arcvh
 			flat (left + turnRadius + CorrectionOMidX * sw) bowlBottom
-			curl (Width - SB * mul + O) bowlBottom [heading Rightward]
+			curl (right + O) bowlBottom [heading Rightward]
 
 
-	define [PShapeOutline] : with-params [top [mul PShape.defaultMul] [bp PShape.BarPos] [overshoot PShape.defaultOvershoot] [sw Stroke] [offset 0]] : glyph-proc
+	define [PShapeOutline] : with-params [
+				top [df [DivFrame 1]]
+				[mul PShape.defaultMul] [bp PShape.BarPos] [overshoot PShape.defaultOvershoot] [sw df.mvs]
+				[offset 0]
+			] : glyph-proc
 		include : spiro-outline
-			PShapeOutlineKnots top mul bp overshoot sw offset
+			PShapeOutlineKnots top df mul bp overshoot sw offset
 
-	define [PShape] : with-params [top [mul PShape.defaultMul] [bp PShape.BarPos] [overshoot PShape.defaultOvershoot] [sw Stroke] [slab null] [withBar true] [setMark false]] : glyph-proc
-		include : dispiro [widths.rhs sw] [PShapeOutlineKnots top mul bp overshoot sw 0]
-		if withBar : include : tagged 'strokeL' : VBar.l (SB * mul) 0 top sw
-		if slab : include : slab top sw mul
+	define [PShape] : with-params [
+				top [df [DivFrame 1]]
+				[mul PShape.defaultMul] [bp PShape.BarPos] [overshoot PShape.defaultOvershoot] [sw df.mvs]
+				[slab null] [withBar true] [setMark false]
+			] : glyph-proc
+		include : dispiro [widths.rhs sw] [PShapeOutlineKnots top df mul bp overshoot sw 0]
+		if withBar : include : tagged 'strokeL' : VBar.l (df.leftSB * mul) 0 top sw
+		if slab : include : slab top df sw mul
 
-	define [PRotundaShape] : with-params [top [mul PShape.defaultMul] [bp PShape.BarPos] [overshoot PShape.defaultOvershoot] [sw Stroke] [slab SLAB] [endX SB] [hook Hook]] : glyph-proc
+	define [PRotundaShape] : with-params [
+				top [df [DivFrame 1]]
+				[mul PShape.defaultMul] [bp PShape.BarPos] [overshoot PShape.defaultOvershoot] [sw df.mvs]
+				[slab null] [endX SB] [hook Hook]
+			] : glyph-proc
 		include : dispiro
 			widths.rhs sw
-			PRotundaOutlineKnots top mul bp overshoot sw 0 endX hook
+			PRotundaOutlineKnots top df mul bp overshoot sw 0 endX hook
 
-	define [RevPShape] : with-params [top [mul PShape.defaultMul] [bp PShape.BarPos] [overshoot PShape.defaultOvershoot] [sw Stroke] [slab SLAB]] : glyph-proc
+	define [RevPShape] : with-params [
+				top [df [DivFrame 1]]
+				[mul PShape.defaultMul] [bp PShape.BarPos] [overshoot PShape.defaultOvershoot] [sw df.mvs]
+				[slab null]
+			] : glyph-proc
 		include : tagged 'bowl' : dispiro
 			widths.lhs sw
-			RevPshapeOutlineKnots top mul bp overshoot sw 0
-		include : tagged 'strokeR' : VBar.r (Width - SB * mul) 0 top sw
-
-		if slab : include : slab top sw mul
+			RevPshapeOutlineKnots top df mul bp overshoot sw 0
+		include : tagged 'strokeR' : VBar.r (df.width - df.leftSB * mul) 0 top sw
+		if slab : include : slab top df sw mul
 
 	set PShape.defaultMul 1.25
 	set PShape.defaultOvershoot (OX * 2)
 	set PShape.BarPos (1 - HBarPos)
 	set PShape.SwBelowBar 0.25
 
-	set PShape.SlabMotion : function [top sw mul] : glyph-proc
-		include : tagged 'serifLT' : HSerif.lt (SB * mul) top SideJut sw
-	set PShape.SlabFullSymmetric : function [top sw mul] : glyph-proc
-		include : tagged 'serifLT' : HSerif.mt (SB * mul + [HSwToV : 0.5 * sw]) top Jut sw
-		include : tagged 'serifLB' : HSerif.mb (SB * mul + [HSwToV : 0.5 * sw]) 0 Jut sw
-	set PShape.SlabSymmetric : function [top sw mul] : glyph-proc
-		include : PShape.SlabMotion top sw mul
-		include : tagged 'serifLB' : HSerif.mb (SB * mul + [HSwToV : 0.5 * sw]) 0 Jut sw
-	set PShape.SlabAsymmetric : function [top sw mul] : glyph-proc
-		include : PShape.SlabMotion top sw mul
+	set PShape.SlabMotion : function [top df sw mul] : glyph-proc
+		include : tagged 'serifLT' : HSerif.lt (df.leftSB * mul) top SideJut sw
+	set PShape.SlabFullSymmetric : function [top df sw mul] : glyph-proc
+		include : tagged 'serifLT' : HSerif.mt (df.leftSB * mul + [HSwToV : 0.5 * sw]) top Jut sw
+		include : tagged 'serifLB' : HSerif.mb (df.leftSB * mul + [HSwToV : 0.5 * sw]) 0 Jut sw
+	set PShape.SlabSymmetric : function [top df sw mul] : glyph-proc
+		include : PShape.SlabMotion top df sw mul
+		include : tagged 'serifLB' : HSerif.mb (df.leftSB * mul + [HSwToV : 0.5 * sw]) 0 Jut sw
+	set PShape.SlabAsymmetric : function [top df sw mul] : glyph-proc
+		include : PShape.SlabMotion top df sw mul
 		include : tagged 'serifLB' : union
-			HSerif.lb (SB * mul) 0 SideJut sw
-			HSerif.rb (SB * mul + [HSwToV : 0.5 * sw]) 0 MidJutSide sw
-	set PShape.OpenGap : function [] : with-params [top [bot 0] [mul PShape.defaultMul] [bp PShape.BarPos] [sw Stroke]] : VBar.l
-		SB * mul + [HSwToV sw]
+			HSerif.lb (df.leftSB * mul) 0 SideJut sw
+			HSerif.rb (df.leftSB * mul + [HSwToV : 0.5 * sw]) 0 MidJutSide sw
+	set PShape.OpenGap : function [] : with-params [top [df [DivFrame 1]] [bot 0] [mul PShape.defaultMul] [bp PShape.BarPos] [sw df.mvs]] : VBar.l
+		df.leftSB * mul + [HSwToV sw]
 		Math.min ([PBarPosY top sw bp] - 0.5 * sw - 0.1) bot
 		Math.max ([PBarPosY top sw bp] + 0.5 * sw + 0.1) [mix top [PBarPosY top sw bp] 0.5]
-		0.2 * (RightSB - SB) * ([AdviceStroke 5] / Stroke)
+		0.2 * (df.rightSB - df.leftSB) * ([AdviceStroke 5] / Stroke)
 
-	set RevPShape.SlabMotion : function [top sw mul] : glyph-proc
-		include : tagged 'serifRT' : HSerif.rt (Width - SB * mul) top SideJut sw
-	set RevPShape.SlabSymmetric : function [top sw mul] : glyph-proc
-		include : RevPShape.SlabMotion top sw mul
-		include : tagged 'serifRB' : HSerif.mb (Width - SB * mul - [HSwToV HalfStroke]) 0 Jut sw
-	set RevPShape.SlabCyrlItalic : function [top sw mul] : glyph-proc
-		include : tagged 'serifRB' : HSerif.rb (Width - SB * mul) 0 SideJut sw
-	set RevPShape.SlabAsymmetric : function [top sw mul] : glyph-proc
-		include : RevPShape.SlabMotion top sw mul
+	set RevPShape.SlabMotion : function [top df sw mul] : glyph-proc
+		include : tagged 'serifRT' : HSerif.rt (df.width - df.leftSB * mul) top SideJut sw
+	set RevPShape.SlabSymmetric : function [top df sw mul] : glyph-proc
+		include : RevPShape.SlabMotion top df sw mul
+		include : tagged 'serifRB' : HSerif.mb (df.width - df.leftSB * mul - [HSwToV HalfStroke]) 0 Jut sw
+	set RevPShape.SlabCyrlItalic : function [top df sw mul] : glyph-proc
+		include : tagged 'serifRB' : HSerif.rb (df.width - df.leftSB * mul) 0 SideJut sw
+	set RevPShape.SlabAsymmetric : function [top df sw mul] : glyph-proc
+		include : RevPShape.SlabMotion top df sw mul
 		include : tagged 'serifRB' : union
-			HSerif.rb (Width - SB * mul) 0 SideJut sw
-			HSerif.lb (Width - SB * mul - [HSwToV : 0.5 * sw]) 0 MidJutSide sw
-	set RevPShape.OpenGap : function [] : with-params [top [bot 0] [mul PShape.defaultMul] [bp PShape.BarPos] [sw Stroke]] : VBar.r
-		Width - SB * mul - [HSwToV sw]
+			HSerif.rb (df.width - df.leftSB * mul) 0 SideJut sw
+			HSerif.lb (df.width - df.leftSB * mul - [HSwToV : 0.5 * sw]) 0 MidJutSide sw
+	set RevPShape.OpenGap : function [] : with-params [top [df [DivFrame 1]] [bot 0] [mul PShape.defaultMul] [bp PShape.BarPos] [sw df.mvs]] : VBar.r
+		df.width - df.leftSB * mul - [HSwToV sw]
 		Math.min ([PBarPosY top sw bp] - 0.5 * sw - 0.1) bot
 		Math.max ([PBarPosY top sw bp] + 0.5 * sw + 0.1) [mix top [PBarPosY top sw bp] 0.5]
-		0.2 * (RightSB - SB) * ([AdviceStroke 5] / Stroke)
+		0.2 * (df.rightSB - df.leftSB) * ([AdviceStroke 5] / Stroke)
 
 	define PConfig : object
 		closedSerifless       { false  null                            null                               }

--- a/font-src/glyphs/letter/latin/upper-r.ptl
+++ b/font-src/glyphs/letter/latin/upper-r.ptl
@@ -11,6 +11,7 @@ glyph-block Letter-Latin-Upper-R : begin
 	glyph-block-import Letter-Latin-Upper-P : PShape RevPShape PBarPosY PRotundaShape BBPShape PShapeOutline
 	glyph-block-import Letter-Blackboard : BBS BBD
 	glyph-block-import Letter-Shared-Shapes : RightwardTailedBar RetroflexHook
+	glyph-block-export RConfig RevRShape RBarPos
 
 	define LEG-SHAPE-CURLY    0
 	define LEG-SHAPE-STRAIGHT 1
@@ -36,7 +37,7 @@ glyph-block Letter-Latin-Upper-R : begin
 				corner xRightBottom bottom [widths.rhs sw]
 
 		if slab : begin
-			include : HSerif.rb xRightBottomSerifStart bottom (SideJut + Jut / 8)
+			include : HSerif.rb xRightBottomSerifStart bottom (SideJut + Jut / 8) sw
 
 	define [RLegShape-Curly] : with-params [top bottom left right charTop slab sw extraShift] : glyph-proc
 		local xRightBottom : RLegTerminalX LEG-SHAPE-CURLY right sw
@@ -48,7 +49,7 @@ glyph-block Letter-Latin-Upper-R : begin
 				quadControls 0 0.4 8
 				g4 left top
 		if slab : begin
-			include : HSerif.rb right bottom (SideJut + Jut / 8)
+			include : HSerif.rb right bottom (SideJut + Jut / 8) sw
 
 	define [RLegShape-Standing] : with-params [top bottom left right charTop slab sw extraShift] : glyph-proc
 		local fine : RStandingLegFine sw
@@ -65,7 +66,7 @@ glyph-block Letter-Latin-Upper-R : begin
 			flat (right + O) [Math.max (yOffset + 1) (ytopRef - bend * charTop / CAP)] [widths.rhs.heading sw Downward]
 			curl (right + O) yOffset [heading Downward]
 			curl (right + O - xOverflow) bottom  [heading Downward]
-		if slab : include : HSerif.rb right bottom SideJut
+		if slab : include : HSerif.rb right bottom SideJut sw
 
 	define RLegShapes { RLegShape-Curly RLegShape-Straight RLegShape-Standing }
 
@@ -83,7 +84,7 @@ glyph-block Letter-Latin-Upper-R : begin
 				corner xRightTop   top    [widths.rhs sw]
 				corner xLeftBottom bottom [widths.lhs sw]
 		if slab : begin
-			include : HSerif.lb xLeftBottomSerifStart bottom (SideJut + Jut / 8)
+			include : HSerif.lb xLeftBottomSerifStart bottom (SideJut + Jut / 8) sw
 
 	define [RevRLegShape-Curly] : with-params [top bottom left right charTop slab sw extraShift] : glyph-proc
 		local xLeftBottom : RevRLegTerminalX LEG-SHAPE-CURLY left sw
@@ -95,7 +96,7 @@ glyph-block Letter-Latin-Upper-R : begin
 				quadControls 0 0.4 8
 				g4 right top
 		if slab : begin
-			include : HSerif.lb left bottom (SideJut + Jut / 8)
+			include : HSerif.lb left bottom (SideJut + Jut / 8) sw
 
 	define [RevRLegShape-Standing] : with-params [top bottom left right charTop slab sw extraShift] : glyph-proc
 		local fine : RStandingLegFine sw
@@ -112,7 +113,7 @@ glyph-block Letter-Latin-Upper-R : begin
 			flat (left - O) [Math.max (yOffset + 1) (ytopRef - bend * charTop / CAP)] [widths.lhs.heading sw Downward]
 			curl (left - O) yOffset [heading Downward]
 			curl (left - O + xOverflow) bottom  [heading Downward]
-		if slab : include : HSerif.lb left bottom SideJut
+		if slab : include : HSerif.lb left bottom SideJut sw
 
 	define RevRLegShapes { RevRLegShape-Curly RevRLegShape-Straight RevRLegShape-Standing }
 
@@ -120,38 +121,38 @@ glyph-block Letter-Latin-Upper-R : begin
 	define [RBarPos charTop slab] : begin PShape.BarPos
 	define [RLegTop charTop sw bp] : (sw / 2) + [PBarPosY charTop sw bp]
 
-	define [RShape] : with-params [legShape top bp [mul 1] [slab null] [legSlab false] [open false] [legBottom 0]] : glyph-proc
-		local right : RightSB - O - [if slab (Jut / 8) 0]
+	define [RShape] : with-params [legShape top bp [df [DivFrame 1]] [mul 1] [slab null] [legSlab false] [open false] [legBottom 0] [sw Stroke]] : glyph-proc
+		local right : df.rightSB - O - [if slab (Jut / 8) 0]
 		include : difference
-			PShape top (mul -- mul) (overshoot -- O) (slab -- slab) (bp -- bp)
-			if open [PShape.OpenGap (mul -- mul) (bp -- bp) (top -- top) (bot -- [if fSlabBot Stroke 0])] [glyph-proc]
+			PShape top (df -- df) (mul -- mul) (overshoot -- O) (slab -- slab) (bp -- bp) (sw -- sw)
+			if open [PShape.OpenGap (df -- df) (mul -- mul) (bp -- bp) (top -- top) (bot -- [if fSlabBot sw 0])] [glyph-proc]
 		include : difference
-			RLegShapes.(legShape) [RLegTop top Stroke bp] legBottom Middle right top legSlab Stroke 0
-			if open [PShape.OpenGap (mul -- mul) (bp -- bp) (top -- top) (bot -- 0) ] [glyph-proc]
+			RLegShapes.(legShape) [RLegTop top sw bp] legBottom df.middle right top legSlab sw 0
+			if open [PShape.OpenGap (df -- df) (mul -- mul) (bp -- bp) (top -- top) (bot -- 0) ] [glyph-proc]
 
-	define [RRotundaShape] : with-params [legShape top [mul 1] [pmRotunda 0] [endX Middle] [hook Hook] [pBar 1] [slab null] [legSlab false]] : glyph-proc
+	define [RRotundaShape] : with-params [legShape top [df [DivFrame 1]] [mul 1] [pmRotunda 0] [endX df.middle] [hook Hook] [pBar 1] [slab null] [legSlab false] [sw Stroke]] : glyph-proc
 		local bp : pBar * [RBarPos top false]
-		local legTop : RLegTop top Stroke bp
-		local right (RightSB - O - [if slab (Jut / 8) 0])
-		local cor : RLegDiagCor legTop 0 endX right 0 Stroke
-		local endX1 : endX - [if legShape (HalfStroke * [HSwToV cor]) HalfStroke] + [if legShape [RSlabExtraShift SLAB Stroke] 0]
-		include : PRotundaShape top (mul -- mul) (bp -- bp) (overshoot -- O) (slab -- false) (endX -- endX1) (hook -- hook)
+		local legTop : RLegTop top sw bp
+		local right (df.rightSB - O - [if slab (Jut / 8) 0])
+		local cor : RLegDiagCor legTop 0 endX right 0 sw
+		local endX1 : endX - [if legShape (sw / 2 * [HSwToV cor]) (sw / 2)] + [if legShape [RSlabExtraShift SLAB sw] 0]
+		include : PRotundaShape top (df -- df) (mul -- mul) (bp -- bp) (overshoot -- O) (slab -- false) (endX -- endX1) (hook -- hook) (sw -- sw)
 		include : difference
-			RLegShapes.(legShape) legTop 0 endX right top legSlab Stroke 0
+			RLegShapes.(legShape) legTop 0 endX right top legSlab sw 0
 			MaskLeft endX1
 
-	define [RevRShape] : with-params [legShape top bp [slab null] [legSlab false] [mul 1] [tailedShape false] [open false]] : glyph-proc
-		local left : SB + O + [if slab (Jut / 8) 0]
+	define [RevRShape] : with-params [legShape top bp [df [DivFrame 1]] [slab null] [legSlab false] [mul 1] [tailedShape false] [open false] [sw Stroke]] : glyph-proc
+		local left : df.leftSB + O + [if slab (Jut / 8) 0]
 		include : difference
-			RevPShape top (mul -- mul) (overshoot -- O) (slab -- slab) (bp -- bp)
-			if open [RevPShape.OpenGap (mul -- mul) (bp -- bp) (top -- top) (bot -- [if fSlabBot Stroke 0]) ] [glyph-proc]
+			RevPShape top (df -- df) (mul -- mul) (overshoot -- O) (slab -- slab) (bp -- bp) (sw -- sw)
+			if open [RevPShape.OpenGap (df -- df) (mul -- mul) (bp -- bp) (top -- top) (bot -- [if fSlabBot sw 0]) ] [glyph-proc]
 		include : difference
-			RevRLegShapes.(legShape) [RLegTop top Stroke bp] 0 left Middle top legSlab Stroke 0
-			if open [RevPShape.OpenGap (mul -- mul) (bp -- bp) (top -- top) (bot -- 0) ] [glyph-proc]
+			RevRLegShapes.(legShape) [RLegTop top sw bp] 0 left df.middle top legSlab sw 0
+			if open [RevPShape.OpenGap (df -- df) (mul -- mul) (bp -- bp) (top -- top) (bot -- 0) ] [glyph-proc]
 		if tailedShape : begin
 			eject-contour 'strokeR'
 			eject-contour 'serifRB'
-			include : tagged 'strokeR' : RightwardTailedBar (Width - SB * mul) 0 top
+			include : tagged 'strokeR' : RightwardTailedBar (df.width - df.leftSB * mul) 0 top
 
 	define [StrikeAnchor] : glyph-proc
 		set-base-anchor 'strike' Middle [mix [PBarPosY CAP Stroke : RBarPos CAP SLAB] CAP 0.5]
@@ -228,8 +229,8 @@ glyph-block Letter-Latin-Upper-R : begin
 			include : VBar.l SB (top - 1) CAP
 			include : RShape legShape top (legSlab -- doLegSlab) (bp -- bp) (open -- fOpen) (legBottom -- Descender)
 			include : match slabs
-				[Just PShape.SlabSymmetric] : PShape.SlabFullSymmetric CAP Stroke 1
-				[Just PShape.SlabMotion]    : PShape.SlabMotion        CAP Stroke 1
+				[Just PShape.SlabSymmetric] : PShape.SlabFullSymmetric CAP [DivFrame 1] Stroke 1
+				[Just PShape.SlabMotion]    : PShape.SlabMotion        CAP [DivFrame 1] Stroke 1
 				__                          : glyph-proc
 
 		create-glyph "smcpRLongRightLeg.\(suffix)" : glyph-proc

--- a/font-src/glyphs/letter/latin/x.ptl
+++ b/font-src/glyphs/letter/latin/x.ptl
@@ -13,14 +13,14 @@ glyph-block Letter-Latin-X : begin
 	glyph-block-import Letter-Shared-Shapes : CyrDescender PalatalHook
 
 	glyph-block-export HalfXStrand
-	define [HalfXStrand stb fSlab _leftx lefty rightx righty turn pStraight tension _fine] : glyph-proc
+	define [HalfXStrand stb fSlab _leftx lefty rightx righty turn pStraight tension _sw] : glyph-proc
+		local sw : fallback _sw Stroke
 		local sbCor : if stb ([StrokeWidthBlend 1 6] * OX * ([Math.abs (lefty - righty)] / CAP)) 0
-		local leftx : _leftx + ([HSwToV HalfStroke] + [Math.max (-SideJut) sbCor]) * [if (rightx > _leftx) 1 (-1)]
-		local fine  : (_fine || Stroke) * 0.5
+		local leftx : _leftx + ([HSwToV : 0.5 * sw] + [Math.max (-SideJut) sbCor]) * [if (rightx > _leftx) 1 (-1)]
 
 		if stb : begin
-			local hst : HalfStroke * [DiagCor (righty - lefty) (rightx - leftx) 0 0]
-			local hse : HalfStroke * [Math.min 0.97 ([AdviceStroke 3] / Stroke)]
+			local hst : (0.5 * sw) * [DiagCor (righty - lefty) (rightx - leftx) 0 0]
+			local hse : (0.5 * sw) * [Math.min 0.97 ([AdviceStroke 3] / Stroke)]
 			local leftx2 : _leftx + ([HSwToV hst] + [Math.max (-SideJut) sbCor]) * [if (rightx > _leftx) 1 (-1)]
 			include : dispiro
 				corner leftx2 lefty [widths.heading hst hst [if (lefty < righty) Upward Downward]]
@@ -28,7 +28,7 @@ glyph-block Letter-Latin-X : begin
 
 		: else : begin
 			local height : Math.abs (lefty - righty)
-			local slabClearance : if fSlab [AdviceStroke2 2 3 height] 0
+			local slabClearance : if fSlab ((sw / Stroke) * [AdviceStroke2 2 3 height]) 0
 			local turnyleft : mix lefty righty [if fSlab [Math.max turn (slabClearance / height)] turn]
 			local cyleft : mix turnyleft righty tension
 			local straightxleft : mix leftx rightx pStraight
@@ -42,28 +42,56 @@ glyph-block Letter-Latin-X : begin
 				curl rightx righty
 
 	glyph-block-export XStrand
-	define [XStrand stb slab _leftx lefty _rightx righty turn pStraight tension] : glyph-proc
+	define [XStrand stb slab _leftx lefty _rightx righty turn pStraight tension _sw] : glyph-proc
 		local middlex : mix _leftx _rightx 0.5
 		local middley : mix lefty righty 0.5
 
-		include : HalfXStrand stb slab _leftx lefty middlex middley turn pStraight tension
-		include : HalfXStrand stb slab _rightx righty middlex middley turn pStraight tension
+		include : HalfXStrand stb slab _leftx lefty middlex middley turn pStraight tension _sw
+		include : HalfXStrand stb slab _rightx righty middlex middley turn pStraight tension _sw
+
+	define [XChanceryStrand sign leftX leftY rightX rightY fHalf _sw] : begin
+		local sw : fallback _sw Stroke
+		local blendK1X : StrokeWidthBlend 0.58 0.65
+		local blendK1Y   0.2
+		local blendK2X   0.78
+		local blendK2Y : StrokeWidthBlend 0.5 0.4
+
+		local pStraightX : StrokeWidthBlend 0.3 0.35
+		local pStraightY : StrokeWidthBlend 0.2 0.25
+
+		local fine : [AdviceStroke 3] * (sw / Stroke)
+
+		return : dispiro
+			if fHalf
+				flat [mix leftX rightX 0.5] [mix leftY rightY 0.5] [widths.center fine]
+				list
+					straight.right.start leftX  (leftY - sign * sw / 2) [widths.center sw]
+					alsoThruThem {{blendK1X blendK1Y} {blendK2X blendK2Y}}
+					flat [mix leftX rightX pStraightX] [mix leftY rightY pStraightY] [widths.center : mix sw fine 0.5]
+					corner [mix leftX rightX 0.5] [mix leftY rightY 0.5] [widths.center fine]
+			curl [mix leftX rightX (1 - pStraightX)] [mix leftY rightY (1 - pStraightY)] [widths.center : mix sw fine 0.5]
+			alsoThruThem {{(1 - blendK2X) (1 - blendK2Y)} {(1 - blendK1X) (1 - blendK1Y)}}
+			straight.right.end   rightX (rightY + sign * sw / 2) [widths.center sw]
 
 	glyph-block-export XCursiveHalfShape
-	define [XCursiveHalfShape] : with-params [top bottom left right [swEnd : AdviceStroke 2.75] [swMid : AdviceStroke 3] [kThin 0.55] [setMark false]] : glyph-proc
+	define [XCursiveHalfShape] : with-params [
+			top bottom left right 
+			[sw Stroke] [swEnd : AdviceStroke 2.75] [swMid : AdviceStroke 3] 
+			[kThin 0.55] [setMark false] [flatTail false]
+		] : glyph-proc
 		local ada : ArchDepthAOf (ArchDepth * 0.8) (Width / 2)
 		local adb : ArchDepthBOf (ArchDepth * 0.8) (Width / 2)
+		local div : (right - left) / (RightSB - Middle)
 
 		define xCenterRight : left + [HSwToV swMid] / 2
-		define xCenterLeft  : left - [HSwToV swMid] / 2
 		define xTurn : mix (right - [HSwToV swEnd]) xCenterRight 0.5
-		define hook1Depth : Hook + Stroke * 0.125
+		define hook1Depth : Hook + sw * 0.125
 		define hook1StraightDepth : Math.min
 			hook1Depth - swEnd * 1.125
 			Math.max 1 : hook1Depth / 5 - swEnd / 4
 
 		define fineMid : swMid * kThin
-		define rIn : Math.max (0.4 * (right - left) - [HSwToV : 0.7 * Stroke]) [AdviceStroke 16]
+		define rIn : Math.max (0.4 * (right - left) - [HSwToV : 0.7 * sw]) [AdviceStroke 16]
 		define flatHookDepth : 1.4 * (right - left) - swEnd - 1.5 * rIn
 
 		define upperHalf : include : dispiro
@@ -75,89 +103,109 @@ glyph-block Letter-Latin-X : begin
 			flat (right - OX) (top - hook1Depth + hook1StraightDepth) [heading Downward]
 			curl (right - OX) (top - hook1Depth) [heading Downward]
 
-		define lowerHalf : include : dispiro
-			flat (xCenterRight - [HSwToV : 0.5 * fineMid]) ([mix bottom top 0.5] - O) [widths.center fineMid]
-			curl (xCenterRight - [HSwToV : 0.5 * fineMid]) (bottom + [Math.min adb (swMid + rIn)])
-			arcvh 16
-			DiagonalTailF 1 [DivFrame 1] (xCenterRight - [HSwToV : 0.5 * Stroke] + TanSlope * rIn) bottom rIn 50 flatHookDepth Stroke
+		define lowerHalf : include : if flatTail
+			dispiro
+				flat (xCenterRight - [HSwToV fineMid]) ([mix bottom top 0.5] - O) [widths.lhs fineMid]
+				curl (xCenterRight - [HSwToV fineMid]) (bottom + [Math.min adb (swMid + rIn)])
+				arcvh
+				flat (xCenterRight + div * rIn + 0.25 * TanSlope * rIn) bottom [widths.lhs.heading sw Rightward]
+				curl right bottom
+			dispiro
+				flat (xCenterRight - [HSwToV : 0.5 * fineMid]) ([mix bottom top 0.5] - O) [widths.center fineMid]
+				curl (xCenterRight - [HSwToV : 0.5 * fineMid]) (bottom + [Math.min adb (swMid + rIn)])
+				arcvh 16
+				DiagonalTailF 1 [DivFrame div] (xCenterRight - [HSwToV : 0.5 * sw] + TanSlope * rIn) bottom rIn 50 flatHookDepth sw
 
 		if setMark : begin
 			define lowerHalfLastKnot lowerHalf.rhsKnots.(lowerHalf.rhsKnots.length - 1)
 			set-base-anchor 'cyrlDescenderAttach' lowerHalfLastKnot.x lowerHalfLastKnot.y
 
-	define [XChanceryStrand sign leftX leftY rightX rightY sw] : begin
-		local blendK1X : StrokeWidthBlend 0.58 0.65
-		local blendK1Y   0.2
-		local blendK2X   0.78
-		local blendK2Y : StrokeWidthBlend 0.5 0.4
+	define STROKE-STRAIGHT     0
+	define STROKE-CURLY        1
+	define STROKE-CHANCERY     2
+	define STROKE-CURSIVE      3
+	define STROKE-CURSIVE-FLAT 4
 
-		local pStraightX : StrokeWidthBlend 0.3 0.35
-		local pStraightY : StrokeWidthBlend 0.2 0.25
+	glyph-block-export XLetterForm
+	define [XLetterForm] : with-params [
+			df top bot
+			stroke1 stroke2
+			turn tension
+			[sw df.mvs]
+		] : namespace
+		export : define [base fSlab] : union
+			match stroke1
+				[Just STROKE-STRAIGHT] : XStrand true  fSlab df.leftSB bot df.rightSB top turn 0.4 tension sw
+				[Just STROKE-CURLY]    : XStrand false fSlab df.leftSB bot df.rightSB top turn 0.4 tension sw
+				[Just STROKE-CHANCERY] : XChanceryStrand (-1) df.leftSB bot df.rightSB top false sw
+				([Just STROKE-CURSIVE] || [Just STROKE-CURSIVE-FLAT]) : composite-proc
+					XCursiveHalfShape top bot df.middle df.rightSB
+						sw -- sw
+						swEnd -- (sw / Stroke) * [AdviceStroke 2.75]
+						swMid -- (sw / Stroke) * [AdviceStroke 3]
+						flatTail -- (stroke1 === STROKE-CURSIVE-FLAT)
+					FlipAround df.middle [mix bot top 0.5]
+				__ : glyph-proc
+			match stroke2
+				[Just STROKE-STRAIGHT] : XStrand true  fSlab df.leftSB top df.rightSB bot turn 0.4 tension sw
+				[Just STROKE-CURLY]    : XStrand false fSlab df.leftSB top df.rightSB bot turn 0.4 tension sw
+				[Just STROKE-CHANCERY] : XChanceryStrand (+1) df.leftSB top df.rightSB bot false sw
+				[Just STROKE-CURSIVE]  : XCursiveHalfShape top bot df.middle df.rightSB
+					sw -- sw
+					swEnd -- (sw / Stroke) * [AdviceStroke 2.75]
+					swMid -- (sw / Stroke) * [AdviceStroke 3]
+					setMark -- true
+				__ : glyph-proc
 
-		local fine : [AdviceStroke 3] / Stroke * sw
+		export : define [rightHalf fSlab] : glyph-proc
+			local midy : mix top bot 0.5
 
-		return : dispiro
-			straight.right.start leftX  (leftY - sign * sw / 2) [widths.center sw]
-			alsoThruThem {{blendK1X blendK1Y} {blendK2X blendK2Y}}
-			flat [mix leftX rightX pStraightX] [mix leftY rightY pStraightY] [widths.center : mix sw fine 0.5]
-			corner [mix leftX rightX 0.5] [mix leftY rightY 0.5] [widths.center fine]
-			curl [mix leftX rightX (1 - pStraightX)] [mix leftY rightY (1 - pStraightY)] [widths.center : mix sw fine 0.5]
-			alsoThruThem {{(1 - blendK2X) (1 - blendK2Y)} {(1 - blendK1X) (1 - blendK1Y)}}
-			straight.right.end   rightX (rightY + sign * sw / 2) [widths.center sw]
+			include : union
+				match stroke1
+					[Just STROKE-STRAIGHT] : HalfXStrand true  fSlab df.rightSB top df.middle midy turn 0.4 tension sw
+					[Just STROKE-CURLY]    : HalfXStrand false fSlab df.rightSB top df.middle midy turn 0.4 tension sw
+					[Just STROKE-CHANCERY] : XChanceryStrand (-1) df.leftSB bot df.rightSB top true sw
+					__ : glyph-proc
+				match stroke2
+					[Just STROKE-STRAIGHT] : HalfXStrand true  fSlab df.rightSB bot df.middle midy turn 0.4 tension sw
+					[Just STROKE-CURLY]    : HalfXStrand false fSlab df.rightSB bot df.middle midy turn 0.4 tension sw
+					[Just STROKE-CHANCERY] : XChanceryStrand (+1) df.leftSB top df.rightSB bot true sw
+					[Just STROKE-CURSIVE]  : XCursiveHalfShape top bot df.middle df.rightSB
+						sw -- sw
+						swEnd -- (sw / Stroke) * [AdviceStroke 2.75]
+						swMid -- (sw / Stroke) * [AdviceStroke 3]
+						setMark -- true
+					__ : glyph-proc
 
-	define Shape : namespace
-		define [XBase fStraight fSlab top bottom turn tension] : composite-proc
-			XStrand fStraight fSlab SB bottom RightSB top turn 0.4 tension
-			XStrand fStraight fSlab SB top RightSB bottom turn 0.4 tension
+	glyph-block-export XSerifs
+	define XSerifs : namespace
+		export : define [Full sf] : composite-proc sf.lt.full sf.rt.full sf.lb.full sf.rb.full
+		export : define [Motion sf] : composite-proc sf.lt.outer
+		export : define [BilateralMotion sf] : composite-proc sf.lt.outer sf.rb.outer
 
-		export : define [StraightBase fSlab top bottom turn tension]
-			XBase true  fSlab top bottom turn tension
-		export : define [CurlyBase    fSlab top bottom turn tension]
-			XBase false fSlab top bottom turn tension
+	glyph-block-export XConfig
+	define XConfig : object
+		straightSerifless              { STROKE-STRAIGHT STROKE-STRAIGHT null                    false }
+		curlySerifless                 { STROKE-CURLY    STROKE-CURLY    null                    false }
+		cursive                        { STROKE-CURSIVE  STROKE-CURSIVE  null                    false }
+		semiChanceryStraight           { STROKE-STRAIGHT STROKE-CHANCERY null                    false }
+		semiChanceryCurly              { STROKE-CURLY    STROKE-CHANCERY null                    false }
+		chancery                       { STROKE-CHANCERY STROKE-CHANCERY null                    false }
+		straightSerifed                { STROKE-STRAIGHT STROKE-STRAIGHT XSerifs.Full            true  }
+		curlySerifed                   { STROKE-CURLY    STROKE-CURLY    XSerifs.Full            true  }
+		straightMotionSerifed          { STROKE-STRAIGHT STROKE-STRAIGHT XSerifs.Motion          false }
+		curlyMotionSerifed             { STROKE-CURLY    STROKE-CURLY    XSerifs.Motion          false }
+		straightBilateralMotionSerifed { STROKE-STRAIGHT STROKE-STRAIGHT XSerifs.BilateralMotion false }
+		curlyBilateralMotionSerifed    { STROKE-CURLY    STROKE-CURLY    XSerifs.BilateralMotion false }
 
-		export : define [CursiveBase fSerifs top bottom turn tension] : glyph-proc
-			include : XCursiveHalfShape top bottom Middle RightSB
-			include : FlipAround Middle [mix bottom top 0.5]
-			include : XCursiveHalfShape top bottom Middle RightSB (setMark -- true)
-
-		export : define [SemiChanceryStr fSlab top bottom turn tension] : union
-			XChanceryStrand (+1) SB top RightSB bottom Stroke
-			XStrand true fSlab SB bottom RightSB top turn 0.4 tension
-		export : define [SemiChanceryCur fSlab top bottom turn tension] : union
-			XChanceryStrand (+1) SB top RightSB bottom Stroke
-			XStrand false fSlab SB bottom RightSB top turn 0.4 tension
-		export : define [ChanceryBase fSlab top bottom turn tension] : union
-			XChanceryStrand (+1) SB top RightSB bottom Stroke
-			XChanceryStrand (-1) SB bottom RightSB top Stroke
-
-		# Serifs
-		export : define [FullSerifs top bot] : let [sf : SerifFrame.fromDf [DivFrame 1] top bot]
-			composite-proc sf.lt.full sf.rt.full sf.lb.full sf.rb.full
-		export : define [MotionSerifs top bot] : glyph-proc
-			include : tagged 'serifLT' : HSerif.lt SB top SideJut
-		export : define [MotionSerifsBilateral top bot] : glyph-proc
-			include : tagged 'serifLT' : HSerif.lt SB top SideJut
-			include : tagged 'serifRB' : HSerif.rb RightSB bot SideJut
-
-	define Config : object
-		straightSerifless              { Shape.StraightBase       null                        false }
-		curlySerifless                 { Shape.CurlyBase          null                        false }
-		cursive                        { Shape.CursiveBase        null                        false }
-		semiChanceryStraight           { Shape.SemiChanceryStr    null                        false }
-		semiChanceryCurly              { Shape.SemiChanceryCur    null                        false }
-		chancery                       { Shape.ChanceryBase       null                        false }
-		straightSerifed                { Shape.StraightBase       Shape.FullSerifs            true  }
-		curlySerifed                   { Shape.CurlyBase          Shape.FullSerifs            true  }
-		straightMotionSerifed          { Shape.StraightBase       Shape.MotionSerifs          false }
-		curlyMotionSerifed             { Shape.CurlyBase          Shape.MotionSerifs          false }
-		straightBilateralMotionSerifed { Shape.StraightBase       Shape.MotionSerifsBilateral false }
-		curlyBilateralMotionSerifed    { Shape.CurlyBase          Shape.MotionSerifsBilateral false }
-
-	foreach { suffix { baseShape serifShape fMaskBase} } [Object.entries Config] : do
-		define [letterShape top bottom turn tension] : glyph-proc
-			local base : baseShape fMaskBase top bottom turn tension
-			include : WithSerifOverflowMask fMaskBase top bottom SB RightSB base
-			if serifShape : include : serifShape top bottom
+	foreach { suffix {stroke1 stroke2 serifShape fMaskBase} } [Object.entries XConfig] : do
+		define [letterShape top bot turn tension] : glyph-proc
+			local df : DivFrame 1
+			local lf : XLetterForm df top bot stroke1 stroke2 turn tension
+			include : WithSerifOverflowMask fMaskBase top bot df.leftSB df.rightSB : lf.base fMaskBase
+			if serifShape : begin
+				local sf : SerifFrame.fromDf df top bot
+				include : serifShape sf
 
 		create-glyph "X.\(suffix)" : glyph-proc
 			include : MarkSet.capital

--- a/font-src/glyphs/letter/shared.ptl
+++ b/font-src/glyphs/letter/shared.ptl
@@ -624,7 +624,7 @@ glyph-block Letter-Shared-Shapes : begin
 		define swMid : mix sw fine 0.7
 
 		define dxTurn : [HSwToV : 0.5 * sw] + rIn * df.div
-		define dxTurnObl : if (sign > 0) (-0.75 * TanSlope * rIn) (0.75 * TanSlope * rIn)
+		define dxTurnObl : 0.75 * TanSlope * rIn
 		define dyTurn : 0.5 * mocSwMid
 		define dxTailStart : dxTurn + sinAngle * (rIn + 0.5 * mocFine * [mix 1 HVContrast sinAngle])
 		define dyTailStart : dyTurn + (1 - cosAngle + [if (sign > 0) 0 (TanSlope)]) * (rIn + 0.5 * mocFine)
@@ -632,7 +632,7 @@ glyph-block Letter-Shared-Shapes : begin
 		define dyDepth : (depth - 0.5 * sw) * sinAngle
 		return : list
 			g4.[if (sign > 0) "right" "left"].mid
-				cx + sign * dxTurn + dxTurnObl
+				cx + sign * (dxTurn - dxTurnObl)
 				cy + O + dyTurn
 				if (sign > 0)
 					widths.center.heading swMid Rightward

--- a/font-src/meta/aesthetics.ptl
+++ b/font-src/meta/aesthetics.ptl
@@ -456,15 +456,16 @@ export : define [GenDivFrame metrics] : begin
 			local divisions : fallback _divisions this.hPack
 			local keeps : fallback _keeps 2
 
-			return : this.sliceFine divisions keeps ((keeps - 1) / (divisions - 1)) o
+			return : this.sliceFine divisions keeps ((keeps - 1) / (divisions - 1)) 0 o
 
-		public [sliceFine strokes keeps pGaps _o] : begin
+		public [sliceFine strokes keeps pGap _extraGap _o] : begin
 			local o : fallback _o 0
+			local extraGap : fallback _extraGap 0
 
 			local oneStroke : metrics.HVContrast * this.mvs
 			local totalGap : this.rightSB - this.leftSB - strokes * oneStroke - 2 * o
 
-			local subDfWidth : 2 * this.leftSB + 2 * o + totalGap * pGaps + oneStroke * keeps
+			local subDfWidth : 2 * this.leftSB + 2 * o + totalGap * pGap + extraGap + oneStroke * keeps
 			local subDfDiv : subDfWidth / metrics.Width
 
 			return : new CDivFrame subDfDiv keeps (this.leftSB / metrics.SB) this.mvs o

--- a/font-src/support/util/mask-bit.mjs
+++ b/font-src/support/util/mask-bit.mjs
@@ -4,6 +4,9 @@ export function maskBit(x, y) {
 export function maskBits(x, y) {
 	return x & y;
 }
+export function maskOffBits(x, y) {
+	return x & ~y;
+}
 export function bitOr(...xs) {
 	let x = 0;
 	for (const a of xs) x |= a;

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1279,12 +1279,14 @@ rank = 1
 descriptionAffix = "straight shape"
 selectorAffix.X = "straight"
 selectorAffix."X/sansSerif" = "straight"
+selectorAffix."cyrl/Rha/right" = "straight"
 
 [prime.capital-x.variants-buildup.stages.body.curly]
 rank = 2
 descriptionAffix = "curly shape"
 selectorAffix.X = "curly"
 selectorAffix."X/sansSerif" = "curly"
+selectorAffix."cyrl/Rha/right" = "curly"
 
 [prime.capital-x.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -1292,18 +1294,21 @@ descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix.X = "serifless"
 selectorAffix."X/sansSerif" = "serifless"
+selectorAffix."cyrl/Rha/right" = "serifless"
 
 [prime.capital-x.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
 descriptionAffix = "motion serifs"
 selectorAffix.X = "motionSerifed"
 selectorAffix."X/sansSerif" = "serifless"
+selectorAffix."cyrl/Rha/right" = "serifless"
 
 [prime.capital-x.variants-buildup.stages.serifs.serifed]
 rank = 3
 descriptionAffix = "serifs"
 selectorAffix.X = "serifed"
 selectorAffix."X/sansSerif" = "serifless"
+selectorAffix."cyrl/Rha/right" = "serifed"
 
 
 
@@ -3972,6 +3977,7 @@ descriptionAffix = "straight shape"
 selectorAffix.x = "straight"
 selectorAffix."x/sansSerif" = "straight"
 selectorAffix."cyrl/ha" = "straight"
+selectorAffix."cyrl/rha/right" = "straight"
 
 [prime.x.variants-buildup.stages.body.curly]
 rank = 2
@@ -3979,6 +3985,7 @@ descriptionAffix = "curly shape"
 selectorAffix.x = "curly"
 selectorAffix."x/sansSerif" = "curly"
 selectorAffix."cyrl/ha" = "curly"
+selectorAffix."cyrl/rha/right" = "curly"
 
 [prime.x.variants-buildup.stages.body.cursive]
 rank = 3
@@ -3987,6 +3994,7 @@ descriptionAffix = "cursive shape"
 selectorAffix.x = "cursive"
 selectorAffix."x/sansSerif" = "cursive"
 selectorAffix."cyrl/ha" = "cursive"
+selectorAffix."cyrl/rha/right" = "cursive"
 
 [prime.x.variants-buildup.stages.body.semi-chancery-straight]
 rank = 4
@@ -3995,6 +4003,7 @@ descriptionAffix = "Semi-chancery shape with straight counter-leg"
 selectorAffix.x = "semiChanceryStraight"
 selectorAffix."x/sansSerif" = "semiChanceryStraight"
 selectorAffix."cyrl/ha" = "semiChanceryStraight"
+selectorAffix."cyrl/rha/right" = "semiChanceryStraight"
 
 [prime.x.variants-buildup.stages.body.semi-chancery-curly]
 rank = 5
@@ -4003,6 +4012,7 @@ descriptionAffix = "Semi-chancery shape with curly counter-leg"
 selectorAffix.x = "semiChanceryCurly"
 selectorAffix."x/sansSerif" = "semiChanceryCurly"
 selectorAffix."cyrl/ha" = "semiChanceryCurly"
+selectorAffix."cyrl/rha/right" = "semiChanceryCurly"
 
 [prime.x.variants-buildup.stages.body.chancery]
 rank = 6
@@ -4011,6 +4021,7 @@ descriptionAffix = "Chancery shape"
 selectorAffix.x = "chancery"
 selectorAffix."x/sansSerif" = "chancery"
 selectorAffix."cyrl/ha" = "chancery"
+selectorAffix."cyrl/rha/right" = "chancery"
 
 [prime.x.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -4019,6 +4030,7 @@ descriptionJoiner = "without"
 selectorAffix.x = "serifless"
 selectorAffix."x/sansSerif" = "serifless"
 selectorAffix."cyrl/ha" = "serifless"
+selectorAffix."cyrl/rha/right" = "serifless"
 
 [prime.x.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
@@ -4026,6 +4038,7 @@ descriptionAffix = "motion serifs"
 selectorAffix.x = "motionSerifed"
 selectorAffix."x/sansSerif" = "serifless"
 selectorAffix."cyrl/ha" = "motionSerifed"
+selectorAffix."cyrl/rha/right" = "serifless"
 
 [prime.x.variants-buildup.stages.serifs.serifed]
 rank = 3
@@ -4033,6 +4046,7 @@ descriptionAffix = "serifs"
 selectorAffix.x = "serifed"
 selectorAffix."x/sansSerif" = "serifless"
 selectorAffix."cyrl/ha" = "serifed"
+selectorAffix."cyrl/rha/right" = "serifed"
 
 
 
@@ -5908,16 +5922,19 @@ next = "openness"
 rank = 1
 descriptionAffix = "straight leg"
 selectorAffix."cyrl/Ya" = "straight"
+selectorAffix."cyrl/Yae/left" = "straight"
 
 [prime.cyrl-capital-ya.variants-buildup.stages.leg.curly]
 rank = 2
 descriptionAffix = "curly leg"
 selectorAffix."cyrl/Ya" = "curly"
+selectorAffix."cyrl/Yae/left" = "curly"
 
 [prime.cyrl-capital-ya.variants-buildup.stages.leg.standing]
 rank = 3
 descriptionAffix = "standing leg (like Helvetica)"
 selectorAffix."cyrl/Ya" = "standing"
+selectorAffix."cyrl/Yae/left" = "standing"
 
 [prime.cyrl-capital-ya.variants-buildup.stages.openness."*"]
 next = "serifs"
@@ -5926,27 +5943,32 @@ next = "serifs"
 rank = 1
 keyAffix = ""
 selectorAffix."cyrl/Ya" = ""
+selectorAffix."cyrl/Yae/left" = ""
 
 [prime.cyrl-capital-ya.variants-buildup.stages.openness.open]
 rank = 2
 descriptionAffix = "open contour"
 selectorAffix."cyrl/Ya" = "open"
+selectorAffix."cyrl/Yae/left" = "open"
 
 [prime.cyrl-capital-ya.variants-buildup.stages.serifs.serifless]
 rank = 1
 descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix."cyrl/Ya" = "serifless"
+selectorAffix."cyrl/Yae/left" = "serifless"
 
 [prime.cyrl-capital-ya.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
 descriptionAffix = "motion serifs at bottom-left"
 selectorAffix."cyrl/Ya" = "bottomRightSerifed"
+selectorAffix."cyrl/Yae/left" = "bottomRightSerifed"
 
 [prime.cyrl-capital-ya.variants-buildup.stages.serifs.serifed]
 rank = 3
 descriptionAffix = "serifs"
 selectorAffix."cyrl/Ya" = "serifed"
+selectorAffix."cyrl/Yae/left" = "bottomRightSerifed"
 
 
 
@@ -5967,18 +5989,21 @@ rank = 1
 groupRank = 1
 descriptionAffix = "straight leg"
 selectorAffix."cyrl/ya" = "straight"
+selectorAffix."cyrl/yae/left" = "straight"
 
 [prime.cyrl-ya.variants-buildup.stages.leg.curly]
 rank = 2
 groupRank = 2
 descriptionAffix = "curly leg"
 selectorAffix."cyrl/ya" = "curly"
+selectorAffix."cyrl/yae/left" = "curly"
 
 [prime.cyrl-ya.variants-buildup.stages.leg.standing]
 rank = 3
 groupRank = 3
 descriptionAffix = "standing leg (like Helvetica)"
 selectorAffix."cyrl/ya" = "standing"
+selectorAffix."cyrl/yae/left" = "standing"
 
 [prime.cyrl-ya.variants-buildup.stages.openness."*"]
 next = "serifs"
@@ -5988,12 +6013,14 @@ rank = 1
 groupRrank = 10
 keyAffix = ""
 selectorAffix."cyrl/ya" = ""
+selectorAffix."cyrl/yae/left" = ""
 
 [prime.cyrl-ya.variants-buildup.stages.openness.open]
 rank = 2
 groupRrank = 20
 descriptionAffix = "open contour"
 selectorAffix."cyrl/ya" = "open"
+selectorAffix."cyrl/yae/left" = "open"
 
 [prime.cyrl-ya.variants-buildup.stages.tails."*"]
 next = "serifs"
@@ -6002,27 +6029,32 @@ next = "serifs"
 rank = 1
 keyAffix = ""
 selectorAffix."cyrl/ya" = ""
+selectorAffix."cyrl/yae/left" = ""
 
 [prime.cyrl-ya.variants-buildup.stages.tails.tailed]
 rank = 2
 descriptionAffix = "tail"
 selectorAffix."cyrl/ya" = "tailed"
+selectorAffix."cyrl/yae/left" = ""
 
 [prime.cyrl-ya.variants-buildup.stages.serifs.serifless]
 rank = 1
 descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix."cyrl/ya" = "serifless"
+selectorAffix."cyrl/yae/left" = "serifless"
 
 [prime.cyrl-ya.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
 descriptionAffix = "motion serifs at bottom-left"
 selectorAffix."cyrl/ya" = "bottomRightSerifed"
+selectorAffix."cyrl/yae/left" = "bottomRightSerifed"
 
 [prime.cyrl-ya.variants-buildup.stages.serifs.serifed]
 rank = 3
 descriptionAffix = "serifs"
 selectorAffix."cyrl/ya" = "smallCyrl"
+selectorAffix."cyrl/yae/left" = "bottomRightSerifed"
 
 
 
@@ -6622,7 +6654,7 @@ tagKind = "symbol"
 
 [prime.underscore.variants.above-baseline]
 rank = 1
-description = "Extra-high `_`, placed right below baseline"
+description = "Extra-high `_`, placed right above baseline"
 selector.underscore = "aboveBaseline"
 
 [prime.underscore.variants.high]


### PR DESCRIPTION
Very incomplete attempt on #2018. 
![](https://user-images.githubusercontent.com/21302803/282311263-aeb5e035-7c68-4366-8460-382115bae220.png)

Known issues to be fixed:
* Changelog
* The diagonal tail of the cursive `x` is deformed, but I've no idea what caused it.
* Lha needs some better adjustment on the stroke width and space allocation, as it is known to overlap in other variants.
* Upper/Lower Rha's Ha part extrudes into the bowl of Er a bit in some settings.
* Lower Rha with cursive Ha still looks a bit off

Any reviews/suggestions on how to fix the above are welcome.