### PR TITLE
Remove earless-rounded variants for letters with hooktop.

### DIFF
--- a/changes/28.0.0-alpha.1.md
+++ b/changes/28.0.0-alpha.1.md
@@ -18,3 +18,5 @@
 * Add Characters:
   - CYRILLIC CAPITAL LETTER LHA (`U+0514`) ... CYRILLIC SMALL LETTER YAE (`U+0519`) (#2018).
 * Add hook-inward-serifed variants for `a` (#2085).
+* Remove earless-rounded variants for `U+01A5`, `U+0256`, `U+02A0`, and `U+1D91`.
+* Remove earless-corner variants for `U+027E`.

--- a/font-src/glyphs/letter/latin/c.ptl
+++ b/font-src/glyphs/letter/latin/c.ptl
@@ -290,13 +290,6 @@ glyph-block Letter-Latin-C : begin
 			include : VBar.r RightSB Descender [ArcStartSerifDepth Hook] [ArcStartSerifWidth Stroke]
 			if styBot : let [sf : SerifFrame.fromDf [DivFrame 1] CAP Descender] : include sf.rb.full
 
-		create-glyph "currency/somSign.\(suffix)" : glyph-proc
-			include : MarkSet.capital
-			local height : mix XH CAP (2 / 3)
-			local lf : CLetterForm [DivFrame 1] sty styBot height (height - XH)
-			include : lf.full
-			include : HBar.b SB RightSB 0 markStroke
-
 	select-variant 'C' 'C'
 	link-reduced-variant 'C/sansSerif' 'C' MathSansSerif
 	select-variant 'revC' 0x2183 (follow -- 'C')
@@ -345,8 +338,6 @@ glyph-block Letter-Latin-C : begin
 		include : intersection
 			CShapeT spiro-outline 0.1 [DivFrame 1] SLAB-NONE SLAB-NONE XH 0 SmallArchDepthA SmallArchDepthB Hook BBS
 			VBar.l (SB + BBD + OX) 0 CAP BBS
-
-	select-variant 'currency/somSign' 0x20C0 (follow -- 'c')
 
 	create-glyph 'currency/euroSign/overlay' : union
 		LetterBarOverlay.l SB (CAP * 0.4)

--- a/font-src/glyphs/letter/latin/lower-b.ptl
+++ b/font-src/glyphs/letter/latin/lower-b.ptl
@@ -48,7 +48,7 @@ glyph-block Letter-Latin-Lower-B : begin
 			set-base-anchor 'overlayOnExtension' (SB + [HSwToV : 0.5 * Stroke]) yOverlay
 			set-base-anchor 'overlay' Middle (XH / 2)
 
-		create-glyph "bBar.\(suffix)" : glyph-proc
+		create-glyph "bStroke.\(suffix)" : glyph-proc
 			include [refer-glyph "b.\(suffix)"] AS_BASE ALSO_METRICS
 			include : LetterBarOverlay.l.in SB XH (Ascender - [if doTS Stroke 0])
 
@@ -72,7 +72,7 @@ glyph-block Letter-Latin-Lower-B : begin
 			eject-contour 'serifLT'
 
 	select-variant 'b'       'b'
-	select-variant 'bBar'    0x180  (follow -- 'b')
+	select-variant 'bStroke' 0x180  (follow -- 'b')
 	select-variant 'bSlash'  0x2422 (follow -- 'b')
 	select-variant 'latn/be' 0x183  (follow -- 'b')
 

--- a/font-src/glyphs/letter/latin/lower-d.ptl
+++ b/font-src/glyphs/letter/latin/lower-d.ptl
@@ -54,10 +54,6 @@ glyph-block Letter-Latin-Lower-D : begin
 		ada -- [df.archDepthA SmallArchDepth df.mvs]
 		adb -- [df.archDepthB SmallArchDepth df.mvs]
 
-	define [ToothlessRoundedHBBBody df yTop] : union
-		ToothlessRoundedBody df yTop
-		tagged 'rightBar' : VBar.r df.rightSB 0 yTop
-
 	define [TailedBody df yTop] : union
 		OBarRight.shape
 			left -- df.leftSB
@@ -79,7 +75,6 @@ glyph-block Letter-Latin-Lower-D : begin
 			toothlessCorner           ToothlessCornerBody
 			toothlessCornerHBB        ToothlessCornerHBBBody
 			toothlessRounded          ToothlessRoundedBody
-			toothlessRoundedHBB       ToothlessRoundedHBBBody
 			tailed                    TailedBody
 
 		function [body] : object # serifs
@@ -102,7 +97,7 @@ glyph-block Letter-Latin-Lower-D : begin
 			include : LeaningAnchor.Above.VBar.r df.rightSB
 			set-base-anchor 'overlayOnExtension' (df.rightSB - [HSwToV : 0.5 * Stroke]) yOverlay
 
-		create-glyph "dcroat.\(suffix)" : glyph-proc
+		create-glyph "dStroke.\(suffix)" : glyph-proc
 			local df : DivFrame 1
 			include [refer-glyph "d.\(suffix)"] AS_BASE ALSO_METRICS
 			include : LetterBarOverlay.r.in df.rightSB XH (Ascender - [if topSerif Stroke 0])
@@ -145,7 +140,7 @@ glyph-block Letter-Latin-Lower-D : begin
 
 	select-variant 'd' 'd'
 	select-variant 'dCaronBase' (follow -- 'd')
-	select-variant 'dcroat' 0x111 (follow -- 'd')
+	select-variant 'dStroke' 0x111 (follow -- 'd')
 	select-variant 'latn/de' 0x18C (follow -- 'd')
 	alias 'cyrl/deKomi' 0x501 'd'
 	link-reduced-variant 'd/sansSerif' 'd' MathSansSerif

--- a/font-src/glyphs/letter/latin/lower-g.ptl
+++ b/font-src/glyphs/letter/latin/lower-g.ptl
@@ -164,7 +164,6 @@ glyph-block Letter-Latin-Lower-G : begin
 			earlessCorner         { SingleStorey.EarlessCornerBody  DToothlessRise         }
 			earlessCornerHTB      { SingleStorey.EarlessCornerBody  0                      }
 			earlessRounded        { SingleStorey.EarlessRoundedBody (XH - SmallArchDepthA) }
-			earlessRoundedHTB     { SingleStorey.EarlessRoundedBody 0                      }
 			scriptCut             { SingleStorey.ScriptCutBody      (Stroke / 2)           }
 
 	foreach { suffix { hookShape {bodyShape hookStart} } } [Object.entries SingleStoreyConfig] : do

--- a/font-src/glyphs/letter/latin/lower-p.ptl
+++ b/font-src/glyphs/letter/latin/lower-p.ptl
@@ -106,7 +106,7 @@ glyph-block Letter-Latin-Lower-P : begin
 
 	CreateAccentedComposition 'pTildeOver' 0x1D71 'p' 'tildeOverOnExension'
 
-	derive-glyphs 'cyrl/rrTick' 0x48F 'cyrl/er' : lambda [src gr] : glyph-proc
+	derive-glyphs 'cyrl/erTick' 0x48F 'cyrl/er' : lambda [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
 		include : dispiro
 			widths.center [AdviceStroke 4]

--- a/font-src/glyphs/letter/latin/upper-b.ptl
+++ b/font-src/glyphs/letter/latin/upper-b.ptl
@@ -233,7 +233,7 @@ glyph-block Letter-Latin-Upper-B : begin
 		include : ItalicCyrveShape XH
 
 	create-glyph 'grek/betaSymbol' 0x3D0 : glyph-proc
-		include : MarkSet.e
+		include : MarkSet.b
 		include : ItalicCyrveShape Ascender
 
 	alias 'cyrl/ve.BGR' null 'grek/betaSymbol'

--- a/font-src/glyphs/letter/latin/upper-d.ptl
+++ b/font-src/glyphs/letter/latin/upper-d.ptl
@@ -99,7 +99,7 @@ glyph-block Letter-Latin-Upper-D : begin
 		include [refer-glyph src] AS_BASE ALSO_METRICS
 		include : LetterBarOverlay.l.in SB Stroke (CAP - Stroke)
 			space -- { 0 (RightSB - [HSwToV Stroke]) }
-	alias 'Dcroat' 0x110 'Eth'
+	alias 'DStroke' 0x110 'Eth'
 	alias 'arficanD' 0x189 'Eth'
 	select-variant 'Dhookleft' 0x18A
 

--- a/font-src/glyphs/symbol/letter.ptl
+++ b/font-src/glyphs/symbol/letter.ptl
@@ -72,7 +72,7 @@ glyph-block Symbol-Currency-Letter-Derived : begin
 
 	derive-composites 'currency/wonSign' 0x20A9 'W' 'currency/overlay/W'
 
-	derive-composites 'currency/dongSign' 0x20AB 'dcroat' 'sbRsbUnderlineBelow'
+	derive-composites 'currency/dongSign' 0x20AB 'dStroke' 'sbRsbUnderlineBelow'
 	derive-composites 'currency/kipSign' 0x20AD 'K' 'hStrike'
 
 	create-glyph 'currency/tugrikOverride' : glyph-proc
@@ -89,6 +89,8 @@ glyph-block Symbol-Currency-Letter-Derived : begin
 
 	derive-composites 'currency/guaraniSign' 0x20B2 'G' 'longVStrokeOver'
 	derive-composites 'currency/cediSign' 0x20B5 'C' 'longVStrokeOver'
+
+	derive-composites 'currency/somSign' 0x20C0 'cyrl/es' 'sbRsbUnderlineBelow'
 
 glyph-block Symbol-Letter : begin
 	glyph-block-import CommonShapes

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1832,10 +1832,10 @@ selectorAffix.d = "toothlessRounded"
 selectorAffix."d/sansSerif" = "toothlessRounded"
 selectorAffix."d/phoneticLeft" = "toothed"
 selectorAffix."d/descBase" = "toothed"
-selectorAffix."d/hookBottomBase" = "toothlessRoundedHBB"
+selectorAffix."d/hookBottomBase" = "toothed"
 selectorAffix.dCurlyTail = "toothed"
 selectorAffix.dHookTop = "toothlessRounded"
-selectorAffix."dHookTop/hookBottomBase" = "toothlessRoundedHBB"
+selectorAffix."dHookTop/hookBottomBase" = "toothed"
 selectorAffix."cyrl/djeKomi" = "toothlessRounded"
 
 [prime.d.variants-buildup.stages.body.tailed]
@@ -2166,7 +2166,7 @@ descriptionAffix = "earless (cornered top-right)"
 selectorAffix.g = "earlessCorner"
 selectorAffix."g/sansSerif" = "earlessCorner"
 selectorAffix."gScript" = "scriptCut"
-selectorAffix."gScript/hookTopBase" = "serifless"
+selectorAffix."gScript/hookTopBase" = "earlessCornerHTB"
 selectorAffix."gScriptCrossedTail" = "scriptCut"
 selectorAffix."g/single" = "earlessCorner"
 
@@ -3169,7 +3169,7 @@ rank = 3
 descriptionAffix = "earless (rounded) shape"
 selectorAffix.p = "earlessRounded"
 selectorAffix."p/sansSerif" = "earlessRounded"
-selectorAffix."p/hookTopBase" = "earlessRounded"
+selectorAffix."p/hookTopBase" = "eared"
 
 [prime.p.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -3239,7 +3239,7 @@ rank = 3
 descriptionAffix = "earless (rounded) shape"
 selectorAffix.q = "earlessRounded"
 selectorAffix."q/sansSerif" = "earlessRounded"
-selectorAffix."q/hookTopBase" = "earlessRounded"
+selectorAffix."q/hookTopBase" = ""
 selectorAffix.qRTail = "earlessRounded"
 
 [prime.q.variants-buildup.stages.terminal."*"]
@@ -3339,7 +3339,7 @@ selectorAffix.r = "earlessCorner"
 selectorAffix."r/sansSerif" = "earlessCorner"
 selectorAffix.rRTail = "earlessCorner"
 selectorAffix."rTurnRTail" = ""
-selectorAffix."rFlap" = "earlessCorner"
+selectorAffix."rFlap" = "earlessRounded"
 selectorAffix."iFishHook" = ""
 
 [prime.r.variants-buildup.stages.body.earless-rounded]


### PR DESCRIPTION
also remove earless-corner variants of rFlap.
Also make g with hook top respond to earless-corner variants to match the other letters with hooktop, even if it doesn't technically match the variants of script g.
`dɖᶑgɠpƥqʠrɾ`
Default for reference (unchanged):
![image](https://github.com/be5invis/Iosevka/assets/37010132/d2352ab3-05e1-4adf-91dc-b836131ddbc0)
Earless rounded:
before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/1c076e3b-f0af-4fc9-ad47-228a8bc5357b)
after:
![image](https://github.com/be5invis/Iosevka/assets/37010132/ae9ef316-213a-497e-827b-47808cffadf1)
Compared to earless corner:
before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/225a280b-d422-42b4-a72b-08387171ece7)
after:
![image](https://github.com/be5invis/Iosevka/assets/37010132/2de99d74-a46d-4551-940c-0497e7de6842)
Also harmonize glyph of som sign with dong sign while I'm at it, since I feel like it doesn't matter as much as I thought it did for it to be above the baseline:
`⃀₫`
![image](https://github.com/be5invis/Iosevka/assets/37010132/4b4816a3-e1d2-41c3-a62f-5fddd84920c7)
also fix above mark anchor point for Greek Beta symbol:
`ϐ́`
![image](https://github.com/be5invis/Iosevka/assets/37010132/c8f8e148-88e9-479f-bd83-b94f53cef0dc)


