### PR TITLE
Add various medievalist dotted/separator punctuation characters.

### DIFF
--- a/changes/28.0.0-alpha.1.md
+++ b/changes/28.0.0-alpha.1.md
@@ -17,6 +17,9 @@
      - Various other glyph variant tags are also changed to reflect this insertion.
 * Add Characters:
   - CYRILLIC CAPITAL LETTER LHA (`U+0514`) ... CYRILLIC SMALL LETTER YAE (`U+0519`) (#2018).
+  - GEORGIAN PARAGRAPH SEPARATOR (`U+10FB`).
+  - LINE SEPARATOR (`U+2028`) ... PARAGRAPH SEPARATOR (`U+2029`).
+  - TWO DOTS OVER ONE DOT PUNCTUATION (`U+2E2A`) ... FIVE DOT MARK (`U+2E2D`).
 * Add hook-inward-serifed variants for `a` (#2085).
 * Remove earless-rounded variants for `U+01A5`, `U+0256`, `U+02A0`, and `U+1D91`.
 * Remove earless-corner variants for `U+027E`.

--- a/font-src/glyphs/space/index.ptl
+++ b/font-src/glyphs/space/index.ptl
@@ -39,6 +39,8 @@ glyph-block Spaces : begin
 		set-width 0
 
 	alias 'nonmarkingreturn'   0x000D 'zwsp'
+	alias 'lineSeparator'      0x2028 'zwsp'
+	alias 'paragraphSeparator' 0x2029 'zwsp'
 	alias 'wj'                 0x2060 'zwsp'
 	alias 'funcApp'            0x2061 'zwsp'
 	alias 'invisibleTimes'     0x2062 'zwsp'

--- a/font-src/glyphs/symbol/punctuation/ellipsis.ptl
+++ b/font-src/glyphs/symbol/punctuation/ellipsis.ptl
@@ -9,6 +9,7 @@ glyph-block Symbol-Punctuation-Ellipsis : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 
+	glyph-block-export  EllipsisDotRadius
 	define [EllipsisDotRadius nDots space] : begin
 		return : 0.5 * [AdviceStroke (nDots + 1.5) (space / Width)] * PeriodSize / Stroke
 

--- a/font-src/glyphs/symbol/punctuation/small.ptl
+++ b/font-src/glyphs/symbol/punctuation/small.ptl
@@ -9,6 +9,7 @@ glyph-module
 glyph-block Symbol-Punctuation-Small : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
+	glyph-block-import Symbol-Punctuation-Ellipsis EllipsisDotRadius
 
 	foreach { suffix { DrawAt kDotRadius overshoot } } [Object.entries DotVariants] : do
 		create-glyph "period.\(suffix)" : glyph-proc
@@ -206,6 +207,27 @@ glyph-block Symbol-Punctuation-Small : begin
 			include : with-transform [ApparentTranslate (-multiDotShift) 0] : composite-proc
 				refer-glyph "halfXhSmallPeriod.\(suffix)"
 
+		create-glyph "geor/paragraphSeparator.\(suffix)" : glyph-proc
+			include : with-transform [ApparentTranslate (+multiDotShift) 0] : composite-proc
+				refer-glyph "halfXhSmallPeriod.\(suffix)"
+			include : with-transform [ApparentTranslate (-multiDotShift) 0] : composite-proc
+				refer-glyph "smallPeriod.\(suffix)"
+				refer-glyph "xhSmallPeriod.\(suffix)"
+
+		create-glyph "twoDotOverOneDotPunct.\(suffix)" : glyph-proc
+			include [refer-glyph "smallPeriod.\(suffix)"]
+			include : with-transform [ApparentTranslate (+multiDotShiftDense) 0] : composite-proc
+				refer-glyph "xhSmallPeriod.\(suffix)"
+			include : with-transform [ApparentTranslate (-multiDotShiftDense) 0] : composite-proc
+				refer-glyph "xhSmallPeriod.\(suffix)"
+
+		create-glyph "oneDotOverTwoDotPunct.\(suffix)" : glyph-proc
+			include [refer-glyph "xhSmallPeriod.\(suffix)"]
+			include : with-transform [ApparentTranslate (+multiDotShiftDense) 0] : composite-proc
+				refer-glyph "smallPeriod.\(suffix)"
+			include : with-transform [ApparentTranslate (-multiDotShiftDense) 0] : composite-proc
+				refer-glyph "smallPeriod.\(suffix)"
+
 		create-glyph "fourDotPunct.\(suffix)" : glyph-proc
 			include [refer-glyph "smallPeriod.\(suffix)"]
 			include [refer-glyph "xhSmallPeriod.\(suffix)"]
@@ -222,14 +244,28 @@ glyph-block Symbol-Punctuation-Small : begin
 			include : with-transform [ApparentTranslate (-multiDotShiftDense) 0] : composite-proc
 				refer-glyph "halfCapSmallPeriod.\(suffix)"
 
-		create-glyph "fiveDotPunct.\(suffix)" : glyph-proc
+		create-glyph "squareFourDotPunct.\(suffix)" : glyph-proc
 			include : with-transform [ApparentTranslate (-multiDotShiftDense) 0] : composite-proc
 				refer-glyph "smallPeriod.\(suffix)"
 				refer-glyph "xhSmallPeriod.\(suffix)"
 			include : with-transform [ApparentTranslate (+multiDotShiftDense) 0] : composite-proc
 				refer-glyph "smallPeriod.\(suffix)"
 				refer-glyph "xhSmallPeriod.\(suffix)"
+
+		create-glyph "fiveDotPunct.\(suffix)" : glyph-proc
+			include : refer-glyph "squareFourDotPunct.\(suffix)"
 			include : refer-glyph "halfXhSmallPeriod.\(suffix)"
+
+		create-glyph "fiveDotMark.\(suffix)" : glyph-proc
+			local l : mix SB 0 0.5
+			local r : mix RightSB Width 0.5
+			local radius : EllipsisDotRadius 3 [Math.min XH (r - l)]
+			include : DrawAt  Middle  radius       (kDotRadius * radius - overshoot)
+			include : DrawAt  Middle (XH / 2)      (kDotRadius * radius - overshoot)
+			include : DrawAt  Middle (XH - radius) (kDotRadius * radius - overshoot)
+
+			include : DrawAt (l + radius) (XH / 2) (kDotRadius * radius - overshoot)
+			include : DrawAt (r - radius) (XH / 2) (kDotRadius * radius - overshoot)
 
 		create-glyph "dottedCross.\(suffix)" : glyph-proc
 			include : HBar.m [mix 0 SB 0.5] [mix Width RightSB 0.5] (XH / 2) OperatorStroke
@@ -246,13 +282,23 @@ glyph-block Symbol-Punctuation-Small : begin
 	select-variant 'modifierLetterRaisedColon' 0x2F8 (follow -- 'punctuationDot')
 	select-variant 'semicolon' ';' (follow -- 'punctuationDot')
 	select-variant 'invertSemicolon' 0x204F (follow -- 'punctuationDot')
+
 	select-variant 'threeDotPunct' 0x2056 (follow -- 'punctuationDot')
+	select-variant 'geor/paragraphSeparator' 0x10FB (follow -- 'punctuationDot')
+	select-variant 'twoDotOverOneDotPunct' 0x2E2A (follow -- 'punctuationDot')
+	select-variant 'oneDotOverTwoDotPunct' 0x2E2B (follow -- 'punctuationDot')
+
 	select-variant 'fourDotPunct' 0x2058 (follow -- 'punctuationDot')
+	select-variant 'squareFourDotPunct' 0x2E2C (follow -- 'punctuationDot')
 	select-variant 'fiveDotPunct' 0x2059 (follow -- 'punctuationDot')
+	select-variant 'fiveDotMark' 0x2E2D (follow -- 'punctuationDot')
+
 	select-variant 'capColon' 0x205A (follow -- 'punctuationDot')
 	select-variant 'capFourDotPunct' 0x205B (follow -- 'punctuationDot')
+
 	select-variant 'dottedCross' 0x205C (follow -- 'punctuationDot')
-	alias 'greekquestion' 0x37E 'semicolon'
+
+	alias 'grek/question' 0x37E 'semicolon'
 
 	turned 'turnSemiColon' 0x2E35 'semicolon' [DivFrame para.diversityF].middle (XH / 2)
 


### PR DESCRIPTION
Note that Georgian Paragraph Separator is a common script character, not just Georgian. Basically another Unicode-ism.

Not shown here are the remaining two zero width characters in the General Punctuation block that aren't the bidirectional control-format characters or other deprecated characters.

```
჻ ⁖ ⸪ ⸫
⁘ ⸬
⸭ ⁙
```
Thin:
![image](https://github.com/be5invis/Iosevka/assets/37010132/e975c95f-6527-4ac9-9803-bceab5b5c111)
Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/1faf5134-61c7-4500-9677-37b9e4459241)
Heavy:
![image](https://github.com/be5invis/Iosevka/assets/37010132/ca8b621e-b284-4173-a009-cff7c4b6d4a0)