### PR TITLE
Add an auto-serifed form for Greek Small Letter Heta (`U+0371`).

### DIFF
--- a/changes/28.0.0-alpha.2.md
+++ b/changes/28.0.0-alpha.2.md
@@ -1,3 +1,4 @@
 * Improve serifs for turned k (`U+029E`) to match `q` and turned h (`U+0265`).
 * Improve top-left serif for LATIN SMALL LETTER KRA (`U+0138`) to match `k`.
 * Make Greek Kappa (`U+03BA`) respond to more serif variants for `k` (`cv36`).
+* Add a top-left serif to GREEK SMALL LETTER HETA (`U+0371`) under slab.

--- a/font-src/glyphs/letter/latin/k.ptl
+++ b/font-src/glyphs/letter/latin/k.ptl
@@ -355,12 +355,12 @@ glyph-block Letter-Latin-K : begin
 			serifedKra                    { 2 1 3 0 }
 			serifedKappa                  { 2 0 3 0 }
 
-	define [UpperKLTSerif top sw xBarLeft slabType straightBar] : match slabType
+	define [UpperKLTSerif top sw xBarLeft slabType] : match slabType
 		2 : HSerif.lt xBarLeft top SideJut
 		1 : HSerif.mt (xBarLeft + [HSwToV : 0.5 * sw]) top Jut
 		_ : glyph-proc
 
-	define [UpperKLBSerif top sw xBarLeft slabType straightBar] : match slabType
+	define [UpperKLBSerif top sw xBarLeft slabType] : match slabType
 		2 : HSerif.lb xBarLeft 0 SideJut
 		1 : HSerif.mb (xBarLeft + [HSwToV : 0.5 * sw]) 0 Jut
 		_ : glyph-proc
@@ -397,13 +397,13 @@ glyph-block Letter-Latin-K : begin
 	# Main building
 	foreach { suffix { LegsImpl {slabLT slabLB slabLegs slabKS} } } [pairs-of UpperKConfig] : do
 		local straightBar : LegsImpl !== KLegs.Curly
-		local KBarLeft : SB + [KBalance slabLT straightBar]
+		local xBarLeft : SB + [KBalance slabLT straightBar]
 
 		define [KBaseShape sw top attachment] : glyph-proc
-			include : VBar.l KBarLeft 0 top sw
+			include : VBar.l xBarLeft 0 top sw
 			include : LegsImpl false SB RightSB sw top slabLT slabLegs attachment
-			if slabLT : include : UpperKLTSerif top sw KBarLeft slabLT straightBar
-			if slabLB : include : UpperKLBSerif top sw KBarLeft slabLB straightBar
+			if slabLT : include : UpperKLTSerif top sw xBarLeft slabLT
+			if slabLB : include : UpperKLBSerif top sw xBarLeft slabLB
 
 		create-glyph "K.\(suffix)" : glyph-proc
 			include : MarkSet.capital
@@ -417,7 +417,7 @@ glyph-block Letter-Latin-K : begin
 		create-glyph "KStroke.\(suffix)" : glyph-proc
 			include [refer-glyph "K.\(suffix)"] AS_BASE ALSO_METRICS
 			include : LetterBarOverlay.l.in
-				x     -- KBarLeft
+				x     -- xBarLeft
 				bot   -- XH
 				top   -- (CAP - [if slabLT Stroke 0])
 				space -- { 0 [mix SB RightSB 0.75] }
@@ -425,7 +425,7 @@ glyph-block Letter-Latin-K : begin
 		create-glyph "KVBar.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : KBaseShape CyrlVbSw CAP
-			include : CyrlKaVBar CAP KBarLeft
+			include : CyrlKaVBar CAP xBarLeft
 
 		create-glyph "grek/KaiSymbol.\(suffix)" : glyph-proc
 			include [refer-glyph "K.\(suffix)"] AS_BASE ALSO_METRICS
@@ -446,15 +446,15 @@ glyph-block Letter-Latin-K : begin
 		create-glyph "smcpKVBar.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : KBaseShape CyrlVbSw XH
-			include : CyrlKaVBar XH KBarLeft
+			include : CyrlKaVBar XH xBarLeft
 
 		create-glyph "KHookTop.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : VBar.l KBarLeft 0 CAP Stroke
+			include : VBar.l xBarLeft 0 CAP Stroke
 			include : LegsImpl true SB RightSB Stroke CAP slabLT slabLegs
 			eject-contour 'serifRT'
-			if slabLT : include : UpperKLTSerif CAP Stroke KBarLeft slabLT straightBar
-			if slabLB : include : UpperKLBSerif CAP Stroke KBarLeft slabLB straightBar
+			if slabLT : include : UpperKLTSerif CAP Stroke xBarLeft slabLT
+			if slabLB : include : UpperKLBSerif CAP Stroke xBarLeft slabLB
 
 		turned "turnK.\(suffix)" nothing "K.\(suffix)" Middle (CAP / 2)
 
@@ -501,15 +501,15 @@ glyph-block Letter-Latin-K : begin
 
 	foreach { suffix { LegsImpl {slabLT slabLB slabLegs} } } [pairs-of LowerKConfig] : do
 		local straightBar : LegsImpl !== KLegs.Curly
-		local kBarLeft : SB + [KBalance slabLT straightBar]
+		local xBarLeft : SB + [KBalance slabLT straightBar]
 
 		define [kBaseShape attachment] : glyph-proc
-			include : LeaningAnchor.Above.VBar.l kBarLeft
-			include : VBar.l kBarLeft 0 Ascender
+			include : LeaningAnchor.Above.VBar.l xBarLeft
+			include : VBar.l xBarLeft 0 Ascender
 			include : LegsImpl false SB RightSB Stroke XH slabLT slabLegs attachment
-			if slabLT : include : HSerif.lt kBarLeft Ascender SideJut
+			if slabLT : include : HSerif.lt xBarLeft Ascender SideJut
 			if slabLB : include : tagged 'serifLB'
-				HSerif.mb (kBarLeft + [HSwToV HalfStroke]) 0 Jut
+				HSerif.mb (xBarLeft + [HSwToV HalfStroke]) 0 Jut
 
 		create-glyph "k.\(suffix)" : glyph-proc
 			include : MarkSet.b
@@ -528,25 +528,25 @@ glyph-block Letter-Latin-K : begin
 		create-glyph "kStroke.\(suffix)" : glyph-proc
 			include [refer-glyph "k.\(suffix)"] AS_BASE ALSO_METRICS
 			include : LetterBarOverlay.l.in
-				x     -- kBarLeft
+				x     -- xBarLeft
 				bot   -- XH
 				top   -- (Ascender - [if slabLT Stroke 0])
 
 		create-glyph "kHookTop.\(suffix)" : glyph-proc
 			include : MarkSet.b
 			include : LegsImpl false SB RightSB Stroke XH slabLT slabLegs
-			include : KHookTopBar kBarLeft
+			include : KHookTopBar xBarLeft
 			if slabLB : include : tagged 'serifLB'
-				HSerif.mb (kBarLeft + [HSwToV HalfStroke]) 0 Jut
+				HSerif.mb (xBarLeft + [HSwToV HalfStroke]) 0 Jut
 
 		create-glyph "turnk.\(suffix)" : glyph-proc
-			include : VBar.l kBarLeft 0 Ascender
+			include : VBar.l xBarLeft 0 Ascender
 			include : LegsImpl false SB RightSB Stroke XH slabLT slabLegs
 			if slabLT : include : tagged 'serifLT' : union
-				HSerif.lt (kBarLeft + [HSwToV HalfStroke]) Ascender Jut
-				HSerif.rt (kBarLeft + [HSwToV HalfStroke]) Ascender MidJutSide
+				HSerif.lt (xBarLeft + [HSwToV HalfStroke]) Ascender Jut
+				HSerif.rt (xBarLeft + [HSwToV HalfStroke]) Ascender MidJutSide
 			if slabLB : include : tagged 'serifLB'
-				HSerif.lb kBarLeft 0 SideJut
+				HSerif.lb xBarLeft 0 SideJut
 			include : FlipAround Middle (XH / 2)
 			include : MarkSet.p
 			include : LeaningAnchor.Below.VBar.r (RightSB - [KBalance slabLT straightBar])
@@ -558,7 +558,7 @@ glyph-block Letter-Latin-K : begin
 	select-variant 'KStroke' 0xA740 (follow -- 'K')
 	select-variant 'cyrl/KaStroke' 0x49E (shapeFrom -- 'KStroke') (follow -- 'cyrl/Ka')
 	select-variant 'KDescender' 0x2C69
-	select-variant 'cyrl/Ka' 0x41A 'K' (shapeFrom -- 'K') (follow -- 'cyrl/Ka')
+	select-variant 'cyrl/Ka' 0x41A (shapeFrom -- 'K')
 	select-variant 'cyrl/KaDescender' 0x49A (shapeFrom -- 'KDescender')
 	select-variant 'cyrl/KaVBar' 0x49C (shapeFrom -- 'KVBar') (follow -- 'cyrl/KaVBar')
 	select-variant 'cyrl/KaHook' 0x4C3 (shapeFrom -- 'K') (follow -- 'cyrl/KaHook')

--- a/font-src/glyphs/letter/latin/upper-h.ptl
+++ b/font-src/glyphs/letter/latin/upper-h.ptl
@@ -100,6 +100,7 @@ glyph-block Letter-Latin-Upper-H : begin
 		serifedExceptBottomRight         { HShape       HTurned SLAB-TAILED-CYRILLIC       true  }
 		serifedBGR                       { HShape       HTurned SLAB-ALL-BGR               true  }
 		tailedSerifedBGR                 { TailedHShape HTurned SLAB-TAILED-CYRILLIC-BGR   true  }
+		serifedSmallHeta                 { HShape       HTurned [if SLAB SLAB-TOP-LEFT SLAB-NONE] false }
 
 	foreach { suffix { Body TurnedBody slabType enGheVSlab } } [Object.entries HConfig] : do
 		create-glyph "H.\(suffix)" : glyph-proc
@@ -217,8 +218,8 @@ glyph-block Letter-Latin-Upper-H : begin
 	select-variant 'grek/Eta' 0x397 (follow -- 'H')
 	select-variant 'HTurned' 0xA78D (follow -- 'H')
 	link-reduced-variant 'grek/Eta/sansSerif' 'grek/Eta' MathSansSerif (follow -- 'H/sansSerif')
-	select-variant 'cyrl/En' 0x41D (shapeFrom -- 'H') (follow -- 'H')
-	select-variant 'cyrl/En/descenderBase' (shapeFrom -- 'H') (follow -- 'H/descenderBase')
+	alias 'cyrl/En' 0x41D 'H'
+	alias 'cyrl/En/descenderBase' null 'H/descenderBase'
 	select-variant 'leftHalfH' 0x2C75
 	select-variant 'rightHalfH' 0xA7F5
 	alias 'grek/Heta' 0x370 'leftHalfH'
@@ -229,7 +230,7 @@ glyph-block Letter-Latin-Upper-H : begin
 	select-variant 'cyrl/en' 0x43D (shapeFrom -- 'smcpH')
 	select-variant 'cyrl/en/descenderBase' (shapeFrom -- 'smcpH')
 	select-variant 'cyrl/en.BGR' (shapeFrom -- 'smcpH')
-	alias 'grek/heta' 0x371 'leftHalfSmcpH.serifless'
+	alias 'grek/heta' 0x371 'leftHalfSmcpH.serifedSmallHeta'
 
 	derive-composites 'HDescender' 0x2C67 'H/descenderBase' [CyrDescender.rSideJut RightSB 0]
 


### PR DESCRIPTION
Also a further cleanup of `k.ptl` from #2094 .
`Ͱͱ`
Default Sans:
![image](https://github.com/be5invis/Iosevka/assets/37010132/1ce03675-f9e9-4b7e-9acc-095ae4d84e6f)
Default Slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/79ae3e9e-6ad4-4c1e-9582-572f44e9a1f4)
Compared to DejaVu Serif:
![image](https://github.com/be5invis/Iosevka/assets/37010132/b47999fd-46b3-494b-952d-53f64026cdd5)
Compared to Noto Serif:
![image](https://github.com/be5invis/Iosevka/assets/37010132/d245f7b8-c089-4cb5-8604-786b72866a76)
