### PR TITLE
Add tailless variants for Greek Lower Iota.

### DIFF
--- a/changes/28.0.0-alpha.2.md
+++ b/changes/28.0.0-alpha.2.md
@@ -1,3 +1,4 @@
+* Add tailless variants for Greek Lower Iota (`ι`).
 * Improve serifs for turned k (`U+029E`) to match `q` and turned h (`U+0265`).
 * Improve top-left serif for LATIN SMALL LETTER KRA (`U+0138`) to match `k`.
 * Make Greek Kappa (`U+03BA`) respond to more serif variants for `k` (`cv36`).

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -4678,62 +4678,74 @@ sampler = "ι"
 samplerExplain = "Greek lower Iota"
 tagKind = "letter"
 
-[prime.lower-iota.variants.zshaped]
+[prime.lower-iota.variants.tailless]
 rank = 1
+description = "Greek lower Iota (`ι`) with a tailless shape"
+selector."grek/iota" = "serifless"
+selector."grek/iota/sansSerif" = "serifless"
+
+[prime.lower-iota.variants.tailless-serifed]
+rank = 2
+description = "Greek lower Iota (`ι`) with a top serif and tailless shape"
+selector."grek/iota" = "hooky"
+selector."grek/iota/sansSerif" = "serifless"
+
+[prime.lower-iota.variants.zshaped]
+rank = 3
 description = "Z-shaped Greek lower Iota (`ι`)"
 selector."grek/iota" = "zshaped"
 selector."grek/iota/sansSerif" = "serifless"
 
 [prime.lower-iota.variants.hooky-bottom]
-rank = 2
+rank = 4
 description = "Greek lower Iota (`ι`) with a sharp-turning horizontal tail"
 selector."grek/iota" = "hookyBottom"
 selector."grek/iota/sansSerif" = "serifless"
 
 [prime.lower-iota.variants.tailed]
-rank = 3
+rank = 5
 description = "Greek lower Iota (`ι`) with curly tail"
 selector."grek/iota" = "tailed"
 selector."grek/iota/sansSerif" = "tailed"
 
 [prime.lower-iota.variants.tailed-serifed]
-rank = 4
+rank = 6
 description = "Greek lower Iota (`ι`) with top serif and curly tail"
 selector."grek/iota" = "tailedSerifed"
 selector."grek/iota/sansSerif" = "tailed"
 
 [prime.lower-iota.variants.flat-tailed]
-rank = 5
+rank = 7
 description = "Greek lower Iota (`ι`) with a curly-then-flat tail"
 selector."grek/iota" = "flatTailed"
 selector."grek/iota/sansSerif" = "flatTailed"
 
 [prime.lower-iota.variants.serifed-flat-tailed]
-rank = 6
+rank = 8
 description = "Greek lower Iota (`ι`) with top serif and a curly-then-flat tail"
 selector."grek/iota" = "serifedFlatTailed"
 selector."grek/iota/sansSerif" = "flatTailed"
 
 [prime.lower-iota.variants.diagonal-tailed]
-rank = 7
+rank = 9
 description = "Greek lower Iota (`ι`) with a diagonal tail"
 selector."grek/iota" = "diagonalTailed"
 selector."grek/iota/sansSerif" = "diagonalTailed"
 
 [prime.lower-iota.variants.serifed-diagonal-tailed]
-rank = 8
+rank = 10
 description = "Greek lower Iota (`ι`) with top serif and a diagonal tail"
 selector."grek/iota" = "serifedDiagonalTailed"
 selector."grek/iota/sansSerif" = "diagonalTailed"
 
 [prime.lower-iota.variants.semi-tailed]
-rank = 9
+rank = 11
 description = "Greek lower Iota (`ι`) with a slightly curly tail"
 selector."grek/iota" = "semiTailed"
 selector."grek/iota/sansSerif" = "semiTailed"
 
 [prime.lower-iota.variants.serifed-semi-tailed]
-rank = 10
+rank = 12
 description = "Greek lower Iota (`ι`) with top serif and a slightly curly tail"
 selector."grek/iota" = "serifedSemiTailed"
 selector."grek/iota/sansSerif" = "semiTailed"
@@ -7888,7 +7900,6 @@ description = "Menlo Style"
 [composite.ss04.design]
 capital-d = "more-rounded-serifless"
 capital-g = "toothless-corner-serifless-hooked"
-capital-k = "straight-serifless"
 capital-q = "straight"
 a = "double-storey-serifless"
 e = "flat-crossbar"
@@ -7903,11 +7914,11 @@ u = "toothed-serifless"
 y = "straight-turn-serifless"
 long-s = "flat-hook-middle-serifed"
 eszet = "longs-s-lig-serifless"
-lower-chi = "semi-chancery-straight"
 lower-eth = "straight-bar"
 lower-iota = "serifed-flat-tailed"
 lower-lambda = "straight-turn"
 lower-tau = "flat-tailed"
+lower-chi = "semi-chancery-straight"
 cyrl-capital-zhe = "straight"
 cyrl-zhe = "straight"
 cyrl-capital-ka = "straight-serifless"
@@ -7938,7 +7949,6 @@ diacritic-dot = "square"
 [composite.ss04.slab-override.design]
 capital-d = "more-rounded-bilateral-serifed"
 capital-g = "toothless-corner-serifed-hooked"
-capital-k = "straight-serifed"
 a = "double-storey-serifed"
 c = "unilateral-serifed"
 d = "toothed-serifed"
@@ -8361,7 +8371,6 @@ description = "Source Code Pro Style"
 [composite.ss09.design]
 capital-d = "more-rounded-serifless"
 capital-g = "toothless-corner-serifless-hooked"
-capital-k = "straight-serifless"
 a = "double-storey-serifless"
 d = "toothed-serifless"
 e = "flat-crossbar"
@@ -8412,7 +8421,6 @@ lower-iota = "tailed-serifed"
 [composite.ss09.slab-override.design]
 capital-d = "more-rounded-bilateral-serifed"
 capital-g = "toothless-corner-serifed-hooked"
-capital-k = "straight-serifed"
 a = "double-storey-serifed"
 d = "toothed-serifed"
 f = "serifed"
@@ -8989,7 +8997,6 @@ cyrl-ef = "split-top-serifed"
 cyrl-yeri = "corner"
 cyrl-yery = "corner"
 cyrl-ya = "straight-motion-serifed"
-zero = "slashed"
 one = "base"
 two = "straight-neck"
 three = "flat-top"


### PR DESCRIPTION
`ΙιΛλΜμΠπΤτ`
Example using a customized build of Aile (real Aile unchanged):
```
[buildPlans.IosevkaCustomAile]
family = "Iosevka Custom Aile"
spacing = "quasi-proportional"
serifs = "sans"
noCvSs = false
exportGlyphNames = false

  [buildPlans.IosevkaCustomAile.variants]
  inherits = "buildPlans.IosevkaAile"

    [buildPlans.IosevkaCustomAile.variants.design]
    lower-iota = "tailless"
    lower-lambda = "straight"
    lower-mu = "toothed-serifless"
    lower-pi = "small-capital"
    lower-tau = "tailless"
```
![image](https://github.com/be5invis/Iosevka/assets/37010132/459bc2e5-30d3-4d86-9d3c-75c406a1c19e)
Compared to Arial:
![image](https://github.com/be5invis/Iosevka/assets/37010132/fa24d6a8-b0a2-4fd2-9875-b90a8ae24e40)
Compared to Tahoma:
![image](https://github.com/be5invis/Iosevka/assets/37010132/ce9a1688-a645-40ec-a648-2377eacc9275)
Compared to Verdana:
![image](https://github.com/be5invis/Iosevka/assets/37010132/3c54a752-a0c1-43f6-a3db-f31b310fef5a)
