### PR TITLE
Thorn With Stroke optimization.

### DIFF
--- a/changes/28.0.0-beta.1.md
+++ b/changes/28.0.0-beta.1.md
@@ -45,6 +45,7 @@
 * Improve top-left serif for LATIN SMALL LETTER KRA (`U+0138`) to match `k`.
 * Make Greek Kappa (`U+03BA`) respond to more serif variants for `k` (`cv36`).
 * Add a top-left serif to GREEK SMALL LETTER HETA (`U+0371`) under slab.
+* Improve vertical alignmant of bowl for LATIN CAPITAL LETTER THORN WITH STROKE (`U+A764`) and LATIN CAPITAL LETTER THORN WITH STROKE THROUGH DESCENDER (`U+A766`).
 * Stylistic set fixes:
   - Fix `cv10` for `ss01`, `ss02`, and `ss08` under slab.
   - Fix `cv53` for `ss16`.

--- a/font-src/glyphs/letter/latin-ext/thorn.ptl
+++ b/font-src/glyphs/letter/latin-ext/thorn.ptl
@@ -12,9 +12,16 @@ glyph-block Letter-Latin-Thorn : begin
 	glyph-block-import Letter-Latin-Lower-P
 
 	define xThornLeftStroke : SB * 1.25
-	define yThornBowlBot : CAP * 0.25 + [if SLAB (Stroke * 0.125) 0]
-	define yThornBowlTop : CAP - 0.7 * yThornBowlBot + [if SLAB (-0.125) 0.25] * Stroke
-	define [ThornShape yBowlBot yBowlTop] : glyph-proc
+
+	define [yThornBowlBot top] : top * 0.25 + [if SLAB (Stroke * 0.125) 0]
+	define [yThornBowlTop top] : top - 0.7 * [yThornBowlBot top] + [if SLAB (-0.125) 0.25] * Stroke
+
+	define [yShoBowlBot top] : mix [yThornBowlBot top] (top - [yThornBowlTop top]) 0.5
+	define [yShoBowlTop top] : top - [yShoBowlBot top]
+
+	define [ThornShape top _yBowlBot _yBowlTop] : glyph-proc
+		local yBowlBot : fallback _yBowlBot [yThornBowlBot top]
+		local yBowlTop : fallback _yBowlTop [yThornBowlTop top]
 
 		local turn : mix yBowlTop yBowlBot (ArchDepthB / (ArchDepthA + ArchDepthB))
 		local turnRadius : (yBowlTop - yBowlBot) / 2
@@ -29,28 +36,41 @@ glyph-block Letter-Latin-Thorn : begin
 			flat (RightSB - turnRadius + CorrectionOMidS) yBowlBot
 			curl xThornLeftStroke yBowlBot [heading Leftward]
 
-		include : VBar.l xThornLeftStroke 0 CAP
+		include : VBar.l xThornLeftStroke 0 top
 		if SLAB : begin
-			local sf : SerifFrame Ascender 0 xThornLeftStroke RightSB
+			local sf : SerifFrame top 0 xThornLeftStroke RightSB
 			include : composite-proc sf.lt.fullSide sf.lb.fullSide
+
+	define [GrekShoShapeImpl top] : ThornShape top [yShoBowlBot top] [yShoBowlTop top]
 
 	create-glyph 'Thorn' 0xDE : glyph-proc
 		include : MarkSet.capital
-		include : ThornShape yThornBowlBot yThornBowlTop
+		include : ThornShape CAP
 		include : LeaningAnchor.Above.VBar.l xThornLeftStroke
 		include : LeaningAnchor.Below.VBar.l xThornLeftStroke
 
 	create-glyph 'grek/Sho' 0x3F7 : glyph-proc
 		include : MarkSet.capital
-		local d : mix yThornBowlBot (CAP - yThornBowlTop) 0.5
-		include : ThornShape d (CAP - d)
+		include : GrekShoShapeImpl CAP
+		include : LeaningAnchor.Above.VBar.l xThornLeftStroke
+		include : LeaningAnchor.Below.VBar.l xThornLeftStroke
+
+	# create-glyph 'smcpThorn' 0xEF15 : glyph-proc
+	# 	include : MarkSet.e
+	# 	include : GrekShoShapeImpl XH
+	# 	include : LeaningAnchor.Above.VBar.l xThornLeftStroke
+	# 	include : LeaningAnchor.Below.VBar.l xThornLeftStroke
+
+	create-glyph 'ThornBarTop/base' : glyph-proc
+		include : MarkSet.capital
+		include : ThornShape CAP (CAP - [yThornBowlTop CAP]) (CAP - [yThornBowlBot CAP])
 		include : LeaningAnchor.Above.VBar.l xThornLeftStroke
 		include : LeaningAnchor.Below.VBar.l xThornLeftStroke
 
 	create-glyph 'ThornBarTop/Overlay' : LetterBarOverlay.l.in
 		x   -- xThornLeftStroke
 		top -- (CAP - [if SLAB Stroke 0])
-		bot -- (CAP - [mix yThornBowlBot (CAP - yThornBowlTop) 0.5])
+		bot -- (CAP - [yThornBowlBot CAP])
 	create-glyph 'thornBarTop/Overlay' : LetterBarOverlay.l.in
 		x   -- SB
 		top -- (Ascender - [if SLAB Stroke 0])
@@ -58,13 +78,13 @@ glyph-block Letter-Latin-Thorn : begin
 	create-glyph 'ThornBarBot/Overlay' : LetterBarOverlay.l.in
 		x   -- xThornLeftStroke
 		bot -- (0 + [if SLAB Stroke 0])
-		top -- [mix yThornBowlBot (CAP - yThornBowlTop) 0.5]
+		top -- (0 + [yThornBowlBot CAP])
 	create-glyph 'thornBarBot/Overlay' : LetterBarOverlay.l.in
 		x   -- SB
 		bot -- (Descender + [if SLAB Stroke 0])
 		top -- 0
 
-	derive-composites 'ThornBarTop' 0xA764 'grek/Sho' 'ThornBarTop/Overlay'
+	derive-composites 'ThornBarTop' 0xA764 'ThornBarTop/base' 'ThornBarTop/Overlay'
 	derive-composites 'thornBarTop' 0xA765 'thorn' 'thornBarTop/Overlay'
-	derive-composites 'ThornBarBot' 0xA766 'grek/Sho' 'ThornBarBot/Overlay'
+	derive-composites 'ThornBarBot' 0xA766 'Thorn' 'ThornBarBot/Overlay'
 	derive-composites 'thornBarBot' 0xA767 'thorn' 'thornBarBot/Overlay'

--- a/font-src/glyphs/letter/latin/u.ptl
+++ b/font-src/glyphs/letter/latin/u.ptl
@@ -36,68 +36,47 @@ glyph-block Letter-Latin-U : begin
 			adb -- adb
 			offset -- offset
 
-	define [UToothed df top] : glyph-proc
+	define [UToothed df top fHookLeft] : glyph-proc
 		set-base-anchor 'trailing' df.rightSB 0
 		include : nShoulder
 			top -- top
+			bottom -- [if fHookLeft (TailY + HalfStroke) 0]
 			left -- (df.leftSB + [HSwToV Stroke])
 			right -- df.rightSB
 			fine -- ShoulderFine
+		if fHookLeft : include : RetroflexHook.rExt df.rightSB (TailY + HalfStroke)
 		include : FlipAround df.middle (top / 2)
 		include : VBar.r df.rightSB 0 top
 
-	define [UHookLeftToothed df top] : glyph-proc
-		set-base-anchor 'trailing' df.rightSB 0
-		include : nShoulder
-			top -- top
-			bottom -- (TailY + HalfStroke)
-			left -- (df.leftSB + [HSwToV Stroke])
-			right -- df.rightSB
-			fine -- ShoulderFine
-		include : RetroflexHook.rExt df.rightSB (TailY + HalfStroke)
-		include : FlipAround df.middle (top / 2)
-		include : VBar.r df.rightSB 0 top
-
-	define [UTailed df top] : glyph-proc
+	define [UTailed df top fHookLeft] : glyph-proc
 		set-base-anchor 'trailing' (df.rightSB + SideJut) 0
 		include : nShoulder
 			top -- top
+			bottom -- [if fHookLeft (TailY + HalfStroke) 0]
 			left -- (df.leftSB + [HSwToV Stroke])
 			right -- df.rightSB
 			fine -- ShoulderFine
-		include : FlipAround df.middle (top / 2)
-		include : RightwardTailedBar df.rightSB 0 top
-
-	define [UHookLeftTailed df top] : glyph-proc
-		set-base-anchor 'trailing' (df.rightSB + SideJut) 0
-		include : nShoulder
-			top -- top
-			bottom -- (TailY + HalfStroke)
-			left -- (df.leftSB + [HSwToV Stroke])
-			right -- df.rightSB
-			fine -- ShoulderFine
-		include : RetroflexHook.rExt df.rightSB (TailY + HalfStroke)
+		if fHookLeft : include : RetroflexHook.rExt df.rightSB (TailY + HalfStroke)
 		include : FlipAround df.middle (top / 2)
 		include : RightwardTailedBar df.rightSB 0 top
 
 	define [UToothlessRounded df top] : glyph-proc
 		include : UShape df top 0
 
-	define [UToothlessRoundedSmall df top] : glyph-proc
-		include : UShape df top 0 (ada -- SmallArchDepthA) (adb -- SmallArchDepthB)
-
-	define [UHookLeftToothlessRoundedSmall df top] : glyph-proc
-		include : dispiro
-			widths.rhs
-			flat df.leftSB 0 [heading Upward]
-			curl df.leftSB (top - SmallArchDepthA)
-			arcvh
-			g4 ([mix df.leftSB df.rightSB 0.5] - CorrectionOMidS) (top - O)
-			archv
-			flat df.rightSB (top - SmallArchDepthB)
-			curl df.rightSB (TailY + HalfStroke) [heading Downward]
-		include : RetroflexHook.rExt df.rightSB (TailY + HalfStroke)
-		include : FlipAround df.middle (top / 2)
+	define [UToothlessRoundedSmall df top fHookLeft] : glyph-proc
+		if fHookLeft : begin
+			include : dispiro
+				widths.rhs
+				flat df.leftSB 0 [heading Upward]
+				curl df.leftSB (top - SmallArchDepthA)
+				arcvh
+				g4 (df.middle - CorrectionOMidS) (top - O)
+				archv
+				flat df.rightSB (top - SmallArchDepthB)
+				curl df.rightSB (TailY + HalfStroke) [heading Downward]
+			include : RetroflexHook.rExt df.rightSB (TailY + HalfStroke)
+			include : FlipAround df.middle (top / 2)
+		: else : include : UShape df top 0 (ada -- SmallArchDepthA) (adb -- SmallArchDepthB)
 
 	define [UToothlessCorner df top] : glyph-proc
 		include : VBar.l df.leftSB 0 (top - DToothlessRise)
@@ -110,7 +89,7 @@ glyph-block Letter-Latin-U : begin
 			curl df.rightSB 0 [heading Downward]
 		include : FlipAround df.middle (top / 2)
 
-	define [UToothlessCornerSmall df top] : glyph-proc
+	define [UToothlessCornerSmall df top fHookLeft] : glyph-proc
 		include : VBar.l df.leftSB 0 (top - DToothlessRise)
 		include : dispiro
 			widths.rhs
@@ -118,19 +97,8 @@ glyph-block Letter-Latin-U : begin
 			g4 (df.middle - CorrectionOMidS) (top - O)
 			archv
 			flat df.rightSB (top - SmallArchDepthB)
-			curl df.rightSB 0 [heading Downward]
-		include : FlipAround df.middle (top / 2)
-
-	define [UHookLeftToothlessCornerSmall df top] : glyph-proc
-		include : VBar.l df.leftSB 0 (top - DToothlessRise)
-		include : dispiro
-			widths.rhs
-			g4 df.leftSB (top - DToothlessRise)
-			g4 ([mix df.leftSB df.rightSB 0.5] - CorrectionOMidS) (top - O)
-			archv
-			flat df.rightSB (top - SmallArchDepthB)
-			curl df.rightSB (TailY + HalfStroke) [heading Downward]
-		include : RetroflexHook.rExt df.rightSB (TailY + HalfStroke)
+			curl df.rightSB [if fHookLeft (TailY + HalfStroke) 0] [heading Downward]
+		if fHookLeft : include : RetroflexHook.rExt df.rightSB (TailY + HalfStroke)
 		include : FlipAround df.middle (top / 2)
 
 	define [UTopLeftSerif df yTop _sw]  : tagged 'serifLT'
@@ -217,24 +185,24 @@ glyph-block Letter-Latin-U : begin
 
 	define SmallUConfig : SuffixCfg.weave
 		object # body
-			toothed           { UToothed               UHookLeftToothed               }
-			tailed            { UTailed                UHookLeftTailed                }
-			toothlessCorner   { UToothlessCornerSmall  UHookLeftToothlessCornerSmall  }
-			toothlessRounded  { UToothlessRoundedSmall UHookLeftToothlessRoundedSmall }
-			urtBase           { UToothed               UHookLeftToothed               }
+			toothed           UToothed
+			tailed            UTailed
+			toothlessCorner   UToothlessCornerSmall
+			toothlessRounded  UToothlessRoundedSmall
+			urtBase           UToothed
 		function [body] : object # serifs
-			serifless              { no-shape            false }
-			bottomRightSerifed     { USerifs.BottomRight false }
+			serifless              no-shape
+			bottomRightSerifed     USerifs.BottomRight
 			motionSerifed : match body
-				[Just 'toothed']   { USerifs.MotionToothed   true }
-				__                 { USerifs.MotionToothless true }
+				[Just 'toothed']   USerifs.MotionToothed
+				__                 USerifs.MotionToothless
 			serifed : match body
-				[Just 'toothed']   { USerifs.Toothed         true }
-				[Just 'tailed']    { USerifs.Tailed          true }
-				[Just 'urtBase']   { USerifs.RTBase          true }
-				__                 { USerifs.SmallToothless  true }
+				[Just 'toothed']   USerifs.Toothed
+				[Just 'tailed']    USerifs.Tailed
+				[Just 'urtBase']   USerifs.RTBase
+				__                 USerifs.SmallToothless
 
-	foreach { suffix { { Base BaseHookLeft } { Slabs fLTSlab } } } [Object.entries SmallUConfig] : do
+	foreach { suffix { Base Slabs } } [Object.entries SmallUConfig] : do
 		create-glyph "u.\(suffix)" : glyph-proc
 			local df : DivFrame 1
 			include : MarkSet.e
@@ -255,7 +223,7 @@ glyph-block Letter-Latin-U : begin
 		create-glyph "uHookLeft.\(suffix)" : glyph-proc
 			local df : DivFrame 1
 			include : MarkSet.e
-			include : BaseHookLeft df XH
+			include : Base df XH true
 			include : Slabs df XH
 			eject-contour 'serifLT'
 

--- a/font-src/glyphs/letter/latin/x.ptl
+++ b/font-src/glyphs/letter/latin/x.ptl
@@ -243,6 +243,7 @@ glyph-block Letter-Latin-X : begin
 	select-variant 'latn/chi' 0xAB53 (follow -- 'x')
 	select-variant 'latn/Chi' 0xA7B3 (follow -- 'X')
 
+	# select-variant 'smcpX' 0xEF11 (shapeFrom -- 'x') (follow -- 'X')
 
 	define [AddDescender Ctor] : function [src sel] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS


### PR DESCRIPTION
Also cleanup of `u.ptl` from #2102 .

Also, commented out are hypothetical Small Capital X and Thorn private use characters from the [MUFI project](https://mufi.info/), which I wanted to add a while back but it appears to now clash with the new Iosevka Custom Dingbats range.
Feel free to do what you want with these codepoints, whether that'd be to actually implement them or just outright remove them. For what it's worth, they conveniently do not define anything for `U+EF10` in particular.

Below are the characters in question including the commented-out ones:
`ÞϷꝤꝦXx`

Sans Thin Upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/3e62de7d-23c3-4e37-8262-4650159758a9)
Sans Thin Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/466bef71-4149-4d79-ae36-221c4aecf13c)
Sans Regular Upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/fc70ce88-6fb4-425a-992e-fe2751cd83bf)
Sans Regular Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/989554b8-432a-48d9-8d96-92d900d9f21a)
Sans Heavy Upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/33c50096-7c8e-42ca-9601-5c4f1c8d25cc)
Sans Heavy Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/ba5e5918-fb72-4398-a131-ffc01aca2027)
Slab Thin Upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/afa29434-9375-4ab0-8edd-9c4bbfb8636f)
Slab Thin Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/df1c93f4-01a7-49e5-a5ce-41a32a320ea0)
Slab Regular Upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/72e89545-4e97-482a-8c40-6c2e92743d29)
Slab Regular Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/d0f1843d-14a9-4099-ab8b-c2a32811a0d4)
Slab Heavy Upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/4d0d68f3-29f8-4c1c-8514-07607c30caa4)
Slab Heavy Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/356fd54a-864d-4673-a1ae-5af2dd600099)

