### PR TITLE
Add double-serifed/serifed-tailed variants for `a`/`α`, add bottom{-right}-serifed variants for `d`/`q`/`U`.

### DIFF
--- a/changes/28.0.0-beta.1.md
+++ b/changes/28.0.0-beta.1.md
@@ -37,7 +37,7 @@
   - TWO DOTS OVER ONE DOT PUNCTUATION (`U+2E2A`) ... FIVE DOT MARK (`U+2E2D`).
   - LATIN SMALL LETTER U WITH LEFT HOOK (`U+AB52`).
   - MODIFIER LETTER SMALL U WITH LEFT HOOK (`U+AB5F`).
-* Add corner-hooked variants for `a` (#2085).
+* Add hook-inward-serifed variants for `a` (#2085).
 * Add double-serifed variants for `a` (#1949).
 * Add bottom-serifed variants for `d`, and `q`.
 * Add bottom-right-serifed variants for `U`.

--- a/changes/28.0.0-beta.1.md
+++ b/changes/28.0.0-beta.1.md
@@ -37,10 +37,13 @@
   - TWO DOTS OVER ONE DOT PUNCTUATION (`U+2E2A`) ... FIVE DOT MARK (`U+2E2D`).
   - LATIN SMALL LETTER U WITH LEFT HOOK (`U+AB52`).
   - MODIFIER LETTER SMALL U WITH LEFT HOOK (`U+AB5F`).
-* Add hook-inward-serifed variants for `a` (#2085).
+* Add corner-hooked variants for `a` (#2085).
+* Add double-serifed variants for `a` (#1949).
+* Add bottom-serifed variants for `d`, and `q`.
+* Add bottom-right-serifed variants for `U`.
+* Add tailless variants for Greek Lower Iota (`ι`).
 * Remove earless-rounded variants for `U+01A5`, `U+0256`, `U+02A0`, and `U+1D91`.
 * Remove earless-corner variants for `U+027E`.
-* Add tailless variants for Greek Lower Iota (`ι`).
 * Improve serifs for turned k (`U+029E`) to match `q` and turned h (`U+0265`).
 * Improve top-left serif for LATIN SMALL LETTER KRA (`U+0138`) to match `k`.
 * Make Greek Kappa (`U+03BA`) respond to more serif variants for `k` (`cv36`).

--- a/font-src/glyphs/letter/greek/lower-epsilon.ptl
+++ b/font-src/glyphs/letter/greek/lower-epsilon.ptl
@@ -377,9 +377,11 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 				singleStoreyEarlessRounded   EarlessRoundedBody
 
 			object # bar
-				serifless  SingleStorey.SeriflessBar
-				serifed    SingleStorey.SerifedBar
-				tailed     SingleStorey.TailedBar
+				serifless     SingleStorey.SeriflessBar
+				serifed       SingleStorey.SerifedBar
+				doubleSerifed SingleStorey.DoubleSerifedBar
+				tailed        SingleStorey.TailedBar
+				tailedSerifed SingleStorey.TailedSerifedBar
 
 		foreach { suffix { body bar } } [Object.entries SingleStoreyConfig] : do
 			create-glyph "AeVolapuk.\(suffix)" : glyph-proc

--- a/font-src/glyphs/letter/greek/lower-epsilon.ptl
+++ b/font-src/glyphs/letter/greek/lower-epsilon.ptl
@@ -370,18 +370,22 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 			include : eps.Shape
 			include : bar df (height - adb2) no-shape stroke
 
-		define SingleStoreyConfig : SuffixCfg.weave
-			object # body
-				singleStorey                 FullBarBody
-				singleStoreyEarlessCorner    EarlessCornerBody
-				singleStoreyEarlessRounded   EarlessRoundedBody
+		define SingleStoreyConfig : object
+			singleStoreySerifless               { FullBarBody        SingleStorey.SeriflessBar     }
+			singleStoreyEarlessCornerSerifless  { EarlessCornerBody  SingleStorey.SeriflessBar     }
+			singleStoreyEarlessRoundedSerifless { EarlessRoundedBody SingleStorey.SeriflessBar     }
 
-			object # bar
-				serifless     SingleStorey.SeriflessBar
-				serifed       SingleStorey.SerifedBar
-				doubleSerifed SingleStorey.DoubleSerifedBar
-				tailed        SingleStorey.TailedBar
-				tailedSerifed SingleStorey.TailedSerifedBar
+			singleStoreySerifed                 { FullBarBody        SingleStorey.SerifedBar       }
+			singleStoreyEarlessCornerSerifed    { EarlessCornerBody  SingleStorey.SerifedBar       }
+			singleStoreyEarlessRoundedSerifed   { EarlessRoundedBody SingleStorey.SerifedBar       }
+
+			singleStoreyDoubleSerifed           { FullBarBody        SingleStorey.DoubleSerifedBar }
+
+			singleStoreyTailed                  { FullBarBody        SingleStorey.TailedBar        }
+			singleStoreyEarlessCornerTailed     { EarlessCornerBody  SingleStorey.TailedBar        }
+			singleStoreyEarlessRoundedTailed    { EarlessRoundedBody SingleStorey.TailedBar        }
+
+			singleStoreyTailedSerifed           { FullBarBody        SingleStorey.TailedSerifedBar }
 
 		foreach { suffix { body bar } } [Object.entries SingleStoreyConfig] : do
 			create-glyph "AeVolapuk.\(suffix)" : glyph-proc

--- a/font-src/glyphs/letter/latin-ext/lower-ae-oe.ptl
+++ b/font-src/glyphs/letter/latin-ext/lower-ae-oe.ptl
@@ -32,16 +32,16 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 
 		glyph-block-import Letter-Latin-Lower-A : DoubleStorey
 		define DoubleStoreyConfig : object
-			doubleStoreySerifless                         { DoubleStorey.Serifless         1 }
-			doubleStoreySerifed                           { DoubleStorey.Serifed           1 }
-			doubleStoreyTailed                            { DoubleStorey.Tailed            1 }
-			doubleStoreyToothlessCorner                   { DoubleStorey.ToothlessCorner   1 }
-			doubleStoreyToothlessRounded                  { DoubleStorey.ToothlessRounded  1 }
-			doubleStoreyHookInwardSerifedSerifless        { DoubleStorey.Serifless         2 }
-			doubleStoreyHookInwardSerifedSerifed          { DoubleStorey.Serifed           2 }
-			doubleStoreyHookInwardSerifedTailed           { DoubleStorey.Tailed            2 }
-			doubleStoreyHookInwardSerifedToothlessCorner  { DoubleStorey.ToothlessCorner   2 }
-			doubleStoreyHookInwardSerifedToothlessRounded { DoubleStorey.ToothlessRounded  2 }
+			doubleStoreySerifless                    { DoubleStorey.Serifless         1 }
+			doubleStoreySerifed                      { DoubleStorey.Serifed           1 }
+			doubleStoreyTailed                       { DoubleStorey.Tailed            1 }
+			doubleStoreyToothlessCorner              { DoubleStorey.ToothlessCorner   1 }
+			doubleStoreyToothlessRounded             { DoubleStorey.ToothlessRounded  1 }
+			doubleStoreyCornerHookedSerifless        { DoubleStorey.Serifless         2 }
+			doubleStoreyCornerHookedSerifed          { DoubleStorey.Serifed           2 }
+			doubleStoreyCornerHookedTailed           { DoubleStorey.Tailed            2 }
+			doubleStoreyCornerHookedToothlessCorner  { DoubleStorey.ToothlessCorner   2 }
+			doubleStoreyCornerHookedToothlessRounded { DoubleStorey.ToothlessRounded  2 }
 
 		foreach { suffix { bodyR hookStyle } } [Object.entries DoubleStoreyConfig] : do
 

--- a/font-src/glyphs/letter/latin-ext/lower-ae-oe.ptl
+++ b/font-src/glyphs/letter/latin-ext/lower-ae-oe.ptl
@@ -32,16 +32,16 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 
 		glyph-block-import Letter-Latin-Lower-A : DoubleStorey
 		define DoubleStoreyConfig : object
-			doubleStoreySerifless                    { DoubleStorey.Serifless         1 }
-			doubleStoreySerifed                      { DoubleStorey.Serifed           1 }
-			doubleStoreyTailed                       { DoubleStorey.Tailed            1 }
-			doubleStoreyToothlessCorner              { DoubleStorey.ToothlessCorner   1 }
-			doubleStoreyToothlessRounded             { DoubleStorey.ToothlessRounded  1 }
-			doubleStoreyCornerHookedSerifless        { DoubleStorey.Serifless         2 }
-			doubleStoreyCornerHookedSerifed          { DoubleStorey.Serifed           2 }
-			doubleStoreyCornerHookedTailed           { DoubleStorey.Tailed            2 }
-			doubleStoreyCornerHookedToothlessCorner  { DoubleStorey.ToothlessCorner   2 }
-			doubleStoreyCornerHookedToothlessRounded { DoubleStorey.ToothlessRounded  2 }
+			doubleStoreySerifless                         { DoubleStorey.Serifless         1 }
+			doubleStoreySerifed                           { DoubleStorey.Serifed           1 }
+			doubleStoreyTailed                            { DoubleStorey.Tailed            1 }
+			doubleStoreyToothlessCorner                   { DoubleStorey.ToothlessCorner   1 }
+			doubleStoreyToothlessRounded                  { DoubleStorey.ToothlessRounded  1 }
+			doubleStoreyHookInwardSerifedSerifless        { DoubleStorey.Serifless         2 }
+			doubleStoreyHookInwardSerifedSerifed          { DoubleStorey.Serifed           2 }
+			doubleStoreyHookInwardSerifedTailed           { DoubleStorey.Tailed            2 }
+			doubleStoreyHookInwardSerifedToothlessCorner  { DoubleStorey.ToothlessCorner   2 }
+			doubleStoreyHookInwardSerifedToothlessRounded { DoubleStorey.ToothlessRounded  2 }
 
 		foreach { suffix { bodyR hookStyle } } [Object.entries DoubleStoreyConfig] : do
 

--- a/font-src/glyphs/letter/latin/lower-a.ptl
+++ b/font-src/glyphs/letter/latin/lower-a.ptl
@@ -109,16 +109,16 @@ glyph-block Letter-Latin-Lower-A : begin
 			__                      : ArcMask df 0 nothing nothing sw
 
 	define DoubleStoreyConfig : object
-		doubleStoreySerifless                         { DoubleStorey.Serifless         (RightSB )          1 }
-		doubleStoreySerifed                           { DoubleStorey.Serifed           (RightSB + SideJut) 1 }
-		doubleStoreyTailed                            { DoubleStorey.Tailed            (RightSB + SideJut) 1 }
-		doubleStoreyToothlessCorner                   { DoubleStorey.ToothlessCorner   nothing             1 }
-		doubleStoreyToothlessRounded                  { DoubleStorey.ToothlessRounded  nothing             1 }
-		doubleStoreyHookInwardSerifedSerifless        { DoubleStorey.Serifless         (RightSB )          2 }
-		doubleStoreyHookInwardSerifedSerifed          { DoubleStorey.Serifed           (RightSB + SideJut) 2 }
-		doubleStoreyHookInwardSerifedTailed           { DoubleStorey.Tailed            (RightSB + SideJut) 2 }
-		doubleStoreyHookInwardSerifedToothlessCorner  { DoubleStorey.ToothlessCorner   nothing             2 }
-		doubleStoreyHookInwardSerifedToothlessRounded { DoubleStorey.ToothlessRounded  nothing             2 }
+		doubleStoreySerifless                    { DoubleStorey.Serifless         (RightSB )          1 }
+		doubleStoreySerifed                      { DoubleStorey.Serifed           (RightSB + SideJut) 1 }
+		doubleStoreyTailed                       { DoubleStorey.Tailed            (RightSB + SideJut) 1 }
+		doubleStoreyToothlessCorner              { DoubleStorey.ToothlessCorner   nothing             1 }
+		doubleStoreyToothlessRounded             { DoubleStorey.ToothlessRounded  nothing             1 }
+		doubleStoreyCornerHookedSerifless        { DoubleStorey.Serifless         (RightSB )          2 }
+		doubleStoreyCornerHookedSerifed          { DoubleStorey.Serifed           (RightSB + SideJut) 2 }
+		doubleStoreyCornerHookedTailed           { DoubleStorey.Tailed            (RightSB + SideJut) 2 }
+		doubleStoreyCornerHookedToothlessCorner  { DoubleStorey.ToothlessCorner   nothing             2 }
+		doubleStoreyCornerHookedToothlessRounded { DoubleStorey.ToothlessRounded  nothing             2 }
 
 	foreach { suffix { body xTrailing hookStyle } } [Object.entries DoubleStoreyConfig] : do
 		create-glyph "a.\(suffix)" : glyph-proc
@@ -220,21 +220,36 @@ glyph-block Letter-Latin-Lower-A : begin
 		export : define [SerifedBar df height mask sw] : glyph-proc
 			include : SeriflessBar df height mask sw
 			include [SerifFrame.fromDf df height 0 (swSerif -- sw)].rb.outer
+		export : define [TopSerifedBar df height mask sw] : glyph-proc
+			include : SeriflessBar df height mask sw
+			include [SerifFrame.fromDf df height 0 (swSerif -- sw)].rt.outer
+		export : define [DoubleSerifedBar df height mask sw] : glyph-proc
+			include : SerifedBar df height mask sw
+			include [SerifFrame.fromDf df height 0 (swSerif -- sw)].rt.outer
 		export : define [TailedBar df height mask sw] : glyph-proc
 			set-base-anchor 'trailing' (df.rightSB + SideJut) 0
 			include : difference
 				RightwardTailedBar df.rightSB 0 height sw
 				mask df height sw
-
-		set SeriflessBar.inv SeriflessBar
-		set SerifedBar.inv : function [df height mask sw] : glyph-proc
-			include : SeriflessBar df height mask sw
+		export : define [TailedSerifedBar df height mask sw] : glyph-proc
+			include : TailedBar df height mask sw
 			include [SerifFrame.fromDf df height 0 (swSerif -- sw)].rt.outer
+
+		set SeriflessBar.inv     SeriflessBar
+		set SerifedBar.inv       TopSerifedBar
+		set TopSerifedBar.inv    SerifedBar
+		set DoubleSerifedBar.inv DoubleSerifedBar
 		set TailedBar.inv : function [df height mask sw] : glyph-proc
 			set-base-anchor 'trailing' (df.rightSB + SideJut) 0
 			include : difference
 				InvRightwardTailedBar df.rightSB 0 height sw
 				mask df height sw
+		set TailedSerifedBar.inv : function [df height mask sw] : glyph-proc
+			set-base-anchor 'trailing' (df.rightSB + SideJut) 0
+			include : difference
+				InvRightwardTailedBar df.rightSB 0 height sw
+				mask df height sw
+			include [SerifFrame.fromDf df height 0 (swSerif -- sw)].rb.outer
 
 
 		export : define [ScriptCut df y sw] : spiro-outline
@@ -253,9 +268,12 @@ glyph-block Letter-Latin-Lower-A : begin
 			singleStoreyEarlessRounded   SingleStorey.EarlessRoundedBody
 
 		object # bar
-			serifless  SingleStorey.SeriflessBar
-			serifed    SingleStorey.SerifedBar
-			tailed     SingleStorey.TailedBar
+			serifless        SingleStorey.SeriflessBar
+			serifed          SingleStorey.SerifedBar
+			topSerifed       SingleStorey.TopSerifedBar
+			doubleSerifed    SingleStorey.DoubleSerifedBar
+			tailed           SingleStorey.TailedBar
+			tailedSerifed    SingleStorey.TailedSerifedBar
 
 	foreach { suffix { body bar } } [Object.entries SingleStoreyConfig] : do
 		create-glyph "a.\(suffix)" : glyph-proc

--- a/font-src/glyphs/letter/latin/lower-a.ptl
+++ b/font-src/glyphs/letter/latin/lower-a.ptl
@@ -109,16 +109,16 @@ glyph-block Letter-Latin-Lower-A : begin
 			__                      : ArcMask df 0 nothing nothing sw
 
 	define DoubleStoreyConfig : object
-		doubleStoreySerifless                    { DoubleStorey.Serifless         (RightSB )          1 }
-		doubleStoreySerifed                      { DoubleStorey.Serifed           (RightSB + SideJut) 1 }
-		doubleStoreyTailed                       { DoubleStorey.Tailed            (RightSB + SideJut) 1 }
-		doubleStoreyToothlessCorner              { DoubleStorey.ToothlessCorner   nothing             1 }
-		doubleStoreyToothlessRounded             { DoubleStorey.ToothlessRounded  nothing             1 }
-		doubleStoreyCornerHookedSerifless        { DoubleStorey.Serifless         (RightSB )          2 }
-		doubleStoreyCornerHookedSerifed          { DoubleStorey.Serifed           (RightSB + SideJut) 2 }
-		doubleStoreyCornerHookedTailed           { DoubleStorey.Tailed            (RightSB + SideJut) 2 }
-		doubleStoreyCornerHookedToothlessCorner  { DoubleStorey.ToothlessCorner   nothing             2 }
-		doubleStoreyCornerHookedToothlessRounded { DoubleStorey.ToothlessRounded  nothing             2 }
+		doubleStoreySerifless                         { DoubleStorey.Serifless         (RightSB )          1 }
+		doubleStoreySerifed                           { DoubleStorey.Serifed           (RightSB + SideJut) 1 }
+		doubleStoreyTailed                            { DoubleStorey.Tailed            (RightSB + SideJut) 1 }
+		doubleStoreyToothlessCorner                   { DoubleStorey.ToothlessCorner   nothing             1 }
+		doubleStoreyToothlessRounded                  { DoubleStorey.ToothlessRounded  nothing             1 }
+		doubleStoreyHookInwardSerifedSerifless        { DoubleStorey.Serifless         (RightSB )          2 }
+		doubleStoreyHookInwardSerifedSerifed          { DoubleStorey.Serifed           (RightSB + SideJut) 2 }
+		doubleStoreyHookInwardSerifedTailed           { DoubleStorey.Tailed            (RightSB + SideJut) 2 }
+		doubleStoreyHookInwardSerifedToothlessCorner  { DoubleStorey.ToothlessCorner   nothing             2 }
+		doubleStoreyHookInwardSerifedToothlessRounded { DoubleStorey.ToothlessRounded  nothing             2 }
 
 	foreach { suffix { body xTrailing hookStyle } } [Object.entries DoubleStoreyConfig] : do
 		create-glyph "a.\(suffix)" : glyph-proc

--- a/font-src/glyphs/letter/latin/lower-a.ptl
+++ b/font-src/glyphs/letter/latin/lower-a.ptl
@@ -261,19 +261,24 @@ glyph-block Letter-Latin-Lower-A : begin
 			corner (df.rightSB - [HSwToV sw]) 0
 			corner (df.rightSB - [HSwToV sw]) (0 + sw / 2)
 
-	define SingleStoreyConfig : SuffixCfg.weave
-		object # body
-			singleStorey                 SingleStorey.FullBarBody
-			singleStoreyEarlessCorner    SingleStorey.EarlessCornerBody
-			singleStoreyEarlessRounded   SingleStorey.EarlessRoundedBody
+	define SingleStoreyConfig : object
+		singleStoreySerifless               { SingleStorey.FullBarBody        SingleStorey.SeriflessBar     }
+		singleStoreyEarlessCornerSerifless  { SingleStorey.EarlessCornerBody  SingleStorey.SeriflessBar     }
+		singleStoreyEarlessRoundedSerifless { SingleStorey.EarlessRoundedBody SingleStorey.SeriflessBar     }
 
-		object # bar
-			serifless        SingleStorey.SeriflessBar
-			serifed          SingleStorey.SerifedBar
-			topSerifed       SingleStorey.TopSerifedBar
-			doubleSerifed    SingleStorey.DoubleSerifedBar
-			tailed           SingleStorey.TailedBar
-			tailedSerifed    SingleStorey.TailedSerifedBar
+		singleStoreyTopSerifed              { SingleStorey.FullBarBody        SingleStorey.TopSerifedBar    }
+
+		singleStoreySerifed                 { SingleStorey.FullBarBody        SingleStorey.SerifedBar       }
+		singleStoreyEarlessCornerSerifed    { SingleStorey.EarlessCornerBody  SingleStorey.SerifedBar       }
+		singleStoreyEarlessRoundedSerifed   { SingleStorey.EarlessRoundedBody SingleStorey.SerifedBar       }
+
+		singleStoreyDoubleSerifed           { SingleStorey.FullBarBody        SingleStorey.DoubleSerifedBar }
+
+		singleStoreyTailed                  { SingleStorey.FullBarBody        SingleStorey.TailedBar        }
+		singleStoreyEarlessCornerTailed     { SingleStorey.EarlessCornerBody  SingleStorey.TailedBar        }
+		singleStoreyEarlessRoundedTailed    { SingleStorey.EarlessRoundedBody SingleStorey.TailedBar        }
+
+		singleStoreyTailedSerifed           { SingleStorey.FullBarBody        SingleStorey.TailedSerifedBar }
 
 	foreach { suffix { body bar } } [Object.entries SingleStoreyConfig] : do
 		create-glyph "a.\(suffix)" : glyph-proc

--- a/font-src/glyphs/letter/latin/u.ptl
+++ b/font-src/glyphs/letter/latin/u.ptl
@@ -157,6 +157,7 @@ glyph-block Letter-Latin-U : begin
 			toothlessRounded  UToothlessRounded
 		function [body] : object # serifs
 			serifless               { no-shape                false }
+			bottomRightSerifed      { USerifs.BottomRight     false }
 			bilateralMotionSerifed  { USerifs.BilateralMotion true  }
 			unilateralMotionSerifed : match body
 				[Just 'toothed']    { USerifs.MotionToothed   true  }

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1541,9 +1541,10 @@ selectorAffix.scripta       = "singleStorey"
 [prime.a.variants-buildup.stages.double-storey-hook."*"]
 next = "bar"
 
-[prime.a.variants-buildup.stages.double-storey-hook.normal]
+[prime.a.variants-buildup.stages.double-storey-hook.hook-serifless]
 rank = 1
 keyAffix = ""
+descriptionAffix = "serifless hook"
 selectorAffix.a = ""
 selectorAffix."ae/a" = ""
 selectorAffix."a/sansSerif" = ""
@@ -1552,14 +1553,15 @@ selectorAffix."a/turnABase" = ""
 selectorAffix."a/single"    = ""
 selectorAffix.scripta       = ""
 
-[prime.a.variants-buildup.stages.double-storey-hook.corner-hooked]
+[prime.a.variants-buildup.stages.double-storey-hook.hook-serifed]
 rank = 2
-descriptionAffix = "corner hook shape"
-selectorAffix.a = "cornerHooked"
-selectorAffix."ae/a" = "cornerHooked"
-selectorAffix."a/sansSerif" = "cornerHooked"
-selectorAffix."a/rtailBase" = "cornerHooked"
-selectorAffix."a/turnABase" = "cornerHooked"
+keyAffix = "hook-inward-serifed"
+descriptionAffix = "serifed hook"
+selectorAffix.a = "hookInwardSerifed"
+selectorAffix."ae/a" = "hookInwardSerifed"
+selectorAffix."a/sansSerif" = "hookInwardSerifed"
+selectorAffix."a/rtailBase" = "hookInwardSerifed"
+selectorAffix."a/turnABase" = "hookInwardSerifed"
 selectorAffix."a/single"    = ""
 selectorAffix.scripta       = ""
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1111,22 +1111,29 @@ descriptionAffix = "motion serifs at top-left and bottom-right"
 selectorAffix.U = "unilateralMotionSerifed"
 selectorAffix."U/sansSerif" = "serifless"
 
-[prime.capital-u.variants-buildup.stages.serifs.unilateral-motion-serifed]
+[prime.capital-u.variants-buildup.stages.serifs.bottom-right-serifed]
 rank = 3
+disableIf = [{ body = "NOT toothed" }]
+descriptionAffix = "serif at bottom-right"
+selectorAffix.U = "bottomRightSerifed"
+selectorAffix."U/sansSerif" = "serifless"
+
+[prime.capital-u.variants-buildup.stages.serifs.unilateral-motion-serifed]
+rank = 4
 disableIf = [{ body = "toothed" }, { body = "tailed" }]
 descriptionAffix = "motion serifs at left side"
 selectorAffix.U = "unilateralMotionSerifed"
 selectorAffix."U/sansSerif" = "serifless"
 
 [prime.capital-u.variants-buildup.stages.serifs.bilateral-motion-serifed]
-rank = 4
+rank = 5
 disableIf = [{ body = "toothed" }, { body = "tailed" }]
 descriptionAffix = "motion serifs at both sides"
 selectorAffix.U = "bilateralMotionSerifed"
 selectorAffix."U/sansSerif" = "serifless"
 
 [prime.capital-u.variants-buildup.stages.serifs.serifed]
-rank = 5
+rank = 6
 descriptionAffix = "serifs"
 selectorAffix.U = "serifed"
 selectorAffix."U/sansSerif" = "serifless"
@@ -1532,12 +1539,11 @@ selectorAffix."a/single"    = "singleStorey"
 selectorAffix.scripta       = "singleStorey"
 
 [prime.a.variants-buildup.stages.double-storey-hook."*"]
-next = "terminal"
+next = "bar"
 
-[prime.a.variants-buildup.stages.double-storey-hook.hook-serifless]
+[prime.a.variants-buildup.stages.double-storey-hook.normal]
 rank = 1
 keyAffix = ""
-descriptionAffix = "serifless hook"
 selectorAffix.a = ""
 selectorAffix."ae/a" = ""
 selectorAffix."a/sansSerif" = ""
@@ -1546,20 +1552,19 @@ selectorAffix."a/turnABase" = ""
 selectorAffix."a/single"    = ""
 selectorAffix.scripta       = ""
 
-[prime.a.variants-buildup.stages.double-storey-hook.hook-serifed]
+[prime.a.variants-buildup.stages.double-storey-hook.corner-hooked]
 rank = 2
-keyAffix = "hook-inward-serifed"
-descriptionAffix = "serifed hook"
-selectorAffix.a = "hookInwardSerifed"
-selectorAffix."ae/a" = "hookInwardSerifed"
-selectorAffix."a/sansSerif" = "hookInwardSerifed"
-selectorAffix."a/rtailBase" = "hookInwardSerifed"
-selectorAffix."a/turnABase" = "hookInwardSerifed"
+descriptionAffix = "corner hook shape"
+selectorAffix.a = "cornerHooked"
+selectorAffix."ae/a" = "cornerHooked"
+selectorAffix."a/sansSerif" = "cornerHooked"
+selectorAffix."a/rtailBase" = "cornerHooked"
+selectorAffix."a/turnABase" = "cornerHooked"
 selectorAffix."a/single"    = ""
 selectorAffix.scripta       = ""
 
 [prime.a.variants-buildup.stages.ear."*"]
-next = "terminal"
+next = "bar"
 
 [prime.a.variants-buildup.stages.ear.eared]
 rank = 1
@@ -1594,7 +1599,7 @@ selectorAffix."a/turnABase" = ""
 selectorAffix."a/single"    = "earlessRounded"
 selectorAffix.scripta       = ""
 
-[prime.a.variants-buildup.stages.terminal.serifless]
+[prime.a.variants-buildup.stages.bar.serifless]
 rank = 1
 descriptionAffix = "serif at terminal"
 descriptionJoiner = "without"
@@ -1606,8 +1611,31 @@ selectorAffix."a/turnABase" = "serifless"
 selectorAffix."a/single"    = "serifless"
 selectorAffix.scripta       = "serifless"
 
-[prime.a.variants-buildup.stages.terminal.tailed]
+[prime.a.variants-buildup.stages.bar.serifed]
 rank = 2
+descriptionAffix = "serif at terminal"
+selectorAffix.a = "serifed"
+selectorAffix."ae/a" = "serifless"
+selectorAffix."a/sansSerif" = "serifless"
+selectorAffix."a/rtailBase" = "serifless"
+selectorAffix."a/turnABase" = "serifed"
+selectorAffix."a/single"    = "serifed"
+selectorAffix.scripta       = "serifed"
+
+[prime.a.variants-buildup.stages.bar.double-serifed]
+rank = 3
+disableIf = [{ storey = "double-storey" }, { ear = "NOT eared" }]
+descriptionAffix = "serifs at top and bottom"
+selectorAffix.a = "doubleSerifed"
+selectorAffix."ae/a" = "serifless"
+selectorAffix."a/sansSerif" = "serifless"
+selectorAffix."a/rtailBase" = "topSerifed"
+selectorAffix."a/turnABase" = "serifed"
+selectorAffix."a/single"    = "doubleSerifed"
+selectorAffix.scripta       = "serifed"
+
+[prime.a.variants-buildup.stages.bar.tailed]
+rank = 4
 descriptionAffix = "curly tail"
 selectorAffix.a = "tailed"
 selectorAffix."ae/a" = "serifless"
@@ -1617,8 +1645,20 @@ selectorAffix."a/turnABase" = "tailed"
 selectorAffix."a/single"    = "tailed"
 selectorAffix.scripta       = "tailed"
 
-[prime.a.variants-buildup.stages.terminal.toothless-corner]
-rank = 3
+[prime.a.variants-buildup.stages.bar.tailed-serifed]
+rank = 5
+disableIf = [{ storey = "double-storey" }, { ear = "NOT eared" }]
+descriptionAffix = "curly tail; with serifs at top and bottom"
+selectorAffix.a = "tailedSerifed"
+selectorAffix."ae/a" = "serifless"
+selectorAffix."a/sansSerif" = "tailed"
+selectorAffix."a/rtailBase" = "topSerifed"
+selectorAffix."a/turnABase" = "tailed"
+selectorAffix."a/single"    = "tailedSerifed"
+selectorAffix.scripta       = "tailed"
+
+[prime.a.variants-buildup.stages.bar.toothless-corner]
+rank = 6
 disableIf = [{ storey = "single-storey" }]
 descriptionAffix = "toothless (cornered bottom-right)"
 selectorAffix.a = "toothlessCorner"
@@ -1629,8 +1669,8 @@ selectorAffix."a/turnABase" = "toothlessCorner"
 selectorAffix."a/single"    = "serifless"
 selectorAffix.scripta       = "serifless"
 
-[prime.a.variants-buildup.stages.terminal.toothless-rounded]
-rank = 4
+[prime.a.variants-buildup.stages.bar.toothless-rounded]
+rank = 7
 disableIf = [{ storey = "single-storey" }]
 descriptionAffix = "toothless (rounded bottom-right)"
 selectorAffix.a = "toothlessRounded"
@@ -1640,17 +1680,6 @@ selectorAffix."a/rtailBase" = "serifless"
 selectorAffix."a/turnABase" = "toothlessRounded"
 selectorAffix."a/single"    = "serifless"
 selectorAffix.scripta       = "serifless"
-
-[prime.a.variants-buildup.stages.terminal.serifed]
-rank = 5
-descriptionAffix = "serif at terminal"
-selectorAffix.a = "serifed"
-selectorAffix."ae/a" = "serifless"
-selectorAffix."a/sansSerif" = "serifless"
-selectorAffix."a/rtailBase" = "serifless"
-selectorAffix."a/turnABase" = "serifed"
-selectorAffix."a/single"    = "serifed"
-selectorAffix.scripta       = "serifed"
 
 
 
@@ -1879,8 +1908,22 @@ selectorAffix.dHookTop = "serifless"
 selectorAffix."dHookTop/hookBottomBase" = "serifless"
 selectorAffix."cyrl/djeKomi" = "topSerifed"
 
-[prime.d.variants-buildup.stages.serifs.serifed__toothed]
+[prime.d.variants-buildup.stages.serifs.bottom-serifed]
 rank = 3
+enableIf = [{ body = "toothed" }]
+descriptionAffix = "serif at bottom"
+selectorAffix.d = "bottomSerifed"
+selectorAffix."d/sansSerif" = "serifless"
+selectorAffix."d/phoneticLeft" = "serifless"
+selectorAffix."d/descBase" = "serifless"
+selectorAffix."d/hookBottomBase" = "serifless"
+selectorAffix.dCurlyTail = "serifless"
+selectorAffix.dHookTop = "bottomSerifed"
+selectorAffix."dHookTop/hookBottomBase" = "serifless"
+selectorAffix."cyrl/djeKomi" = "bottomSerifed"
+
+[prime.d.variants-buildup.stages.serifs.serifed__toothed]
+rank = 4
 enableIf = [{ body = "toothed" }]
 keyAffix = "serifed"
 descriptionAffix = "serifs"
@@ -1895,7 +1938,7 @@ selectorAffix."dHookTop/hookBottomBase" = "serifless"
 selectorAffix."cyrl/djeKomi" = "serifed"
 
 [prime.d.variants-buildup.stages.serifs.serifed__toothless]
-rank = 3
+rank = 4
 enableIf = [{ body = "NOT toothed" }]
 keyAffix = "serifed"
 descriptionAffix = "serifs"
@@ -3278,8 +3321,17 @@ selectorAffix."q/sansSerif" = "serifless"
 selectorAffix."q/hookTopBase" = "serifless"
 selectorAffix.qRTail = "serifless"
 
-[prime.q.variants-buildup.stages.serifs.motion-serifed]
+[prime.q.variants-buildup.stages.serifs.bottom-serifed]
 rank = 2
+enableIf = [{ body = "eared", terminal = "straight" }]
+descriptionAffix = "serif at bottom"
+selectorAffix.q = "bottomSerifed"
+selectorAffix."q/sansSerif" = "serifless"
+selectorAffix."q/hookTopBase" = "bottomSerifed"
+selectorAffix.qRTail = "serifless"
+
+[prime.q.variants-buildup.stages.serifs.motion-serifed]
+rank = 3
 enableIf = [{ body = "eared" }]
 descriptionAffix = "motion serifs"
 selectorAffix.q = "motionSerifed"
@@ -3288,7 +3340,7 @@ selectorAffix."q/hookTopBase" = "serifless"
 selectorAffix.qRTail = "motionSerifed"
 
 [prime.q.variants-buildup.stages.serifs.serifed__eared]
-rank = 3
+rank = 4
 enableIf = [{ body = "eared", terminal = "straight" }]
 keyAffix = "serifed"
 descriptionAffix = "serifs"
@@ -3298,7 +3350,7 @@ selectorAffix."q/hookTopBase" = "bottomSerifed"
 selectorAffix.qRTail = "motionSerifed"
 
 [prime.q.variants-buildup.stages.serifs.serifed__eareless]
-rank = 3
+rank = 4
 enableIf = [{ body = "NOT eared", terminal = "straight" }]
 keyAffix = "serifed"
 descriptionAffix = "serifs"
@@ -4556,7 +4608,7 @@ selectorAffix."grek/alpha" = "singleStorey"
 selectorAffix."grek/alpha/sansSerif" = "singleStorey"
 
 [prime.lower-alpha.variants-buildup.stages.ear."*"]
-next = "terminal"
+next = "bar"
 
 [prime.lower-alpha.variants-buildup.stages.ear.eared]
 rank = 1
@@ -4576,23 +4628,37 @@ descriptionAffix = "earless (rounded top-right)"
 selectorAffix."grek/alpha" = "earlessRounded"
 selectorAffix."grek/alpha/sansSerif" = "earlessRounded"
 
-[prime.lower-alpha.variants-buildup.stages.terminal.serifless]
+[prime.lower-alpha.variants-buildup.stages.bar.serifless]
 rank = 1
 keyAffix = ""
 selectorAffix."grek/alpha" = "serifless"
 selectorAffix."grek/alpha/sansSerif" = "serifless"
 
-[prime.lower-alpha.variants-buildup.stages.terminal.tailed]
+[prime.lower-alpha.variants-buildup.stages.bar.serifed]
 rank = 2
+descriptionAffix = "serif at terminal"
+selectorAffix."grek/alpha" = "serifed"
+selectorAffix."grek/alpha/sansSerif" = "serifless"
+
+[prime.lower-alpha.variants-buildup.stages.bar.double-serifed]
+rank = 3
+disableIf = [{ ear = "NOT eared" }]
+descriptionAffix = "serifs at top and bottom"
+selectorAffix."grek/alpha" = "doubleSerifed"
+selectorAffix."grek/alpha/sansSerif" = "serifless"
+
+[prime.lower-alpha.variants-buildup.stages.bar.tailed]
+rank = 4
 descriptionAffix = "curly tail"
 selectorAffix."grek/alpha" = "tailed"
 selectorAffix."grek/alpha/sansSerif" = "tailed"
 
-[prime.lower-alpha.variants-buildup.stages.terminal.serifed]
-rank = 3
-descriptionAffix = "serif at terminal"
-selectorAffix."grek/alpha" = "serifed"
-selectorAffix."grek/alpha/sansSerif" = "serifless"
+[prime.lower-alpha.variants-buildup.stages.bar.tailed-serifed]
+rank = 5
+disableIf = [{ ear = "NOT eared" }]
+descriptionAffix = "curly tail; with serifs at top and bottom"
+selectorAffix."grek/alpha" = "tailedSerifed"
+selectorAffix."grek/alpha/sansSerif" = "tailed"
 
 
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1843,8 +1843,21 @@ selectorAffix.dHookTop = "toothed"
 selectorAffix."dHookTop/hookBottomBase" = "toothed"
 selectorAffix."cyrl/djeKomi" = "toothed"
 
-[prime.d.variants-buildup.stages.body.toothless-corner]
+[prime.d.variants-buildup.stages.body.tailed]
 rank = 2
+descriptionAffix = "tailed shape"
+selectorAffix.d = "tailed"
+selectorAffix."d/sansSerif" = "tailed"
+selectorAffix."d/phoneticLeft" = "toothed"
+selectorAffix."d/descBase" = "toothed"
+selectorAffix."d/hookBottomBase" = "toothed"
+selectorAffix.dCurlyTail = "toothed"
+selectorAffix.dHookTop = "tailed"
+selectorAffix."dHookTop/hookBottomBase" = "toothed"
+selectorAffix."cyrl/djeKomi" = "toothed"
+
+[prime.d.variants-buildup.stages.body.toothless-corner]
+rank = 3
 descriptionAffix = "toothless (cornered) shape"
 selectorAffix.d = "toothlessCorner"
 selectorAffix."d/sansSerif" = "toothlessCorner"
@@ -1857,7 +1870,7 @@ selectorAffix."dHookTop/hookBottomBase" = "toothlessCornerHBB"
 selectorAffix."cyrl/djeKomi" = "toothlessRounded"
 
 [prime.d.variants-buildup.stages.body.toothless-rounded]
-rank = 3
+rank = 4
 descriptionAffix = "toothless (rounded) shape"
 selectorAffix.d = "toothlessRounded"
 selectorAffix."d/sansSerif" = "toothlessRounded"
@@ -1868,19 +1881,6 @@ selectorAffix.dCurlyTail = "toothed"
 selectorAffix.dHookTop = "toothlessRounded"
 selectorAffix."dHookTop/hookBottomBase" = "toothed"
 selectorAffix."cyrl/djeKomi" = "toothlessRounded"
-
-[prime.d.variants-buildup.stages.body.tailed]
-rank = 4
-descriptionAffix = "tailed shape"
-selectorAffix.d = "tailed"
-selectorAffix."d/sansSerif" = "tailed"
-selectorAffix."d/phoneticLeft" = "toothed"
-selectorAffix."d/descBase" = "toothed"
-selectorAffix."d/hookBottomBase" = "toothed"
-selectorAffix.dCurlyTail = "toothed"
-selectorAffix.dHookTop = "tailed"
-selectorAffix."dHookTop/hookBottomBase" = "toothed"
-selectorAffix."cyrl/djeKomi" = "toothed"
 
 [prime.d.variants-buildup.stages.serifs.serifless]
 rank = 1


### PR DESCRIPTION
Closes #1949 .

`aæ𝖺ᶏɐꞛɑꭤ`
All `a` variants:
![image](https://github.com/be5invis/Iosevka/assets/37010132/e766ee9c-a704-45d6-89b7-3657940ff628)
`α𝝰`
All alpha variants:
![image](https://github.com/be5invis/Iosevka/assets/37010132/6b0ceea0-3aeb-478e-a29b-0117ce409f0c)

For the case of `U` and `d`, the bottom serif variants are because the serif may be used as an alternative to a tailed terminal.

`U𝖴ᴜꞾ`
All `U` variants:
![image](https://github.com/be5invis/Iosevka/assets/37010132/fb43beed-8c3a-4e01-a283-43922b45aa10)
`d𝖽ʤᶁɖȡɗᶑԃ`
All `d` variants:
![image](https://github.com/be5invis/Iosevka/assets/37010132/f11695b7-53d2-4f86-8dd6-284775c2b286)

For the case of `q`, having only a bottom serif is an extremely common variant I've seen around:

Liberation Serif:
![image](https://github.com/be5invis/Iosevka/assets/37010132/c39f30a3-2d36-4cb3-a90d-8887f0c6bf7d)
IBM Plex Serif:
![image](https://github.com/be5invis/Iosevka/assets/37010132/ac536b49-8ea2-43a8-8416-456f5ecd84ef)
Roboto Serif:
![image](https://github.com/be5invis/Iosevka/assets/37010132/efe036b8-5e44-4ab8-a25c-80133240a7bc)
Times New Roman:
![image](https://github.com/be5invis/Iosevka/assets/37010132/b3b6ef80-7c09-43fb-bf5e-13cdf79bd61c)
Georgia:
![image](https://github.com/be5invis/Iosevka/assets/37010132/89d1cdaf-e585-48f0-8610-0bf5009c2d58)

`q𝗊ʠɋ`
all `q` variants:
![image](https://github.com/be5invis/Iosevka/assets/37010132/fedbc60c-3a53-4de9-bc5b-8dcd18ca2372)
