### PR TITLE
Add a serif to Blackboard Bold Lower J to match Blackboard Bold Lower I/L.

### DIFF
--- a/changes/28.0.0-beta.1.md
+++ b/changes/28.0.0-beta.1.md
@@ -49,6 +49,7 @@
 * Improve top-left serif for LATIN SMALL LETTER KRA (`U+0138`) to match `k`.
 * Make Greek Kappa (`U+03BA`) respond to more serif variants for `k` (`cv36`).
 * Add a top-left serif to GREEK SMALL LETTER HETA (`U+0371`) under slab.
+* Add a serif to MATHEMATICAL DOUBLE-STRUCK SMALL J (`U+1D55B`) to match that of MATHEMATICAL DOUBLE-STRUCK SMALL I (`U+1D55A`).
 * Improve vertical alignmant of bowl for LATIN CAPITAL LETTER THORN WITH STROKE (`U+A764`) and LATIN CAPITAL LETTER THORN WITH STROKE THROUGH DESCENDER (`U+A766`).
 * Stylistic set fixes:
   - Fix `cv10` for `ss01`, `ss02`, and `ss08` under slab.

--- a/font-src/glyphs/letter/latin/lower-il.ptl
+++ b/font-src/glyphs/letter/latin/lower-il.ptl
@@ -403,7 +403,7 @@ glyph-block Letter-Latin-Lower-I : begin
 		create-glyph 'mathbb/dotlessi' : glyph-proc
 			include : MarkSet.e
 			include : BBBarCenter Middle 0 XH
-			include : HBar.t    (Middle - BBD / 2 - Jut) Middle                   XH  BBS
+			include : HBar.t (Middle - BBD / 2 - Jut)  Middle                  XH  BBS
 			include : HBar.b (Middle - BBD / 2 - Jut) (Middle + BBD / 2 + Jut) 0   BBS
 
 		create-glyph 'mathbb/i' 0x1D55A : glyph-proc
@@ -414,5 +414,5 @@ glyph-block Letter-Latin-Lower-I : begin
 		create-glyph 'mathbb/l' 0x1D55D : glyph-proc
 			include : MarkSet.b
 			include : BBBarCenter Middle 0 Ascender
-			include : HBar.t    (Middle - BBD / 2 - Jut) Middle                   Ascender BBS
+			include : HBar.t (Middle - BBD / 2 - Jut)  Middle                  Ascender BBS
 			include : HBar.b (Middle - BBD / 2 - Jut) (Middle + BBD / 2 + Jut) 0        BBS

--- a/font-src/glyphs/letter/latin/lower-j.ptl
+++ b/font-src/glyphs/letter/latin/lower-j.ptl
@@ -149,9 +149,9 @@ glyph-block Letter-Latin-Lower-J : begin
 	create-glyph 'mathbb/dotlessj' : glyph-proc
 		include : MarkSet.p
 		local center : Middle + JBalance + BBD / 2
-		set-base-anchor 'above'   (center - [HSwToV BBS] / 2 - BBD / 2) XH
+		set-base-anchor 'above'   (center - [HSwToV BBS] / 2 - BBD / 2)  XH
 		set-base-anchor 'overlay' (center - [HSwToV BBS] / 2 - BBD / 2) (XH / 2)
-		local hookx  : center - (Width * 0.5) - [HSwToV BBD] + OXHook
+		local hookx : center - (Width * 0.5) - [HSwToV BBD] + OXHook
 		local turn : [mix center hookx 0.5] + CorrectionOMidS
 		include : dispiro
 			widths.rhs BBS
@@ -159,7 +159,7 @@ glyph-block Letter-Latin-Lower-J : begin
 			curl center (Descender + ArchDepthA)
 			hookend (Descender + O)
 			g4 hookx (Descender + JHook)
-		include : HBar.t (center - BBD) center XH BBS
+		include : HBar.t (center - [HSwToV BBS] / 2 - BBD - Jut) center XH BBS
 		include : intersection
 			VBar.r (center - BBD) Descender XH BBS
 			spiro-outline


### PR DESCRIPTION
`𝕝𝕚𝕛ⅈⅉ`
Before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/a5397f49-893a-4280-8b4b-a929d3e4f33a)
After:
![image](https://github.com/be5invis/Iosevka/assets/37010132/6ba39156-679e-4ecf-8417-6c356c052c74)
Also correctly compensating for changes in font weight:
Heavy:
![image](https://github.com/be5invis/Iosevka/assets/37010132/17187420-b966-4770-9960-6d4efd840140)
Thin:
![image](https://github.com/be5invis/Iosevka/assets/37010132/a28f2321-beaa-4f74-9ca7-6e2edc93bf72)
