### PR TITLE
Add brack bars to Idris ligation

### DIFF
--- a/params/ligation-set.toml
+++ b/params/ligation-set.toml
@@ -497,7 +497,10 @@ buildup = [
 [composite.idris]
 tag     = 'IDRS'
 desc    = 'Idris'
-buildup = [ 'haskell' ]
+buildup = [
+	'haskell',
+	'brack-bar',
+]
 
 [composite.elm]
 tag     = 'ELMX'


### PR DESCRIPTION
Unlike Haskell, Idris has the `[| ... |]` syntax for so called Idiom brackets (i.e., applicative composition), so it would be great to have it (as soon as a special variant for Idris already exitsts)