### PR TITLE
Make serifs of Cyrillic Small Letter Ghe with Middle Hook respond to italics.

### DIFF
--- a/changes/28.0.2.md
+++ b/changes/28.0.2.md
@@ -1,1 +1,2 @@
-* Refine shape of Tshe and Cyrillic Capital Letter Te with Middle Hook (#2123).
+* Refine shape of Tshe and Cyrillic Capital Letter Te with Middle Hook (`U+A68A`) (#2123).
+* Remove bottom serif of Cyrillic Small Letter Ghe with Middle Hook (`U+0495`) under italics.

--- a/packages/font-glyphs/src/letter/cyrillic/orthography.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/orthography.ptl
@@ -6,32 +6,31 @@ glyph-block Letter-Cyrillic-Orthography : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared : CreateAccentedComposition
 
+	orthographic-italic 'cyrl/ve'             0x432
+	orthographic-italic 'cyrl/ghe'            0x433
 	orthographic-italic 'cyrl/de'             0x434
-	orthographic-italic 'cyrl/dzhe'           0x45F
-	orthographic-italic 'cyrl/dzze'           0xA689
-	orthographic-italic 'cyrl/dzzhe'          0x52B
 	orthographic-italic 'cyrl/i'              0x438
-	orthographic-italic 'cyrl/iShortTail'     0x48B
+	orthographic-italic 'cyrl/pe'             0x43F
+	orthographic-italic 'cyrl/te'             0x442
+	orthographic-italic 'cyrl/tse'            0x446
 	orthographic-italic 'cyrl/sha'            0x448
 	orthographic-italic 'cyrl/shcha'          0x449
-	orthographic-italic 'cyrl/te'             0x442
-	orthographic-italic 'cyrl/teDescender'    0x4AD
-	orthographic-italic 'cyrl/tse'            0x446
-	orthographic-italic 'cyrl/teMidHook'      0xA68B
-	orthographic-italic 'cyrl/teThreeLeg'     0x1C85
-	orthographic-italic 'cyrl/tetse'          0x4B5
-	orthographic-italic 'cyrl/tjeKomi'        0x50F
+	orthographic-italic 'cyrl/dzhe'           0x45F
 	orthographic-italic 'cyrl/yat'            0x463
-	orthographic-italic 'cyrl/pe'             0x43F
-	orthographic-italic 'cyrl/peMidHook'      0x4A7
-	orthographic-italic 'cyrl/peDescender'    0x525
-	orthographic-italic 'cyrl/dche'           0x52D
-	orthographic-italic 'cyrl/ghe'            0x433
-	orthographic-italic 'cyrl/ge'             0x491
+	orthographic-italic 'cyrl/iShortTail'     0x48B
 	orthographic-italic 'cyrl/ghayn'          0x493
+	orthographic-italic 'cyrl/peMidHook'      0x4A7
+	orthographic-italic 'cyrl/teDescender'    0x4AD
+	orthographic-italic 'cyrl/tetse'          0x4B5
 	orthographic-italic 'cyrl/gheDescender'   0x4F7
-	orthographic-italic 'cyrl/ve'             0x432
 	orthographic-italic 'cyrl/gheStrokeHook'  0x4FB
+	orthographic-italic 'cyrl/tjeKomi'        0x50F
+	orthographic-italic 'cyrl/peDescender'    0x525
+	orthographic-italic 'cyrl/dzzhe'          0x52B
+	orthographic-italic 'cyrl/dche'           0x52D
+	orthographic-italic 'cyrl/teThreeLeg'     0x1C85
+	orthographic-italic 'cyrl/dzze'           0xA689
+	orthographic-italic 'cyrl/teMidHook'      0xA68B
 	orthographic-italic 'latn/yatSakha'       0xAB60
 
 	# Accented forms

--- a/packages/font-glyphs/src/letter/greek/upper-gamma.ptl
+++ b/packages/font-glyphs/src/letter/greek/upper-gamma.ptl
@@ -17,8 +17,8 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 
 	define SLAB-NONE   0
 	define SLAB-TR     1
-	define SLAB-BOTTOM 3
-	define SLAB-ALL    4
+	define SLAB-BOTTOM 2
+	define SLAB-ALL    3
 
 	define GammaBarLeft (SB * 1.5)
 	define [GammaShape top bot slabType] : glyph-proc

--- a/packages/font-glyphs/src/letter/greek/upper-gamma.ptl
+++ b/packages/font-glyphs/src/letter/greek/upper-gamma.ptl
@@ -17,7 +17,6 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 
 	define SLAB-NONE   0
 	define SLAB-TR     1
-	define SLAB-LT     2
 	define SLAB-BOTTOM 3
 	define SLAB-ALL    4
 
@@ -29,20 +28,17 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 		match slabType
 			[Just SLAB-ALL] : begin
 				include : HSerif.lt GammaBarLeft top SideJut
-				include : HSerif.lb (GammaBarLeft + [HSwToV HalfStroke]) bot Jut
-				include : HSerif.rb (GammaBarLeft + [HSwToV HalfStroke]) bot MidJutSide
+				include : tagged 'serifLB' : HSerif.lb (GammaBarLeft + [HSwToV HalfStroke]) bot Jut
+				include : tagged 'serifLB' : HSerif.rb (GammaBarLeft + [HSwToV HalfStroke]) bot MidJutSide
 				include : tagged 'serifRT' : VSerif.dr (RightSB - OX) top VJut
 			[Just SLAB-BOTTOM] : begin
-				include : HSerif.lb (GammaBarLeft + [HSwToV HalfStroke]) bot Jut
-				include : HSerif.rb (GammaBarLeft + [HSwToV HalfStroke]) bot MidJutSide
-			[Just SLAB-LT] : begin
-				include : HSerif.lt GammaBarLeft top SideJut
+				include : tagged 'serifLB' : HSerif.lb (GammaBarLeft + [HSwToV HalfStroke]) bot Jut
+				include : tagged 'serifLB' : HSerif.rb (GammaBarLeft + [HSwToV HalfStroke]) bot MidJutSide
 			[Just SLAB-TR] : begin
 				include : tagged 'serifRT' : VSerif.dr (RightSB - OX) top VJut
 
 	define GammaConfig : object
 		serifless       { SLAB-NONE   SLAB }
-		topLeftSerifed  { SLAB-LT     SLAB }
 		topRightSerifed { SLAB-TR     true }
 		bottomSerifed   { SLAB-BOTTOM SLAB }
 		serifed         { SLAB-ALL    true }
@@ -100,19 +96,34 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 			eject-contour 'serifRT'
 			include : VBar.r (RightSB - OX) CAP (CAP + LongJut - 0.5 * Stroke)
 
-		create-glyph "cyrl/ge.upright.\(suffix)" : glyph-proc
+		create-glyph "cyrl/ge.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : ExtendAboveBaseAnchors (XH + LongJut - 0.5 * Stroke)
 			include : GammaShape XH 0 slabType
 			eject-contour 'serifRT'
 			include : VBar.r (RightSB - OX) XH (XH + LongJut - 0.5 * Stroke)
+			if para.isItalic : eject-contour 'serifLB'
 
-		create-glyph "cyrl/ge.italic.\(suffix)" : glyph-proc
-			include : MarkSet.e
-			include : ExtendAboveBaseAnchors (XH + LongJut - 0.5 * Stroke)
-			include : GammaShape XH 0 slabType
-			eject-contour 'serifRT'
-			include : VBar.r (RightSB - OX) XH (XH + LongJut - 0.5 * Stroke)
+		create-glyph "cyrl/GheMidHook.\(suffix)" : glyph-proc
+			include [refer-glyph "grek/Gamma.\(suffix)"] AS_BASE ALSO_METRICS
+			include : MarkSet.capDesc
+			include : MidHook.general
+				left   -- (GammaBarLeft + [HSwToV Stroke])
+				right  -- RightSB
+				top    -- CAP * HBarPos + Stroke / 4
+				ada    -- ArchDepthA
+				adb    -- ArchDepthB
+
+		create-glyph "cyrl/gheMidHook.\(suffix)" : glyph-proc
+			include [refer-glyph "cyrl/ghe.upright.\(suffix)"] AS_BASE ALSO_METRICS
+			include : MarkSet.p
+			include : MidHook.general
+				left   -- (GammaBarLeft + [HSwToV Stroke])
+				right  -- RightSB
+				top    -- XH * HBarPos + Stroke / 4
+				ada    -- ArchDepthA * [Math.pow HBarPos 0.3]
+				adb    -- ArchDepthB * [Math.pow HBarPos 0.3]
+			if para.isItalic : eject-contour 'serifLB'
 
 	select-variant 'grek/Gamma' 0x393
 	link-reduced-variant 'grek/Gamma/sansSerif' 'grek/Gamma' MathSansSerif
@@ -120,35 +131,24 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 	select-variant 'cyrl/GheDescender' 0x4F6 (follow -- 'cyrl/Ghe')
 	select-variant 'cyrl/GheDHook' (follow -- 'cyrl/Ghe')
 	select-variant 'cyrl/Ge' 0x490
+	select-variant 'cyrl/GheMidHook' 0x494 (follow -- 'cyrl/Ghe')
 
 	select-variant 'cyrl/ghe.upright'
 	select-variant 'cyrl/gheDescender.upright' (follow -- 'cyrl/ghe.upright')
 	select-variant 'cyrl/gheDHook.upright' (follow -- 'cyrl/ghe.upright')
 	select-variant 'grek/smcpGamma' 0x1D26 (shapeFrom -- 'cyrl/ghe.upright') (follow -- 'grek/Gamma')
-	select-variant 'cyrl/ge.upright'
-	select-variant 'cyrl/ge.italic'
+	select-variant 'cyrl/ge' 0x491
+	select-variant 'cyrl/gheMidHook' 0x495 (follow -- 'cyrl/ghe.upright')
 
 	select-variant 'grek/Digamma' 0x3DC (follow -- 'grek/Gamma')
 
-	derive-glyphs 'cyrl/GheMidHook' 0x494 'cyrl/Ghe' : lambda [src gr] : glyph-proc
-		include [refer-glyph src] AS_BASE ALSO_METRICS
-		include : MarkSet.capDesc
-		include : MidHook.general
-			left   -- (GammaBarLeft + [HSwToV Stroke])
-			right  -- RightSB
-			top    -- CAP * HBarPos + Stroke / 4
-			ada    -- ArchDepthA
-			adb    -- ArchDepthB
-
-	derive-glyphs 'cyrl/gheMidHook' 0x495 'cyrl/ghe.upright' : lambda [src gr] : glyph-proc
-		include [refer-glyph src] AS_BASE ALSO_METRICS
+	create-glyph 'grek/digamma' 0x3DD : glyph-proc
 		include : MarkSet.p
-		include : MidHook.general
-			left   -- (GammaBarLeft + [HSwToV Stroke])
-			right  -- RightSB
-			top    -- XH * HBarPos + Stroke / 4
-			ada    -- ArchDepthA * [Math.pow HBarPos 0.3]
-			adb    -- ArchDepthB * [Math.pow HBarPos 0.3]
+		include : GammaShape XH Descender SLAB-NONE
+		local yBar : mix 0 XH DesignParameters.upperEBarPos
+		include : HBar.m GammaBarLeft (RightSB - [xMidBarShrink SLAB]) yBar
+		if SLAB : include : tagged 'serifRM'
+			VSerif.dr (RightSB - [xMidBarShrink SLAB]) (yBar + HalfStroke) [mix Stroke VJut 0.5]
 
 	define [GhaynOverlayBar top] : LetterBarOverlay.l GammaBarLeft (top * (1 - OverlayPos))
 
@@ -162,11 +162,3 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 		include : MarkSet.capital
 		include : BBBarLeft GammaBarLeft 0 CAP
 		include : HBar.t GammaBarLeft RightSB CAP BBS
-
-	create-glyph 'grek/digamma' 0x3DD : glyph-proc
-		include : MarkSet.p
-		include : GammaShape XH Descender SLAB-NONE
-		local yBar : mix 0 XH DesignParameters.upperEBarPos
-		include : HBar.m GammaBarLeft (RightSB - [xMidBarShrink SLAB]) yBar
-		if SLAB : include : tagged 'serifRM'
-			VSerif.dr (RightSB - [xMidBarShrink SLAB]) (yBar + HalfStroke) [mix Stroke VJut 0.5]

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -4676,8 +4676,7 @@ selector."grek/Gamma/sansSerif" = "serifless"
 selector."cyrl/Ghe" = "serifless"
 selector."cyrl/Ge" = "serifless"
 selector."cyrl/ghe.upright" = "serifless"
-selector."cyrl/ge.upright" = "serifless"
-selector."cyrl/ge.italic" = "serifless"
+selector."cyrl/ge" = "serifless"
 
 [prime.capital-gamma.variants.top-right-serifed]
 rank = 2
@@ -4687,8 +4686,7 @@ selector."grek/Gamma/sansSerif" = "serifless"
 selector."cyrl/Ghe" = "topRightSerifed"
 selector."cyrl/Ge" = "serifless"
 selector."cyrl/ghe.upright" = "topRightSerifed"
-selector."cyrl/ge.upright" = "serifless"
-selector."cyrl/ge.italic" = "serifless"
+selector."cyrl/ge" = "serifless"
 
 [prime.capital-gamma.variants.bottom-serifed]
 rank = 3
@@ -4698,8 +4696,7 @@ selector."grek/Gamma/sansSerif" = "serifless"
 selector."cyrl/Ghe" = "bottomSerifed"
 selector."cyrl/Ge" = "bottomSerifed"
 selector."cyrl/ghe.upright" = "serifless"
-selector."cyrl/ge.upright" = "serifless"
-selector."cyrl/ge.italic" = "serifless"
+selector."cyrl/ge" = "serifless"
 
 [prime.capital-gamma.variants.serifed]
 rank = 4
@@ -4709,8 +4706,7 @@ selector."grek/Gamma/sansSerif" = "serifless"
 selector."cyrl/Ghe" = "serifed"
 selector."cyrl/Ge" = "serifed"
 selector."cyrl/ghe.upright" = "serifed"
-selector."cyrl/ge.upright" = "serifed"
-selector."cyrl/ge.italic" = "topLeftSerifed"
+selector."cyrl/ge" = "serifed"
 
 
 


### PR DESCRIPTION
This also simplifies the italic behavior of the serifs of Lower Ge (`U+0491`) as all it effectively does is remove the bottom serif, so instead of create a whole unique glyph, it just ejects the serif, as the removal of that serif does not turn it into a duplicate of any other existing (lowercase) Ghe variants currently in use.
`ҐґҔҕԠԡԢԣҦҧꚊꚋ`
Upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/8bf2e17c-a588-4362-bbf3-1f73b49ee690)
Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/1da68ecc-57e5-4ab1-a3ab-b5c9daf880a0)
