### PR TITLE
Optimize italic serif behavior of several extended Cyrllic characters.

### DIFF
--- a/changes/28.0.2.md
+++ b/changes/28.0.2.md
@@ -1,2 +1,4 @@
 * Refine shape of Tshe and Cyrillic Capital Letter Te with Middle Hook (`U+A68A`) (#2123).
 * Remove bottom serif of Cyrillic Small Letter Ghe with Middle Hook (`U+0495`) under italics.
+* Make serif variants of Cyrillic Small Letter Tall Te (`U+1C84`) respond to italics.
+* Make terminal serif behavior of palatalized Komi consonants (`U+0502`...`U+0505`, `U+0508`..`U+050F`) more consistent with each other.

--- a/packages/font-glyphs/src/letter/cyrillic/orthography.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/orthography.ptl
@@ -28,6 +28,7 @@ glyph-block Letter-Cyrillic-Orthography : begin
 	orthographic-italic 'cyrl/peDescender'    0x525
 	orthographic-italic 'cyrl/dzzhe'          0x52B
 	orthographic-italic 'cyrl/dche'           0x52D
+	orthographic-italic 'cyrl/teTall'         0x1C84
 	orthographic-italic 'cyrl/teThreeLeg'     0x1C85
 	orthographic-italic 'cyrl/dzze'           0xA689
 	orthographic-italic 'cyrl/teMidHook'      0xA68B

--- a/packages/font-glyphs/src/letter/latin-ext/hwair.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/hwair.ptl
@@ -12,11 +12,11 @@ glyph-block Letter-Latin-Hwair : begin
 	glyph-block-import Letter-Shared-Shapes : SerifFrame
 
 	define Variants : object
-		straightSerifless      { false false false }
-		straightTopLeftSerifed { true  false false }
-		straightSerifed        { true  true  true  }
+		straightSerifless      { false false }
+		straightTopLeftSerifed { true  false }
+		straightSerifed        { true  true  }
 
-	foreach { suffix { serifLT serifLB serifRT } } [pairs-of Variants] : do
+	foreach { suffix { serifLT serifLB } } [pairs-of Variants] : do
 		create-glyph "hwair.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.b

--- a/packages/font-glyphs/src/letter/latin-ext/hwair.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/hwair.ptl
@@ -37,6 +37,6 @@ glyph-block Letter-Latin-Hwair : begin
 				local jut : Jut * 0.75
 				if serifLT : include : tagged 'serifLT' sf1.lt.outer
 				if serifLB : include : tagged 'serifLB' sf1.lb.full
-				if serifRT : include : tagged 'serifRT' sf2.rt.full
+				if SLAB    : include : tagged 'serifRT' sf2.rt.full
 
 	select-variant 'hwair' 0x195 (follow -- 'heng')

--- a/packages/font-glyphs/src/letter/latin/lower-d.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-d.ptl
@@ -106,8 +106,10 @@ glyph-block Letter-Latin-Lower-D : begin
 			local df : DivFrame 1
 			include [refer-glyph "d.\(suffix)"] AS_BASE ALSO_METRICS
 			local xLeft : mix df.rightSB df.leftSB 0.9
-			include : HBar.t xLeft (df.rightSB + O) CAP
-			if topSerif : include : VSerif.dl xLeft CAP : Math.min VJut (0.8 * (Ascender - XH))
+			include : HBar.t xLeft (df.rightSB + O) Ascender
+			if topSerif : begin
+				include : VSerif.dl xLeft Ascender : Math.min VJut (0.8 * (Ascender - XH))
+				if [not para.isItalic] : include : HSerif.rt df.rightSB Ascender SideJut
 
 		create-glyph "dHookTop.\(suffix)" : glyph-proc
 			local df : DivFrame 1
@@ -134,7 +136,7 @@ glyph-block Letter-Latin-Lower-D : begin
 				sw -- df.mvs
 
 			if topSerif    : include : topSerif dfHalf Ascender
-			if bottomSerif : begin
+			if SLAB : begin
 				local sf2 : [SerifFrame.fromDf df (XH / 2) 0].slice 1 2
 				include sf2.rt.full
 

--- a/packages/font-glyphs/src/letter/latin/upper-h.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-h.ptl
@@ -80,7 +80,7 @@ glyph-block Letter-Latin-Upper-H : begin
 		include : HSerifs slabType top 0 df.leftSB (df.middle + [HSwToV : 0.5 * df.mvs]) df.mvs
 
 		local sf2 : [SerifFrame.fromDf df yend 0].slice 1 2
-		if (slabType === SLAB-ALL || slabType === SLAB-TAILED-CYRILLIC) : include sf2.rt.full
+		if SLAB : include sf2.rt.full
 
 	define [OverlayStrokeShape top slabType] : begin
 		local yb : top * HBarPos + HalfStroke

--- a/packages/font-glyphs/src/letter/latin/upper-t.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-t.ptl
@@ -95,7 +95,7 @@ glyph-block Letter-Latin-Upper-T : begin
 				y -- 0
 				jut -- [if doSB MidJutCenter Jut]
 
-		create-glyph "TBar.\(suffix)" : glyph-proc
+		create-glyph "TStroke.\(suffix)" : glyph-proc
 			include [refer-glyph "T.\(suffix)"] AS_BASE ALSO_METRICS
 			include : LetterBarOverlay.m.in df.middle 0 CAP 0.45
 
@@ -156,15 +156,15 @@ glyph-block Letter-Latin-Upper-T : begin
 			include : df.markSet.e
 			include : TjeShape df XH doST
 
-		create-glyph "cyrl/TeTall.\(suffix)" : glyph-proc
+		create-glyph "cyrl/teTall.upright.\(suffix)" : glyph-proc
 			local df : include : DivFrame 1
-			include : df.markSet.capital
-			include : CyrlTallTeShape df CAP doST doSB
+			include : df.markSet.b
+			include : CyrlTallTeShape df Ascender doST doSB
 
 	select-variant 'T' 'T'
 	link-reduced-variant 'T/sansSerif' 'T' MathSansSerif
 	select-variant 'smcpT' 0x1D1B (follow -- 'T')
-	select-variant "TBar" 0x166 (follow -- 'T')
+	select-variant "TStroke" 0x166 (follow -- 'T')
 	select-variant "Thookleft" 0x1AC (follow -- 'T')
 	select-variant "cyrl/TeDescender" 0x4AC (follow -- 'T')
 	select-variant 'turnT' 0xA7B1 (follow -- 'T')
@@ -187,7 +187,8 @@ glyph-block Letter-Latin-Upper-T : begin
 
 	select-variant 'currency/tengeSign' 0x20B8 (follow -- 'T')
 
-	select-variant 'cyrl/TeTall' 0x1C84 (follow -- 'T')
+	select-variant 'cyrl/teTall.upright' (follow -- 'T')
+	select-variant 'cyrl/teTall.italic' (shapeFrom -- 'cyrl/teTall.upright') (follow -- 'T/rtailBase')
 
 	create-glyph 'mathbb/T' 0x1D54B : glyph-proc
 		local df : DivFrame 1

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1879,7 +1879,7 @@ selectorAffix."d/hookBottomBase" = "toothed"
 selectorAffix.dCurlyTail = "toothed"
 selectorAffix.dHookTop = "toothlessRounded"
 selectorAffix."dHookTop/hookBottomBase" = "toothed"
-selectorAffix."cyrl/djeKomi" = "toothlessRounded"
+selectorAffix."cyrl/djeKomi" = "toothed"
 
 [prime.d.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -1921,7 +1921,7 @@ selectorAffix."d/hookBottomBase" = "serifless"
 selectorAffix.dCurlyTail = "serifless"
 selectorAffix.dHookTop = "bottomSerifed"
 selectorAffix."dHookTop/hookBottomBase" = "serifless"
-selectorAffix."cyrl/djeKomi" = "bottomSerifed"
+selectorAffix."cyrl/djeKomi" = "serifless"
 
 [prime.d.variants-buildup.stages.serifs.serifed__toothed]
 rank = 4
@@ -1936,7 +1936,7 @@ selectorAffix."d/hookBottomBase" = "topSerifed"
 selectorAffix.dCurlyTail = "topSerifed"
 selectorAffix.dHookTop = "bottomSerifed"
 selectorAffix."dHookTop/hookBottomBase" = "serifless"
-selectorAffix."cyrl/djeKomi" = "serifed"
+selectorAffix."cyrl/djeKomi" = "topSerifed"
 
 [prime.d.variants-buildup.stages.serifs.serifed__toothless]
 rank = 4


### PR DESCRIPTION
```
ƃƌ Ƕƕ ґᲄᲆ
ԂԃԄԅԈԉԊԋԌԍԎԏ
```
Upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/315c1b8e-4198-486f-926a-03c86bc46af3)
Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/d4914f42-5742-4c97-8fff-f0d454799f47)
