### PR TITLE
Remove tailless variants for `{latn|cyrl}/iota` for disambiguation.

### DIFF
--- a/changes/28.0.2.md
+++ b/changes/28.0.2.md
@@ -2,7 +2,6 @@
   - LATIN CAPITAL LETTER AU (`U+A736`) (#1689).
   - LATIN SMALL LETTER AU (`U+A737`) (#1689).
 * Refine shape of Tshe and Cyrillic Capital Letter Te with Middle Hook (`U+A68A`) (#2123).
-* Remove tailless variants for Latin Iota (`U+0196`, `U+0269`) and Cyrillic Iota (`U+A646`, `U+A647`).
 * Remove bottom serif of Cyrillic Small Letter Ghe with Middle Hook (`U+0495`) under italics.
 * Make serif variants of Cyrillic Small Letter Tall Te (`U+1C84`) respond to italics.
 * Make terminal serif behavior of palatalized Komi consonants (`U+0502`...`U+0505`, `U+0508`...`U+050F`) more consistent with each other.

--- a/changes/28.0.2.md
+++ b/changes/28.0.2.md
@@ -2,6 +2,7 @@
   - LATIN CAPITAL LETTER AU (`U+A736`) (#1689).
   - LATIN SMALL LETTER AU (`U+A737`) (#1689).
 * Refine shape of Tshe and Cyrillic Capital Letter Te with Middle Hook (`U+A68A`) (#2123).
+* Remove tailless variants for Latin Iota (`U+0196`, `U+0269`) and Cyrillic Iota (`U+A646`, `U+A647`).
 * Remove bottom serif of Cyrillic Small Letter Ghe with Middle Hook (`U+0495`) under italics.
 * Make serif variants of Cyrillic Small Letter Tall Te (`U+1C84`) respond to italics.
 * Make terminal serif behavior of palatalized Komi consonants (`U+0502`...`U+0505`, `U+0508`...`U+050F`) more consistent with each other.

--- a/changes/28.0.3.md
+++ b/changes/28.0.3.md
@@ -1,0 +1,1 @@
+* Remove tailless variants for Latin Iota (`U+0196`, `U+0269`) and Cyrillic Iota (`U+A646`, `U+A647`).

--- a/packages/font-glyphs/src/auto-build/transformed.ptl
+++ b/packages/font-glyphs/src/auto-build/transformed.ptl
@@ -325,7 +325,7 @@ glyph-block Autobuild-Transformed : begin
 			list 0x1E049 'cyrl/yu'
 			list 0x1E04A 'cyrl/dzze'
 			list 0x1E04B 'cyrl/schwa'
-			list 0x1E04C 'cyrl/Ukrainiani'
+			list 0x1E04C 'cyrl/iUkrainian'
 			list 0x1E04D 'cyrl/je'
 			list 0x1E04E 'cyrl/oe'
 			list 0x1E04F 'cyrl/ue'
@@ -454,7 +454,7 @@ glyph-block Autobuild-Transformed : begin
 			list 0x1E065 'cyrl/yer'
 			list 0x1E066 'cyrl/yery'
 			list 0x1E067 'cyrl/ge'
-			list 0x1E068 'cyrl/Ukrainiani'
+			list 0x1E068 'cyrl/iUkrainian'
 			list 0x1E069 'cyrl/dze'
 			list 0x1E06A 'cyrl/dzhe'
 
@@ -583,7 +583,7 @@ glyph-block Autobuild-Transformed : begin
 			list 0x2DE0 'cyrl/be'
 			list 0x2DFA 'cyrl/yat'
 			list 0xA676 'cyrl/yi'
-			list 0x1E08F 'cyrl/Ukrainiani'
+			list 0x1E08F 'cyrl/iUkrainian'
 
 		createMedievalCombs Descender XH : list
 			list 0x1ACC 'gInsular'

--- a/packages/font-glyphs/src/letter/latin/lower-il.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-il.ptl
@@ -300,7 +300,7 @@ glyph-block Letter-Latin-Lower-I : begin
 		select-variant 'dotlessi' 0x131
 		link-reduced-variant 'dotlessi/sansSerif' 'dotlessi' MathSansSerif
 		select-variant 'dotlessi/compLigRight' (shapeFrom -- 'dotlessi')
-		select-variant 'dotlessi/italic' (shapeFrom -- 'dotlessi')
+		select-variant 'dotlessi/tailed' (shapeFrom -- 'dotlessi')
 		select-variant 'dotlessiRetroflexHook' (follow -- 'dotlessi')
 		CreateOgonekComposition 'iOgonek.dotless' null 'dotlessi'
 
@@ -315,16 +315,16 @@ glyph-block Letter-Latin-Lower-I : begin
 		select-variant 'grek/iota' 0x3B9 (shapeFrom -- 'dotlessi')
 		link-reduced-variant 'grek/iota/sansSerif' 'grek/iota' MathSansSerif (shapeFrom -- 'dotlessi')
 
-		select-variant 'latn/iota' 0x269 (shapeFrom -- 'dotlessi') (follow -- 'grek/iota/tailed')
+		select-variant 'latn/iota' 0x269 (shapeFrom -- 'dotlessi')
 		alias 'cyrl/iota' 0xA647 'latn/iota'
 
-		select-variant 'latn/Iota' 0x196 (follow -- 'grek/iota/tailed')
+		select-variant 'latn/Iota' 0x196 (follow -- 'latn/iota')
 		alias 'cyrl/Iota' 0xA646 'latn/Iota'
 
 		turned 'turni' 0x1D09 'i' HalfAdvance (XH / 2) [TurnMarks 'p']
 
-		CreateAccentedComposition      'cyrl/ghe.SRB' null 'dotlessi/italic'   'macronAbove'
-		CreateMultiAccentedComposition 'cyrl/gje.SRB' null 'dotlessi/italic' { 'macronAbove' 'acuteAbove' }
+		CreateAccentedComposition      'cyrl/ghe.SRB' null 'dotlessi/tailed'   'macronAbove'
+		CreateMultiAccentedComposition 'cyrl/gje.SRB' null 'dotlessi/tailed' { 'macronAbove' 'acuteAbove' }
 		CreateAccentedComposition 'dotlessiBarOver' null 'dotlessi' 'barOver'
 		CreateAccentedComposition 'iBarOver' 0x268 'dotlessiBarOver' 'dotAbove'
 		CreateAccentedComposition 'iOgonek' 0x12F 'iOgonek.dotless' 'dotAbove'

--- a/packages/font-glyphs/src/letter/latin/lower-il.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-il.ptl
@@ -300,29 +300,31 @@ glyph-block Letter-Latin-Lower-I : begin
 		select-variant 'dotlessi' 0x131
 		link-reduced-variant 'dotlessi/sansSerif' 'dotlessi' MathSansSerif
 		select-variant 'dotlessi/compLigRight' (shapeFrom -- 'dotlessi')
-		select-variant 'dotlessi/ital' (shapeFrom -- 'dotlessi')
+		select-variant 'dotlessi/italic' (shapeFrom -- 'dotlessi')
 		select-variant 'dotlessiRetroflexHook' (follow -- 'dotlessi')
 		CreateOgonekComposition 'iOgonek.dotless' null 'dotlessi'
 
 		CreateAccentedComposition 'i' 'i' 'dotlessi' 'dotAbove'
 		CreateAccentedComposition 'i/sansSerif' null 'dotlessi/sansSerif' 'dotAbove'
-		CreateAccentedComposition 'cyrl/Ukrainiani' 0x456 'dotlessi' 'dotAbove'
-		CreateAccentedComposition 'cyrl/yi' 0x457 'dotlessi' 'dieresisAbove'
 		CreateAccentedComposition 'i/compLigRight' null 'dotlessi/compLigRight' 'dotAbove'
 		link-reduced-variant 'i/sansSerif' 'i' MathSansSerif
 
+		alias 'cyrl/iUkrainian' 0x456 'i'
+		CreateAccentedComposition 'cyrl/yi' 0x457 'dotlessi' 'dieresisAbove'
+
 		select-variant 'grek/iota' 0x3B9 (shapeFrom -- 'dotlessi')
 		link-reduced-variant 'grek/iota/sansSerif' 'grek/iota' MathSansSerif (shapeFrom -- 'dotlessi')
-		alias 'latn/iota' 0x269 'grek/iota'
-		alias 'cyrl/iota' 0xA647 'grek/iota'
 
-		select-variant 'latn/Iota' 0x196 (follow -- 'grek/iota')
+		select-variant 'latn/iota' 0x269 (shapeFrom -- 'dotlessi') (follow -- 'grek/iota/tailed')
+		alias 'cyrl/iota' 0xA647 'latn/iota'
+
+		select-variant 'latn/Iota' 0x196 (follow -- 'grek/iota/tailed')
 		alias 'cyrl/Iota' 0xA646 'latn/Iota'
 
 		turned 'turni' 0x1D09 'i' HalfAdvance (XH / 2) [TurnMarks 'p']
 
-		CreateAccentedComposition      'cyrl/ghe.SRB' null 'dotlessi/ital'   'macronAbove'
-		CreateMultiAccentedComposition 'cyrl/gje.SRB' null 'dotlessi/ital' { 'macronAbove' 'acuteAbove' }
+		CreateAccentedComposition      'cyrl/ghe.SRB' null 'dotlessi/italic'   'macronAbove'
+		CreateMultiAccentedComposition 'cyrl/gje.SRB' null 'dotlessi/italic' { 'macronAbove' 'acuteAbove' }
 		CreateAccentedComposition 'dotlessiBarOver' null 'dotlessi' 'barOver'
 		CreateAccentedComposition 'iBarOver' 0x268 'dotlessiBarOver' 'dotAbove'
 		CreateAccentedComposition 'iOgonek' 0x12F 'iOgonek.dotless' 'dotAbove'

--- a/packages/font-glyphs/src/letter/latin/upper-i.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-i.ptl
@@ -53,7 +53,7 @@ glyph-block Letter-Latin-Upper-I : begin
 	link-reduced-variant 'I/sansSerif' 'I' MathSansSerif
 	select-variant 'grek/Iota' 0x399 (follow -- 'I')
 	link-reduced-variant 'grek/Iota/sansSerif' 'grek/Iota' MathSansSerif (follow -- 'I/sansSerif')
-	alias 'cyrl/UkrainianI' 0x406 'I'
+	alias 'cyrl/IUkrainian' 0x406 'I'
 	CreateAccentedComposition 'cyrl/Yi' 0x407 'I' 'dieresisAbove'
 	alias 'cyrl/Palochka' 0x4C0 'I'
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2328,7 +2328,7 @@ description = "Serifed `i`"
 selector.dotlessi = "serifed"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "serifed"
-selector."dotlessi/italic" = "serifedFlatTailed"
+selector."dotlessi/tailed" = "serifedFlatTailed"
 
 [prime.i.variants.serifless]
 rank = 2
@@ -2337,7 +2337,7 @@ description = "`i` like a straight line"
 selector.dotlessi = "serifless"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "hooky"
-selector."dotlessi/italic" = "flatTailed"
+selector."dotlessi/tailed" = "flatTailed"
 
 [prime.i.variants.hooky]
 rank = 3
@@ -2346,7 +2346,7 @@ description = "Hooky `i`"
 selector.dotlessi = "hooky"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "hooky"
-selector."dotlessi/italic" = "serifedFlatTailed"
+selector."dotlessi/tailed" = "serifedFlatTailed"
 
 [prime.i.variants.hooky-bottom]
 rank = 4
@@ -2355,7 +2355,7 @@ description = "`i` with a sharp-turning horizontal tail"
 selector.dotlessi = "hookyBottom"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "zshaped"
-selector."dotlessi/italic" = "flatTailed"
+selector."dotlessi/tailed" = "flatTailed"
 
 [prime.i.variants.zshaped]
 rank = 5
@@ -2364,7 +2364,7 @@ description = "Z-shaped `i`"
 selector.dotlessi = "zshaped"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "zshaped"
-selector."dotlessi/italic" = "serifedFlatTailed"
+selector."dotlessi/tailed" = "serifedFlatTailed"
 
 [prime.i.variants.serifed-asymmetric]
 rank = 6
@@ -2373,7 +2373,7 @@ description = "`i` with shorter top serif and full bottom serif"
 selector.dotlessi = "serifedAsymmetric"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "serifed"
-selector."dotlessi/italic" = "serifedFlatTailed"
+selector."dotlessi/tailed" = "serifedFlatTailed"
 
 [prime.i.variants.tailed]
 rank = 7
@@ -2382,7 +2382,7 @@ description = "`i` with curly tail"
 selector.dotlessi = "tailed"
 selector."dotlessi/sansSerif" = "tailed"
 selector."dotlessi/compLigRight" = "tailedSerifed"
-selector."dotlessi/italic" = "tailed"
+selector."dotlessi/tailed" = "tailed"
 
 [prime.i.variants.tailed-serifed]
 rank = 8
@@ -2391,7 +2391,7 @@ description = "`i` with top serif and curly tail"
 selector.dotlessi = "tailedSerifed"
 selector."dotlessi/sansSerif" = "tailed"
 selector."dotlessi/compLigRight" = "tailedSerifed"
-selector."dotlessi/italic" = "tailedSerifed"
+selector."dotlessi/tailed" = "tailedSerifed"
 
 [prime.i.variants.flat-tailed]
 rank = 9
@@ -2400,7 +2400,7 @@ description = "`i` with curly-then-flat tail"
 selector.dotlessi = "flatTailed"
 selector."dotlessi/sansSerif" = "flatTailed"
 selector."dotlessi/compLigRight" = "serifedFlatTailed"
-selector."dotlessi/italic" = "flatTailed"
+selector."dotlessi/tailed" = "flatTailed"
 
 [prime.i.variants.serifed-flat-tailed]
 rank = 10
@@ -2409,7 +2409,7 @@ description = "`i` with top serif and curly-then-flat tail"
 selector.dotlessi = "serifedFlatTailed"
 selector."dotlessi/sansSerif" = "flatTailed"
 selector."dotlessi/compLigRight" = "serifedFlatTailed"
-selector."dotlessi/italic" = "serifedFlatTailed"
+selector."dotlessi/tailed" = "serifedFlatTailed"
 
 [prime.i.variants.diagonal-tailed]
 rank = 11
@@ -2418,7 +2418,7 @@ description = "`i` with diagonal tail"
 selector.dotlessi = "diagonalTailed"
 selector."dotlessi/sansSerif" = "diagonalTailed"
 selector."dotlessi/compLigRight" = "serifedDiagonalTailed"
-selector."dotlessi/italic" = "diagonalTailed"
+selector."dotlessi/tailed" = "diagonalTailed"
 
 [prime.i.variants.serifed-diagonal-tailed]
 rank = 12
@@ -2427,7 +2427,7 @@ description = "`i` with top serif and diagonal tail"
 selector.dotlessi = "serifedDiagonalTailed"
 selector."dotlessi/sansSerif" = "diagonalTailed"
 selector."dotlessi/compLigRight" = "serifedDiagonalTailed"
-selector."dotlessi/italic" = "serifedDiagonalTailed"
+selector."dotlessi/tailed" = "serifedDiagonalTailed"
 
 [prime.i.variants.semi-tailed]
 rank = 13
@@ -2436,7 +2436,7 @@ description = "`i` with slightly curly tail"
 selector.dotlessi = "semiTailed"
 selector."dotlessi/sansSerif" = "semiTailed"
 selector."dotlessi/compLigRight" = "serifedSemiTailed"
-selector."dotlessi/italic" = "semiTailed"
+selector."dotlessi/tailed" = "semiTailed"
 
 [prime.i.variants.serifed-semi-tailed]
 rank = 14
@@ -2445,7 +2445,7 @@ description = "`i` with top serif and slightly curly tail"
 selector.dotlessi = "serifedSemiTailed"
 selector."dotlessi/sansSerif" = "semiTailed"
 selector."dotlessi/compLigRight" = "serifedSemiTailed"
-selector."dotlessi/italic" = "serifedSemiTailed"
+selector."dotlessi/tailed" = "serifedSemiTailed"
 
 
 
@@ -4772,84 +4772,84 @@ rank = 1
 description = "Greek lower Iota (`ι`) like a straight line"
 selector."grek/iota" = "serifless"
 selector."grek/iota/sansSerif" = "serifless"
-selector."grek/iota/tailed" = "flatTailed"
+selector."latn/iota" = "flatTailed"
 
 [prime.lower-iota.variants.tailless-serifed]
 rank = 2
 description = "Greek lower Iota (`ι`) like a straight line with top serif"
 selector."grek/iota" = "hooky"
 selector."grek/iota/sansSerif" = "serifless"
-selector."grek/iota/tailed" = "serifedFlatTailed"
+selector."latn/iota" = "serifedFlatTailed"
 
 [prime.lower-iota.variants.hooky-bottom]
 rank = 3
 description = "Greek lower Iota (`ι`) with a sharp-turning horizontal tail"
 selector."grek/iota" = "hookyBottom"
 selector."grek/iota/sansSerif" = "serifless"
-selector."grek/iota/tailed" = "flatTailed"
+selector."latn/iota" = "flatTailed"
 
 [prime.lower-iota.variants.zshaped]
 rank = 4
 description = "Z-shaped Greek lower Iota (`ι`)"
 selector."grek/iota" = "zshaped"
 selector."grek/iota/sansSerif" = "serifless"
-selector."grek/iota/tailed" = "serifedFlatTailed"
+selector."latn/iota" = "serifedFlatTailed"
 
 [prime.lower-iota.variants.tailed]
 rank = 5
 description = "Greek lower Iota (`ι`) with curly tail"
 selector."grek/iota" = "tailed"
 selector."grek/iota/sansSerif" = "tailed"
-selector."grek/iota/tailed" = "tailed"
+selector."latn/iota" = "tailed"
 
 [prime.lower-iota.variants.tailed-serifed]
 rank = 6
 description = "Greek lower Iota (`ι`) with top serif and curly tail"
 selector."grek/iota" = "tailedSerifed"
 selector."grek/iota/sansSerif" = "tailed"
-selector."grek/iota/tailed" = "tailedSerifed"
+selector."latn/iota" = "tailedSerifed"
 
 [prime.lower-iota.variants.flat-tailed]
 rank = 7
 description = "Greek lower Iota (`ι`) with a curly-then-flat tail"
 selector."grek/iota" = "flatTailed"
 selector."grek/iota/sansSerif" = "flatTailed"
-selector."grek/iota/tailed" = "flatTailed"
+selector."latn/iota" = "flatTailed"
 
 [prime.lower-iota.variants.serifed-flat-tailed]
 rank = 8
 description = "Greek lower Iota (`ι`) with top serif and a curly-then-flat tail"
 selector."grek/iota" = "serifedFlatTailed"
 selector."grek/iota/sansSerif" = "flatTailed"
-selector."grek/iota/tailed" = "serifedFlatTailed"
+selector."latn/iota" = "serifedFlatTailed"
 
 [prime.lower-iota.variants.diagonal-tailed]
 rank = 9
 description = "Greek lower Iota (`ι`) with a diagonal tail"
 selector."grek/iota" = "diagonalTailed"
 selector."grek/iota/sansSerif" = "diagonalTailed"
-selector."grek/iota/tailed" = "diagonalTailed"
+selector."latn/iota" = "diagonalTailed"
 
 [prime.lower-iota.variants.serifed-diagonal-tailed]
 rank = 10
 description = "Greek lower Iota (`ι`) with top serif and a diagonal tail"
 selector."grek/iota" = "serifedDiagonalTailed"
 selector."grek/iota/sansSerif" = "diagonalTailed"
-selector."grek/iota/tailed" = "serifedDiagonalTailed"
+selector."latn/iota" = "serifedDiagonalTailed"
 
 [prime.lower-iota.variants.semi-tailed]
 rank = 11
 description = "Greek lower Iota (`ι`) with a slightly curly tail"
 selector."grek/iota" = "semiTailed"
 selector."grek/iota/sansSerif" = "semiTailed"
-selector."grek/iota/tailed" = "semiTailed"
+selector."latn/iota" = "semiTailed"
 
 [prime.lower-iota.variants.serifed-semi-tailed]
 rank = 12
 description = "Greek lower Iota (`ι`) with top serif and a slightly curly tail"
 selector."grek/iota" = "serifedSemiTailed"
 selector."grek/iota/sansSerif" = "semiTailed"
-selector."grek/iota/tailed" = "serifedSemiTailed"
+selector."latn/iota" = "serifedSemiTailed"
 
 
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2328,7 +2328,7 @@ description = "Serifed `i`"
 selector.dotlessi = "serifed"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "serifed"
-selector."dotlessi/ital" = "tailedSerifed"
+selector."dotlessi/italic" = "serifedFlatTailed"
 
 [prime.i.variants.serifless]
 rank = 2
@@ -2337,7 +2337,7 @@ description = "`i` like a straight line"
 selector.dotlessi = "serifless"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "hooky"
-selector."dotlessi/ital" = "tailed"
+selector."dotlessi/italic" = "flatTailed"
 
 [prime.i.variants.hooky]
 rank = 3
@@ -2346,7 +2346,7 @@ description = "Hooky `i`"
 selector.dotlessi = "hooky"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "hooky"
-selector."dotlessi/ital" = "tailedSerifed"
+selector."dotlessi/italic" = "serifedFlatTailed"
 
 [prime.i.variants.hooky-bottom]
 rank = 4
@@ -2355,7 +2355,7 @@ description = "`i` with a sharp-turning horizontal tail"
 selector.dotlessi = "hookyBottom"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "zshaped"
-selector."dotlessi/ital" = "tailed"
+selector."dotlessi/italic" = "flatTailed"
 
 [prime.i.variants.zshaped]
 rank = 5
@@ -2364,7 +2364,7 @@ description = "Z-shaped `i`"
 selector.dotlessi = "zshaped"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "zshaped"
-selector."dotlessi/ital" = "tailedSerifed"
+selector."dotlessi/italic" = "serifedFlatTailed"
 
 [prime.i.variants.serifed-asymmetric]
 rank = 6
@@ -2373,7 +2373,7 @@ description = "`i` with shorter top serif and full bottom serif"
 selector.dotlessi = "serifedAsymmetric"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "serifed"
-selector."dotlessi/ital" = "tailedSerifed"
+selector."dotlessi/italic" = "serifedFlatTailed"
 
 [prime.i.variants.tailed]
 rank = 7
@@ -2382,7 +2382,7 @@ description = "`i` with curly tail"
 selector.dotlessi = "tailed"
 selector."dotlessi/sansSerif" = "tailed"
 selector."dotlessi/compLigRight" = "tailedSerifed"
-selector."dotlessi/ital" = "tailed"
+selector."dotlessi/italic" = "tailed"
 
 [prime.i.variants.tailed-serifed]
 rank = 8
@@ -2391,7 +2391,7 @@ description = "`i` with top serif and curly tail"
 selector.dotlessi = "tailedSerifed"
 selector."dotlessi/sansSerif" = "tailed"
 selector."dotlessi/compLigRight" = "tailedSerifed"
-selector."dotlessi/ital" = "tailedSerifed"
+selector."dotlessi/italic" = "tailedSerifed"
 
 [prime.i.variants.flat-tailed]
 rank = 9
@@ -2400,7 +2400,7 @@ description = "`i` with curly-then-flat tail"
 selector.dotlessi = "flatTailed"
 selector."dotlessi/sansSerif" = "flatTailed"
 selector."dotlessi/compLigRight" = "serifedFlatTailed"
-selector."dotlessi/ital" = "flatTailed"
+selector."dotlessi/italic" = "flatTailed"
 
 [prime.i.variants.serifed-flat-tailed]
 rank = 10
@@ -2409,7 +2409,7 @@ description = "`i` with top serif and curly-then-flat tail"
 selector.dotlessi = "serifedFlatTailed"
 selector."dotlessi/sansSerif" = "flatTailed"
 selector."dotlessi/compLigRight" = "serifedFlatTailed"
-selector."dotlessi/ital" = "serifedFlatTailed"
+selector."dotlessi/italic" = "serifedFlatTailed"
 
 [prime.i.variants.diagonal-tailed]
 rank = 11
@@ -2418,7 +2418,7 @@ description = "`i` with diagonal tail"
 selector.dotlessi = "diagonalTailed"
 selector."dotlessi/sansSerif" = "diagonalTailed"
 selector."dotlessi/compLigRight" = "serifedDiagonalTailed"
-selector."dotlessi/ital" = "diagonalTailed"
+selector."dotlessi/italic" = "diagonalTailed"
 
 [prime.i.variants.serifed-diagonal-tailed]
 rank = 12
@@ -2427,7 +2427,7 @@ description = "`i` with top serif and diagonal tail"
 selector.dotlessi = "serifedDiagonalTailed"
 selector."dotlessi/sansSerif" = "diagonalTailed"
 selector."dotlessi/compLigRight" = "serifedDiagonalTailed"
-selector."dotlessi/ital" = "serifedDiagonalTailed"
+selector."dotlessi/italic" = "serifedDiagonalTailed"
 
 [prime.i.variants.semi-tailed]
 rank = 13
@@ -2436,7 +2436,7 @@ description = "`i` with slightly curly tail"
 selector.dotlessi = "semiTailed"
 selector."dotlessi/sansSerif" = "semiTailed"
 selector."dotlessi/compLigRight" = "serifedSemiTailed"
-selector."dotlessi/ital" = "semiTailed"
+selector."dotlessi/italic" = "semiTailed"
 
 [prime.i.variants.serifed-semi-tailed]
 rank = 14
@@ -2445,7 +2445,7 @@ description = "`i` with top serif and slightly curly tail"
 selector.dotlessi = "serifedSemiTailed"
 selector."dotlessi/sansSerif" = "semiTailed"
 selector."dotlessi/compLigRight" = "serifedSemiTailed"
-selector."dotlessi/ital" = "serifedSemiTailed"
+selector."dotlessi/italic" = "serifedSemiTailed"
 
 
 
@@ -4772,72 +4772,84 @@ rank = 1
 description = "Greek lower Iota (`ι`) like a straight line"
 selector."grek/iota" = "serifless"
 selector."grek/iota/sansSerif" = "serifless"
+selector."grek/iota/tailed" = "flatTailed"
 
 [prime.lower-iota.variants.tailless-serifed]
 rank = 2
 description = "Greek lower Iota (`ι`) like a straight line with top serif"
 selector."grek/iota" = "hooky"
 selector."grek/iota/sansSerif" = "serifless"
+selector."grek/iota/tailed" = "serifedFlatTailed"
 
 [prime.lower-iota.variants.hooky-bottom]
 rank = 3
 description = "Greek lower Iota (`ι`) with a sharp-turning horizontal tail"
 selector."grek/iota" = "hookyBottom"
 selector."grek/iota/sansSerif" = "serifless"
+selector."grek/iota/tailed" = "flatTailed"
 
 [prime.lower-iota.variants.zshaped]
 rank = 4
 description = "Z-shaped Greek lower Iota (`ι`)"
 selector."grek/iota" = "zshaped"
 selector."grek/iota/sansSerif" = "serifless"
+selector."grek/iota/tailed" = "serifedFlatTailed"
 
 [prime.lower-iota.variants.tailed]
 rank = 5
 description = "Greek lower Iota (`ι`) with curly tail"
 selector."grek/iota" = "tailed"
 selector."grek/iota/sansSerif" = "tailed"
+selector."grek/iota/tailed" = "tailed"
 
 [prime.lower-iota.variants.tailed-serifed]
 rank = 6
 description = "Greek lower Iota (`ι`) with top serif and curly tail"
 selector."grek/iota" = "tailedSerifed"
 selector."grek/iota/sansSerif" = "tailed"
+selector."grek/iota/tailed" = "tailedSerifed"
 
 [prime.lower-iota.variants.flat-tailed]
 rank = 7
 description = "Greek lower Iota (`ι`) with a curly-then-flat tail"
 selector."grek/iota" = "flatTailed"
 selector."grek/iota/sansSerif" = "flatTailed"
+selector."grek/iota/tailed" = "flatTailed"
 
 [prime.lower-iota.variants.serifed-flat-tailed]
 rank = 8
 description = "Greek lower Iota (`ι`) with top serif and a curly-then-flat tail"
 selector."grek/iota" = "serifedFlatTailed"
 selector."grek/iota/sansSerif" = "flatTailed"
+selector."grek/iota/tailed" = "serifedFlatTailed"
 
 [prime.lower-iota.variants.diagonal-tailed]
 rank = 9
 description = "Greek lower Iota (`ι`) with a diagonal tail"
 selector."grek/iota" = "diagonalTailed"
 selector."grek/iota/sansSerif" = "diagonalTailed"
+selector."grek/iota/tailed" = "diagonalTailed"
 
 [prime.lower-iota.variants.serifed-diagonal-tailed]
 rank = 10
 description = "Greek lower Iota (`ι`) with top serif and a diagonal tail"
 selector."grek/iota" = "serifedDiagonalTailed"
 selector."grek/iota/sansSerif" = "diagonalTailed"
+selector."grek/iota/tailed" = "serifedDiagonalTailed"
 
 [prime.lower-iota.variants.semi-tailed]
 rank = 11
 description = "Greek lower Iota (`ι`) with a slightly curly tail"
 selector."grek/iota" = "semiTailed"
 selector."grek/iota/sansSerif" = "semiTailed"
+selector."grek/iota/tailed" = "semiTailed"
 
 [prime.lower-iota.variants.serifed-semi-tailed]
 rank = 12
 description = "Greek lower Iota (`ι`) with top serif and a slightly curly tail"
 selector."grek/iota" = "serifedSemiTailed"
 selector."grek/iota/sansSerif" = "semiTailed"
+selector."grek/iota/tailed" = "serifedSemiTailed"
 
 
 


### PR DESCRIPTION
All Iota variants:
`ιƖɩꙆꙇ`
![image](https://github.com/be5invis/Iosevka/assets/37010132/630ac19c-8258-4ddc-86aa-993b3322c111)
All Tau variants:
`τꚌꚍ`
![image](https://github.com/be5invis/Iosevka/assets/37010132/b16febc5-4f36-43a8-ac43-981af51d6eb0)
Additionally, for consistency, italic Serbian Cyrillic ghe defaults to flat-tailed when `i` is tailless.
All `i` variants:
`iг`
![image](https://github.com/be5invis/Iosevka/assets/37010132/ea0c769e-3afd-4f21-80d0-6e15788c5f8d)
