### PR TITLE
Further leaning mark fixes.

### DIFF
--- a/changes/28.0.5.md
+++ b/changes/28.0.5.md
@@ -1,0 +1,3 @@
+* Fix leaning marks of Turned/Reversed Sans-Serif Capital L.
+* Fix leaning marks of Cyrillic Tall Te.
+* Fix leaning marks of Greek Lower Mu/Rho.

--- a/packages/font-glyphs/src/auto-build/transformed.ptl
+++ b/packages/font-glyphs/src/auto-build/transformed.ptl
@@ -332,7 +332,7 @@ glyph-block Autobuild-Transformed : begin
 			list 0x1E050 'cyrl/palochka'
 			list 0x1E06B 'cyrl/the'
 			list 0x1E06C 'cyrl/yeryBack'
-			list 0x1E06D 'cyrl/KazakhShortu'
+			list 0x1E06D 'cyrl/uShortKazakh'
 			list null   'S' # there is no superscript S in unicode, but is is used for the SM symbol
 
 		createSuperscripts 'numerator' NumeratorForm : list
@@ -667,6 +667,7 @@ glyph-block Autobuild-Transformed : begin
 
 	do
 		createReversed : list
+			list 0x2143  'L.serifless'
 			list 0xA7FB  'F'
 			list 0xA7FC  'P'
 			list 0xA7FD  'turnM'

--- a/packages/font-glyphs/src/letter/cyrillic/tse.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/tse.ptl
@@ -84,29 +84,3 @@ glyph-block Letter-Cyrillic-Tse : begin
 
 	select-variant 'cyrl/TeTse' 0x4B4 (follow -- 'T')
 	select-variant 'cyrl/tetse.upright' (follow -- 'T')
-
-	define ItalicVariants {
-		'toothedSerifless'
-		'toothedMotionSerifed'
-		'toothedBottomRightSerifed'
-		'toothedSerifed'
-		'tailedSerifless'
-		'tailedMotionSerifed'
-		'tailedSerifed'
-	}
-
-	foreach suffix [items-of ItalicVariants] : do
-		create-glyph "cyrl/tse.italic.\(suffix)" : glyph-proc
-			include [refer-glyph "u.\(suffix)"] AS_BASE
-			eject-contour 'serifRB'
-			include : CyrDescender.rSideJut RightSB 0
-
-		create-glyph "cyrl/tetse.italic.\(suffix)" : glyph-proc
-			include [refer-glyph "u.\(suffix)"] AS_BASE ALSO_METRICS
-			include [refer-glyph "tildeAbove"]
-			eject-contour 'serifRB'
-			include : CyrDescender.rSideJut RightSB 0
-
-	select-variant 'cyrl/tse.italic'
-	select-variant 'cyrl/tetse.italic' (follow -- 'cyrl/tse.italic')
-	alias 'cyrl/tse.BGR' null 'cyrl/tse.italic'

--- a/packages/font-glyphs/src/letter/greek.ptl
+++ b/packages/font-glyphs/src/letter/greek.ptl
@@ -20,7 +20,7 @@ export : define [apply] : begin
 	run-glyph-module "./greek/lower-kappa-symbol.mjs"
 	run-glyph-module "./greek/lower-nu.mjs"
 	run-glyph-module "./greek/lower-xi.mjs"
-	run-glyph-module "./greek/lower-rho.mjs"
+	run-glyph-module "./greek/lower-rho-symbol.mjs"
 	run-glyph-module "./greek/lower-sigma.mjs"
 	run-glyph-module "./greek/lower-sigma-final.mjs"
 	run-glyph-module "./greek/lower-upsilon.mjs"

--- a/packages/font-glyphs/src/letter/greek/lower-rho-symbol.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-rho-symbol.ptl
@@ -5,15 +5,10 @@ import [DesignParameters] from "../../meta/aesthetics.mjs"
 
 glyph-module
 
-glyph-block Letter-Greek-Lower-Rho : begin
+glyph-block Letter-Greek-Lower-Rho-Symbol : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : OBarRight LetterBarOverlay
-
-	create-glyph 'grek/rho' 0x3C1 : glyph-proc
-		include : MarkSet.p
-		include : tagged 'bowl' : OBarRight.rounded (yTerminal -- CAP)
-		include : FlipAround Middle (XH / 2)
+	glyph-block-import Letter-Shared-Shapes : OBarRight
 
 	create-glyph 'grek/rhoSymbol' 0x3F1 : glyph-proc
 		include : MarkSet.p
@@ -27,6 +22,3 @@ glyph-block Letter-Greek-Lower-Rho : begin
 			g4 (Middle + CorrectionOMidS) (Descender + O)
 			g4 ([mix SB RightSB 0.75] + CorrectionOMidS) (Descender - 0.5 * O) [heading Rightward]
 			g4 (RightSB + CorrectionOMidS) (Descender + 0.5 * O) [heading Rightward]
-
-	create-glyph 'grek/rhoBar/overlay' : LetterBarOverlay.l.in SB Descender 0
-	derive-composites 'grek/rhoBar' 0x3FC 'grek/rho' 'grek/rhoBar/overlay'

--- a/packages/font-glyphs/src/letter/latin/lower-p.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-p.ptl
@@ -120,6 +120,11 @@ glyph-block Letter-Latin-Lower-P : begin
 	select-variant 'cyrl/er' 0x440 (shapeFrom -- 'p')
 	select-variant 'pPalatalHook' 0x1D88 (follow -- 'p')
 
+	alias 'grek/rho' 0x3C1 'p.earlessRoundedSerifless'
+
+	create-glyph 'grek/rhoBar/overlay' : LetterBarOverlay.l.in SB Descender 0
+	derive-composites 'grek/rhoBar' 0x3FC 'grek/rho' 'grek/rhoBar/overlay'
+
 	CreateAccentedComposition 'pStroke' 0x1D7D 'p' 'hStrike'
 	select-variant 'pStrokeBot' 0xA751 (follow -- 'p')
 

--- a/packages/font-glyphs/src/letter/latin/lower-p.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-p.ptl
@@ -122,11 +122,10 @@ glyph-block Letter-Latin-Lower-P : begin
 
 	alias 'grek/rho' 0x3C1 'p.earlessRoundedSerifless'
 
-	create-glyph 'grek/rhoBar/overlay' : LetterBarOverlay.l.in SB Descender 0
-	derive-composites 'grek/rhoBar' 0x3FC 'grek/rho' 'grek/rhoBar/overlay'
-
 	CreateAccentedComposition 'pStroke' 0x1D7D 'p' 'hStrike'
 	select-variant 'pStrokeBot' 0xA751 (follow -- 'p')
+
+	alias 'grek/rhoStroke' 0x3FC 'pStrokeBot.earlessRoundedSerifless'
 
 	select-variant 'thorn' 0xFE
 	alias 'grek/sho' 0x3F8 'thorn.earedSerifless'

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -9,10 +9,11 @@ glyph-block Letter-Latin-U : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Shared-Metrics : markHalfStroke
+	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared : CreateAccentedComposition CreateOgonekComposition
 	glyph-block-import Letter-Shared : SetGrekUpperTonos
 	glyph-block-import Letter-Shared-Shapes : nShoulder RightwardTailedBar DToothlessRise SerifFrame
-	glyph-block-import Letter-Shared-Shapes : CyrTailDescender RetroflexHook VerticalHook
+	glyph-block-import Letter-Shared-Shapes : CyrDescender CyrTailDescender RetroflexHook VerticalHook
 
 	glyph-block-export UShape USerifs
 
@@ -219,6 +220,20 @@ glyph-block Letter-Latin-U : begin
 				curl SB (Descender / 2) [heading Upward]
 				straight.up.end SB SmallArchDepthB [widths.heading 0 [AdviceStroke 4] Upward]
 			include : Slabs df XH
+			include : LeaningAnchor.Below.VBar.l SB
+			set-base-anchor 'overlayOnExtension' (SB + [HSwToV : 0.5 * Stroke]) [mix 0 Descender 0.5]
+			set-base-anchor 'strike' Middle (XH / 2)
+
+		create-glyph "cyrl/tse.italic.\(suffix)" : glyph-proc
+			include [refer-glyph "u.\(suffix)"] AS_BASE
+			eject-contour 'serifRB'
+			include : CyrDescender.rSideJut RightSB 0
+
+		create-glyph "cyrl/tetse.italic.\(suffix)" : glyph-proc
+			include [refer-glyph "u.\(suffix)"] AS_BASE ALSO_METRICS
+			include [refer-glyph "tildeAbove"]
+			eject-contour 'serifRB'
+			include : CyrDescender.rSideJut RightSB 0
 
 		create-glyph "uHookLeft.\(suffix)" : glyph-proc
 			local df : DivFrame 1
@@ -261,6 +276,11 @@ glyph-block Letter-Latin-U : begin
 	select-variant 'cyrl/i.italic' (shapeFrom -- 'u')
 	select-variant 'cyrl/i.italic/descBase' (shapeFrom -- 'u')
 	alias 'cyrl/i.BGR' null 'cyrl/i.italic'
+
+	select-variant 'cyrl/tse.italic'
+	select-variant 'cyrl/tetse.italic' (follow -- 'cyrl/tse.italic')
+	alias 'cyrl/tse.BGR' null 'cyrl/tse.italic'
+
 	select-variant 'uSideways' 0x1D1D (follow -- 'u')
 	select-variant 'uDieresisSidewaysBase' null (follow -- 'u')
 

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -221,8 +221,7 @@ glyph-block Letter-Latin-U : begin
 				straight.up.end SB SmallArchDepthB [widths.heading 0 [AdviceStroke 4] Upward]
 			include : Slabs df XH
 			include : LeaningAnchor.Below.VBar.l SB
-			set-base-anchor 'overlayOnExtension' (SB + [HSwToV : 0.5 * Stroke]) [mix 0 Descender 0.5]
-			set-base-anchor 'strike' Middle (XH / 2)
+			set-base-anchor 'overlay' Middle (XH / 2)
 
 		create-glyph "cyrl/tse.italic.\(suffix)" : glyph-proc
 			include [refer-glyph "u.\(suffix)"] AS_BASE

--- a/packages/font-glyphs/src/letter/latin/upper-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-g.ptl
@@ -110,8 +110,11 @@ glyph-block Letter-Latin-Upper-G : begin
 	select-variant 'G' 'G'
 	link-reduced-variant 'G/sansSerif' 'G' MathSansSerif
 	select-variant 'smcpG' 0x262 (follow -- 'G')
+
 	select-variant 'GHookTop' 0x193
 	select-variant 'smcpGHookTop' 0x29B (follow -- 'GHookTop')
+
+	CreateTurnedLetter 'turnG/sansSerif' 0x2141 'G/sansSerif' HalfAdvance (CAP / 2)
 	CreateTurnedLetter 'turnSmcpG' 0x1DF02 'smcpG' HalfAdvance (XH / 2)
 
 	derive-composites 'Gbar' 0x1E4 'G' 'GBarOverlay'

--- a/packages/font-glyphs/src/letter/latin/upper-l.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-l.ptl
@@ -73,6 +73,7 @@ glyph-block Letter-Latin-Upper-L : begin
 	select-variant 'LHighBar' 0xA748 (follow -- 'L')
 
 	CreateTurnedLetter 'turnL' 0xA780 'L' HalfAdvance (CAP / 2)
+	CreateTurnedLetter 'turnL/sansSerif' 0x2142 'L/sansSerif' HalfAdvance (CAP / 2)
 
 	create-glyph 'mathbb/L' 0x1D543 : glyph-proc
 		local df : include : DivFrame 1

--- a/packages/font-glyphs/src/letter/latin/upper-t.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-t.ptl
@@ -8,6 +8,7 @@ glyph-module
 glyph-block Letter-Latin-Upper-T : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
+	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Blackboard : BBS BBD
 	glyph-block-import Letter-Latin-Lower-M
 	glyph-block-import Letter-Shared : CreateTurnedLetter
@@ -159,6 +160,7 @@ glyph-block Letter-Latin-Upper-T : begin
 			local df : include : DivFrame 1
 			include : df.markSet.b
 			include : CyrlTallTeShape df Ascender doST doSB
+			include : LeaningAnchor.Below.VBar.r (df.width - 1.5 * df.leftSB)
 
 	select-variant 'T' 'T'
 	link-reduced-variant 'T/sansSerif' 'T' MathSansSerif

--- a/packages/font-glyphs/src/letter/latin/upper-y.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-y.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Letter-Latin-Upper-Y : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared : CreateAccentedComposition
+	glyph-block-import Letter-Shared : CreateAccentedComposition CreateTurnedLetter
 	glyph-block-import Letter-Latin-X : HalfXStrand
 	glyph-block-import Letter-Shared : SetGrekUpperTonos
 	glyph-block-import Letter-Shared-Shapes : SerifFrame WithSerifOverflowMask
@@ -137,14 +137,16 @@ glyph-block Letter-Latin-Upper-Y : begin
 	select-variant 'smcpY' 0x28F (follow -- 'Y')
 	select-variant 'YHookTop' 0x1B3 (follow -- 'Y')
 
+	CreateTurnedLetter 'turnY/sansSerif' 0x2144 'Y/sansSerif' HalfAdvance (CAP / 2)
+
 	select-variant 'grek/Upsilon' 0x3A5 (follow -- 'Y')
 	link-reduced-variant 'grek/Upsilon/sansSerif' 'grek/Upsilon' MathSansSerif (follow -- 'Y/sansSerif')
 	select-variant 'grek/UpsilonHookTop' 0x3D2
 
 	alias 'cyrl/Ue' 0x4AE 'Y'
 	select-variant 'cyrl/ue' 0x4AF
-	CreateAccentedComposition 'cyrl/KazakhShortU' 0x4B0 'cyrl/Ue' 'barOver'
-	CreateAccentedComposition 'cyrl/KazakhShortu' 0x4B1 'cyrl/ue' 'barOver'
+	CreateAccentedComposition 'cyrl/UShortKazakh' 0x4B0 'cyrl/Ue' 'barOver'
+	CreateAccentedComposition 'cyrl/uShortKazakh' 0x4B1 'cyrl/ue' 'barOver'
 
 	create-glyph 'YStrokeOverlay' : HOverlayBar ([mix 0 SB 0.5]) ([mix Width RightSB 0.5]) [mix 0 CAP 0.75]
 	derive-composites 'YStroke' 0x24E 'Y' 'YStrokeOverlay'

--- a/packages/font-glyphs/src/letter/latin/upper-y.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-y.ptl
@@ -148,8 +148,8 @@ glyph-block Letter-Latin-Upper-Y : begin
 	CreateAccentedComposition 'cyrl/UShortKazakh' 0x4B0 'cyrl/Ue' 'barOver'
 	CreateAccentedComposition 'cyrl/uShortKazakh' 0x4B1 'cyrl/ue' 'barOver'
 
-	create-glyph 'YStrokeOverlay' : HOverlayBar ([mix 0 SB 0.5]) ([mix Width RightSB 0.5]) [mix 0 CAP 0.75]
-	derive-composites 'YStroke' 0x24E 'Y' 'YStrokeOverlay'
+	create-glyph 'YStroke/Overlay' : HOverlayBar ([mix 0 SB 0.5]) ([mix Width RightSB 0.5]) [mix 0 CAP 0.75]
+	derive-composites 'YStroke' 0x24E 'Y' 'YStroke/Overlay'
 
 	select-variant 'currency/yenSign' 0xA5 (follow -- 'Y')
 

--- a/packages/font-glyphs/src/symbol/letter.ptl
+++ b/packages/font-glyphs/src/symbol/letter.ptl
@@ -256,11 +256,6 @@ glyph-block Symbol-Letter : begin
 		include : HSerif.rb (Middle + [HSwToV : 0.5 * sw]) 0  (LongJut / 2)
 		include : DotAt Middle (XH + AccentStackOffset) (DotRadius * sw / Stroke)
 
-	turned 'turnG/sansSerif' 0x2141 'G/sansSerif' Middle (CAP / 2)
-	turned 'turnL/sansSerif' 0x2142 'L/sansSerif' Middle (CAP / 2)
-	turned 'revL/sansSerif' 0x2143 'grek/Gamma/sansSerif' Middle (CAP / 2)
-	turned 'turnY/sansSerif' 0x2144 'Y/sansSerif' Middle (CAP / 2)
-
 	turned 'turnAmpersand' 0x214B 'ampersand' Middle (CAP / 2)
 
 	do "Tironian Et"


### PR DESCRIPTION
`µ̣ ρ̣ ᲄ̣̇ ⅂̣̇ ⅃̣̇`

Before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/dcd392d1-e158-4d58-9f44-72a806909186)
After:
![image](https://github.com/be5invis/Iosevka/assets/37010132/9a18bfed-2e63-4995-8d4b-c711178516ac)
