### PR TITLE
Add untagged variant selector for Cyrillic Capital Ef.

### DIFF
--- a/changes/28.0.5.md
+++ b/changes/28.0.5.md
@@ -1,3 +1,4 @@
+* Add untagged variant selector for Cyrillic Capital Ef (`Ф`) for style-driven variation.
 * Fix leaning marks of Turned/Reversed Sans-Serif Capital L.
 * Fix leaning marks of Cyrillic Tall Te.
 * Fix leaning marks of Greek Lower Mu/Rho.

--- a/packages/font-glyphs/src/letter/greek/upper-phi.ptl
+++ b/packages/font-glyphs/src/letter/greek/upper-phi.ptl
@@ -71,42 +71,55 @@ glyph-block Letter-Greek-Upper-Phi : begin
 	define [MtSerif df y] : tagged 'serifMT' : HSerif.lt df.middle y Jut
 	define [MbSerif df y] : tagged 'serifMB' : HSerif.mb df.middle y Jut
 
-	define [GrekCapitalPhiImpl fFlatTB df] : glyph-proc
-		local y1 : mix [if SLAB Stroke 0] [if SLAB (CAP - Stroke) CAP] 0.125
-		local y2 : mix [if SLAB Stroke 0] [if SLAB (CAP - Stroke) CAP] 0.875
-		include : VarPhiRing fFlatTB df y1 y2
-		include : StraightBar df 0 y1 y2 CAP
+	define CyrlCapitalEfConfig : SuffixCfg.weave
+		object # bowl
+			""         VarPhiRing
+			splitBowl  CyrlEfSplitRing
+		object # serifs
+			serifless  false
+			serifed    true
 
-		if SLAB : begin
-			include : tagged 'serifMT' : HSerif.mt df.middle CAP MidJutSide
-			include : tagged 'serifMB' : HSerif.mb df.middle 0 MidJutSide
+	foreach { suffix { Bowl Serifs } } [Object.entries CyrlCapitalEfConfig] : do
+		define [GrekCapitalPhiImpl fFlatTB df slab] : glyph-proc
+			local y1 : mix [if slab Stroke 0] [if slab (CAP - Stroke) CAP] 0.125
+			local y2 : mix [if slab Stroke 0] [if slab (CAP - Stroke) CAP] 0.875
+			include : Bowl fFlatTB df y1 y2
+			include : StraightBar df 0 y1 y2 CAP
 
-	create-glyph 'grek/Phi' 0x3A6 : glyph-proc
-		local df : include : DivFrame para.diversityM 3
-		include : df.markSet.capital
-		include : GrekCapitalPhiImpl 0 df
+			if slab : begin
+				include : tagged 'serifMT' : HSerif.mt df.middle CAP MidJutSide
+				include : tagged 'serifMB' : HSerif.mb df.middle 0 MidJutSide
 
-	create-glyph 'cyrl/Ef' 0x424 : glyph-proc
-		local df : include : DivFrame para.diversityM 3
-		include : df.markSet.capital
-		include : GrekCapitalPhiImpl 1 df
+		create-glyph "grek/Phi.\(suffix)" : glyph-proc
+			local df : include : DivFrame para.diversityM 3
+			include : df.markSet.capital
+			include : GrekCapitalPhiImpl 0 df Serifs
 
-	create-glyph 'cyrl/Ef.BGR' : glyph-proc
-		local df : include : DivFrame para.diversityM 3
-		include : df.markSet.capital
+		create-glyph "cyrl/Ef.\(suffix)" : glyph-proc
+			local df : include : DivFrame para.diversityM 3
+			include : df.markSet.capital
+			include : GrekCapitalPhiImpl 1 df Serifs
 
-		local top : CAP + LongJut - HalfStroke
-		local bot : 0   - LongJut + HalfStroke
+		create-glyph "cyrl/Ef.BGR.\(suffix)" : glyph-proc
+			local df : include : DivFrame para.diversityM 3
+			include : df.markSet.capital
 
-		include : ExtendAboveBaseAnchors top
-		include : ExtendBelowBaseAnchors bot
+			local top : CAP + LongJut - HalfStroke
+			local bot : 0   - LongJut + HalfStroke
 
-		include : VarPhiRing 0 df 0 CAP
-		include : StraightBar df bot 0 CAP top
+			include : ExtendAboveBaseAnchors top
+			include : ExtendBelowBaseAnchors bot
 
-		if SLAB : begin
-			include : tagged 'serifMT' : HSerif.mt df.middle top MidJutSide
-			include : tagged 'serifMB' : HSerif.mb df.middle bot MidJutSide
+			include : VarPhiRing 0 df 0 CAP
+			include : StraightBar df bot 0 CAP top
+
+			if Serifs : begin
+				include : tagged 'serifMT' : HSerif.mt df.middle top MidJutSide
+				include : tagged 'serifMB' : HSerif.mb df.middle bot MidJutSide
+
+	select-variant 'grek/Phi' 0x3A6
+	select-variant 'cyrl/Ef' 0x424
+	select-variant 'cyrl/Ef.BGR'
 
 	create-glyph 'grek/varphi' 0x3D5 : glyph-proc
 		local df : include : DivFrame para.diversityM 3
@@ -123,7 +136,7 @@ glyph-block Letter-Greek-Upper-Phi : begin
 			include : tagged 'serifMT' : HSerif.mt df.middle Ascender Jut
 			include : tagged 'serifMB' : HSerif.mb df.middle Descender Jut
 
-	define CyrlEfConfig : SuffixCfg.weave
+	define CyrlLowerEfConfig : SuffixCfg.weave
 		object # bowl
 			""                  VarPhiRing
 			splitBowl           CyrlEfSplitRing
@@ -133,7 +146,7 @@ glyph-block Letter-Greek-Upper-Phi : begin
 			serifed            { StraightBar MtSerif MbSerif }
 			cursive            { CursiveBar  nothing nothing }
 
-	foreach { suffix { Bowl { Bar sMT sMB } } } [Object.entries CyrlEfConfig] : do
+	foreach { suffix { Bowl { Bar sMT sMB } } } [Object.entries CyrlLowerEfConfig] : do
 		create-glyph "cyrl/ef.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.bp

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -5832,6 +5832,35 @@ selectorAffix."cyrl/u" = "serifed"
 
 
 
+[prime.cyrl-capital-ef]
+# No tags and sampler -- for style-driven variation
+
+[prime.cyrl-capital-ef.variants.serifless]
+rank = 1
+selector."grek/Phi"  = "serifless"
+selector."cyrl/Ef"  = "serifless"
+selector."cyrl/Ef.BGR" = "serifless"
+
+[prime.cyrl-capital-ef.variants.serifed]
+rank = 2
+selector."grek/Phi"  = "serifed"
+selector."cyrl/Ef"  = "serifed"
+selector."cyrl/Ef.BGR" = "serifed"
+
+[prime.cyrl-capital-ef.variants.split-serifless]
+rank = 3
+selector."grek/Phi"  = "serifless"
+selector."cyrl/Ef"  = "splitBowlSerifless"
+selector."cyrl/Ef.BGR" = "serifless"
+
+[prime.cyrl-capital-ef.variants.split-serifed]
+rank = 4
+selector."grek/Phi"  = "serifed"
+selector."cyrl/Ef"  = "splitBowlSerifed"
+selector."cyrl/Ef.BGR" = "serifed"
+
+
+
 [prime.cyrl-ef]
 sampler = "ф"
 samplerExplain = "Cyrillic Lower Ef"
@@ -7560,6 +7589,7 @@ cyrl-en = "serifless"
 cyrl-er = "eared-serifless"
 cyrl-capital-u = "straight-serifless"
 cyrl-u = "straight-serifless"
+cyrl-capital-ef = "serifless"
 cyrl-ef = "serifless"
 cyrl-che = "standard"
 cyrl-capital-yeri = "corner"
@@ -7699,6 +7729,7 @@ cyrl-en = "serifed"
 cyrl-er = "eared-serifed"
 cyrl-capital-u = "straight-turn-serifed"
 cyrl-u = "straight-turn-serifed"
+cyrl-capital-ef = "serifed"
 cyrl-ef = "serifed"
 cyrl-capital-ya = "straight-serifed"
 cyrl-ya = "straight-serifed"


### PR DESCRIPTION
The new selector is untagged; Existing defaults, SS's, and CV order are all unchanged.
This goes along with the variant selectors for the obscure rounded/cursive capital Yer/Yeri/Yery variants that are uncommon but technically exist.

Below are two examples of custom builds using a split-bowl Capital Cyrillic Ef under sans and slab. The first two characters are Greek Upper/Lower (Var)Phi and the second two are Cyrillic Upper/Lower Ef.

`ΦϕФф`

```
[buildPlans.IosevkaCustom]
family = "Iosevka Custom"
spacing = "normal"
serifs = "sans"
noCvSs = false
exportGlyphNames = false

[buildPlans.IosevkaCustom.variants.design]
cyrl-capital-ef = "split-serifless"
cyrl-ef = "split-serifless"
```

Sans Thin:
![image](https://github.com/be5invis/Iosevka/assets/37010132/1871b19e-6aa3-4734-a94d-aa552352efdc)
Sans Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/44799029-92eb-4cca-9821-28b680cbc7ec)
Sans Heavy:
![image](https://github.com/be5invis/Iosevka/assets/37010132/85ec4294-985e-4815-bcf7-c825d01fc5fd)

```
[buildPlans.IosevkaCustomSlab]
family = "Iosevka Custom Slab"
spacing = "normal"
serifs = "slab"
noCvSs = false
exportGlyphNames = false

[buildPlans.IosevkaCustomSlab.variants.design]
cyrl-capital-ef = "split-serifed"
cyrl-ef = "split-serifed"
```

Slab Thin:
![image](https://github.com/be5invis/Iosevka/assets/37010132/2c822bbc-861c-4914-a85d-96c7439c2f4d)
Slab Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/a2714d06-f242-41fe-b365-97c89f70eeec)
Slab Heavy:
![image](https://github.com/be5invis/Iosevka/assets/37010132/e57c8473-4e99-4b5a-b1af-e917ea50d697)

Compared to Charis SIL (it does not support the Greek characters):
`Фф`
Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/77fba925-f013-47e5-8521-816cd77b2bbe)
Bold:
![image](https://github.com/be5invis/Iosevka/assets/37010132/765e9445-db58-4cbb-8d97-535e9fa2ca04)
