### PR TITLE
Allow turnh and turnmLeg to use toothless-corner variants.

### DIFF
--- a/changes/28.0.5.md
+++ b/changes/28.0.5.md
@@ -3,6 +3,7 @@
   - SUBSET WITH DOT (`U+2ABD`).
   - SUPERSET WITH DOT (`U+2ABE`).
 * Add untagged variant selector for Cyrillic Capital Ef (`Ф`) for style-driven variation.
+* Allow turned h (`ɥ`) and turned m with long leg (`ɰ`) to use toothless-corner variants.
 * Fix leaning marks of Turned/Reversed Sans-Serif Capital L.
 * Fix leaning marks of Cyrillic Tall Te.
 * Fix leaning marks of Greek Lower Mu/Rho.

--- a/packages/font-glyphs/src/letter/latin/lower-h.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-h.ptl
@@ -30,23 +30,6 @@ glyph-block Letter-Latin-Lower-H : begin
 	define [SmallHTopLeftSerifs tailed hookTop] : glyph-proc
 		if [not hookTop] : include : tagged 'serifLT' : HSerif.lt SB Ascender SideJut
 
-	define [SmallTurnHSerifs tailed hookTop] : glyph-proc : begin
-		include : SmallTurnHLeftSerifs tailed hookTop
-		if [not tailed] : include : tagged 'serifRB' : HSerif.rb RightSB 0 SideJut
-
-	define [SmallTurnHLeftSerifs tailed hookTop] : glyph-proc : begin
-		include : SmallTurnHTopLeftSerifs tailed hookTop
-		include : tagged 'serifLB' : HSerif.rb (SB + [HSwToV HalfStroke]) 0 Jut
-
-	define [SmallTurnHMotionSerifs tailed hookTop] : glyph-proc
-		include : SmallTurnHTopLeftSerifs tailed hookTop
-		if [not tailed] : include : tagged 'serifRB' : HSerif.rb RightSB 0 SideJut
-
-	define [SmallTurnHTopLeftSerifs tailed hookTop] : glyph-proc
-		if [not hookTop] : include : tagged 'serifLT' : union
-			HSerif.lt (SB + [HSwToV HalfStroke]) Ascender Jut
-			HSerif.rt (SB + [HSwToV HalfStroke]) Ascender MidJutSide
-
 	define [HBar.mOverlay fHasTopSerif] : glyph-proc
 		local barSpaceTop : Ascender - [if fHasTopSerif Stroke 0]
 		local s : Math.min OverlayStroke (0.625 * (barSpaceTop - XH))

--- a/packages/font-glyphs/src/letter/latin/lower-h.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-h.ptl
@@ -125,7 +125,8 @@ glyph-block Letter-Latin-Lower-H : begin
 	select-variant 'heng' 0xA727
 	select-variant 'cyrl/dje' 0x452 (follow -- 'heng') (shapeFrom -- 'hengStroke')
 
-	select-variant 'cyrl/shha' 0x4BB (shapeFrom -- 'h')
+	alias 'cyrl/shha' 0x4BB 'h'
+	alias 'cyrl/tshe' 0x45B 'hStroke'
 
 	derive-composites 'hPalatalHook' 0xA795 'h/descBase' [PalatalHook.rSideJut RightSB 0]
 	derive-composites 'hDescender' 0x2C68 'h/descBase' [CyrDescender.rSideJut RightSB 0]
@@ -146,54 +147,6 @@ glyph-block Letter-Latin-Lower-H : begin
 		include : MarkSet.bp
 		set-base-anchor 'belowBraceL' ((-Middle) + shift - 0.5 * markExtend) belowMarkMid
 		set-base-anchor 'belowBraceR' ((-Middle) + shift + 0.5 * markExtend) belowMarkMid
-
-	alias 'cyrl/tshe' 0x45B 'hStroke'
-
-	define TurnHConfig : object
-		toothedSerifless     { no-shape                }
-		toothedSerifed       { SmallTurnHSerifs        }
-		toothedMotionSerifed { SmallTurnHMotionSerifs  }
-
-	foreach { suffix { Serifs } } [Object.entries TurnHConfig] : do
-		create-glyph "turnh.\(suffix)" : glyph-proc
-			include : nShoulder
-				left -- (SB + [HSwToV Stroke])
-				right -- RightSB
-				bottom -- 0
-			include : VBar.l SB 0 Ascender
-			include : Serifs false false
-			include : FlipAround Middle (XH / 2)
-			include : MarkSet.p
-			include : LeaningAnchor.Below.VBar.r RightSB
-
-		create-glyph "turnhHookLeft.\(suffix)" : glyph-proc
-			include : nShoulder
-				left -- (SB + [HSwToV Stroke])
-				right -- RightSB
-				bottom -- (TailY + HalfStroke)
-			include : VBar.l SB 0 Ascender
-			include : RetroflexHook.rExt RightSB (TailY + HalfStroke)
-			include : Serifs true false
-			include : FlipAround Middle (XH / 2)
-			include : MarkSet.p
-			include : LeaningAnchor.Below.VBar.r RightSB
-
-		if (Serifs !== SmallTurnHMotionSerifs) : begin
-			create-glyph "turnhHookLeftRTail.\(suffix)" : glyph-proc
-				include : nShoulder
-					left -- (SB + [HSwToV Stroke])
-					right -- RightSB
-					bottom -- (TailY + HalfStroke)
-				include : VBar.l SB 0 XH
-				include : RetroflexHook.rExt RightSB (TailY + HalfStroke)
-				include : Serifs true true
-				include : FlipAround Middle (XH / 2)
-				include : RetroflexHook.rExt RightSB (Descender + TailY + HalfStroke) (yAttach -- 0)
-				include : MarkSet.p
-
-	select-variant 'turnh' 0x265
-	select-variant 'turnhHookLeft' 0x2AE
-	select-variant 'turnhHookLeftRTail' 0x2AF
 
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarLeft
 	create-glyph 'mathbb/h' 0x1D559 : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/lower-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-m.ptl
@@ -315,19 +315,20 @@ glyph-block Letter-Latin-Lower-M : begin
 	select-variant 'mCrossedTail' 0xAB3A (follow -- 'meng')
 
 	define TurnMConfig : SuffixCfg.weave
-		object
-			"toothed"            { SmallMArches                        0 0 }
-			"tailed"             { SmallMArches                        0 1 }
-			"toothlessCorner"    { EarlessCornerDoubleArchSmallMShape  1 0 }
-			"toothlessRounded"   { EarlessRoundedDoubleArchSmallMShape 1 0 }
-		object
-			"serifless"          { no-shape        0 }
-			"serifed"            { FullTurnMSerifs 1 }
-			"topLeftSerifed"     { RbSerifs        0 } # The name-shaping mapping is swapped by design
-			"bottomRightSerifed" { LtSerifs        1 } # The name-shaping mapping is swapped by design
-			"motionSerifed"      { LtRbSerifs      1 }
+		object # body
+			toothed            { SmallMArches                        0 0 }
+			tailed             { SmallMArches                        0 1 }
+			toothlessCorner    { EarlessCornerDoubleArchSmallMShape  1 0 }
+			toothlessRounded   { EarlessRoundedDoubleArchSmallMShape 1 0 }
+		function [body] : object # serifs
+			serifless          { no-shape         }
+			serifed            { FullTurnMSerifs  }
+			bottomRightSerifed { LtSerifs         } # The name-shaping mapping is swapped by design
+			motionSerifed : match body
+				[Just 'toothed'] { LtRbSerifs }
+				__               { RbSerifs   } # The name-shaping mapping is swapped by design
 
-	foreach { suffix { {Body toothless tailed} {Serifs doBottomSerif} } } [pairs-of TurnMConfig] : do
+	foreach { suffix { {Body toothless tailed} {Serifs} } } [pairs-of TurnMConfig] : do
 		define [turnMShapeBody df top] : glyph-proc
 			include : Body df top 0 0 0
 			include : Serifs df top 0 0 0 0 toothless
@@ -347,14 +348,14 @@ glyph-block Letter-Latin-Lower-M : begin
 			include : df.markSet.capital
 			include : turnMShapeBody df CAP
 
-		if (!toothless && !tailed) : begin
+		if (!tailed) : begin
 			create-glyph "turnmLeg.\(suffix)" : glyph-proc
 				local df : include : DivFrame para.diversityM 3
 				include : df.markSet.p
 				include : turnMShapeBody df XH
 				eject-contour 'serifLT'
 				include : VBar.r df.rightSB Descender XH df.mvs
-				if doBottomSerif : begin
+				if (Serifs !== no-shape) : begin
 					local sf : SerifFrame.fromDf df XH Descender
 					include sf.rb.fullSide
 				include : LeaningAnchor.Below.VBar.r df.rightSB
@@ -369,12 +370,13 @@ glyph-block Letter-Latin-Lower-M : begin
 				include : turnMShapeBody df (Width - SB)
 				include : Translate 0 (SB / 2)
 
-		create-glyph "cyrl/shcha.italic.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.diversityM 3
-			include : df.markSet.e
-			include : turnMShapeBody df XH
-			eject-contour 'serifLT'
-			include : CyrDescender.rSideJut df.rightSB 0 (refSw -- df.mvs)
+		if (!tailed) : begin
+			create-glyph "cyrl/shcha.italic.\(suffix)" : glyph-proc
+				local df : include : DivFrame para.diversityM 3
+				include : df.markSet.e
+				include : turnMShapeBody df XH
+				eject-contour 'serifLT'
+				include : CyrDescender.rSideJut df.rightSB 0 (refSw -- df.mvs)
 
 	select-variant 'turnm' 0x26F
 	select-variant 'capitalTurnm' 0x19C (follow -- 'turnm')

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -206,13 +206,13 @@ glyph-block Letter-Latin-U : begin
 	foreach { suffix { Base Slabs } } [Object.entries : SmallUConfigT ULower] : do
 		create-glyph "u.\(suffix)" : glyph-proc
 			local df : DivFrame 1
-			include : MarkSet.e
+			include : df.markSet.e
 			include : Base df XH Stroke
 			include : Slabs df XH
 
 		create-glyph "grek/mu.\(suffix)" : glyph-proc
 			local df : DivFrame 1
-			include : MarkSet.p
+			include : df.markSet.p
 			include : Base df XH Stroke
 			include : dispiro
 				widths.rhs
@@ -221,7 +221,6 @@ glyph-block Letter-Latin-U : begin
 				straight.up.end SB SmallArchDepthB [widths.heading 0 [AdviceStroke 4] Upward]
 			include : Slabs df XH
 			include : LeaningAnchor.Below.VBar.l SB
-			set-base-anchor 'overlay' Middle (XH / 2)
 
 		create-glyph "cyrl/tse.italic.\(suffix)" : glyph-proc
 			include [refer-glyph "u.\(suffix)"] AS_BASE
@@ -234,12 +233,48 @@ glyph-block Letter-Latin-U : begin
 			eject-contour 'serifRB'
 			include : CyrDescender.rSideJut RightSB 0
 
+		create-glyph "turnh.\(suffix)" : glyph-proc
+			local df : DivFrame 1
+			include : df.markSet.p
+			include : Base df XH Stroke
+			include : Slabs df XH
+			eject-contour 'serifRB'
+			include : VBar.r df.rightSB Descender XH Stroke
+			if (Slabs !== no-shape) : begin
+				local sf : SerifFrame.fromDf df XH Descender
+				include sf.rb.fullSide
+			include : LeaningAnchor.Below.VBar.r df.rightSB
+
 		create-glyph "uHookLeft.\(suffix)" : glyph-proc
 			local df : DivFrame 1
-			include : MarkSet.e
+			include : df.markSet.e
 			include : Base df XH Stroke true
 			include : Slabs df XH
 			eject-contour 'serifLT'
+
+		create-glyph "turnhHookLeft.\(suffix)" : glyph-proc
+			local df : DivFrame 1
+			include : df.markSet.p
+			include : Base df XH Stroke true
+			include : Slabs df XH
+			eject-contour 'serifLT'
+			eject-contour 'serifRB'
+			include : VBar.r df.rightSB Descender XH Stroke
+			if (Slabs !== no-shape) : begin
+				local sf : SerifFrame.fromDf df XH Descender
+				include sf.rb.fullSide
+			include : LeaningAnchor.Below.VBar.r df.rightSB
+
+		create-glyph "turnhHookLeftRTail.\(suffix)" : glyph-proc
+			local df : DivFrame 1
+			include : df.markSet.p
+			include : Base df XH Stroke true
+			include : Slabs df XH
+			eject-contour 'serifLT'
+			eject-contour 'serifRB'
+			include : VBar.r df.rightSB 0 XH Stroke
+			include : RetroflexHook.rExt df.rightSB (Descender + TailY + HalfStroke) (yAttach -- 0)
+			include : LeaningAnchor.Below.VBar.r df.rightSB
 
 		create-glyph "uSideways.\(suffix)" : glyph-proc
 			local df : DivFrame (XH / Width) 2 (XH * 0.1 / SB)
@@ -279,6 +314,10 @@ glyph-block Letter-Latin-U : begin
 	select-variant 'cyrl/tse.italic'
 	select-variant 'cyrl/tetse.italic' (follow -- 'cyrl/tse.italic')
 	alias 'cyrl/tse.BGR' null 'cyrl/tse.italic'
+
+	select-variant 'turnh' 0x265
+	select-variant 'turnhHookLeft' 0x2AE
+	select-variant 'turnhHookLeftRTail' 0x2AF
 
 	select-variant 'uSideways' 0x1D1D (follow -- 'u')
 	select-variant 'uDieresisSidewaysBase' null (follow -- 'u')

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2256,7 +2256,6 @@ selectorAffix."h/sansSerif" = "straight"
 selectorAffix.hHookTop = "straight"
 selectorAffix.hengHookTop = "straight"
 selectorAffix.heng = "straight"
-selectorAffix."cyrl/shha" = "straight"
 
 [prime.h.variants-buildup.stages.tail.tailed]
 rank = 2
@@ -2267,7 +2266,6 @@ selectorAffix."h/sansSerif" = "tailed"
 selectorAffix.hHookTop = "tailed"
 selectorAffix.hengHookTop = "straight"
 selectorAffix.heng = "straight"
-selectorAffix."cyrl/shha" = "tailed"
 
 [prime.h.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -2279,7 +2277,6 @@ selectorAffix."h/sansSerif" = "serifless"
 selectorAffix.hHookTop = "serifless"
 selectorAffix.hengHookTop = "serifless"
 selectorAffix.heng = "serifless"
-selectorAffix."cyrl/shha" = "serifless"
 
 [prime.h.variants-buildup.stages.serifs.top-left-serifed]
 rank = 2
@@ -2291,7 +2288,6 @@ selectorAffix."h/sansSerif" = "serifless"
 selectorAffix.hHookTop = "serifless"
 selectorAffix.hengHookTop = "serifless"
 selectorAffix.heng = "topLeftSerifed"
-selectorAffix."cyrl/shha" = "topLeftSerifed"
 
 [prime.h.variants-buildup.stages.serifs.motion-serifed]
 rank = 3
@@ -2302,7 +2298,6 @@ selectorAffix."h/sansSerif" = "serifless"
 selectorAffix.hHookTop = { if = [{ tail = "straight" }], then = "motionSerifed", else = "serifless" }
 selectorAffix.hengHookTop = "serifless"
 selectorAffix.heng = "topLeftSerifed"
-selectorAffix."cyrl/shha" = "motionSerifed"
 
 [prime.h.variants-buildup.stages.serifs.serifed]
 rank = 4
@@ -2313,7 +2308,6 @@ selectorAffix."h/sansSerif" = "serifless"
 selectorAffix.hHookTop = "serifed"
 selectorAffix.hengHookTop = "serifed"
 selectorAffix.heng = "serifed"
-selectorAffix."cyrl/shha" = "serifed"
 
 
 
@@ -3759,11 +3753,11 @@ selectorAffix.u = "toothlessCorner"
 selectorAffix."u/sansSerif" = "toothlessCorner"
 selectorAffix."u/uRTailBase" = "urtBase"
 selectorAffix.uHookLeft = "toothlessCorner"
-selectorAffix.turnh = "toothed"
-selectorAffix.turnhHookLeft = "toothed"
-selectorAffix.turnhHookLeftRTail = "toothed"
+selectorAffix.turnh = "toothlessCorner"
+selectorAffix.turnhHookLeft = "toothlessCorner"
+selectorAffix.turnhHookLeftRTail = "toothlessCorner"
 selectorAffix.turnm = "toothlessCorner"
-selectorAffix.turnmLeg = "toothed"
+selectorAffix.turnmLeg = "toothlessCorner"
 selectorAffix."cyrl/i.italic" = "toothed"
 selectorAffix."cyrl/i.italic/descBase" = "toothed"
 selectorAffix."cyrl/sha.italic" = "toothed"
@@ -3824,9 +3818,9 @@ selectorAffix."u/sansSerif" = "serifless"
 selectorAffix."u/uRTailBase" = "motionSerifed"
 selectorAffix.uHookLeft = {if = [{body = "toothed"}], then = "bottomRightSerifed", else = "serifless"}
 selectorAffix.turnh = "motionSerifed"
-selectorAffix.turnhHookLeft = "motionSerifed"
+selectorAffix.turnhHookLeft = "bottomRightSerifed"
 selectorAffix.turnhHookLeftRTail = "serifless"
-selectorAffix.turnm = {if = [{body = "toothed"}], then = "motionSerifed", else = "topLeftSerifed"}
+selectorAffix.turnm = "motionSerifed"
 selectorAffix.turnmLeg = "motionSerifed"
 selectorAffix."cyrl/i.italic" = "motionSerifed"
 selectorAffix."cyrl/i.italic/descBase" = "motionSerifed"


### PR DESCRIPTION
This unifies the construction of uHookLeft and turnhHookLeft.
This also cleans up the name shaping for turnm = motion-serifed when toothless.
`uᵘɥᶣꭒꭟʮʯɯᵚɰᶭᴝᴟи𞀸ц𞁄ш𞁆щ◌ⷳ`
All `u` variants:
![image](https://github.com/be5invis/Iosevka/assets/37010132/4065a5a1-b0c9-4cb6-83a1-25e454cced0f)
