### PR TITLE
Add Docker build with Node.js LTS

### DIFF
--- a/doc/custom-build.md
+++ b/doc/custom-build.md
@@ -21,6 +21,8 @@ To build Iosevka you should:
 
 You will find TTFs, as well as WOFF(2) web fonts and one Webfont CSS in the `dist/` directory.
 
+To using Docker build, read [docker/README.md](../docker/README.md).
+
 ## Customized Build
 
 To create a custom build, you need:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:lts-slim
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+        apt-transport-https ca-certificates curl ttfautohint \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY build.sh /
+WORKDIR /work
+ENTRYPOINT ["bash", "/build.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,48 @@
+## Make docker image
+```
+git clone --depth=1 https://github.com/be5invis/Iosevka.git $HOME/mkdkimg
+cd $HOME/mkdkimg/docker
+docker build -t=fontcc .
+docker images | grep fontcc  # Confirm that the docker image is generated successfully
+fontcc                     latest      c847d5e08886   About a minute ago   491MB
+cd ../..
+rm -rf mkdkimg/
+```
+Note: Make docker image need execute only one time.
+
+## Usage
+`docker run -it --rm -v $PWD:/work fontcc <BUILD_ARGS>`
+Please refer to the `<BUILD_ARGS>` parameters to [Customized Build](../dev/doc/custom-build.md#customized-build)
+### Optional parameters (put them before `fontcc`):
+1. `-e "VERSION_TAG=<tag>"`
+
+`<tag>` can be the following values
+-  `main`    git main branch
+-  `dev`     git dev branch
+-  `v8.0.5`  git [release version tags](../../tags)
+
+When this variable is omitted, the tag of the latest release will be selected
+
+2. `-e "NPM_REG=<npm repository mirror url>"`
+
+change `npm install` download repository to mirror site.
+
+eg. change npm repos to huawei mirror
+ `docker run -it --rm -v $PWD:/work -e "NPM_REG=https://mirrors.huaweicloud.com/repository/npm" fontcc contents::Iosevka`
+
+## Example
+### Partially Build dev branch
+```
+mkdir -p $HOME/build_fonts
+cd $HOME/build_fonts
+docker run -it --rm -v $PWD:/work -e "VERSION_TAG=dev" fontcc contents::IosevkaSS06 ttf::IosevkaSS12 webfont::IosevkaSS15
+ls -lR dist/
+```
+### Customized Build
+```
+cd $HOME/mycustomfonts
+cat myfont1.toml myfont2.toml myfont3.toml > private-build-plans.toml
+docker run -it --rm -v $PWD:/work fontcc ttf::myfont1 ttf::myfont2 contents::myfont3
+ls -lR dist/
+```
+Note: You need prepare myfont1.toml myfont2.toml myfont3.toml youself, The [Customizer](https://be5invis.github.io/Iosevka/customizer) can help you easily generate font configuration file `.toml`.

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/bash
+TMP_BUD="/tmp/IosevkaDockerBuild"
+WORK_DIR="/work"
+PRIVATE_FILE="private-build-plans.toml"
+DEFAULT_ARGS="contents::Iosevka"
+HAS_CUSTOM=0
+BUILD_ARGS="$@"
+set -e
+rm -rf $TMP_BUD
+mkdir -p $TMP_BUD
+cd $TMP_BUD
+[[ -z $BUILD_ARGS ]] && echo 'Usage: docker run -it --rm -v $PWD:/work fontcc <BUILD_ARGS>'
+[[ -f "${WORK_DIR}/${PRIVATE_FILE}" ]] && {
+    HAS_CUSTOM=1
+    echo "Found $PRIVATE_FILE, custom build."
+    [[ -z $BUILD_ARGS ]] && {
+        FONT_NAME=$(grep -m1 -Po '(?<=\[buildPlans\.)[^\]]+' ${WORK_DIR}/${PRIVATE_FILE})
+        [[ -z "$FONT_NAME" ]] && {
+		echo "$PRIVATE_FILE file format error!"
+		exit 1
+	}
+        BUILD_ARGS="contents::$FONT_NAME"
+    }
+} || {
+    [[ -z $BUILD_ARGS ]] && {
+        BUILD_ARGS="$DEFAULT_ARGS"
+        echo "No parameter, default build."
+    }
+}
+echo "Fonts building param: $BUILD_ARGS"
+
+[[ -z "$VERSION_TAG" ]] && VERSION_TAG=$(curl -Ls --max-filesize 4096 \
+    'https://api.github.com/repos/be5invis/Iosevka/releases' \
+    | grep -m1 -Po '(?<="tag_name": ")v[\d\.]+')
+echo "Downloading source code tarball ${VERSION_TAG}"
+
+TARGZ_URL="https://github.com/be5invis/Iosevka/archive/${VERSION_TAG}.tar.gz"
+if [[ "main" == "$VERSION_TAG" ]] || [[ "dev" == "$VERSION_TAG" ]]; then
+    TARGZ_URL="https://github.com/be5invis/Iosevka/archive/refs/heads/${VERSION_TAG}.tar.gz"
+fi
+curl -LSOs "$TARGZ_URL" \
+    && tar -xf "${VERSION_TAG}.tar.gz" || {
+        echo "Decompression failed!"
+        exit 2
+    }
+cd Iosevka*
+
+[ "$HAS_CUSTOM" -eq 1 ] && cp "${WORK_DIR}/${PRIVATE_FILE}" .
+
+echo "Now building fonts ${VERSION_TAG}"
+
+[[ -n "$NPM_REG" ]] && npm config set registry $NPM_REG
+
+npm install \
+    && npm run build -- $BUILD_ARGS \
+    && cp -rf dist ${WORK_DIR}/
+


### PR DESCRIPTION
Solve https://github.com/be5invis/Iosevka/issues/2163
Add Dockerfile to build fonts

## Make docker image
```
git clone --depth=1 https://github.com/be5invis/Iosevka.git $HOME/mkdkimg
cd $HOME/mkdkimg/docker
docker build -t=fontcc .
docker images | grep fontcc  # Confirm that the docker image is generated successfully
fontcc                     latest      c847d5e08886   About a minute ago   491MB
cd ../..
rm -rf mkdkimg/
```
Note: Make docker image need execute only one time.

## Usage
`docker run -it --rm -v $PWD:/work fontcc <BUILD_ARGS>`
Please refer to the `<BUILD_ARGS>` parameters to [Customized Build](../dev/doc/custom-build.md#customized-build)
### Optional parameters (put them before `fontcc`):
1. `-e "VERSION_TAG=<tag>"`

`<tag>` can be the following values
-  `main`    git main branch
-  `dev`     git dev branch
-  `v8.0.5`  git [release version tags](../../tags)

When this variable is omitted, the tag of the latest release will be selected

2. `-e "NPM_REG=<npm repository mirror url>"`

change `npm install` download repository to mirror site.

eg. change npm repos to huawei mirror
 `docker run -it --rm -v $PWD:/work -e "NPM_REG=https://mirrors.huaweicloud.com/repository/npm" fontcc contents::Iosevka`

## Example
### Partially Build dev branch
```
mkdir -p $HOME/build_fonts
cd $HOME/build_fonts
docker run -it --rm -v $PWD:/work -e "VERSION_TAG=dev" fontcc contents::IosevkaSS06 ttf::IosevkaSS12 webfont::IosevkaSS15
ls -lR dist/
```
### Customized Build
```
cd $HOME/mycustomfonts
cat myfont1.toml myfont2.toml myfont3.toml > private-build-plans.toml
docker run -it --rm -v $PWD:/work fontcc ttf::myfont1 ttf::myfont2 contents::myfont3
ls -lR dist/
```
Note: You need prepare myfont1.toml myfont2.toml myfont3.toml youself, The [Customizer](https://be5invis.github.io/Iosevka/customizer) can help you easily generate font configuration file `.toml`.
