### PR TITLE
Make serifs of `cyrl/ue` and `latn/gamma` respond to italics.

### DIFF
--- a/changes/28.0.7.md
+++ b/changes/28.0.7.md
@@ -2,3 +2,4 @@
 * Add IPA localization forms for Greek Lower Beta (`β`) and Chi (`χ`).
 * Add APLF variants for `U+25F0`, `U+25F3`, and `U+25F4`.
 * Fix serif form for Cyrillic Lower Tall / Iotified Yat (#2178).
+* Make top serifs of Cyrillic Lower Straight U (`ү`, `ұ`) and Latin Lower Gamma (`ɣ`) respond to italics.

--- a/packages/font-glyphs/src/letter/latin-ext/rams-horn.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/rams-horn.ptl
@@ -31,7 +31,7 @@ glyph-block Letter-Latin-Rams-Horn : begin
 		include : LatinGammaShape Descender XH
 		if SLAB : begin
 			local sf : SerifFrame.fromDf [DivFrame 1] XH Descender
-			include : composite-proc sf.lt.full sf.rt.full
+			include : if para.isItalic sf.lt.outer [composite-proc sf.lt.full sf.rt.full]
 
 	create-glyph 'latn/Gamma' 0x194 : glyph-proc
 		include : MarkSet.capDesc

--- a/packages/font-glyphs/src/letter/latin/upper-y.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-y.ptl
@@ -20,6 +20,7 @@ glyph-block Letter-Latin-Upper-Y : begin
 	define SLAB-ALL    1
 	define SLAB-BASE   2
 	define SLAB-MOTION 3
+	define SLAB-CYRL   4
 
 	define [YCrossPos top bot] : mix bot top 0.4
 
@@ -31,6 +32,9 @@ glyph-block Letter-Latin-Upper-Y : begin
 				include : HSerif.mb Middle bot MidJutSide
 			[Just SLAB-MOTION] : include sf.lt.outer
 			[Just SLAB-BASE] : include : HSerif.mb Middle bot MidJutSide
+			[Just SLAB-CYRL] : begin
+				include : if para.isItalic sf.lt.outer [composite-proc sf.lt.full sf.rt.full]
+				include : HSerif.mb Middle bot MidJutSide
 
 	define [YShape bodyType slabType top bot] : glyph-proc
 		local cross : YCrossPos top bot
@@ -90,6 +94,8 @@ glyph-block Letter-Latin-Upper-Y : begin
 		curlyMotionSerifed    { BODY-CURLY    SLAB-MOTION }
 		straightSerifed       { BODY-STRAIGHT SLAB-ALL    }
 		curlySerifed          { BODY-CURLY    SLAB-ALL    }
+		straightSmallCyrl     { BODY-STRAIGHT SLAB-CYRL   }
+		curlySmallCyrl        { BODY-CURLY    SLAB-CYRL   }
 
 	foreach { suffix { bodyType slabType } } [Object.entries YConfig] : do
 		create-glyph "Y.\(suffix)" : glyph-proc

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1393,7 +1393,7 @@ selectorAffix.Y = "serifed"
 selectorAffix."Y/sansSerif" = "serifless"
 selectorAffix.YLoop = "serifed"
 selectorAffix."grek/UpsilonHookTop" = "BaseSerifed"
-selectorAffix."cyrl/ue" = "serifed"
+selectorAffix."cyrl/ue" = "smallCyrl"
 
 
 


### PR DESCRIPTION
Since the CV selection for these characters wouldn't change under italics, the behavior is implemented automatically.
`рүvɣ`
Slab Upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/c524b9d0-7a61-4cc8-9cad-4c2004e1d77b)
Slab Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/a28d4f85-15fc-44c5-96a6-9d401708664a)
Compared to Noto Serif:
![image](https://github.com/be5invis/Iosevka/assets/37010132/01a4674e-0ad6-4be7-9c05-583f8bc15c4b)
![image](https://github.com/be5invis/Iosevka/assets/37010132/486c11ed-66a8-4577-91c0-4d8e1e9ee4d7)
Compared to Source Serif 4 (doesn't have Latin gamma):
![image](https://github.com/be5invis/Iosevka/assets/37010132/8f7d4b20-00f1-4dca-a857-8b102012d17f)
![image](https://github.com/be5invis/Iosevka/assets/37010132/16050346-3296-4e77-82d4-8e220ee8e050)
Compared to DejaVu Serif (the only reason the base serif completely disappears here is because that behavior is consistent across all descender characters, so it shouldn't apply to Iosevka literally):
![image](https://github.com/be5invis/Iosevka/assets/37010132/45cdfda8-ebdd-444b-8c37-e51a85861c9f)
![image](https://github.com/be5invis/Iosevka/assets/37010132/2e79a084-3e50-4031-8a2d-46a29957523a)
