### PR TITLE
Fix leaning marks of several phonetic characters.

### DIFF
--- a/changes/28.0.7.md
+++ b/changes/28.0.7.md
@@ -5,5 +5,7 @@
 * Fix serif form for Cyrillic Lower Tall / Iotified Yat (#2178).
 * Make top serifs of Cyrillic Lower Straight U (`ү`, `ұ`) and Latin Lower Gamma (`ɣ`) respond to italics.
 * Fix leaning marks of Capital Turned/Half H (`U+2C75`, `U+2C76`, `U+A78D`, `U+A7F5`, `U+A7F6`).
+* Fix leaning marks of Wynn (`U+01BF`, `U+01F7`).
 * Fix leaning marks of Insular R (`U+A782`, `U+A783`).
 * Fix leaning marks of Greek/Latin Beta (`U+03B2`, `U+A7B4`, `U+A7B5`).
+* Fix leaning marks of Greek Lower San (`U+03FB`).

--- a/changes/28.0.7.md
+++ b/changes/28.0.7.md
@@ -4,3 +4,6 @@
 * Make Ezh follow variants of `Z`/`z` (#1957).
 * Fix serif form for Cyrillic Lower Tall / Iotified Yat (#2178).
 * Make top serifs of Cyrillic Lower Straight U (`ү`, `ұ`) and Latin Lower Gamma (`ɣ`) respond to italics.
+* Fix leaning marks of Capital Turned/Half H (`U+2C75`, `U+2C76`, `U+A78D`, `U+A7F5`, `U+A7F6`).
+* Fix leaning marks of Insular R (`U+A782`, `U+A783`).
+* Fix leaning marks of Greek/Latin Beta (`U+03B2`, `U+A7B4`, `U+A7B5`).

--- a/packages/font-glyphs/src/letter/latin-ext/wynn.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/wynn.ptl
@@ -7,6 +7,7 @@ glyph-module
 glyph-block Letter-Latin-Wynn : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
+	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared-Shapes : SerifFrame SerifedArcStart
 
 	define [SerifLT top bot] : return [SerifFrame.fromDf [DivFrame 1] top bot].lt.outer
@@ -36,6 +37,7 @@ glyph-block Letter-Latin-Wynn : begin
 	foreach { suffix { Serifs doBS } } [Object.entries WynnConfig] : do
 		create-glyph "wynn.\(suffix)" : glyph-proc
 			include : MarkSet.p
+			include : LeaningAnchor.Below.VBar.l SB
 			include : WynnShape Descender XH
 			include : Serifs XH Descender
 
@@ -43,5 +45,6 @@ glyph-block Letter-Latin-Wynn : begin
 
 	create-glyph 'Wynn' 0x1F7 : glyph-proc
 		include : MarkSet.capital
+		include : LeaningAnchor.Below.VBar.l SB
 		include : WynnShape 0 CAP
 		if SLAB : include : FullSerifs CAP 0

--- a/packages/font-glyphs/src/letter/latin/lower-n.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-n.ptl
@@ -9,6 +9,7 @@ glyph-block Letter-Latin-Lower-N : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Shared-Metrics : markHalfStroke
+	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared-Shapes : CurlyTail nShoulder nShoulderKnots nShoulderMask
 	glyph-block-import Letter-Shared-Shapes : RightwardTailedBar DToothlessRise DMBlend MidHook
 	glyph-block-import Letter-Shared-Shapes : CyrDescender PalatalHook RetroflexHook EngHook
@@ -137,21 +138,21 @@ glyph-block Letter-Latin-Lower-N : begin
 			if sLB : include : sLB [DivFrame 1] 0
 			if sRB : include : sRB [DivFrame 1] 0
 
-		create-glyph "eng.\(suffix)" : glyph-proc
+		if (!tailed) : create-glyph "eng.\(suffix)" : glyph-proc
 			include : MarkSet.p
 			include : Body XH SB RightSB 0 Stroke
 			include : EngHook RightSB 0 Descender
 			if sLT : include : sLT [DivFrame 1] XH
 			if sLB : include : sLB [DivFrame 1] 0
 
-		create-glyph "nHookBottom.\(suffix)" : glyph-proc
+		if (!tailed) : create-glyph "nHookBottom.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : Body XH SB RightSB 0 Stroke
 			include : RetroflexHook.rExt RightSB 0
 			if sLT : include : sLT [DivFrame 1] XH
 			if sLB : include : sLB [DivFrame 1] 0
 
-		create-glyph "nCurlyTail.\(suffix)" : glyph-proc
+		if (!tailed) : create-glyph "nCurlyTail.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			local fine : AdviceStroke 4
 			local rinner : clamp (Width * 0.065) (XH * 0.05) (fine * 0.35)
@@ -166,7 +167,7 @@ glyph-block Letter-Latin-Lower-N : begin
 			if sLT : include : sLT [DivFrame 1] XH
 			if sLB : include : sLB [DivFrame 1] 0
 
-		create-glyph "NExt.\(suffix)" : glyph-proc
+		create-glyph "latn/Eta.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
 			include : Body CAP SB RightSB [if tailed (CAP - SmallArchDepthB + O) Descender] Stroke
 			if tailed : include : EndingTail RightSB Descender (CAP - SmallArchDepthB) Stroke
@@ -174,7 +175,7 @@ glyph-block Letter-Latin-Lower-N : begin
 			if sLB : include : sLB [DivFrame 1] 0
 			if sRB : include : sRB [DivFrame 1] Descender
 
-		create-glyph "nExt.\(suffix)" : glyph-proc
+		create-glyph "latn/eta.\(suffix)" : glyph-proc
 			include : MarkSet.p
 			include : Body XH SB RightSB [if tailed (XH - SmallArchDepthB + O) Descender] Stroke
 			if tailed : include : EndingTail RightSB Descender (XH - SmallArchDepthB) Stroke
@@ -182,13 +183,11 @@ glyph-block Letter-Latin-Lower-N : begin
 			if sLB : include : sLB [DivFrame 1] 0
 			if sRB : include : sRB [DivFrame 1] Descender
 
-		create-glyph "grek/eta.\(suffix)" : glyph-proc
-			include : MarkSet.p
+		if (!tailed && !sRB) : create-glyph "grek/eta.\(suffix)" : glyph-proc
+			include [refer-glyph "latn/eta.\(suffix)"] AS_BASE ALSO_METRICS
 			set-base-anchor 'lf' (SB + HalfStroke) 0
-			include : Body XH SB RightSB Descender Stroke
-			if sLT : include : sLT [DivFrame 1] XH
 
-		create-glyph "nCrossedTail.\(suffix)" : glyph-proc
+		if (!tailed) : create-glyph "nCrossedTail.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			local fine : AdviceStroke 4
 			local rinner : XH * 0.15 - fine * 0.75
@@ -206,7 +205,7 @@ glyph-block Letter-Latin-Lower-N : begin
 				NBottomLeftSerif      [DivFrame 1] 0
 				NBottomLeftOuterSerif [DivFrame 1] 0
 
-		create-glyph "engCrossedTail.\(suffix)" : glyph-proc
+		if (!tailed) : create-glyph "engCrossedTail.\(suffix)" : glyph-proc
 			include : MarkSet.p
 			include : Body XH SB RightSB 0 Stroke
 			local fine : AdviceStroke 3.5
@@ -220,15 +219,17 @@ glyph-block Letter-Latin-Lower-N : begin
 			if sLT : include : sLT [DivFrame 1] XH
 			if sLB : include : sLB [DivFrame 1] 0
 
-		create-glyph "RInsular.\(suffix)" : glyph-proc
+		if (!tailed && !sRB) : create-glyph "RInsular.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
+			include : LeaningAnchor.Below.VBar.l SB
 			include : Body CAP SB RightSB (-Descender) Stroke
 			include : RetroflexHook.rExt RightSB (-Descender)
 			include : VBar.l SB Descender 0
 			if sLT : include : sLT [DivFrame 1] CAP
 
-		create-glyph "rInsular.\(suffix)" : glyph-proc
+		if (!tailed && !sRB) : create-glyph "rInsular.\(suffix)" : glyph-proc
 			include : MarkSet.p
+			include : LeaningAnchor.Below.VBar.l SB
 			include : Body XH SB RightSB (-Descender) Stroke
 			include : RetroflexHook.rExt RightSB (-Descender)
 			include : VBar.l SB Descender 0
@@ -247,7 +248,7 @@ glyph-block Letter-Latin-Lower-N : begin
 
 			include : MidHook.m df XH
 
-		create-glyph "cyrl/yat.italic/base.\(suffix)" : glyph-proc
+		if (!tailed) : create-glyph "cyrl/yat.italic/base.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.e
 
@@ -273,14 +274,13 @@ glyph-block Letter-Latin-Lower-N : begin
 	select-variant 'nCrossedTail' 0xAB3B (follow -- 'eng')
 	select-variant 'engCrossedTail' 0xAB3C (follow -- 'eng')
 
-	select-variant 'eng/lTailBase' (shapeFrom -- 'eng')
 	select-variant 'RInsular' 0xA782 (follow -- 'eng/lTailBase')
 	select-variant 'rInsular' 0xA783 (follow -- 'eng/lTailBase')
 
 	select-variant 'grek/eta' 0x3B7
 	link-reduced-variant 'grek/eta/sansSerif' 'grek/eta' MathSansSerif
-	select-variant 'NExt' 0x220 (follow -- 'n')
-	select-variant 'nExt' 0x19E (follow -- 'n')
+	select-variant 'latn/Eta' 0x220 (follow -- 'n')
+	select-variant 'latn/eta' 0x19E (follow -- 'n')
 
 	derive-composites 'nDescender' 0xA791 'n/descBase' [CyrDescender.rSideJut RightSB 0]
 	derive-composites 'nPalatalHook' 0x1D87 'n/descBase' [PalatalHook.rSideJut RightSB 0]

--- a/packages/font-glyphs/src/letter/latin/upper-b.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-b.ptl
@@ -8,6 +8,7 @@ glyph-module
 glyph-block Letter-Latin-Upper-B : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
+	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared-Metrics : BowlXDepth
 	glyph-block-import Letter-Shared-Shapes : ShoulderMidKnotRhs LetterBarOverlay SerifFrame LeftHook
 	glyph-block-import Letter-Blackboard : BBS BBD
@@ -167,6 +168,7 @@ glyph-block Letter-Latin-Upper-B : begin
 
 		create-glyph "latn/Beta.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
+			include : LeaningAnchor.Below.VBar.l SB
 			include : body CAP [AdviceStroke2 2 3 CAP] ts false
 			include : VBar.l SB Descender 0
 			if bs : begin
@@ -240,6 +242,7 @@ glyph-block Letter-Latin-Upper-B : begin
 
 	create-glyph 'grek/beta' 0x3B2 : glyph-proc
 		include : MarkSet.bp
+		include : LeaningAnchor.Below.VBar.l SB
 		define pBar 0.55
 		define fine : Stroke * CThin
 		define yMiddle : [mix 0 Ascender pBar] - Stroke * 0.7 # Bottom edge

--- a/packages/font-glyphs/src/letter/latin/upper-h.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-h.ptl
@@ -9,6 +9,7 @@ glyph-block Letter-Latin-Upper-H : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Shared-Metrics : markExtend
+	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Mark-Below : belowMarkMid
 	glyph-block-import Letter-Blackboard : BBS BBD
 	glyph-block-import Letter-Shared : SetGrekUpperTonos
@@ -114,6 +115,7 @@ glyph-block Letter-Latin-Upper-H : begin
 
 		create-glyph "HTurned.\(suffix)" : glyph-proc
 			include : MarkSet.capital
+			include : LeaningAnchor.Below.VBar.r RightSB
 			include : TurnedBody SB RightSB CAP
 			include : HSerifs slabType CAP 0 SB RightSB
 			eject-contour 'serifLB'
@@ -125,6 +127,8 @@ glyph-block Letter-Latin-Upper-H : begin
 
 		create-glyph "leftHalfH.\(suffix)" : glyph-proc
 			include : MarkSet.capital
+			include : LeaningAnchor.Above.VBar.l SB
+			include : LeaningAnchor.Below.VBar.l SB
 			include : Body SB RightSB CAP
 			eject-contour 'strokeR'
 			include : HSerifs slabType CAP 0 SB RightSB
@@ -133,6 +137,8 @@ glyph-block Letter-Latin-Upper-H : begin
 
 		create-glyph "rightHalfH.\(suffix)" : glyph-proc
 			include : MarkSet.capital
+			include : LeaningAnchor.Above.VBar.r RightSB
+			include : LeaningAnchor.Below.VBar.r RightSB
 			include : Body SB RightSB CAP
 			eject-contour 'strokeL'
 			include : HSerifs slabType CAP 0 SB RightSB
@@ -141,6 +147,8 @@ glyph-block Letter-Latin-Upper-H : begin
 
 		create-glyph "leftHalfSmcpH.\(suffix)" : glyph-proc
 			include : MarkSet.e
+			include : LeaningAnchor.Above.VBar.l SB
+			include : LeaningAnchor.Below.VBar.l SB
 			include : Body SB RightSB XH
 			eject-contour 'strokeR'
 			include : HSerifs slabType XH 0 SB RightSB
@@ -149,6 +157,8 @@ glyph-block Letter-Latin-Upper-H : begin
 
 		create-glyph "rightHalfSmcpH.\(suffix)" : glyph-proc
 			include : MarkSet.e
+			include : LeaningAnchor.Above.VBar.r RightSB
+			include : LeaningAnchor.Below.VBar.r RightSB
 			include : Body SB RightSB XH
 			eject-contour 'strokeL'
 			include : HSerifs slabType XH 0 SB RightSB

--- a/packages/font-glyphs/src/letter/latin/upper-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-m.ptl
@@ -8,6 +8,7 @@ glyph-module
 glyph-block Letter-Latin-Upper-M : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
+	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared : CreateTurnedLetter
 	glyph-block-import Letter-Shared-Shapes : SerifFrame CyrTailDescender PalatalHook
 
@@ -147,6 +148,7 @@ glyph-block Letter-Latin-Upper-M : begin
 		create-glyph "smcpMWithDescender.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.p
+			include : LeaningAnchor.Below.VBar.l df.leftSB
 			include : MShape XH df form slab slanted
 
 		create-glyph "cyrl/EmSoft.\(suffix)" : glyph-proc


### PR DESCRIPTION
This additionally attempts to reduce the number of unused glyphs surrounding `n` by disallowing creation of tailed variants for characters which follow eng (`ŋ`), and also simplifying construction of `grek/eta` without changing any of its variants or anchors.
Basically, other than leaning marks, everything not shown here is unchanged.
`Ꞵ̣̇ꞵ̣̇ Β̣̇β̣̇ Ɥ̣̇ɥ̣̇ Ч̣̇ч̣̇ Ⱶ̣̇ⱶ̣̇ Ꟶ̣̇ꟶ̣̇ Ͱ̣̇ͱ̣̇ μ̣̇ϻ̣̇ Ꞃ̣̇ꞃ̣̇ Ꞅ̣̇ꞅ̣̇ Ƿ̣̇ƿ̣̇ Þ̣̇þ̣̇`
Before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/bec3ef3a-16d6-4319-b82f-322d92908e41)
After:
![image](https://github.com/be5invis/Iosevka/assets/37010132/f5adc5d7-19af-4329-b911-07201ee4de5d)
