### PR TITLE
Fix potential NaN errors when diversityM is raised.

### DIFF
--- a/packages/font-glyphs/src/symbol/punctuation/percentages.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/percentages.ptl
@@ -12,7 +12,10 @@ glyph-block Symbol-Punctuation-Percentages : begin
 	define NarrowUnicode : NarrowUnicodeT WideWidth1
 	define WideUnicode   : WideUnicodeT   WideWidth1
 
-	define [PercentBarCor df sw] : HVContrast / [Math.sqrt (1 - [Math.pow ((df.rightSB - df.leftSB - sw) / (CAP - 0)) 2])]
+	define [PercentBarCor df sw] : begin
+		local a : 1 - [Math.pow ((df.rightSB - df.leftSB - sw) / (CAP - 0)) 2]
+		return : HSwToV : 1 / [if (a > 0) [Math.sqrt a] 1]
+
 	define [PercentBarShape df sw] : begin
 		local cor : PercentBarCor df sw
 		return : spiro-outline

--- a/packages/font-glyphs/src/symbol/punctuation/percentages.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/percentages.ptl
@@ -14,7 +14,7 @@ glyph-block Symbol-Punctuation-Percentages : begin
 
 	define [PercentBarCor df sw] : begin
 		local a : 1 - [Math.pow ((df.rightSB - df.leftSB - sw) / (CAP - 0)) 2]
-		return : HSwToV : 1 / [if (a > 0) [Math.sqrt a] 1]
+		return : HVContrast / [if (a > 0) [Math.sqrt a] 1]
 
 	define [PercentBarShape df sw] : begin
 		local cor : PercentBarCor df sw


### PR DESCRIPTION
This is the only part of the source code which threw an error when I experimented with a custom build using a `private-parameters.toml` file that included a custom spacing family based on `quasi-proportional` where `diversityM` was raised to `1.50` or `1.75` etc.

Example:
```
[spacing-quasi-proportional-high-diversity]
spacing = 3
isQuasiProportional = true
diversityM  = 1.50
diversityF  = 0.75
diversityI  = 0.75
diversityII = 0.50
```

This change fixes two operations that could cause a NaN error:
1. `[Math.sqrt a]` where `a` is negative.
2. `HVContrast / [Math.sqrt a]` where `a` is 0.

If the value of `a` is 0 or lower, it returns `HVContrast / 1`.

Here's a test using fullblock characters to show the side bearings to prove it doesn't misbehave:
```
mnn
wvv
█%█‰█
```
![image](https://github.com/be5invis/Iosevka/assets/37010132/885582c3-655e-43c8-8cc2-fa1b5c1a2a46)
