### PR TITLE
Fix Serbian/Macedonian Cyrillic localization forms, add Bosnian Cyrillic localization forms.

### DIFF
--- a/changes/28.1.0.md
+++ b/changes/28.1.0.md
@@ -6,4 +6,6 @@
   - OVERLAPPING WHITE AND BLACK SQUARES (`U+2BBB`).
   - OVERLAPPING BLACK SQUARES (`U+2BBC`).
 * Fix metrics of Cyrillic Yery (#2182).
+* Fix Italic/Upright localization forms for Serbian/Macedonian Cyrillic.
+* Add Bosnian Cyrillic localization forms based on Serbian/Macedonian.
 * Add italic form for Combining Cyrillic Letter Es-Te (U+2DF5) (#2187).

--- a/packages/font-glyphs/src/letter/cyrillic/orthography.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/orthography.ptl
@@ -42,14 +42,14 @@ glyph-block Letter-Cyrillic-Orthography : begin
 	CreateAccentedComposition 'cyrl/igrave' 0x45D 'cyrl/i'   'graveAbove'
 
 	# Link localization forms
-	link-gr LocalizedForm.SRB.Upright 'cyrl/be'  'cyrl/be.SRB'
-	link-gr LocalizedForm.SRB.Upright 'cyrl/ghe' 'cyrl/ghe.SRB'
-	link-gr LocalizedForm.SRB.Upright 'cyrl/de'  'cyrl/de.SRB'
-	link-gr LocalizedForm.SRB.Upright 'cyrl/gje' 'cyrl/gje.SRB'
-	link-gr LocalizedForm.SRB.Upright 'cyrl/pe'  'cyrl/pe.SRB'
-	link-gr LocalizedForm.SRB.Upright 'cyrl/te'  'cyrl/te.SRB'
-	
-	link-gr LocalizedForm.SRB.Italic  'cyrl/be'  'cyrl/be.SRB'
+	link-gr LocalizedForm.SRB.Upright 'cyrl/be'      'cyrl/be.SRB'
+
+	link-gr LocalizedForm.SRB.Italic  'cyrl/be'      'cyrl/be.SRB'
+	link-gr LocalizedForm.SRB.Italic  'cyrl/ghe'     'cyrl/ghe.SRB'
+	link-gr LocalizedForm.SRB.Italic  'cyrl/de'      'cyrl/de.SRB'
+	link-gr LocalizedForm.SRB.Italic  'cyrl/gje'     'cyrl/gje.SRB'
+	link-gr LocalizedForm.SRB.Italic  'cyrl/pe'      'cyrl/pe.SRB'
+	link-gr LocalizedForm.SRB.Italic  'cyrl/te'      'cyrl/te.SRB'
 
 	link-gr LocalizedForm.BGR         'cyrl/ve'      'cyrl/ve.BGR'
 	link-gr LocalizedForm.BGR         'cyrl/ghe'     'cyrl/ghe.italic'

--- a/packages/font-otl/src/gsub-locl.ptl
+++ b/packages/font-otl/src/gsub-locl.ptl
@@ -12,6 +12,7 @@ export : define [buildLOCL gsub para glyphStore] : begin
 
 	define cyrlSRB  : gsub.copyLanguage 'cyrl_SRB ' 'cyrl_DFLT'
 	define cyrlMKD  : gsub.copyLanguage 'cyrl_MKD ' 'cyrl_DFLT'
+	define cyrlBOS  : gsub.copyLanguage 'cyrl_BOS ' 'cyrl_DFLT'
 	define cyrlBGR  : gsub.copyLanguage 'cyrl_BGR ' 'cyrl_DFLT'
 	define latnVIT  : gsub.copyLanguage 'latn_VIT ' 'latn_DFLT'
 	define grekIPPH : gsub.copyLanguage 'grek_IPPH ' 'grek_DFLT'
@@ -21,6 +22,7 @@ export : define [buildLOCL gsub para glyphStore] : begin
 	define loclSRB : gsub.createFeature 'locl'
 	cyrlSRB.addFeature loclSRB
 	cyrlMKD.addFeature loclSRB
+	cyrlBOS.addFeature loclSRB
 	loclSRB.addLookup : createGsubLookupFromGr gsub glyphStore
 		if [not para.isItalic] LocalizedForm.SRB.Upright LocalizedForm.SRB.Italic
 


### PR DESCRIPTION
I originally just wanted to add the Bosnian forms based on [this issue on noto fonts' repo](https://github.com/notofonts/latin-greek-cyrillic/issues/41), but then I noticed that Iosevka's italic/upright localization forms for Serbian/Macedonian have also been swapped since 6a36130 , so of course I fixed that too while I was at it.

The text below also contains unaffected accented forms, but just ignore those. It's just because it's from an offline test site I've made for testing more things than just this specific bug. Mainly focus on the characters specific to Serbian/Macedonian/etc.
```
δб𞀱 в𞀲 гӷ𞀳 ɡgд𞀴 жӝӂҗ𞀶
иӥйҋ𞀸 к𞀹 пԥ𞀽 тҭ𞁀 Фф𞁂
ч𞁅 ицшщ𞀸𞁄𞁆◌ⷳ ъыьꚜ𞁇ꚝ ю𞁉
δб𞀱 в𞀲 гӷ𞀳 ɡgд𞀴 жӝӂҗ𞀶
иӥйҋ𞀸 к𞀹 пԥ𞀽 тҭ𞁀 Фф𞁂
ч𞁅 ицшщ𞀸𞁄𞁆◌ⷳ ъыьꚜ𞁇ꚝ ю𞁉
```
Before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/86614e4f-1c41-46a9-8fec-4f2a009f0e0b)
After:
![image](https://github.com/be5invis/Iosevka/assets/37010132/2a13c887-0d98-4ba1-9451-fc59ce32b4b8)
