### PR TITLE
Some box drawing + Large Type Pieces

### DIFF
--- a/changes/28.1.0.md
+++ b/changes/28.1.0.md
@@ -8,8 +8,7 @@
   - OUTLINED LATIN CAPITAL LETTER A (`U+1CCD6`) ... OUTLINED LATIN CAPITAL LETTER Z (`U+1CCEF`) (Purposed for Unicode 16; L2/21-235).
   - OUTLINED DIGIT ZERO (`U+1CCF0`) ... OUTLINED DIGIT NINE (`U+1CCF9`) (Purposed for Unicode 16; L2/21-235).
   - BLOCK OCTANT-3 (`U+1CD00`) ... BLOCK OCTANT-2345678 (`U+1CDE5`) (Purposed for Unicode 16; L2/21-235).
-  - LEFT HALF TRIPLE DASH HORIZONTAL (`U+1CE0D`) ... BOX DRAWINGS LIGHT VERTICAL AND
-BOTTOM LEFT (`U+1CE19`) (Purposed for Unicode 16; L2/21-235).
+  - LEFT HALF TRIPLE DASH HORIZONTAL (`U+1CE0D`) ... LARGE TYPE PIECE STEM-12 (`U+1CE50`) (Purposed for Unicode 16; L2/21-235).
 * Fix metrics of Cyrillic Yery (#2182).
 * Fix Italic/Upright localization forms for Serbian/Macedonian Cyrillic.
 * Add Bosnian Cyrillic localization forms based on Serbian/Macedonian.

--- a/changes/28.1.0.md
+++ b/changes/28.1.0.md
@@ -8,6 +8,8 @@
   - OUTLINED LATIN CAPITAL LETTER A (`U+1CCD6`) ... OUTLINED LATIN CAPITAL LETTER Z (`U+1CCEF`) (Purposed for Unicode 16; L2/21-235).
   - OUTLINED DIGIT ZERO (`U+1CCF0`) ... OUTLINED DIGIT NINE (`U+1CCF9`) (Purposed for Unicode 16; L2/21-235).
   - BLOCK OCTANT-3 (`U+1CD00`) ... BLOCK OCTANT-2345678 (`U+1CDE5`) (Purposed for Unicode 16; L2/21-235).
+  - LEFT HALF TRIPLE DASH HORIZONTAL (`U+1CE0D`) ... BOX DRAWINGS LIGHT VERTICAL AND
+BOTTOM LEFT (`U+1CE19`) (Purposed for Unicode 16; L2/21-235).
 * Fix metrics of Cyrillic Yery (#2182).
 * Fix Italic/Upright localization forms for Serbian/Macedonian Cyrillic.
 * Add Bosnian Cyrillic localization forms based on Serbian/Macedonian.

--- a/packages/font-glyphs/src/symbol/mosaic.ptl
+++ b/packages/font-glyphs/src/symbol/mosaic.ptl
@@ -695,6 +695,52 @@ glyph-block Symbol-Mosaic : begin
 			hline 0x23BC (1 / 4)
 			hline 0x23BD 0
 
+			# Split Dashed Lines
+			create-glyph [BdGlyphName 0x1CE0D] [MangleUnicode 0x1CE0D] : glyph-proc
+				set-width MosaicWidth
+				include : ForceUpright
+				include : HBar.m 0 (MosaicWidth / 3) midy light
+				include : HBar.m (MosaicWidth * 2 / 3) MosaicWidth midy light
+
+			create-glyph [BdGlyphName 0x1CE0E] [MangleUnicode 0x1CE0E] : glyph-proc
+				set-width MosaicWidth
+				include : ForceUpright
+				include : HBar.m (MosaicWidth / 3) (MosaicWidth * 2 / 3) midy light
+
+			define [hlinetick unicode a b c] : begin
+				create-glyph [BdGlyphName unicode] [MangleUnicode unicode] : glyph-proc
+					set-width MosaicWidth
+					include : ForceUpright
+					include : HBar.m 0 MosaicWidth midy light
+					if a : include : VBar.r (MosaicWidth / 3)     bottom midy light
+					if b : include : VBar.r (MosaicWidth * 2 / 3) bottom midy light
+					if c : include : VBar.r  MosaicWidth          bottom midy light 
+
+			define [vlinetick unicode a b c d rev] : begin
+				create-glyph [BdGlyphName unicode] [MangleUnicode unicode] : glyph-proc
+					set-width MosaicWidth
+					include : ForceUpright
+					include : VBar.m midx [if d bottom boty] [if c top topy] light
+					local tickleft : if rev midx 0
+					local tickright : if rev MosaicWidth midx
+					if a : include : HBar.t tickleft tickright [mix bottom top (1 / 3)] light
+					if b : include : HBar.t tickleft tickright [mix bottom top (2 / 3)] light
+					if c : include : HBar.t tickleft tickright top light
+					if d : include : HBar.b tickleft tickright bottom light
+
+			# Box Drawing with Ticks
+			hlinetick 0x1CE0F 0 0 1
+			hlinetick 0x1CE10 0 1 0
+			hlinetick 0x1CE11 1 0 1
+			hlinetick 0x1CE12 1 1 1
+			vlinetick 0x1CE13 0 1 0 0 0
+			vlinetick 0x1CE14 1 0 1 0 0
+			vlinetick 0x1CE15 1 1 1 0 0
+			vlinetick 0x1CE16 0 0 1 0 1
+			vlinetick 0x1CE17 0 0 0 1 1
+			vlinetick 0x1CE18 0 0 1 0 0
+			vlinetick 0x1CE19 0 0 0 1 0
+
 			define [boxdraw unicode u d l r] : begin
 				create-glyph [BdGlyphName unicode] [MangleUnicode unicode] : glyph-proc
 					set-width MosaicWidth

--- a/packages/font-glyphs/src/symbol/mosaic.ptl
+++ b/packages/font-glyphs/src/symbol/mosaic.ptl
@@ -541,7 +541,7 @@ glyph-block Symbol-Mosaic : begin
 			MakePiece 0x1CE40 : union [Stem 0 2] [Arm 2 2 0 MosaicWidth]
 			MakePiece 0x1CE41 : union [Arm 1 2.5 0 stemmid] [Arm 2.5 1 stemmid MosaicWidth]
 			MakePiece 0x1CE42 : union [Arc 1 0 0] [Arc 1 0 1]
-			MakePiece 0x1CE43 : union [Stem 0 0] [Arc 1 0 0]
+			MakePiece 0x1CE43 : union [Stem 0 0] [Arc 2 1 0]
 			MakePiece 0x1CE44 : union [Stem 0 2] [Arm 2 2 0 stemleft] 
 			MakePiece 0x1CE45 : union [Stem 0 0] [Arc 2 1 0] [Arm 0 2 0 stemright]
 			MakePiece 0x1CE46 : union [Stem 0 2] [Arm 1 2 0 stemleft]
@@ -809,9 +809,9 @@ glyph-block Symbol-Mosaic : begin
 					set-width MosaicWidth
 					include : ForceUpright
 					include : HBar.m 0 MosaicWidth midy light
-					if a : include : VBar.r (MosaicWidth / 3)     bottom midy light
-					if b : include : VBar.r (MosaicWidth * 2 / 3) bottom midy light
-					if c : include : VBar.r  MosaicWidth          bottom midy light 
+					if a : include : VBar.r (MosaicWidth / 3)     [mix bottom midy 0.5] midy light
+					if b : include : VBar.r (MosaicWidth * 2 / 3) [mix bottom midy 0.5] midy light
+					if c : include : VBar.r  MosaicWidth          [mix bottom midy 0.5] midy light 
 
 			define [vlinetick unicode a b c d rev] : begin
 				create-glyph [BdGlyphName unicode] [MangleUnicode unicode] : glyph-proc

--- a/packages/font-glyphs/src/symbol/mosaic.ptl
+++ b/packages/font-glyphs/src/symbol/mosaic.ptl
@@ -459,6 +459,103 @@ glyph-block Symbol-Mosaic : begin
 			SmoothMosaic22 0x1FB9A '1379'
 			SmoothMosaic22 0x1FB9B '1739'
 
+		### Large Type Pieces
+		do 'Large Type Pieces'
+			local stemleft  : mix 0 MosaicWidth (1 / 3)
+			local stemright : mix 0 MosaicWidth (2 / 3)
+			local stemmid   : mix 0 MosaicWidth 0.5
+			define [yPart n] : return : mix top bottom (n / 5)
+
+			define [Stem start end] : spiro-outline
+				corner stemleft [yPart start]
+				corner stemright [yPart start]
+				corner stemright [yPart (end + 1)]
+				corner stemleft [yPart (end + 1)]
+
+			define [TopBit] : spiro-outline
+				corner stemleft top
+				corner stemright top
+				corner stemmid [mix top bottom 0.1]
+
+			define [BottomBit] : spiro-outline
+				corner stemmid [mix top bottom 0.9]
+				corner stemleft bottom
+				corner stemright bottom
+
+			define [Arm yStart yEnd left right] : spiro-outline
+				corner left [yPart yStart]
+				corner right [yPart yEnd]
+				corner right [yPart (yEnd + 1)]
+				corner left [yPart (yStart + 1)]
+			
+			define [Arc yHori yVert fRight] : spiro-outline
+				corner [if fRight MosaicWidth 0] [yPart [if fRight yHori (yHori + 1)]]
+				corner [if fRight MosaicWidth 0] [yPart [if fRight (yHori + 1) yHori]]
+				corner [if (yHori < yVert) stemright stemleft] [yPart [if (yHori < yVert) (yVert + 1) yVert]]
+				corner [if (yHori < yVert) stemleft stemright] [yPart [if (yHori < yVert) (yVert + 1) yVert]]
+
+			define [MakePiece unicode shape] : begin
+				create-glyph [MangleName unicode] [MangleUnicode unicode] : glyph-proc
+					set-width MosaicWidth
+					include : ForceUpright
+					include shape
+
+			MakePiece 0x1CE1A : union [Stem 4 4] [Arc 2 3 1] 
+			MakePiece 0x1CE1B : union [Stem 2 4] [Arm 2 2 stemright MosaicWidth]
+			MakePiece 0x1CE1C : union [Stem 2 4]
+			MakePiece 0x1CE1D : union [Stem 2 4] [Arm 2 3 stemright MosaicWidth]
+			MakePiece 0x1CE1E : union [Arm 2 2 stemleft MosaicWidth]
+			MakePiece 0x1CE1F : union [Arm 2 2 0 MosaicWidth]
+			MakePiece 0x1CE20 : union [Stem 2 4] [Arm 2 2 0 MosaicWidth]
+			MakePiece 0x1CE21 : union [Arc 3 4 0] [Arc 3 4 1]
+			MakePiece 0x1CE22 : union [Arc 3 4 0]
+			MakePiece 0x1CE23 : union [Stem 4 4]
+			MakePiece 0x1CE24 : union [Stem 4 4] [Arc 2 3 0]
+			MakePiece 0x1CE25 : union [Arm 2 2 0 stemright]
+			MakePiece 0x1CE26 : union [Stem 2 4] [Arm 3 2 0 stemleft]
+			MakePiece 0x1CE27 : union [Stem 2 4] [Arm 2 2 0 stemleft]
+			MakePiece 0x1CE28 : union [Stem 0 4] [Arm 2 2 stemright MosaicWidth]
+			MakePiece 0x1CE29 : union [Stem 0 4]
+			MakePiece 0x1CE2A : union [Arc 1 0 1] [Arc 3 4 1]
+			MakePiece 0x1CE2B : union [Arc 1 0 1]
+			MakePiece 0x1CE2C : union [Arc 3 4 1]
+			MakePiece 0x1CE2D : union [Stem 0 0]
+			MakePiece 0x1CE2E : union [Stem 0 0] [Stem 4 4] [Arc 2 1 1] [Arc 2 3 1]
+			MakePiece 0x1CE2F : union [Arm 2 2 0 stemmid] [Arm 2 1 stemmid MosaicWidth] [Arm 2 3 stemmid MosaicWidth]
+			MakePiece 0x1CE30 : union [TopBit]
+			MakePiece 0x1CE31 : union [BottomBit]
+			MakePiece 0x1CE32 : union [Arm 1 3 0 MosaicWidth] [Arm 3 1 0 MosaicWidth]
+			MakePiece 0x1CE33 : union [Stem 3 4] [Arc 1 2 0] [Arc 1 2 1]
+			MakePiece 0x1CE34 : union [Arm 2 2 0 MosaicWidth] [Arm 3 1 0 MosaicWidth]
+			MakePiece 0x1CE35 : union [Stem 3 4] [Arc 1 2 1]
+			MakePiece 0x1CE36 : union [Stem 0 4] [Arm 2 2 0 stemleft]
+			MakePiece 0x1CE37 : union [Stem 0 0] [Stem 4 4] [Arc 2 1 0] [Arc 2 3 0]
+			MakePiece 0x1CE38 : union [Arc 1 0 0] [Arc 3 4 0]
+			MakePiece 0x1CE39 : union [Stem 0 4] [Arm 1 2 0 stemleft]
+			MakePiece 0x1CE3A : union [Stem 0 4] [Arm 2 2 0 MosaicWidth]
+			MakePiece 0x1CE3B : union [Arc 0 1 0]
+			MakePiece 0x1CE3C : union [Stem 0 2]
+			MakePiece 0x1CE3D : union [Stem 0 2] [Arm 2 2 stemright MosaicWidth]
+			MakePiece 0x1CE3E : union [Stem 0 0] [Arc 2 1 1]
+			MakePiece 0x1CE3F : union [Stem 0 2] [Arm 2 1 stemright MosaicWidth]
+			MakePiece 0x1CE40 : union [Stem 0 2] [Arm 2 2 0 MosaicWidth]
+			MakePiece 0x1CE41 : union [Arm 1 2.5 0 stemmid] [Arm 2.5 1 stemmid MosaicWidth]
+			MakePiece 0x1CE42 : union [Arc 1 0 0] [Arc 1 0 1]
+			MakePiece 0x1CE43 : union [Stem 0 0] [Arc 1 0 0]
+			MakePiece 0x1CE44 : union [Stem 0 2] [Arm 2 2 0 stemleft] 
+			MakePiece 0x1CE45 : union [Stem 0 0] [Arc 2 1 0] [Arm 0 2 0 stemright]
+			MakePiece 0x1CE46 : union [Stem 0 2] [Arm 1 2 0 stemleft]
+			MakePiece 0x1CE47 : union [Stem 3 4]
+			MakePiece 0x1CE48 : union [Stem 1 4]
+			MakePiece 0x1CE49 : union [Stem 3 3]
+			MakePiece 0x1CE4A : union [Stem 2 3]
+			MakePiece 0x1CE4B : union [Stem 1 3]
+			MakePiece 0x1CE4C : union [Stem 0 3]
+			MakePiece 0x1CE4D : union [Stem 2 2]
+			MakePiece 0x1CE4E : union [Stem 1 2]
+			MakePiece 0x1CE4F : union [Stem 1 1]
+			MakePiece 0x1CE50 : union [Stem 0 1]
+
 		### Blocks
 		do 'Block Shapes'
 			define [FillBlock hStart hEnd vStart vEnd] : spiro-outline


### PR DESCRIPTION
Part of #2189.

Including ranges:
- `U+1CE0D` - `U+1CE0E` (dash lines)
	- Implemented with bars filling `1/3` of the mosaic width.
- `U+1CE0F` - `U+1CE19` (lines with ticks + box drawing with top/bottom lines)
	- It looks like the vertical bar ticks are actually the same length as the box drawing one-sided lines, considering there isn't a separate top-tick vertical line. So they are implemented together.
	- The horizontal bar ticks however don't seem like they should touch the bounding box, so I just made the ticks go half way between `midy` and `bottom`.
	- For the vertical ones, the stem(?) overshoots if there are no ticks on that side.
- `U+1CE1A` - `U+1CE50` (large type pieces)
	- Actual composition not tested, but cross-checked with Fairfaxhd
	- The pieces can be constructed by taking union of 4 types of strokes:
		- A vertical stem
		- A "horizontal" (vertical terminal) stroke that may slant up or down
		- An "Arc" that connects a horizontal and a vertical stroke
		- The "bits" used to compose `M` and `W`
	- The coordinates of the piece "strokes" are aligned on a 3x5 grid, with a few exceptions:
		- The "center of K" piece which the horizontal strokes join at the center
		- The "bottom of V" piece where the stroke joins somewhere between 2 y-levels.

Top: FairfaxHD, Bottom: This PR
![image](https://github.com/be5invis/Iosevka/assets/21302803/d78fd27c-0c42-414a-b823-ceecc93f57bc)

![image](https://github.com/be5invis/Iosevka/assets/21302803/723473b1-8a82-4274-8468-aba8282b2e15)
