### PR TITLE
Some more Legacy Computing symbols

### DIFF
--- a/changes/29.0.0.md
+++ b/changes/29.0.0.md
@@ -12,4 +12,17 @@
   - `five`.`upright-flat` → `five`.`upright-flat-serifless`
   - `five`.`oblique-arched` → `five`.`oblique-arched-serifless`
   - `five`.`oblique-flat` → `five`.`oblique-flat-serifless`
+* Add characters:
+  - LOWER HORIZONTAL RULER SEGMENT (U+1CC05)  (Purposed for Unicode 16; L2/21-235).
+  - RIGHT VERTICAL RULER SEGMENT (U+1CC06)  (Purposed for Unicode 16; L2/21-235).
+  - LOWER RIGHT RULER SEGMENT (U+1CC07)  (Purposed for Unicode 16; L2/21-235).
+  - BOX DRAWINGS LIGHT HORIZONTAL AND UPPER RIGHT (U+1CC1B) ... BOX DRAWINGS LIGHT BOTTOM AND LOWER LEFT (U+1CC1E)  (Purposed for Unicode 16; L2/21-235).
+  - BLACK NEUTRAL FACE (U+1CC6F)  (Purposed for Unicode 16; L2/21-235).
+  - VERTICAL LINE WITH FOUR TICK MARKS (U+1CC90)  (Purposed for Unicode 16; L2/21-235).
+  - HORIZONTAL LINE WITH FOUR TICK MARKS (U+1CC91)  (Purposed for Unicode 16; L2/21-235).
+  - UPPER LEFT ONE SIXTEENTH BLOCK (U+1CE90) ... LOWER HALF RIGHT ONE QUARTER BLOCK (U+1CEAF)  (Purposed for Unicode 16; L2/21-235).
+  - NEGATIVE SQUARED LEFTWARDS ARROW (U+1F8B4) ... NEGATIVE SQUARED DOWNWARDS ARROW (U+1F8B7)  (Purposed for Unicode 16; L2/21-235).
+  - LEFT TWO THIRDS BLOCK (U+1FBCE)  (Purposed for Unicode 16; L2/21-235).
+  - LEFT ONE THIRD BLOCK (U+1FBCF)  (Purposed for Unicode 16; L2/21-235).
+  - UPPER CENTRE ONE QUARTER BLOCK (U+1FBE4) ... MIDDLE RIGHT ONE QUARTER BLOCK (U+1FBE7)  (Purposed for Unicode 16; L2/21-235).
 * Fix a disjoint stroke of Outlined Curly `Z` under some weights (#2195).

--- a/packages/font-glyphs/src/symbol/mosaic.ptl
+++ b/packages/font-glyphs/src/symbol/mosaic.ptl
@@ -1307,9 +1307,6 @@ glyph-block Symbol-Geometric-Mosaic-Inverted : for-width-kinds WideWidth1
 		include : difference
 			refer-glyph : MangleName 'be2588'
 			refer-glyph : MangleName 'blackCircle'
-		include : difference
-			refer-glyph : MangleName 'be2588'
-			refer-glyph : MangleName 'blackCircle'
 
 	create-glyph [MangleName 'uni25DA'] [MangleUnicode 0x25DA] : glyph-proc
 		set-width MosaicWidth
@@ -1327,3 +1324,44 @@ glyph-block Symbol-Geometric-Mosaic-Inverted : for-width-kinds WideWidth1
 		set-width MosaicWidth
 		include : refer-glyph : MangleName 'uni25DA'
 		include : refer-glyph : MangleName 'uni25DB'
+
+	# create-glyph [MangleName 'uni1CC8D'] [MangleUnicode 0x1CC8D] : glyph-proc
+	# 	set-width MosaicWidth
+	# 	include : difference
+	# 		refer-glyph : MangleName 'be2588'
+	# 		refer-glyph : MangleName 'blackDiamond'
+
+	create-glyph [MangleName 'uni1CC8E'] [MangleUnicode 0x1CC8E] : glyph-proc
+		set-width MosaicWidth
+		include : refer-glyph : MangleName 'be1FB7D'
+		include : refer-glyph : MangleName 'blackSmallSquare'
+
+	create-glyph [MangleName 'uni1CC8F'] [MangleUnicode 0x1CC8F] : glyph-proc
+		set-width MosaicWidth
+		include : difference
+			refer-glyph : MangleName 'be2588'
+			refer-glyph : MangleName 'blackSmallSquare'
+
+	create-glyph [MangleName 'uni1F8B4'] [MangleUnicode 0x1F8B4] : glyph-proc
+		set-width MosaicWidth
+		include : difference
+			refer-glyph : MangleName 'be2588'
+			refer-glyph : MangleName 'arrowLeft'
+
+	create-glyph [MangleName 'uni1F8B5'] [MangleUnicode 0x1F8B5] : glyph-proc
+		set-width MosaicWidth
+		include : difference
+			refer-glyph : MangleName 'be2588'
+			refer-glyph : MangleName 'arrowUp'
+
+	create-glyph [MangleName 'uni1F8B6'] [MangleUnicode 0x1F8B6] : glyph-proc
+		set-width MosaicWidth
+		include : difference
+			refer-glyph : MangleName 'be2588'
+			refer-glyph : MangleName 'arrowRight'
+
+	create-glyph [MangleName 'uni1F8B7'] [MangleUnicode 0x1F8B7] : glyph-proc
+		set-width MosaicWidth
+		include : difference
+			refer-glyph : MangleName 'be2588'
+			refer-glyph : MangleName 'arrowDown'

--- a/packages/font-glyphs/src/symbol/mosaic.ptl
+++ b/packages/font-glyphs/src/symbol/mosaic.ptl
@@ -616,8 +616,8 @@ glyph-block Symbol-Mosaic : begin
 
 			BlockElementGlyph 0x1FBCE 0 (2 / 3) 0 1
 			BlockElementGlyph 0x1FBCF 0 (1 / 3) 0 1
-			BlockElementGlyph 0x1FBE4 (1 / 4) (3 / 4) 0 (1 / 2)
-			BlockElementGlyph 0x1FBE5 (1 / 4) (3 / 4) (1 / 2) 1
+			BlockElementGlyph 0x1FBE4 (1 / 4) (3 / 4) (1 / 2) 1
+			BlockElementGlyph 0x1FBE5 (1 / 4) (3 / 4) 0 (1 / 2)
 			BlockElementGlyph 0x1FBE6 0 (1 / 2) (1 / 4) (3 / 4)
 			BlockElementGlyph 0x1FBE7 (1 / 2) 1 (1 / 4) (3 / 4)
 

--- a/packages/font-glyphs/src/symbol/mosaic.ptl
+++ b/packages/font-glyphs/src/symbol/mosaic.ptl
@@ -461,9 +461,9 @@ glyph-block Symbol-Mosaic : begin
 
 		### Large Type Pieces
 		do 'Large Type Pieces'
-			local stemleft  : mix 0 MosaicWidth (1 / 3)
-			local stemright : mix 0 MosaicWidth (2 / 3)
-			local stemmid   : mix 0 MosaicWidth 0.5
+			local stemleft  : mix left right (1 / 3)
+			local stemright : mix left right (2 / 3)
+			local stemmid   : mix left right 0.5
 			define [yPart n] : return : mix top bottom (n / 5)
 
 			define [Stem start end] : spiro-outline
@@ -487,10 +487,10 @@ glyph-block Symbol-Mosaic : begin
 				corner right [yPart yEnd]
 				corner right [yPart (yEnd + 1)]
 				corner left [yPart (yStart + 1)]
-			
+
 			define [Arc yHori yVert fRight] : spiro-outline
-				corner [if fRight MosaicWidth 0] [yPart [if fRight yHori (yHori + 1)]]
-				corner [if fRight MosaicWidth 0] [yPart [if fRight (yHori + 1) yHori]]
+				corner [if fRight right left] [yPart [if fRight yHori (yHori + 1)]]
+				corner [if fRight right left] [yPart [if fRight (yHori + 1) yHori]]
 				corner [if (yHori < yVert) stemright stemleft] [yPart [if (yHori < yVert) (yVert + 1) yVert]]
 				corner [if (yHori < yVert) stemleft stemright] [yPart [if (yHori < yVert) (yVert + 1) yVert]]
 
@@ -500,51 +500,51 @@ glyph-block Symbol-Mosaic : begin
 					include : ForceUpright
 					include shape
 
-			MakePiece 0x1CE1A : union [Stem 4 4] [Arc 2 3 1] 
-			MakePiece 0x1CE1B : union [Stem 2 4] [Arm 2 2 stemright MosaicWidth]
+			MakePiece 0x1CE1A : union [Stem 4 4] [Arc 2 3 1]
+			MakePiece 0x1CE1B : union [Stem 2 4] [Arm 2 2 stemright right]
 			MakePiece 0x1CE1C : union [Stem 2 4]
-			MakePiece 0x1CE1D : union [Stem 2 4] [Arm 2 3 stemright MosaicWidth]
-			MakePiece 0x1CE1E : union [Arm 2 2 stemleft MosaicWidth]
-			MakePiece 0x1CE1F : union [Arm 2 2 0 MosaicWidth]
-			MakePiece 0x1CE20 : union [Stem 2 4] [Arm 2 2 0 MosaicWidth]
+			MakePiece 0x1CE1D : union [Stem 2 4] [Arm 2 3 stemright right]
+			MakePiece 0x1CE1E : union [Arm 2 2 stemleft right]
+			MakePiece 0x1CE1F : union [Arm 2 2 left right]
+			MakePiece 0x1CE20 : union [Stem 2 4] [Arm 2 2 left right]
 			MakePiece 0x1CE21 : union [Arc 3 4 0] [Arc 3 4 1]
 			MakePiece 0x1CE22 : union [Arc 3 4 0]
 			MakePiece 0x1CE23 : union [Stem 4 4]
 			MakePiece 0x1CE24 : union [Stem 4 4] [Arc 2 3 0]
 			MakePiece 0x1CE25 : union [Arm 2 2 0 stemright]
-			MakePiece 0x1CE26 : union [Stem 2 4] [Arm 3 2 0 stemleft]
-			MakePiece 0x1CE27 : union [Stem 2 4] [Arm 2 2 0 stemleft]
-			MakePiece 0x1CE28 : union [Stem 0 4] [Arm 2 2 stemright MosaicWidth]
+			MakePiece 0x1CE26 : union [Stem 2 4] [Arm 3 2 left stemleft]
+			MakePiece 0x1CE27 : union [Stem 2 4] [Arm 2 2 left stemleft]
+			MakePiece 0x1CE28 : union [Stem 0 4] [Arm 2 2 stemright right]
 			MakePiece 0x1CE29 : union [Stem 0 4]
 			MakePiece 0x1CE2A : union [Arc 1 0 1] [Arc 3 4 1]
 			MakePiece 0x1CE2B : union [Arc 1 0 1]
 			MakePiece 0x1CE2C : union [Arc 3 4 1]
 			MakePiece 0x1CE2D : union [Stem 0 0]
 			MakePiece 0x1CE2E : union [Stem 0 0] [Stem 4 4] [Arc 2 1 1] [Arc 2 3 1]
-			MakePiece 0x1CE2F : union [Arm 2 2 0 stemmid] [Arm 2 1 stemmid MosaicWidth] [Arm 2 3 stemmid MosaicWidth]
+			MakePiece 0x1CE2F : union [Arm 2 2 left stemmid] [Arm 2 1 stemmid right] [Arm 2 3 stemmid right]
 			MakePiece 0x1CE30 : union [TopBit]
 			MakePiece 0x1CE31 : union [BottomBit]
-			MakePiece 0x1CE32 : union [Arm 1 3 0 MosaicWidth] [Arm 3 1 0 MosaicWidth]
+			MakePiece 0x1CE32 : union [Arm 1 3 left right] [Arm 3 1 left right]
 			MakePiece 0x1CE33 : union [Stem 3 4] [Arc 1 2 0] [Arc 1 2 1]
-			MakePiece 0x1CE34 : union [Arm 2 2 0 MosaicWidth] [Arm 3 1 0 MosaicWidth]
+			MakePiece 0x1CE34 : union [Arm 2 2 left right] [Arm 3 1 left right]
 			MakePiece 0x1CE35 : union [Stem 3 4] [Arc 1 2 1]
-			MakePiece 0x1CE36 : union [Stem 0 4] [Arm 2 2 0 stemleft]
+			MakePiece 0x1CE36 : union [Stem 0 4] [Arm 2 2 left stemleft]
 			MakePiece 0x1CE37 : union [Stem 0 0] [Stem 4 4] [Arc 2 1 0] [Arc 2 3 0]
 			MakePiece 0x1CE38 : union [Arc 1 0 0] [Arc 3 4 0]
-			MakePiece 0x1CE39 : union [Stem 0 4] [Arm 1 2 0 stemleft]
-			MakePiece 0x1CE3A : union [Stem 0 4] [Arm 2 2 0 MosaicWidth]
+			MakePiece 0x1CE39 : union [Stem 0 4] [Arm 1 2 left stemleft]
+			MakePiece 0x1CE3A : union [Stem 0 4] [Arm 2 2 left right]
 			MakePiece 0x1CE3B : union [Arc 0 1 0]
 			MakePiece 0x1CE3C : union [Stem 0 2]
-			MakePiece 0x1CE3D : union [Stem 0 2] [Arm 2 2 stemright MosaicWidth]
+			MakePiece 0x1CE3D : union [Stem 0 2] [Arm 2 2 stemright right]
 			MakePiece 0x1CE3E : union [Stem 0 0] [Arc 2 1 1]
-			MakePiece 0x1CE3F : union [Stem 0 2] [Arm 2 1 stemright MosaicWidth]
-			MakePiece 0x1CE40 : union [Stem 0 2] [Arm 2 2 0 MosaicWidth]
-			MakePiece 0x1CE41 : union [Arm 1 2.5 0 stemmid] [Arm 2.5 1 stemmid MosaicWidth]
+			MakePiece 0x1CE3F : union [Stem 0 2] [Arm 2 1 stemright right]
+			MakePiece 0x1CE40 : union [Stem 0 2] [Arm 2 2 0 right]
+			MakePiece 0x1CE41 : union [Arm 1 2.5 left stemmid] [Arm 2.5 1 stemmid right]
 			MakePiece 0x1CE42 : union [Arc 1 0 0] [Arc 1 0 1]
 			MakePiece 0x1CE43 : union [Stem 0 0] [Arc 2 1 0]
-			MakePiece 0x1CE44 : union [Stem 0 2] [Arm 2 2 0 stemleft] 
-			MakePiece 0x1CE45 : union [Stem 0 0] [Arc 2 1 0] [Arm 0 2 0 stemright]
-			MakePiece 0x1CE46 : union [Stem 0 2] [Arm 1 2 0 stemleft]
+			MakePiece 0x1CE44 : union [Stem 0 2] [Arm 2 2 left stemleft]
+			MakePiece 0x1CE45 : union [Stem 0 0] [Arc 2 1 0] [Arm 0 2 left stemright]
+			MakePiece 0x1CE46 : union [Stem 0 2] [Arm 1 2 left stemleft]
 			MakePiece 0x1CE47 : union [Stem 3 4]
 			MakePiece 0x1CE48 : union [Stem 1 4]
 			MakePiece 0x1CE49 : union [Stem 3 3]
@@ -795,13 +795,13 @@ glyph-block Symbol-Mosaic : begin
 					set-width MosaicWidth
 					include : ForceUpright
 					local posy : mix (bottom + light / 2) (top - light / 2) pos
-					include : HBar.m 0 MosaicWidth posy light
+					include : HBar.m left right posy light
 
 			define [vline unicode pos] : begin
 				create-glyph [BdGlyphName unicode] [MangleUnicode unicode] : glyph-proc
 					set-width MosaicWidth
 					include : ForceUpright
-					local posx : mix (light / 2) (MosaicWidth - light / 2) pos
+					local posx : mix (left + light / 2) (right - light / 2) pos
 					include : VBar.m posx bottom top light
 
 			# Scan Lines
@@ -812,26 +812,52 @@ glyph-block Symbol-Mosaic : begin
 			hline 0x23BC (1 / 4)
 			hline 0x23BD 0
 
+			create-glyph [BdGlyphName 0x1CC1B] [MangleUnicode 0x1CC1B] : glyph-proc
+				set-width MosaicWidth
+				include : ForceUpright
+				include : HBar.m left right midy light
+				include : VBar.r right midy topy light
+
+			create-glyph [BdGlyphName 0x1CC1C] [MangleUnicode 0x1CC1C] : glyph-proc
+				set-width MosaicWidth
+				include : ForceUpright
+				include : HBar.m left right midy light
+				include : VBar.r right boty midy light
+
+			create-glyph [BdGlyphName 0x1CC1D] [MangleUnicode 0x1CC1D] : glyph-proc
+				set-width MosaicWidth
+				include : ForceUpright
+				include : HBar.t left right top light
+				include : VBar.l left (midy - 0.5 * light) top light
+
+			create-glyph [BdGlyphName 0x1CC1E] [MangleUnicode 0x1CC1E] : glyph-proc
+				set-width MosaicWidth
+				include : ForceUpright
+				include : HBar.b left right bottom light
+				include : VBar.l left bottom (midy + 0.5 * light) light
+
 			# Split Dashed Lines
 			create-glyph [BdGlyphName 0x1CE0D] [MangleUnicode 0x1CE0D] : glyph-proc
 				set-width MosaicWidth
 				include : ForceUpright
-				include : HBar.m 0 (MosaicWidth / 3) midy light
-				include : HBar.m (MosaicWidth * 2 / 3) MosaicWidth midy light
+				include : HBar.m left [mix left right (1 / 3)] midy light
+				include : HBar.m [mix left right (2 / 3)] right midy light
 
 			create-glyph [BdGlyphName 0x1CE0E] [MangleUnicode 0x1CE0E] : glyph-proc
 				set-width MosaicWidth
 				include : ForceUpright
-				include : HBar.m (MosaicWidth / 3) (MosaicWidth * 2 / 3) midy light
+				include : HBar.m [mix left right (1 / 3)] [mix left right (2 / 3)] midy light
 
 			define [hlinetick unicode a b c] : begin
 				create-glyph [BdGlyphName unicode] [MangleUnicode unicode] : glyph-proc
 					set-width MosaicWidth
 					include : ForceUpright
-					include : HBar.m 0 MosaicWidth midy light
-					if a : include : VBar.r (MosaicWidth / 3)     [mix bottom midy 0.5] midy light
-					if b : include : VBar.r (MosaicWidth * 2 / 3) [mix bottom midy 0.5] midy light
-					if c : include : VBar.r  MosaicWidth          [mix bottom midy 0.5] midy light 
+					include : HBar.m left right midy light
+					local tickbot : mix bottom midy 0.5
+					local ticktop midy
+					if a : include : VBar.r [mix left right (1 / 3)] tickbot ticktop light
+					if b : include : VBar.r [mix left right (2 / 3)] tickbot ticktop light
+					if c : include : VBar.r           right          tickbot ticktop light
 
 			define [vlinetick unicode a b c d rev] : begin
 				create-glyph [BdGlyphName unicode] [MangleUnicode unicode] : glyph-proc
@@ -858,14 +884,50 @@ glyph-block Symbol-Mosaic : begin
 			vlinetick 0x1CE18 0 0 1 0 0
 			vlinetick 0x1CE19 0 0 0 1 0
 
+			create-glyph [BdGlyphName 0x1CC90] [MangleUnicode 0x1CC90] : glyph-proc
+				set-width MosaicWidth
+				include : ForceUpright
+				include : VBar.m midx boty top light
+				local tickleft : mix left right (1 / 4)
+				local tickright : mix left right (3 / 4)
+				foreach i [range 0 4] : begin
+					include : HBar.t tickleft tickright [mix bottom top ((i + 1) / 4)] light
+
+			create-glyph [BdGlyphName 0x1CC91] [MangleUnicode 0x1CC91] : glyph-proc
+				set-width MosaicWidth
+				include : ForceUpright
+				include : HBar.m left right midy light
+				local tickbot : mix bottom midy 0.75
+				local ticktop : mix midy top 0.25
+				foreach i [range 0 4] : begin
+					include : VBar.l [mix left right (i / 4)] tickbot ticktop light
+
+			create-glyph [BdGlyphName 0x1CC05] [MangleUnicode 0x1CC05] : glyph-proc
+				set-width MosaicWidth
+				include : ForceUpright
+				include : VBar.m [mix left right (6.5 / 8)] boty [mix bottom top (3 / 8)] light
+				include : HBar.m left right [mix bottom top (1.5 / 8)] light
+
+			create-glyph [BdGlyphName 0x1CC06] [MangleUnicode 0x1CC06] : glyph-proc
+				set-width MosaicWidth
+				include : ForceUpright
+				include : VBar.m [mix left right (6.5 / 8)] boty topy light
+				include : HBar.m [mix left right (5 / 8)] right [mix bottom top (1.5 / 8)] light
+
+			create-glyph [BdGlyphName 0x1CC07] [MangleUnicode 0x1CC07] : glyph-proc
+				set-width MosaicWidth
+				include : ForceUpright
+				include : VBar.m [mix left right (6.5 / 8)] boty topy light
+				include : HBar.m left right [mix bottom top (1.5 / 8)] light
+
 			define [boxdraw unicode u d l r] : begin
 				create-glyph [BdGlyphName unicode] [MangleUnicode unicode] : glyph-proc
 					set-width MosaicWidth
 					include : ForceUpright
 					local stopH : [Math.max u d] / 2
 					local stopV : [Math.max l r] / 2
-					if l : include : HBar.m 0 (midx + stopH) midy l
-					if r : include : HBar.m (midx - stopH) MosaicWidth midy r
+					if l : include : HBar.m left (midx + stopH) midy l
+					if r : include : HBar.m (midx - stopH) right midy r
 					if d : include : VBar.m midx boty (midy + stopV) d
 					if u : include : VBar.m midx (midy - stopV) topy u
 
@@ -878,11 +940,11 @@ glyph-block Symbol-Mosaic : begin
 					local capH  : [Math.max u d] - light * 1
 					local capV  : [Math.max l r] - light * 1
 					if l : begin
-						include : HBar.m 0 (midx - stopH) (midy + (l - light)) light
-						if (l > light) : include : HBar.m 0 (midx - stopH) (midy - (l - light)) light
+						include : HBar.m left (midx - stopH) (midy + (l - light)) light
+						if (l > light) : include : HBar.m left (midx - stopH) (midy - (l - light)) light
 					if r : begin
-						include : HBar.m (midx + stopH) MosaicWidth (midy + (r - light)) light
-						if (r > light) : include : HBar.m (midx + stopH) MosaicWidth (midy - (r - light)) light
+						include : HBar.m (midx + stopH) right (midy + (r - light)) light
+						if (r > light) : include : HBar.m (midx + stopH) right (midy - (r - light)) light
 					if d : begin
 						include : VBar.m (midx + (d - light)) boty (midy - stopV) light
 						if (d > light) : include : VBar.m (midx - (d - light)) boty (midy - stopV) light
@@ -1334,13 +1396,13 @@ glyph-block Symbol-Geometric-Mosaic-Inverted : for-width-kinds WideWidth1
 	create-glyph [MangleName 'uni1CC8E'] [MangleUnicode 0x1CC8E] : glyph-proc
 		set-width MosaicWidth
 		include : refer-glyph : MangleName 'be1FB7D'
-		include : refer-glyph : MangleName 'blackSmallSquare'
+		include : with-transform [ApparentTranslate (MosaicWidth / 16) ((MosaicBottom - MosaicTop) / 16)] : refer-glyph : MangleName 'blackSmallSquare'
 
 	create-glyph [MangleName 'uni1CC8F'] [MangleUnicode 0x1CC8F] : glyph-proc
 		set-width MosaicWidth
 		include : difference
 			refer-glyph : MangleName 'be2588'
-			refer-glyph : MangleName 'blackSmallSquare'
+			with-transform [ApparentTranslate (MosaicWidth / 16) ((MosaicBottom - MosaicTop) / 16)] : refer-glyph : MangleName 'blackSmallSquare'
 
 	create-glyph [MangleName 'uni1F8B4'] [MangleUnicode 0x1F8B4] : glyph-proc
 		set-width MosaicWidth

--- a/packages/font-glyphs/src/symbol/mosaic.ptl
+++ b/packages/font-glyphs/src/symbol/mosaic.ptl
@@ -601,6 +601,26 @@ glyph-block Symbol-Mosaic : begin
 					BlockElementGlyph (0x1FB70 - 2 + fill) ((fill - 1) / 8) (fill / 8) 0 1
 					BlockElementGlyph (0x1FB76 - 2 + fill) 0 1 (1 - (fill - 1) / 8) (1 - fill / 8)
 
+			foreach [pos : range 0 16] : begin
+				local xCoord : (pos % 4) / 4
+				local yCoord : 1 - [Math.floor (pos / 4)] / 4
+				BlockElementGlyph (0x1CE90 + pos) xCoord (xCoord + 0.25) (yCoord - 0.25) yCoord
+
+			foreach [index : range 0 4] : begin
+				local lower : [Math.max 0 (index - 1)] / 4
+				local upper : [Math.min 4 (index + 2)] / 4
+				BlockElementGlyph (0x1CEA0 + index) (1 - upper) (1 - lower) 0 (1 / 4)
+				BlockElementGlyph (0x1CEA4 + index) 0 (1 / 4) lower upper
+				BlockElementGlyph (0x1CEA8 + index) lower upper (3 / 4) 1
+				BlockElementGlyph (0x1CEAC + index) (3 / 4) 1 (1 - upper) (1 - lower)
+
+			BlockElementGlyph 0x1FBCE 0 (2 / 3) 0 1
+			BlockElementGlyph 0x1FBCF 0 (1 / 3) 0 1
+			BlockElementGlyph 0x1FBE4 (1 / 4) (3 / 4) 0 (1 / 2)
+			BlockElementGlyph 0x1FBE5 (1 / 4) (3 / 4) (1 / 2) 1
+			BlockElementGlyph 0x1FBE6 0 (1 / 2) (1 / 4) (3 / 4)
+			BlockElementGlyph 0x1FBE7 (1 / 2) 1 (1 / 4) (3 / 4)
+
 			BlockElementGlyph2 0x1FB7C     0 (1 / 8) 0 1    0 1 0 (1 / 8)
 			BlockElementGlyph2 0x1FB7D     0 (1 / 8) 0 1    0 1 (7 / 8) 1
 			BlockElementGlyph2 0x1FB7E     (7 / 8) 1 0 1    0 1 (7 / 8) 1

--- a/packages/font-glyphs/src/symbol/pictograph/faces.ptl
+++ b/packages/font-glyphs/src/symbol/pictograph/faces.ptl
@@ -62,6 +62,12 @@ glyph-block Symbol-Pictograph-Faces : begin
 				FaceRing OShape
 				SmileFace 0 : 0.6 * (faceWidth - faceStroke * 2)
 
+		create-glyph [MangleName 'blackNeutralFace'] [MangleUnicode 0x1CC6F] : glyph-proc
+			set-width MosaicWidth
+			include : difference
+				FaceRing OShapeOutline
+				SmileFace 0 : 0.6 * (faceWidth - faceStroke * 2)
+
 		create-glyph [MangleName 'mouthlessFace'] [MangleUnicode 0x1F636] : glyph-proc
 			set-width MosaicWidth
 			include : union


### PR DESCRIPTION
Part of #2189.

Including ranges:
- `U+1CC6F` (black neutral face)
	- Extension of the existing face code.
- `U+1CE90` - `U+1CEAF` (block elements)
- `U+1FBE4` - `U+1FBE7` (centered quarter blocks)
- `U+1FBCE` - `U+1FBCF` (third blocks)
	- Extensions of the existing block elements.
- `U+1F8B4` - `U+1F8B7` (negative arrows)
- `U+1CC8E` - `U+1CC8F`
	- These are simple union/difference compositions of existing glyphs
	- According to FairfaxHD (and Nishiki-teki), the squares seem to be centered around the lower right region instead of the whole glyph. They are shifted accordingly.
	- `U+1CC8D` (negative diamond) is implemented but commented out, since I'm not sure if this is the desired implementation.
		- Since most of these characters assume a square bounding box, there seems to be some ambiguity on what should happen for half width/narrower fonts (e.g. stretch the shape like `🮿` or shrink them like `⯁`).
- `U+1CC05` - `U+1CC07` (ruler segment)
	- Aligned the lines to a 8x8 grid, intersecting them at the center of the 7th row 7th column grid.
- `U+1CC1B` - `U+1CC1E` (box drawing lines containing bounding box lines)
- `U+1CC90` - `U+1CC91` (4-tick lines)

Comparison with Fairfax HD (upper one):
![image](https://github.com/be5invis/Iosevka/assets/21302803/904a0e00-1521-40ab-9188-cabb5fa5759f)
![image](https://github.com/be5invis/Iosevka/assets/21302803/df7493a6-3f75-431b-8b6d-f0159e812bee)
