### PR TITLE
Reorder `U`/`u`/`μ`/`µ` bottom-right serif variants to be in ascending buildup order.

### DIFF
--- a/changes/29.0.0.md
+++ b/changes/29.0.0.md
@@ -12,6 +12,8 @@
   - `five`.`upright-flat` → `five`.`upright-flat-serifless`
   - `five`.`oblique-arched` → `five`.`oblique-arched-serifless`
   - `five`.`oblique-flat` → `five`.`oblique-flat-serifless`
+* \[**BREAKING**\] Reorder of glyph variants:
+   - Influenced characters: `U`, `u`, Greek Lower Mu (`μ`), Micro Sign (`µ`).
 * Add characters:
   - UPWARDS WHITE ARROW FROM BAR (`U+21EA`) ... RIGHTWARDS WHITE ARROW FROM WALL (`U+21F0`).
   - RETURN SYMBOL (`U+23CE`).

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1108,20 +1108,20 @@ selectorAffix.U = "serifless"
 selectorAffix."U/noTopLeftSerif" = "serifless"
 selectorAffix."U/sansSerif" = "serifless"
 
-[prime.capital-u.variants-buildup.stages.serifs.motion-serifed]
-rank = 2
-disableIf = [{ body = "toothless-corner" }, { body = "toothless-rounded" }]
-descriptionAffix = "motion serifs at top-left and bottom-right"
-selectorAffix.U = "unilateralMotionSerifed"
-selectorAffix."U/noTopLeftSerif" = "serifless"
-selectorAffix."U/sansSerif" = "serifless"
-
 [prime.capital-u.variants-buildup.stages.serifs.bottom-right-serifed]
-rank = 3
+rank = 2
 disableIf = [{ body = "NOT toothed" }]
 descriptionAffix = "serif at bottom-right"
 selectorAffix.U = "bottomRightSerifed"
 selectorAffix."U/noTopLeftSerif" = "bottomRightSerifed"
+selectorAffix."U/sansSerif" = "serifless"
+
+[prime.capital-u.variants-buildup.stages.serifs.motion-serifed]
+rank = 3
+disableIf = [{ body = "toothless-corner" }, { body = "toothless-rounded" }]
+descriptionAffix = "motion serifs at top-left and bottom-right"
+selectorAffix.U = "unilateralMotionSerifed"
+selectorAffix."U/noTopLeftSerif" = "serifless"
 selectorAffix."U/sansSerif" = "serifless"
 
 [prime.capital-u.variants-buildup.stages.serifs.unilateral-motion-serifed]
@@ -3833,29 +3833,8 @@ selectorAffix."cyrl/tse.italic" = "serifless"
 selectorAffix."ue/u" = "serifless"
 selectorAffix."au/u" = "serifless"
 
-[prime.u.variants-buildup.stages.serifs.motion-serifed]
-rank = 2
-descriptionAffix = "motion serifs at top-left and bottom-right"
-selectorAffix.u = "motionSerifed"
-selectorAffix."u/sansSerif" = "serifless"
-selectorAffix."u/uRTailBase" = "motionSerifed"
-selectorAffix.uHookLeft = {if = [{body = "toothed"}], then = "bottomRightSerifed", else = "serifless"}
-selectorAffix.turnh = "motionSerifed"
-selectorAffix.turnhHookLeft = "bottomRightSerifed"
-selectorAffix.turnhHookLeftRTail = "serifless"
-selectorAffix.turnm = "motionSerifed"
-selectorAffix.turnmLeg = "motionSerifed"
-selectorAffix."cyrl/i.italic" = "motionSerifed"
-selectorAffix."cyrl/i.italic/descBase" = "motionSerifed"
-selectorAffix."cyrl/sha.italic" = "motionSerifed"
-selectorAffix."cyrl/shcha.italic" = "motionSerifed"
-selectorAffix."cyrl/dzhe.italic" = "motionSerifed"
-selectorAffix."cyrl/tse.italic" = "motionSerifed"
-selectorAffix."ue/u" = "serifed"
-selectorAffix."au/u" = {if = [{body = "toothed"}], then = "bottomRightSerifed", else = "serifless"}
-
 [prime.u.variants-buildup.stages.serifs.bottom-right-serifed]
-rank = 3
+rank = 2
 disableIf = [{ body = "NOT toothed" }]
 descriptionAffix = "serif at bottom-right"
 selectorAffix.u = "bottomRightSerifed"
@@ -3874,6 +3853,27 @@ selectorAffix."cyrl/shcha.italic" = "serifless"
 selectorAffix."cyrl/dzhe.italic" = "bottomRightSerifed"
 selectorAffix."cyrl/tse.italic" = "serifless"
 selectorAffix."ue/u" = "serifless"
+selectorAffix."au/u" = "bottomRightSerifed"
+
+[prime.u.variants-buildup.stages.serifs.motion-serifed]
+rank = 3
+descriptionAffix = "motion serifs at top-left and bottom-right"
+selectorAffix.u = "motionSerifed"
+selectorAffix."u/sansSerif" = "serifless"
+selectorAffix."u/uRTailBase" = "motionSerifed"
+selectorAffix.uHookLeft = {if = [{body = "toothed"}], then = "bottomRightSerifed", else = "serifless"}
+selectorAffix.turnh = "motionSerifed"
+selectorAffix.turnhHookLeft = "bottomRightSerifed"
+selectorAffix.turnhHookLeftRTail = "serifless"
+selectorAffix.turnm = "motionSerifed"
+selectorAffix.turnmLeg = "motionSerifed"
+selectorAffix."cyrl/i.italic" = "motionSerifed"
+selectorAffix."cyrl/i.italic/descBase" = "motionSerifed"
+selectorAffix."cyrl/sha.italic" = "motionSerifed"
+selectorAffix."cyrl/shcha.italic" = "motionSerifed"
+selectorAffix."cyrl/dzhe.italic" = "motionSerifed"
+selectorAffix."cyrl/tse.italic" = "motionSerifed"
+selectorAffix."ue/u" = "serifed"
 selectorAffix."au/u" = {if = [{body = "toothed"}], then = "bottomRightSerifed", else = "serifless"}
 
 [prime.u.variants-buildup.stages.serifs.serifed]
@@ -5017,17 +5017,17 @@ descriptionJoiner = "without"
 selectorAffix."grek/mu" = "serifless"
 selectorAffix."grek/mu/sansSerif" = "serifless"
 
-[prime.lower-mu.variants-buildup.stages.serifs.motion-serifed]
-rank = 2
-descriptionAffix = "motion serifs at top-left and bottom-right"
-selectorAffix."grek/mu" = "motionSerifed"
-selectorAffix."grek/mu/sansSerif" = "serifless"
-
 [prime.lower-mu.variants-buildup.stages.serifs.bottom-right-serifed]
-rank = 3
+rank = 2
 disableIf = [{ body = "NOT toothed" }]
 descriptionAffix = "serif at bottom-right"
 selectorAffix."grek/mu" = "bottomRightSerifed"
+selectorAffix."grek/mu/sansSerif" = "serifless"
+
+[prime.lower-mu.variants-buildup.stages.serifs.motion-serifed]
+rank = 3
+descriptionAffix = "motion serifs at top-left and bottom-right"
+selectorAffix."grek/mu" = "motionSerifed"
 selectorAffix."grek/mu/sansSerif" = "serifless"
 
 [prime.lower-mu.variants-buildup.stages.serifs.serifed]
@@ -7424,16 +7424,16 @@ descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix."micro" = "serifless"
 
-[prime.micro-sign.variants-buildup.stages.serifs.motion-serifed]
-rank = 2
-descriptionAffix = "motion serifs at top-left and bottom-right"
-selectorAffix."micro" = "motionSerifed"
-
 [prime.micro-sign.variants-buildup.stages.serifs.bottom-right-serifed]
-rank = 3
+rank = 2
 disableIf = [{ body = "NOT toothed" }]
 descriptionAffix = "serif at bottom-right"
 selectorAffix."micro" = "bottomRightSerifed"
+
+[prime.micro-sign.variants-buildup.stages.serifs.motion-serifed]
+rank = 3
+descriptionAffix = "motion serifs at top-left and bottom-right"
+selectorAffix."micro" = "motionSerifed"
 
 [prime.micro-sign.variants-buildup.stages.serifs.serifed]
 rank = 4


### PR DESCRIPTION
Basically bottom-right serif is moved to come before motion serifed like how all other variant selectors are ordered.
