### PR TITLE
Reorder `Z`/`z` {top|bottom}-serifed variants to in ascending buildup order.

### DIFF
--- a/changes/29.0.0.md
+++ b/changes/29.0.0.md
@@ -13,7 +13,7 @@
   - `five`.`oblique-arched` → `five`.`oblique-arched-serifless`
   - `five`.`oblique-flat` → `five`.`oblique-flat-serifless`
 * \[**BREAKING**\] Reorder of glyph variants:
-   - Influenced characters: `U`, `u`, Greek Lower Mu (`μ`), Micro Sign (`µ`).
+   - Influenced characters: `U`, `Z`, `u`, `z`, Greek Lower Mu (`μ`), Micro Sign (`µ`).
 * Add characters:
   - UPWARDS WHITE ARROW FROM BAR (`U+21EA`) ... RIGHTWARDS WHITE ARROW FROM WALL (`U+21F0`).
   - RETURN SYMBOL (`U+23CE`).

--- a/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
@@ -97,9 +97,9 @@ glyph-block Letter-Latin-Ezh : begin
 		return : object yMidBar
 
 	define EzhConfig : object
-		straightSerifless { false false }
-		straightSerifed   { false true  }
-		cursive           { true  false }
+		straightSerifless  { false false }
+		straightTopSerifed { false true  }
+		cursive            { true  false }
 
 	foreach { suffix { isCursive isSerifed } } [pairs-of EzhConfig] : do
 		create-glyph "Ezh.\(suffix)" : glyph-proc

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1457,16 +1457,16 @@ selectorAffix.ZDesc = "serifless"
 selectorAffix."ZDesc/reduced" = "serifless"
 selectorAffix.Ezh = "serifless"
 
-[prime.capital-z.variants-buildup.stages.serifs.serifed]
+[prime.capital-z.variants-buildup.stages.serifs.top-serifed]
 rank = 2
-descriptionAffix = "serifs"
-selectorAffix.Z = "serifed"
+descriptionAffix = "serifs at top"
+selectorAffix.Z = "topSerifed"
 selectorAffix."Z/sansSerif" = "serifless"
-selectorAffix."Z/reduced" = "serifed"
+selectorAffix."Z/reduced" = "topSerifed"
 selectorAffix."Z/reduced/sansSerif" = "serifless"
 selectorAffix.ZDesc = "topSerifed"
 selectorAffix."ZDesc/reduced" = "topSerifed"
-selectorAffix.Ezh = "serifed"
+selectorAffix.Ezh = "topSerifed"
 
 [prime.capital-z.variants-buildup.stages.serifs.bottom-serifed]
 rank = 3
@@ -1479,16 +1479,16 @@ selectorAffix.ZDesc = "serifless"
 selectorAffix."ZDesc/reduced" = "serifless"
 selectorAffix.Ezh = "serifless"
 
-[prime.capital-z.variants-buildup.stages.serifs.top-serifed]
+[prime.capital-z.variants-buildup.stages.serifs.serifed]
 rank = 4
-descriptionAffix = "serifs at top"
-selectorAffix.Z = "topSerifed"
+descriptionAffix = "serifs"
+selectorAffix.Z = "serifed"
 selectorAffix."Z/sansSerif" = "serifless"
-selectorAffix."Z/reduced" = "topSerifed"
+selectorAffix."Z/reduced" = "serifed"
 selectorAffix."Z/reduced/sansSerif" = "serifless"
 selectorAffix.ZDesc = "topSerifed"
 selectorAffix."ZDesc/reduced" = "topSerifed"
-selectorAffix.Ezh = "serifed"
+selectorAffix.Ezh = "topSerifed"
 
 [prime.capital-z.variants-buildup.stages.overlay.no-overlay]
 rank = 1
@@ -4263,7 +4263,6 @@ next = "serifs"
 
 [prime.z.variants-buildup.stages.body.straight]
 rank = 1
-groupRank = 10
 descriptionAffix = "straight body shape"
 selectorAffix.z = "straight"
 selectorAffix."z/sansSerif" = "straight"
@@ -4274,7 +4273,6 @@ selectorAffix.ezh = "straight"
 
 [prime.z.variants-buildup.stages.body.curly]
 rank = 2
-groupRank = 20
 descriptionAffix = "curly body shape"
 selectorAffix.z = "curly"
 selectorAffix."z/sansSerif" = "curly"
@@ -4285,7 +4283,6 @@ selectorAffix.ezh = "straight"
 
 [prime.z.variants-buildup.stages.body.cursive]
 rank = 3
-groupRank = 30
 next = "overlay"
 descriptionAffix = "cursive body shape"
 selectorAffix.z = "cursive"
@@ -4300,7 +4297,6 @@ next = "overlay"
 
 [prime.z.variants-buildup.stages.serifs.serifless]
 rank = 1
-groupRank = 1
 descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix.z = "serifless"
@@ -4310,20 +4306,18 @@ selectorAffix.zDesc = "serifless"
 selectorAffix."zDesc/reduced" = "serifless"
 selectorAffix.ezh = "serifless"
 
-[prime.z.variants-buildup.stages.serifs.serifed]
+[prime.z.variants-buildup.stages.serifs.top-serifed]
 rank = 2
-groupRank = 1
-descriptionAffix = "serifs"
-selectorAffix.z = "serifed"
+descriptionAffix = "serifs at top"
+selectorAffix.z = "topSerifed"
 selectorAffix."z/sansSerif" = "serifless"
-selectorAffix."z/reduced" = "serifed"
+selectorAffix."z/reduced" = "topSerifed"
 selectorAffix.zDesc = "topSerifed"
 selectorAffix."zDesc/reduced" = "topSerifed"
-selectorAffix.ezh = "serifed"
+selectorAffix.ezh = "topSerifed"
 
 [prime.z.variants-buildup.stages.serifs.bottom-serifed]
 rank = 3
-groupRank = 2
 descriptionAffix = "serifs at bottom"
 selectorAffix.z = "bottomSerifed"
 selectorAffix."z/sansSerif" = "serifless"
@@ -4332,16 +4326,15 @@ selectorAffix.zDesc = "serifless"
 selectorAffix."zDesc/reduced" = "serifless"
 selectorAffix.ezh = "serifless"
 
-[prime.z.variants-buildup.stages.serifs.top-serifed]
+[prime.z.variants-buildup.stages.serifs.serifed]
 rank = 4
-groupRank = 2
-descriptionAffix = "serifs at top"
-selectorAffix.z = "topSerifed"
+descriptionAffix = "serifs"
+selectorAffix.z = "serifed"
 selectorAffix."z/sansSerif" = "serifless"
-selectorAffix."z/reduced" = "topSerifed"
+selectorAffix."z/reduced" = "serifed"
 selectorAffix.zDesc = "topSerifed"
 selectorAffix."zDesc/reduced" = "topSerifed"
-selectorAffix.ezh = "serifed"
+selectorAffix.ezh = "topSerifed"
 
 [prime.z.variants-buildup.stages.overlay.no-overlay]
 rank = 1


### PR DESCRIPTION
Basically going from serifless, then top serifed, then bottom serifed, then fully serifed; Or more simply, serifless, then partially serifed, then fully serifed, in a similar manner to other letters' order.

Effectively this just involves swapping the index of top serifed and fully serifed, where serifless and bottom serifed stay put.

Also, the group rank definitions are no longer necessary as the serifs are now built up in contiguous order rather than two vague groups of none/all first then partial/partial second. They were also only defined for lowercase before for some reason and not the uppercase.

All `z` variants:
`z𝗓ʒ`
![image](https://github.com/be5invis/Iosevka/assets/37010132/d6dcff1c-4867-4e9a-8504-8b16535876d3)
All `Z` variants:
`Z𝖹Ʒ`
![image](https://github.com/be5invis/Iosevka/assets/37010132/9601233f-f250-4d5b-be52-c56271ab6b86)
