### PR TITLE
fix(hashFile): use path.basename to get file name

### DIFF
--- a/tools/misc/src/create-sha-file.mjs
+++ b/tools/misc/src/create-sha-file.mjs
@@ -24,7 +24,7 @@ export default (async function (out, archiveFiles) {
 	const filesToAnalyze = Array.from(new Set(archiveFiles.map(f => f.full))).sort();
 	let s = "";
 	for (const file of filesToAnalyze) {
-		s += `${await hashFile(file)}\t${file.name}\n`;
+		s += `${await hashFile(file)}\t${path.basename(file.full)}\n`;
 	}
 	await fs.promises.writeFile(out, s);
 });


### PR DESCRIPTION
Previously, the hashFile function was using file.name to get the file name, which resulted in undefined values in the output file. This commit fixes that by using path.basename(file.full) instead, which correctly extracts the file name from the full path.