### PR TITLE
Reorder `I`/`i`/`l` fully serifed variants in ascending buildup order.

### DIFF
--- a/changes/29.0.0.md
+++ b/changes/29.0.0.md
@@ -13,7 +13,7 @@
   - `five`.`oblique-arched` → `five`.`oblique-arched-serifless`
   - `five`.`oblique-flat` → `five`.`oblique-flat-serifless`
 * \[**BREAKING**\] Reorder of glyph variants:
-   - Influenced characters: `U`, `Z`, `u`, `z`, Greek Lower Mu (`μ`), Micro Sign (`µ`).
+   - Influenced characters: `I`, `U`, `Z`, `i`, `l`, `u`, `z`, Greek Lower Mu (`μ`), Micro Sign (`µ`).
 * Add characters:
   - UPWARDS WHITE ARROW FROM BAR (`U+21EA`) ... RIGHTWARDS WHITE ARROW FROM WALL (`U+21F0`).
   - RETURN SYMBOL (`U+23CE`).

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -440,16 +440,16 @@ selector."cyrl/Nje/leftHalf/reduced" = "serifedExceptBottomRight"
 sampler = "I"
 tagKind = "letter"
 
-[prime.capital-i.variants.serifed]
-rank = 1
-description = "I with standard (long) serifs"
-selector.I = "serifed"
-selector."I/sansSerif" = "serifless"
-
 [prime.capital-i.variants.serifless]
-rank = 2
+rank = 1
 description = "I without serifs, like a straight bar"
 selector.I = "serifless"
+selector."I/sansSerif" = "serifless"
+
+[prime.capital-i.variants.serifed]
+rank = 2
+description = "I with standard (long) serifs"
+selector.I = "serifed"
 selector."I/sansSerif" = "serifless"
 
 [prime.capital-i.variants.short-serifed]
@@ -2325,17 +2325,8 @@ selectorAffix.heng = "serifed"
 sampler = "i"
 tagKind = "letter"
 
-[prime.i.variants.serifed]
-rank = 1
-groupRank = 1
-description = "Serifed `i`"
-selector.dotlessi = "serifed"
-selector."dotlessi/sansSerif" = "serifless"
-selector."dotlessi/compLigRight" = "serifed"
-selector."dotlessi/tailed" = "serifedFlatTailed"
-
 [prime.i.variants.serifless]
-rank = 2
+rank = 1
 groupRank = 1
 description = "`i` like a straight line"
 selector.dotlessi = "serifless"
@@ -2344,7 +2335,7 @@ selector."dotlessi/compLigRight" = "hooky"
 selector."dotlessi/tailed" = "flatTailed"
 
 [prime.i.variants.hooky]
-rank = 3
+rank = 2
 groupRank = 1
 description = "Hooky `i`"
 selector.dotlessi = "hooky"
@@ -2353,7 +2344,7 @@ selector."dotlessi/compLigRight" = "hooky"
 selector."dotlessi/tailed" = "serifedFlatTailed"
 
 [prime.i.variants.hooky-bottom]
-rank = 4
+rank = 3
 groupRank = 1
 description = "`i` with a sharp-turning horizontal tail"
 selector.dotlessi = "hookyBottom"
@@ -2362,12 +2353,21 @@ selector."dotlessi/compLigRight" = "zshaped"
 selector."dotlessi/tailed" = "flatTailed"
 
 [prime.i.variants.zshaped]
-rank = 5
+rank = 4
 groupRank = 1
 description = "Z-shaped `i`"
 selector.dotlessi = "zshaped"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "zshaped"
+selector."dotlessi/tailed" = "serifedFlatTailed"
+
+[prime.i.variants.serifed]
+rank = 5
+groupRank = 1
+description = "Serifed `i`"
+selector.dotlessi = "serifed"
+selector."dotlessi/sansSerif" = "serifless"
+selector."dotlessi/compLigRight" = "serifed"
 selector."dotlessi/tailed" = "serifedFlatTailed"
 
 [prime.i.variants.serifed-asymmetric]
@@ -2657,22 +2657,8 @@ selectorAffix."grek/kappa/sansSerif" = "serifless"
 sampler = "l"
 tagKind = "letter"
 
-[prime.l.variants.serifed]
-rank = 1
-groupRank = 1
-description = "Serifed `l`"
-selector.l = "serifed"
-selector."l/sansSerif" = "serifless"
-selector."l/compLigRight" = "serifed"
-selector."l/reduced/decompress" = "serifed"
-selector."l/reduced/rtail" = "hookyRTail"
-selector."l/reduced/rtailDec" = "hookyRTailDec"
-selector."l/phoneticLeft" = "hookyPL"
-selector.lCurlyTail = "hooky"
-selector.lyogh = "hooky"
-
 [prime.l.variants.serifless]
-rank = 2
+rank = 1
 groupRank = 1
 description = "`l` like a straight line"
 selector.l = "serifless"
@@ -2686,7 +2672,7 @@ selector.lCurlyTail = "serifless"
 selector.lyogh = "serifless"
 
 [prime.l.variants.hooky]
-rank = 3
+rank = 2
 groupRank = 1
 description = "Hooky `l`"
 selector.l = "hooky"
@@ -2700,7 +2686,7 @@ selector.lCurlyTail = "hooky"
 selector.lyogh = "hooky"
 
 [prime.l.variants.hooky-bottom]
-rank = 4
+rank = 3
 groupRank = 1
 description = "`l` with a straight sharp-turning horizontal tail"
 selector.l = "hookyBottom"
@@ -2714,13 +2700,27 @@ selector.lCurlyTail = "serifless"
 selector.lyogh = "serifless"
 
 [prime.l.variants.zshaped]
-rank = 5
+rank = 4
 groupRank = 1
 description = "Z-shaped `l`"
 selector.l = "zshaped"
 selector."l/sansSerif" = "serifless"
 selector."l/compLigRight" = "zshaped"
 selector."l/reduced/decompress" = "zshaped"
+selector."l/reduced/rtail" = "hookyRTail"
+selector."l/reduced/rtailDec" = "hookyRTailDec"
+selector."l/phoneticLeft" = "hookyPL"
+selector.lCurlyTail = "hooky"
+selector.lyogh = "hooky"
+
+[prime.l.variants.serifed]
+rank = 5
+groupRank = 1
+description = "Serifed `l`"
+selector.l = "serifed"
+selector."l/sansSerif" = "serifless"
+selector."l/compLigRight" = "serifed"
+selector."l/reduced/decompress" = "serifed"
 selector."l/reduced/rtail" = "hookyRTail"
 selector."l/reduced/rtailDec" = "hookyRTailDec"
 selector."l/phoneticLeft" = "hookyPL"


### PR DESCRIPTION
Basically, for within group 1 (tailless), serifless comes first, and fully serifed comes last (or otherwise followed by alternative forms of the fully serifed variant) which is the same order as all other characters.

This will probably be the last time I reorganize serif variants for this version, as I'm not aware of any more characters after this whose serifed variants are not already in this type of ascending order.