### PR TITLE
Mention additional long arrows removed by `fontconfig-mono` spacing in `custom-build.md`.

### DIFF
--- a/doc/custom-build.md
+++ b/doc/custom-build.md
@@ -60,8 +60,16 @@ Inside the plan, top-level properties include:
       - As a consequence, the following characters will be **removed**:
         - `U+27F5` LONG LEFTWARDS ARROW
         - `U+27F6` LONG RIGHTWARDS ARROW
+        - `U+27F7` LONG LEFT RIGHT ARROW
+        - `U+27F8` LONG LEFTWARDS DOUBLE ARROW
+        - `U+27F9` LONG RIGHTWARDS DOUBLE ARROW
+        - `U+27FA` LONG LEFT RIGHT DOUBLE ARROW
         - `U+27FB` LONG LEFTWARDS ARROW FROM BAR
         - `U+27FC` LONG RIGHTWARDS ARROW FROM BAR
+        - `U+27FD` LONG LEFTWARDS DOUBLE ARROW FROM BAR
+        - `U+27FE` LONG RIGHTWARDS DOUBLE ARROW FROM BAR
+        - `U+27FF` LONG RIGHTWARDS SQUIGGLE ARROW
+        - `U+2B33` LONG LEFTWARDS SQUIGGLE ARROW
     - Remove `NWID` and `WWID` features typographic features
   - `fixed`: Apply `fontconfig-mono` changes and further remove ligations.
 * `serifs`: Optional, String, configures style of serifs.


### PR DESCRIPTION
May need to be updated automatically in the future if we start to support more permanently long/wide characters, like the arrows in [this proposal in the Unicode pipeline](https://www.unicode.org/L2/L2023/23193r2-ten-chemical-symbols.pdf) (not technically accepted yet), or like the wide ASCII characters in #759 if they end up being implemented as permanently wide as well.