### PR TITLE
Make Git EOL consistent with .editorconfig (LF)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
+# Use LF line endings; do not normlize to CRLF
+* text eol=lf
+
+# Recognize PatEL files for GitHub language stats
 *.ptl linguist-language=PatEL


### PR DESCRIPTION
## What's In This PR

The `.editorconfig` file sets `end_of_line = lf`, but `.gitattributes` does not.  This leaves Git to behave as per its own configuration or defaults.  On Windows, it is very common (and IMO, best practice) to enable the [`autocrlf`](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_autocrlf) feature to perform EOL normalization, which transforms LF to CRLF on checkout and performs the inverse transformation on commit.  For Iosevka, however, the result is that a fresh `git clone` consists of files with CRLFs, in contravention of the `.editorconfig`.

One consequence is that a Windows user following the [Docker build instructions](https://github.com/be5invis/Iosevka/blob/main/docker/README.md) can generate a container image whose [`build.sh`](https://github.com/be5invis/Iosevka/blob/main/docker/build.sh) contains CRLFs, which Bash does not understand.  This results in containerized Iosevka builds failing with a rather cryptic error:

![image](https://github.com/be5invis/Iosevka/assets/708461/4bdf8438-0ff5-4ce8-b372-3bb7703d99f4)

Another consequence is that tools that understand `.editorconfig` might complain about inconsistent line endings and convert the CRLFs to LFs on save, generating seemingly spurious changes in `git status`.

A few Git commands fix this, but an easier way is to ensure that Git checks out using LF regardless of the developer's platform or Git configuration.  This PR does that.

## An Alternative Way

A slightly more complicated way would be to enable Git EOL normalization everywhere except for the one file that must use LF.  Doing so would enable Windows users to use CRLF while everyone else (and the repository itself) remains using LF.  This is the choice I make for my own repositories if the build tools support both LF and CRLF.  If you'd prefer this, I am happy to change the PR.

#### `.editorconfig`
First, **remove** the line `end_of_line = lf`.
Then add:
```editorconfig
[/docker/*.sh]
end_of_line = lf
```

#### `.gitattributes`
Add:
```gitattributes
# Autodetect text files and perform EOL normalization
* text=auto

# Bash understands LF only
/docker/*.sh text eol=lf
```