### PR TITLE
Make Gha respond to `q` variants.

### DIFF
--- a/changes/29.0.3.md
+++ b/changes/29.0.3.md
@@ -1,1 +1,3 @@
 * Fix height of block quadrants (`U+2596`..`U+259F`) (#2240).
+* Make LATIN {CAPITAL|SMALL} LETTER GHA (`U+01A2`..`U+01A3`) respond to variants of `q` (`cv41`).
+* Make the behavior of serifs of `U+027F` automatic.

--- a/packages/font-glyphs/src/letter/latin-ext/gha.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/gha.ptl
@@ -1,6 +1,6 @@
 $$include '../../meta/macros.ptl'
 
-import [mix linreg clamp fallback] from "@iosevka/util"
+import [mix linreg clamp fallback SuffixCfg] from "@iosevka/util"
 
 
 glyph-module
@@ -8,14 +8,23 @@ glyph-module
 glyph-block Letter-Latin-Gha : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : SerifFrame
+	glyph-block-import Letter-Shared-Shapes : SerifFrame RightwardTailedBar
+	glyph-block-import Letter-Latin-Lower-Q : RDiagTailedBar
+	glyph-block-import Mark-Adjustment : LeaningAnchor
 
-	define [GhaShape df top] : glyph-proc
+	define TERMINAL-NORMAL  0
+	define TERMINAL-TAILED  1
+	define TERMINAL-DIAG    2
+
+	define [GhaShape df terminal top bot slab] : glyph-proc
 		local abarRight : df.middle + [HSwToV : 0.5 * df.mvs]
 		local ada : ArchDepthAOf [Math.max (df.mvs * 1.125) (SmallArchDepth * 0.6 * df.div)] (Width * df.div)
 		local adb : ArchDepthBOf [Math.max (df.mvs * 1.125) (SmallArchDepth * 0.6 * df.div)] (Width * df.div)
 		include : OShape top 0 df.leftSB abarRight df.mvs ada adb
-		include : VBar.r (df.rightSB - O) Descender top df.mvs
+		include : match terminal
+			[Just TERMINAL-NORMAL] : VBar.r             (df.rightSB - O) bot top df.mvs
+			[Just TERMINAL-TAILED] : RightwardTailedBar (df.rightSB - O) bot top df.mvs
+			[Just TERMINAL-DIAG]   : RDiagTailedBar     (df.rightSB - O) bot top df.mvs
 		include : dispiro
 			widths.lhs df.mvs
 			flat df.middle (top - adb) [heading Rightward]
@@ -23,16 +32,28 @@ glyph-block Letter-Latin-Gha : begin
 			alsoThru 0.5 0.15
 			g4   (df.rightSB - O - [HSwToV df.mvs]) top [widths 0 df.mvs]
 
-		if SLAB : begin
-			local sf : SerifFrame.fromDf df top Descender
+		if slab : begin
+			local sf : SerifFrame.fromDf df top bot
 			include sf.rb.full
 
-	create-glyph 'Gha' 0x1A2 : glyph-proc
-		local df : include : DivFrame para.diversityM 3
-		include : df.markSet.capDesc
-		include : GhaShape df CAP
+	define GhaConfig : object
+		straightSerifless       { TERMINAL-NORMAL false }
+		straightBottomSerifed   { TERMINAL-NORMAL true  }
+		tailedSerifless         { TERMINAL-TAILED false }
+		diagonalTailedSerifless { TERMINAL-DIAG   false }
 
-	create-glyph 'gha' 0x1A3 : glyph-proc
-		local df : include : DivFrame para.diversityM 3
-		include : df.markSet.p
-		include : GhaShape df XH
+	foreach { suffix { terminal doSerif } } [Object.entries GhaConfig] : do
+		create-glyph "Gha.\(suffix)" : glyph-proc
+			local df : include : DivFrame para.diversityM 3
+			include : df.markSet.capDesc
+			include : GhaShape df terminal CAP Descender doSerif
+			include : LeaningAnchor.Below.VBar.r df.rightSB
+
+		create-glyph "gha.\(suffix)" : glyph-proc
+			local df : include : DivFrame para.diversityM 3
+			include : df.markSet.p
+			include : GhaShape df terminal XH Descender doSerif
+			include : LeaningAnchor.Below.VBar.r df.rightSB
+
+	select-variant 'Gha' 0x1A2 (follow -- 'gha')
+	select-variant 'gha' 0x1A3

--- a/packages/font-glyphs/src/letter/latin-ext/long-s.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/long-s.ptl
@@ -249,15 +249,9 @@ glyph-block Letter-Latin-Long-S : begin
 					x2 -- x2
 					y2 -- y2
 
-	create-glyph "iFishHook.serifless" : glyph-proc
+	create-glyph "iFishHook" 0x27F : glyph-proc
 		include : MarkSet.p
-		include : IFishHookShape XH Descender false
-
-	create-glyph "iFishHook.serifed" : glyph-proc
-		include : MarkSet.p
-		include : IFishHookShape XH Descender true
-
-	select-variant 'iFishHook' 0x27F
+		include : IFishHookShape XH Descender SLAB
 
 	create-glyph "iviby" 0x285 : glyph-proc
 		include : MarkSet.p

--- a/packages/font-glyphs/src/letter/latin/lower-il.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-il.ptl
@@ -319,6 +319,7 @@ glyph-block Letter-Latin-Lower-I : begin
 		alias 'cyrl/Iota' 0xA646 'latn/Iota'
 
 		CreateTurnedLetter 'turni' 0x1D09 'i' HalfAdvance (XH / 2)
+		CreateTurnedLetter 'turniota' 0x2129 'grek/iota' HalfAdvance (XH / 2)
 
 		CreateAccentedComposition      'cyrl/ghe.SRB' null 'dotlessi/tailed'   'macronAbove'
 		CreateMultiAccentedComposition 'cyrl/gje.SRB' null 'dotlessi/tailed' { 'macronAbove' 'acuteAbove' }

--- a/packages/font-glyphs/src/letter/latin/lower-q.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-q.ptl
@@ -17,12 +17,15 @@ glyph-block Letter-Latin-Lower-Q : begin
 	define TERMINAL-NORMAL  0
 	define TERMINAL-TAILED  1
 	define TERMINAL-DIAG    2
-	define [RDiagTailedBar x0 yb yt] : begin
+
+	glyph-block-export RDiagTailedBar
+	define [RDiagTailedBar x0 yb yt _sw] : begin
 		local df : DivFrame 1
-		local xMid : x0 - [HSwToV HalfStroke]
+		local sw : fallback _sw Stroke
+		local xMid : x0 - [HSwToV : 0.5 * sw]
 		return : dispiro
-			flat xMid yt [widths.center.heading Stroke Downward]
-			DiagTail.R xMid yb (0.875 * Hook - Stroke * 0.375) Stroke
+			flat xMid yt [widths.center.heading sw Downward]
+			DiagTail.R xMid yb (0.875 * Hook - sw * 0.375) sw
 
 	define [EaredBody terminal top bottom] : glyph-proc
 		set-base-anchor 'trailing' (RightSB - markHalfStroke) Descender

--- a/packages/font-glyphs/src/symbol/letter.ptl
+++ b/packages/font-glyphs/src/symbol/letter.ptl
@@ -158,7 +158,7 @@ glyph-block Symbol-Letter : begin
 
 	alias 'Ohm' 0x2126 'grek/Omega'
 	turned 'Mho' 0x2127 'Ohm' Middle (CAP / 2)
-	turned 'turniota' 0x2129 'grek/iota' HalfAdvance (XH / 2)
+
 	alias 'letterLike/kelvinSign' 0x212A 'K'
 
 	create-glyph 'estimated' 0x212E : glyph-proc

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -3296,6 +3296,7 @@ selectorAffix.q = ""
 selectorAffix."q/sansSerif" = ""
 selectorAffix."q/hookTopBase" = ""
 selectorAffix.qRTail = ""
+selectorAffix.gha = ""
 
 [prime.q.variants-buildup.stages.body.earless-corner]
 rank = 2
@@ -3304,6 +3305,7 @@ selectorAffix.q = "earlessCorner"
 selectorAffix."q/sansSerif" = "earlessCorner"
 selectorAffix."q/hookTopBase" = "earlessCorner"
 selectorAffix.qRTail = "earlessCorner"
+selectorAffix.gha = ""
 
 [prime.q.variants-buildup.stages.body.earless-rounded]
 rank = 3
@@ -3312,6 +3314,7 @@ selectorAffix.q = "earlessRounded"
 selectorAffix."q/sansSerif" = "earlessRounded"
 selectorAffix."q/hookTopBase" = ""
 selectorAffix.qRTail = "earlessRounded"
+selectorAffix.gha = ""
 
 [prime.q.variants-buildup.stages.terminal."*"]
 next = "serifs"
@@ -3323,6 +3326,7 @@ selectorAffix.q = "straight"
 selectorAffix."q/sansSerif" = "straight"
 selectorAffix."q/hookTopBase" = "straight"
 selectorAffix.qRTail = "straight"
+selectorAffix.gha = "straight"
 
 [prime.q.variants-buildup.stages.terminal.tailed]
 rank = 2
@@ -3331,6 +3335,7 @@ selectorAffix.q = "tailed"
 selectorAffix."q/sansSerif" = "tailed"
 selectorAffix."q/hookTopBase" = "tailed"
 selectorAffix.qRTail = "straight"
+selectorAffix.gha = "tailed"
 
 [prime.q.variants-buildup.stages.terminal.diagonal-tailed]
 rank = 2
@@ -3339,6 +3344,7 @@ selectorAffix.q = "diagonalTailed"
 selectorAffix."q/sansSerif" = "diagonalTailed"
 selectorAffix."q/hookTopBase" = "diagonalTailed"
 selectorAffix.qRTail = "straight"
+selectorAffix.gha = "diagonalTailed"
 
 [prime.q.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -3348,6 +3354,7 @@ selectorAffix.q = "serifless"
 selectorAffix."q/sansSerif" = "serifless"
 selectorAffix."q/hookTopBase" = "serifless"
 selectorAffix.qRTail = "serifless"
+selectorAffix.gha = "serifless"
 
 [prime.q.variants-buildup.stages.serifs.bottom-serifed]
 rank = 2
@@ -3357,6 +3364,7 @@ selectorAffix.q = "bottomSerifed"
 selectorAffix."q/sansSerif" = "serifless"
 selectorAffix."q/hookTopBase" = "bottomSerifed"
 selectorAffix.qRTail = "serifless"
+selectorAffix.gha = "bottomSerifed"
 
 [prime.q.variants-buildup.stages.serifs.motion-serifed]
 rank = 3
@@ -3366,6 +3374,7 @@ selectorAffix.q = "motionSerifed"
 selectorAffix."q/sansSerif" = "serifless"
 selectorAffix."q/hookTopBase" = "serifless"
 selectorAffix.qRTail = "motionSerifed"
+selectorAffix.gha = "serifless"
 
 [prime.q.variants-buildup.stages.serifs.serifed__eared]
 rank = 4
@@ -3376,6 +3385,7 @@ selectorAffix.q = "serifed"
 selectorAffix."q/sansSerif" = "serifless"
 selectorAffix."q/hookTopBase" = "bottomSerifed"
 selectorAffix.qRTail = "motionSerifed"
+selectorAffix.gha = "bottomSerifed"
 
 [prime.q.variants-buildup.stages.serifs.serifed__eareless]
 rank = 4
@@ -3386,6 +3396,7 @@ selectorAffix.q = "bottomSerifed"
 selectorAffix."q/sansSerif" = "serifless"
 selectorAffix."q/hookTopBase" = "bottomSerifed"
 selectorAffix.qRTail = "serifless"
+selectorAffix.gha = "bottomSerifed"
 
 
 
@@ -3409,7 +3420,6 @@ selectorAffix."r/sansSerif" = ""
 selectorAffix.rRTail = ""
 selectorAffix."rTurnRTail" = ""
 selectorAffix."rFlap" = "earlessRounded"
-selectorAffix."iFishHook" = ""
 
 [prime.r.variants-buildup.stages.body.earless-corner]
 rank = 2
@@ -3420,7 +3430,6 @@ selectorAffix."r/sansSerif" = "earlessCorner"
 selectorAffix.rRTail = "earlessCorner"
 selectorAffix."rTurnRTail" = ""
 selectorAffix."rFlap" = "earlessRounded"
-selectorAffix."iFishHook" = ""
 
 [prime.r.variants-buildup.stages.body.earless-rounded]
 rank = 3
@@ -3431,7 +3440,6 @@ selectorAffix."r/sansSerif" = "earlessRounded"
 selectorAffix.rRTail = "earlessRounded"
 selectorAffix."rTurnRTail" = ""
 selectorAffix."rFlap" = "earlessRounded"
-selectorAffix."iFishHook" = ""
 
 [prime.r.variants-buildup.stages.body.hookless]
 rank = 4
@@ -3441,7 +3449,6 @@ selectorAffix."r/sansSerif" = "hookless"
 selectorAffix.rRTail = "hookless"
 selectorAffix."rTurnRTail" = "hookless"
 selectorAffix."rFlap" = "hooklessFlap"
-selectorAffix."iFishHook" = ""
 
 [prime.r.variants-buildup.stages.body.corner-hooked]
 rank = 5
@@ -3451,7 +3458,6 @@ selectorAffix."r/sansSerif" = "hookless"
 selectorAffix.rRTail = "cornerHooked"
 selectorAffix."rTurnRTail" = "cornerHooked"
 selectorAffix."rFlap" = "hooklessFlap"
-selectorAffix."iFishHook" = ""
 
 [prime.r.variants-buildup.stages.body.compact]
 rank = 6
@@ -3461,7 +3467,6 @@ selectorAffix."r/sansSerif" = "compact"
 selectorAffix.rRTail = "compact"
 selectorAffix."rTurnRTail" = "compact"
 selectorAffix."rFlap" = "compactFlap"
-selectorAffix."iFishHook" = ""
 
 [prime.r.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -3472,7 +3477,6 @@ selectorAffix."r/sansSerif" = "serifless"
 selectorAffix.rRTail = "serifless"
 selectorAffix."rTurnRTail" = "serifless"
 selectorAffix."rFlap" = "serifless"
-selectorAffix."iFishHook" = "serifless"
 
 [prime.r.variants-buildup.stages.serifs.top-serifed]
 rank = 2
@@ -3483,7 +3487,6 @@ selectorAffix."r/sansSerif" = "serifless"
 selectorAffix.rRTail = "topSerifed"
 selectorAffix."rTurnRTail" = "serifless"
 selectorAffix."rFlap" = "serifless"
-selectorAffix."iFishHook" = "serifless"
 
 [prime.r.variants-buildup.stages.serifs.base-serifed]
 rank = 3
@@ -3494,7 +3497,6 @@ selectorAffix."r/sansSerif" = "serifless"
 selectorAffix.rRTail = "serifless"
 selectorAffix."rTurnRTail" = "serifed"
 selectorAffix."rFlap" = "serifed"
-selectorAffix."iFishHook" = "serifed"
 
 [prime.r.variants-buildup.stages.serifs.serifed]
 rank = 4
@@ -3504,7 +3506,6 @@ selectorAffix."r/sansSerif" = "serifless"
 selectorAffix.rRTail = {if =  [{body="earless-corner"}, {body="earless-rounded"}], then = "serifless", else = "topSerifed"}
 selectorAffix."rTurnRTail" = "serifed"
 selectorAffix."rFlap" = "serifed"
-selectorAffix."iFishHook" = "serifed"
 
 
 
@@ -3841,11 +3842,11 @@ selectorAffix.u = "bottomRightSerifed"
 selectorAffix."u/sansSerif" = "serifless"
 selectorAffix."u/uRTailBase" = "serifless"
 selectorAffix.uHookLeft = "bottomRightSerifed"
-selectorAffix.turnh = "serifless"
-selectorAffix.turnhHookLeft = "serifless"
+selectorAffix.turnh = "bottomRightSerifed"
+selectorAffix.turnhHookLeft = "bottomRightSerifed"
 selectorAffix.turnhHookLeftRTail = "serifless"
 selectorAffix.turnm = "bottomRightSerifed"
-selectorAffix.turnmLeg = "serifless"
+selectorAffix.turnmLeg = "bottomRightSerifed"
 selectorAffix."cyrl/i.italic" = "bottomRightSerifed"
 selectorAffix."cyrl/i.italic/descBase" = "serifless"
 selectorAffix."cyrl/sha.italic" = "bottomRightSerifed"


### PR DESCRIPTION
Gha is famously a letter originally encoded as "oi" and later re-analyzed and found to be based on a script `q`. Fonts that do special things with its tail under italics often line up with how they treat `q`.
All `q` variants:
`q𝗊ʠɊɋƢƣ`:
![image](https://github.com/be5invis/Iosevka/assets/37010132/799ef48e-3c30-485b-ae28-5027108ba5a3)
Compared to Gentium Plus Upright/Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/80ffdd52-6136-4069-ac93-5ed39e9b8616)
![image](https://github.com/be5invis/Iosevka/assets/37010132/016801a3-60fb-4577-8dd3-a8620ce7bf65)
Also FWIW, here's the cursive form according to Wikipedia:
![image](https://github.com/be5invis/Iosevka/assets/37010132/8fa932ee-98cb-4864-bbd9-f8fe894368b5)
