### PR TITLE
Make Punctuation Space (`U+2008`) actually the width of a narrow punctuation mark.

### DIFF
--- a/changes/29.0.3.md
+++ b/changes/29.0.3.md
@@ -1,3 +1,5 @@
 * Fix height of block quadrants (`U+2596`..`U+259F`) (#2240).
 * Make LATIN {CAPITAL|SMALL} LETTER GHA (`U+01A2`..`U+01A3`) respond to variants of `q` (`cv41`).
 * Make the behavior of serifs of `U+027F` automatic.
+* Fix side bearings of `U+29E2` under Quasi-Proportional.
+* Fix width of PUNCTUATION SPACE (`U+2008`) under Quasi-Proportional.

--- a/packages/font-glyphs/src/space/index.ptl
+++ b/packages/font-glyphs/src/space/index.ptl
@@ -33,7 +33,9 @@ glyph-block Spaces : begin
 	alias 'ensp'             0x2002 'sp1'
 	alias 'brailleBlank'     0x2800 'sp1'
 	alias 'figureSpace'      0x2007 'sp1'
-	alias 'punctuationSpace' 0x2008 'sp1'
+
+	create-glyph 'punctuationSpace' 0x2008 : glyph-proc
+		local df : include : DivFrame para.diversityF
 
 	create-glyph 'zwsp' 0x200B : glyph-proc
 		set-width 0

--- a/packages/font-glyphs/src/symbol/math/v-and-cup.ptl
+++ b/packages/font-glyphs/src/symbol/math/v-and-cup.ptl
@@ -233,5 +233,5 @@ glyph-block Symbol-Math-VAndCup : begin
 	turned 'squareCup' 0x2294 'squareCap' Middle SymbolMid
 
 	create-glyph 'shuffleProduct' 0x29E2 : glyph-proc
-		local df : DivFrame para.diversityM 3
+		local df : include : DivFrame para.diversityM 3
 		include : CyrShaShape df OperTop OperBot (fine -- OperatorStroke) (doSerif -- false)


### PR DESCRIPTION
Demonstration under Aile using appropriate font metric private use characters to show side bearings:
```
f
.
 
```
![image](https://github.com/be5invis/Iosevka/assets/37010132/873df56c-dbb1-48ae-8ff0-6d3f289b2d50)
