### PR TITLE
Fix NWID/WWID properties of negative box drawing characters (`U+1FBBD`..`U+1FBBF`).

### DIFF
--- a/changes/29.0.3.md
+++ b/changes/29.0.3.md
@@ -1,6 +1,7 @@
 * Fix height of block quadrants (`U+2596`..`U+259F`) (#2240).
 * Fix the design of the ESTIMATED SYMBOL (`U+212E`) to match its spec (#2243).
 * Refine design of POWER SYMBOL (`U+23FB`) and HEAVY CHECK MARK (`U+2714`) (#2243).
+* Make `U+1FBBD`..`U+1FBBF` narrow by default.
 * Make LATIN {CAPITAL|SMALL} LETTER GHA (`U+01A2`..`U+01A3`) respond to variants of `q` (`cv41`).
 * Make the behavior of serifs of `U+027F` automatic.
 * Fix side bearings of `U+29E2` under Quasi-Proportional.

--- a/packages/font-glyphs/src/symbol/mosaic.ptl
+++ b/packages/font-glyphs/src/symbol/mosaic.ptl
@@ -11,3 +11,4 @@ export : define [apply] : begin
 	run-glyph-module "./mosaic/powerline.mjs"
 	run-glyph-module "./mosaic/notdef.mjs"
 	run-glyph-module "./mosaic/inverted.mjs"
+	run-glyph-module "./mosaic/masked.mjs"

--- a/packages/font-glyphs/src/symbol/mosaic/inverted.ptl
+++ b/packages/font-glyphs/src/symbol/mosaic/inverted.ptl
@@ -5,10 +5,9 @@ import as Gr from "@iosevka/glyph/relation"
 
 glyph-module
 
-glyph-block Symbol-Geometric-Mosaic-Inverted : for-width-kinds WideWidth1
+glyph-block Symbol-Mosaic-Inverted : for-width-kinds WideWidth1
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade GeometricSizes
 
 	define MosaicTop    fontMetrics.os2.sTypoAscender
 	define MosaicBottom fontMetrics.os2.sTypoDescender
@@ -86,7 +85,13 @@ glyph-block Symbol-Geometric-Mosaic-Inverted : for-width-kinds WideWidth1
 			refer-glyph : MangleName : NameUni 0x2588
 			refer-glyph : MangleName 'arrowDown'
 
-	# Box Drawing
+glyph-block Symbol-Mosaic-Inverted-Box-Drawing : for-width-kinds WideWidth4
+	glyph-block-import CommonShapes
+	glyph-block-import Common-Derivatives
+
+	define MosaicTop    fontMetrics.os2.sTypoAscender
+	define MosaicBottom fontMetrics.os2.sTypoDescender
+
 	create-glyph [MangleName : NameUni 0x1FBBD] [MangleUnicode 0x1FBBD] : glyph-proc
 		set-width MosaicWidth
 		include : ForceUpright
@@ -107,44 +112,3 @@ glyph-block Symbol-Geometric-Mosaic-Inverted : for-width-kinds WideWidth1
 		include : difference
 			refer-glyph : MangleName : NameUni 0x2588
 			refer-glyph : MangleName : NameUni 0x1FBAE
-
-	do "Split Shapes"
-		define [CellMask] : spiro-outline
-			corner 0 MosaicTop
-			corner MosaicWidth MosaicTop
-			corner MosaicWidth MosaicBottom
-			corner 0 MosaicBottom
-
-		define halfHeight : 0.5 * (MosaicTop - MosaicBottom)
-		define halfWidth : 0.5 * MosaicWidth
-
-		define [SplitShape dstName dstUnicode srcName dx dy] : begin
-			create-glyph [MangleName dstName] [MangleUnicode dstUnicode] : glyph-proc
-				set-width MosaicWidth
-				include : intersection
-					CellMask
-					with-transform [ApparentTranslate dx dy] : refer-glyph : MangleName srcName
-
-		SplitShape 'whiteCircleLowerHalfJustified' 0x1FBE0 'whiteCircle' 0 halfHeight
-		SplitShape 'whiteCircleLeftHalfJustified'  0x1FBE1 'whiteCircle' halfWidth 0
-		SplitShape 'whiteCircleUpperHalfJustified' 0x1FBE2 'whiteCircle' 0 (-halfHeight)
-		SplitShape 'whiteCircleRightHalfJustified' 0x1FBE3 'whiteCircle' (-halfWidth) 0
-		SplitShape 'blackCircleLowerHalfJustified' 0x1FBE8 'blackCircle' 0 halfHeight
-		SplitShape 'blackCircleLeftHalfJustified'  0x1FBE9 'blackCircle' halfWidth 0
-		SplitShape 'blackCircleUpperHalfJustified' 0x1FBEA 'blackCircle' 0 (-halfHeight)
-		SplitShape 'blackCircleRightHalfJustified' 0x1FBEB 'blackCircle' (-halfWidth) 0
-		SplitShape 'blackCircleLBQuarterJustified' 0x1FBEC 'blackCircle' halfWidth halfHeight
-		SplitShape 'blackCircleRTQuarterJustified' 0x1FBED 'blackCircle' (-halfWidth) (-halfHeight)
-		SplitShape 'blackCircleLTQuarterJustified' 0x1FBEE 'blackCircle' halfWidth (-halfHeight)
-		SplitShape 'blackCircleRBQuarterJustified' 0x1FBEF 'blackCircle' (-halfWidth) halfHeight
-		SplitShape 'whiteEllipseLeftHalfJustified'  0x1CE0B 'whiteEllipse' halfWidth 0
-		SplitShape 'whiteEllipseRightHalfJustified' 0x1CE0C 'whiteEllipse' (-halfWidth) 0
-
-		create-glyph [MangleName 'whiteCircleLeftRightHalf'] [MangleUnicode 0x1CE01] : glyph-proc
-			set-width MosaicWidth
-			include : refer-glyph : MangleName 'whiteCircleLowerHalfJustified'
-			include : refer-glyph : MangleName 'whiteCircleUpperHalfJustified'
-		create-glyph [MangleName 'whiteCircleUpperLowerHalf'] [MangleUnicode 0x1CE00] : glyph-proc
-			set-width MosaicWidth
-			include : refer-glyph : MangleName 'whiteCircleLeftHalfJustified'
-			include : refer-glyph : MangleName 'whiteCircleRightHalfJustified'

--- a/packages/font-glyphs/src/symbol/mosaic/masked.ptl
+++ b/packages/font-glyphs/src/symbol/mosaic/masked.ptl
@@ -1,0 +1,53 @@
+$$include '../../meta/macros.ptl'
+
+import [mix linreg clamp fallback] from "@iosevka/util"
+import as Gr from "@iosevka/glyph/relation"
+
+glyph-module
+
+glyph-block Symbol-Mosaic-Masked : for-width-kinds WideWidth1
+	glyph-block-import CommonShapes
+	glyph-block-import Common-Derivatives
+
+	define MosaicTop    fontMetrics.os2.sTypoAscender
+	define MosaicBottom fontMetrics.os2.sTypoDescender
+
+	define [CellMask] : spiro-outline
+		corner 0 MosaicTop
+		corner MosaicWidth MosaicTop
+		corner MosaicWidth MosaicBottom
+		corner 0 MosaicBottom
+
+	define halfHeight : 0.5 * (MosaicTop - MosaicBottom)
+	define halfWidth : 0.5 * MosaicWidth
+
+	define [SplitShape dstName dstUnicode srcName dx dy] : begin
+		create-glyph [MangleName dstName] [MangleUnicode dstUnicode] : glyph-proc
+			set-width MosaicWidth
+			include : intersection
+				CellMask
+				with-transform [ApparentTranslate dx dy] : refer-glyph : MangleName srcName
+
+	SplitShape 'whiteCircleLowerHalfJustified' 0x1FBE0 'whiteCircle' 0 halfHeight
+	SplitShape 'whiteCircleLeftHalfJustified'  0x1FBE1 'whiteCircle' halfWidth 0
+	SplitShape 'whiteCircleUpperHalfJustified' 0x1FBE2 'whiteCircle' 0 (-halfHeight)
+	SplitShape 'whiteCircleRightHalfJustified' 0x1FBE3 'whiteCircle' (-halfWidth) 0
+	SplitShape 'blackCircleLowerHalfJustified' 0x1FBE8 'blackCircle' 0 halfHeight
+	SplitShape 'blackCircleLeftHalfJustified'  0x1FBE9 'blackCircle' halfWidth 0
+	SplitShape 'blackCircleUpperHalfJustified' 0x1FBEA 'blackCircle' 0 (-halfHeight)
+	SplitShape 'blackCircleRightHalfJustified' 0x1FBEB 'blackCircle' (-halfWidth) 0
+	SplitShape 'blackCircleLBQuarterJustified' 0x1FBEC 'blackCircle' halfWidth halfHeight
+	SplitShape 'blackCircleRTQuarterJustified' 0x1FBED 'blackCircle' (-halfWidth) (-halfHeight)
+	SplitShape 'blackCircleLTQuarterJustified' 0x1FBEE 'blackCircle' halfWidth (-halfHeight)
+	SplitShape 'blackCircleRBQuarterJustified' 0x1FBEF 'blackCircle' (-halfWidth) halfHeight
+	SplitShape 'whiteEllipseLeftHalfJustified'  0x1CE0B 'whiteEllipse' halfWidth 0
+	SplitShape 'whiteEllipseRightHalfJustified' 0x1CE0C 'whiteEllipse' (-halfWidth) 0
+
+	create-glyph [MangleName 'whiteCircleLeftRightHalf'] [MangleUnicode 0x1CE01] : glyph-proc
+		set-width MosaicWidth
+		include : refer-glyph : MangleName 'whiteCircleLowerHalfJustified'
+		include : refer-glyph : MangleName 'whiteCircleUpperHalfJustified'
+	create-glyph [MangleName 'whiteCircleUpperLowerHalf'] [MangleUnicode 0x1CE00] : glyph-proc
+		set-width MosaicWidth
+		include : refer-glyph : MangleName 'whiteCircleLeftHalfJustified'
+		include : refer-glyph : MangleName 'whiteCircleRightHalfJustified'

--- a/packages/font-glyphs/src/symbol/mosaic/split-graphic.ptl
+++ b/packages/font-glyphs/src/symbol/mosaic/split-graphic.ptl
@@ -5,7 +5,7 @@ import [Box] from "@iosevka/geometry/box"
 
 glyph-module
 
-glyph-block Symbol-Split-Graphic : for-width-kinds WideWidth4
+glyph-block Symbol-Mosaic-Split-Graphic : for-width-kinds WideWidth4
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Symbol-Pictograph-Stick-Figure : StickFigureKit PointingHandShape


### PR DESCRIPTION
This was their behavior before 29.0.0 but was changed by accident as a side effect of one of the commits adding some of the new Unicode 16 characters.

This also moves the justified half shapes into their own file (`masked.ptl`) as they don't really belong in `inverted.ptl` but also are handled differently than the characters in `split-graphic.ptl`.

```
╳🮣🮮
🮽🮾🮿
```

Before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/6a8ace6d-8161-4dfc-aabc-c0defe76a9b9)

After:
![image](https://github.com/be5invis/Iosevka/assets/37010132/f80d46ba-dbc5-4283-b085-74828dc11d2e)
