### PR TITLE
Fix broken NWID glyphs for Permille/Permyriad under Quasi-Proportional for `percent`=`dots`.

### DIFF
--- a/changes/29.0.3.md
+++ b/changes/29.0.3.md
@@ -6,3 +6,4 @@
 * Make the behavior of serifs of `U+027F` automatic.
 * Fix side bearings of `U+29E2` under Quasi-Proportional.
 * Fix width of PUNCTUATION SPACE (`U+2008`) under Quasi-Proportional.
+* Fix `percent`=`dots` glyphs for PER {MILLE|TEN THOUSAND} SIGN (`U+2030`..`U+2031`) under Quasi-Proportional when `NWID` is enabled.

--- a/packages/font-glyphs/src/symbol/punctuation/percentages.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/percentages.ptl
@@ -38,27 +38,28 @@ glyph-block Symbol-Punctuation-Percentages : begin
 
 	create-glyph 'permille.NWID.dots' : glyph-proc
 		define df : include : DivFrame para.diversityM
+		define slopeDf : DivFrame 1
 
 		define refSw : AdviceStroke 4 df.div
 
-		include : PercentBarShape df refSw
+		include : PercentBarShape slopeDf refSw
 		local dotwidth : refSw * 1.5
-		include : VBar.l df.leftSB [mix CAP 0 0.3] CAP dotwidth
+		include : VBar.l SB [mix CAP 0 0.3] CAP dotwidth
 
-		local gap : (df.width - df.leftSB) * 0.9 - refSw * [PercentBarCor df refSw]
+		local gap : (df.width - df.leftSB) * 0.9 - refSw * [PercentBarCor slopeDf refSw]
 		local lowerDotWidth : 1.5 * [AdviceStroke 3 (gap / Width)]
 		include : VBar.r (df.rightSB - gap * 0.45) 0 [mix 0 CAP 0.3] lowerDotWidth
 		include : VBar.r  df.rightSB               0 [mix 0 CAP 0.3] lowerDotWidth
 
 	create-glyph 'basepoint.NWID.dots' : glyph-proc
 		define df : include : DivFrame para.diversityM
-		define slopeDf : DivFrame (para.diversityM * 0.8)
+		define slopeDf : DivFrame [Math.min (para.diversityM * 0.8) 1]
 
 		define refSw : AdviceStroke 5 df.div
 
 		include : PercentBarShape slopeDf refSw
 		local dotwidth : refSw * 1.5
-		include : VBar.l df.leftSB [mix CAP 0 0.3] CAP dotwidth
+		include : VBar.l SB [mix CAP 0 0.3] CAP dotwidth
 
 		local gap : (df.width - df.leftSB) * 0.9 - refSw * [PercentBarCor slopeDf refSw]
 		local lowerDotWidth : 1.5 * [AdviceStroke 4 (gap / Width)]

--- a/packages/font-glyphs/src/symbol/punctuation/percentages.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/percentages.ptl
@@ -43,12 +43,12 @@ glyph-block Symbol-Punctuation-Percentages : begin
 
 		include : PercentBarShape df refSw
 		local dotwidth : refSw * 1.5
-		include : VBar.l SB [mix CAP 0 0.3] CAP dotwidth
+		include : VBar.l df.leftSB [mix CAP 0 0.3] CAP dotwidth
 
 		local gap : (df.width - df.leftSB) * 0.9 - refSw * [PercentBarCor df refSw]
 		local lowerDotWidth : 1.5 * [AdviceStroke 3 (gap / Width)]
-		include : VBar.r (RightSB - gap * 0.45) 0 [mix 0 CAP 0.3] lowerDotWidth
-		include : VBar.r RightSB                0 [mix 0 CAP 0.3] lowerDotWidth
+		include : VBar.r (df.rightSB - gap * 0.45) 0 [mix 0 CAP 0.3] lowerDotWidth
+		include : VBar.r  df.rightSB               0 [mix 0 CAP 0.3] lowerDotWidth
 
 	create-glyph 'basepoint.NWID.dots' : glyph-proc
 		define df : include : DivFrame para.diversityM
@@ -58,13 +58,13 @@ glyph-block Symbol-Punctuation-Percentages : begin
 
 		include : PercentBarShape slopeDf refSw
 		local dotwidth : refSw * 1.5
-		include : VBar.l SB [mix CAP 0 0.3] CAP dotwidth
+		include : VBar.l df.leftSB [mix CAP 0 0.3] CAP dotwidth
 
 		local gap : (df.width - df.leftSB) * 0.9 - refSw * [PercentBarCor slopeDf refSw]
 		local lowerDotWidth : 1.5 * [AdviceStroke 4 (gap / Width)]
-		include : VBar.r (RightSB - gap * 0.6) 0 [mix 0 CAP 0.3] lowerDotWidth
-		include : VBar.r (RightSB - gap * 0.3) 0 [mix 0 CAP 0.3] lowerDotWidth
-		include : VBar.r RightSB                0 [mix 0 CAP 0.3] lowerDotWidth
+		include : VBar.r (df.rightSB - gap * 0.6) 0 [mix 0 CAP 0.3] lowerDotWidth
+		include : VBar.r (df.rightSB - gap * 0.3) 0 [mix 0 CAP 0.3] lowerDotWidth
+		include : VBar.r  df.rightSB              0 [mix 0 CAP 0.3] lowerDotWidth
 
 	create-glyph 'percent.ringsContinuousSlash' : glyph-proc
 		set-width Width


### PR DESCRIPTION
`%‰‱`
Before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/6ae2fc6e-6149-4416-9e7d-0443ff4bce45)
After:
![image](https://github.com/be5invis/Iosevka/assets/37010132/1ba78937-741b-4bbe-bf21-04dec0af2a8f)
