### PR TITLE
Remove untagged variant selector for Cyrillic Capital Ef from #2155 as it was never a good idea.

### DIFF
--- a/changes/29.0.3.md
+++ b/changes/29.0.3.md
@@ -7,3 +7,4 @@
 * Fix side bearings of `U+29E2` under Quasi-Proportional.
 * Fix width of PUNCTUATION SPACE (`U+2008`) under Quasi-Proportional.
 * Fix `percent`=`dots` glyphs for PER {MILLE|TEN THOUSAND} SIGN (`U+2030`..`U+2031`) under Quasi-Proportional when `NWID` is enabled.
+* Remove untagged variant selector for Cyrillic Capital Ef (`Ф`).

--- a/packages/font-glyphs/src/letter/greek/upper-phi.ptl
+++ b/packages/font-glyphs/src/letter/greek/upper-phi.ptl
@@ -71,55 +71,42 @@ glyph-block Letter-Greek-Upper-Phi : begin
 	define [MtSerif df y] : tagged 'serifMT' : HSerif.lt df.middle y Jut
 	define [MbSerif df y] : tagged 'serifMB' : HSerif.mb df.middle y Jut
 
-	define CyrlCapitalEfConfig : SuffixCfg.weave
-		object # bowl
-			""         VarPhiRing
-			splitBowl  CyrlEfSplitRing
-		object # serifs
-			serifless  false
-			serifed    true
+	define [GrekCapitalPhiImpl fFlatTB df] : glyph-proc
+		local y1 : mix [if SLAB Stroke 0] [if SLAB (CAP - Stroke) CAP] 0.125
+		local y2 : mix [if SLAB Stroke 0] [if SLAB (CAP - Stroke) CAP] 0.875
+		include : VarPhiRing fFlatTB df y1 y2
+		include : StraightBar df 0 y1 y2 CAP
 
-	foreach { suffix { Bowl Serifs } } [Object.entries CyrlCapitalEfConfig] : do
-		define [GrekCapitalPhiImpl fFlatTB df slab] : glyph-proc
-			local y1 : mix [if slab Stroke 0] [if slab (CAP - Stroke) CAP] 0.125
-			local y2 : mix [if slab Stroke 0] [if slab (CAP - Stroke) CAP] 0.875
-			include : Bowl fFlatTB df y1 y2
-			include : StraightBar df 0 y1 y2 CAP
+		if SLAB : begin
+			include : tagged 'serifMT' : HSerif.mt df.middle CAP MidJutSide
+			include : tagged 'serifMB' : HSerif.mb df.middle 0 MidJutSide
 
-			if slab : begin
-				include : tagged 'serifMT' : HSerif.mt df.middle CAP MidJutSide
-				include : tagged 'serifMB' : HSerif.mb df.middle 0 MidJutSide
+	create-glyph 'grek/Phi' 0x3A6 : glyph-proc
+		local df : include : DivFrame para.diversityM 3
+		include : df.markSet.capital
+		include : GrekCapitalPhiImpl 0 df
 
-		create-glyph "grek/Phi.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.diversityM 3
-			include : df.markSet.capital
-			include : GrekCapitalPhiImpl 0 df Serifs
+	create-glyph 'cyrl/Ef' 0x424 : glyph-proc
+		local df : include : DivFrame para.diversityM 3
+		include : df.markSet.capital
+		include : GrekCapitalPhiImpl 1 df
 
-		create-glyph "cyrl/Ef.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.diversityM 3
-			include : df.markSet.capital
-			include : GrekCapitalPhiImpl 1 df Serifs
+	create-glyph 'cyrl/Ef.BGR' : glyph-proc
+		local df : include : DivFrame para.diversityM 3
+		include : df.markSet.capital
 
-		create-glyph "cyrl/Ef.BGR.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.diversityM 3
-			include : df.markSet.capital
+		local top : CAP + LongJut - HalfStroke
+		local bot : 0   - LongJut + HalfStroke
 
-			local top : CAP + LongJut - HalfStroke
-			local bot : 0   - LongJut + HalfStroke
+		include : ExtendAboveBaseAnchors top
+		include : ExtendBelowBaseAnchors bot
 
-			include : ExtendAboveBaseAnchors top
-			include : ExtendBelowBaseAnchors bot
+		include : VarPhiRing 0 df 0 CAP
+		include : StraightBar df bot 0 CAP top
 
-			include : VarPhiRing 0 df 0 CAP
-			include : StraightBar df bot 0 CAP top
-
-			if Serifs : begin
-				include : tagged 'serifMT' : HSerif.mt df.middle top MidJutSide
-				include : tagged 'serifMB' : HSerif.mb df.middle bot MidJutSide
-
-	select-variant 'grek/Phi' 0x3A6
-	select-variant 'cyrl/Ef' 0x424
-	select-variant 'cyrl/Ef.BGR'
+		if SLAB : begin
+			include : tagged 'serifMT' : HSerif.mt df.middle top MidJutSide
+			include : tagged 'serifMB' : HSerif.mb df.middle bot MidJutSide
 
 	create-glyph 'grek/varphi' 0x3D5 : glyph-proc
 		local df : include : DivFrame para.diversityM 3

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -5853,35 +5853,6 @@ selectorAffix."cyrl/u" = "serifed"
 
 
 
-[prime.cyrl-capital-ef]
-# No tags and sampler -- for style-driven variation
-
-[prime.cyrl-capital-ef.variants.serifless]
-rank = 1
-selector."grek/Phi"  = "serifless"
-selector."cyrl/Ef"  = "serifless"
-selector."cyrl/Ef.BGR" = "serifless"
-
-[prime.cyrl-capital-ef.variants.serifed]
-rank = 2
-selector."grek/Phi"  = "serifed"
-selector."cyrl/Ef"  = "serifed"
-selector."cyrl/Ef.BGR" = "serifed"
-
-[prime.cyrl-capital-ef.variants.split-serifless]
-rank = 3
-selector."grek/Phi"  = "serifless"
-selector."cyrl/Ef"  = "splitBowlSerifless"
-selector."cyrl/Ef.BGR" = "serifless"
-
-[prime.cyrl-capital-ef.variants.split-serifed]
-rank = 4
-selector."grek/Phi"  = "serifed"
-selector."cyrl/Ef"  = "splitBowlSerifed"
-selector."cyrl/Ef.BGR" = "serifed"
-
-
-
 [prime.cyrl-ef]
 sampler = "ф"
 samplerExplain = "Cyrillic Lower Ef"
@@ -7702,7 +7673,6 @@ cyrl-en = "serifless"
 cyrl-er = "eared-serifless"
 cyrl-capital-u = "straight-serifless"
 cyrl-u = "straight-serifless"
-cyrl-capital-ef = "serifless"
 cyrl-ef = "serifless"
 cyrl-che = "standard"
 cyrl-capital-yeri = "corner"
@@ -7842,7 +7812,6 @@ cyrl-en = "serifed"
 cyrl-er = "eared-serifed"
 cyrl-capital-u = "straight-turn-serifed"
 cyrl-u = "straight-turn-serifed"
-cyrl-capital-ef = "serifed"
 cyrl-ef = "serifed"
 cyrl-capital-ya = "straight-serifed"
 cyrl-ya = "straight-serifed"


### PR DESCRIPTION
The variants are rare and the split bowl is extremely sensitive to breaking after having adjusted `diversityM`.

As far as the default configurations are concerned, the font will present as unchanged to the end-user.