### PR TITLE
Miscellanious last-minute fixes and optimizations.

### DIFF
--- a/changes/29.0.3.md
+++ b/changes/29.0.3.md
@@ -9,3 +9,4 @@
 * Fix `percent`=`dots` glyphs for PER {MILLE|TEN THOUSAND} SIGN (`U+2030`..`U+2031`) under Quasi-Proportional when `NWID` is enabled.
 * Remove untagged variant selector for Cyrillic Capital Ef (`Ф`).
 * Fix glyph visual for COMBINING DOUBLE CIRCUMFLEX ABOVE (`U+1DCD`).
+* Fix variant assignment of `cv92` for `ss08` under slab.

--- a/changes/29.0.3.md
+++ b/changes/29.0.3.md
@@ -10,3 +10,4 @@
 * Remove untagged variant selector for Cyrillic Capital Ef (`Ф`).
 * Fix glyph visual for COMBINING DOUBLE CIRCUMFLEX ABOVE (`U+1DCD`).
 * Fix variant assignment of `cv92` for `ss08` under slab.
+* Make `--c-like-chaining--` ligation group require at least three hyphen-minuses for hyphen chain.

--- a/packages/font-glyphs/src/letter/latin-ext/gha.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/gha.ptl
@@ -47,13 +47,13 @@ glyph-block Letter-Latin-Gha : begin
 			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.capDesc
 			include : GhaShape df terminal CAP Descender doSerif
-			include : LeaningAnchor.Below.VBar.r df.rightSB
+			include : LeaningAnchor.Below.VBar.r (df.rightSB - O)
 
 		create-glyph "gha.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.p
 			include : GhaShape df terminal XH Descender doSerif
-			include : LeaningAnchor.Below.VBar.r df.rightSB
+			include : LeaningAnchor.Below.VBar.r (df.rightSB - O)
 
 	select-variant 'Gha' 0x1A2 (follow -- 'gha')
 	select-variant 'gha' 0x1A3

--- a/packages/font-glyphs/src/marks/tie.ptl
+++ b/packages/font-glyphs/src/marks/tie.ptl
@@ -12,8 +12,7 @@ glyph-block Mark-Tie : begin
 	glyph-block-import Mark-Shared-Metrics : markExtend markHalfStroke markStress markFine
 	glyph-block-import Mark-Shared-Metrics : markMiddle markDotsRadius
 	glyph-block-import Mark-Above : aboveMarkTop aboveMarkBot aboveMarkMid aboveMarkStack
-	glyph-block-import Mark-Above : TildeShape CaretShape CaretCaronWidth
-	glyph-block-import Mark-Above : CaretCaronMidSw CaretCaronTerminalSw
+	glyph-block-import Mark-Above : TildeShape CaretCaronMidSw CaretCaronTerminalSw
 	glyph-block-import Mark-Below : belowMarkBot belowMarkTop belowMarkMid
 
 	define aboveTieBase   : aboveMarkStack - AccentClearance
@@ -130,12 +129,9 @@ glyph-block Mark-Tie : begin
 
 	create-glyph 'circumflexTieAbove' 0x1DCD : glyph-proc
 		set-width 0
-		set-mark-anchor 'tieAbove' 0 aboveTieBase 0 aboveTieTop
-		set-base-anchor 'aboveBraceL' (0 - 0.5 * markExtend) aboveTieMid
-		set-base-anchor 'aboveBraceR' (0 + 0.5 * markExtend) aboveTieMid
+		include : TieAboveAnchors
 
 		TieGlyph.set currentGlyph
-
 		local leftHalf : include : dispiro
 			flat tieLeft aboveTieBottom [widths.center CaretCaronTerminalSw]
 			curl 0 aboveTieTop [widths.center CaretCaronMidSw]

--- a/params/ligation-set.toml
+++ b/params/ligation-set.toml
@@ -278,28 +278,28 @@ buildup = [
 buildup = [ 'eqeq', 'exeq', 'lteq', 'gteq' ]
 
 [composite.--c-equality-inequality--]
-buildup = [	'eqeqeq', 'eqeq', 'exeqeq', 'exeq', 'lteq', 'gteq' ]
+buildup = [ 'eqeqeq', 'eqeq', 'exeqeq', 'exeq', 'lteq', 'gteq' ]
 
 [composite.--raku-equality-inequality--]
-buildup = [	'eqeqeq', 'eqeq', 'exeqeqeq', 'exeq', 'lteq', 'gteq' ]
+buildup = [ 'eqeqeq', 'eqeq', 'exeqeqeq', 'exeq', 'lteq', 'gteq' ]
 
 [composite.--ml-equality-inequality--]
-buildup = [	'eqeq', 'ltgt-ne', 'lteq', 'gteq' ]
+buildup = [ 'eqeq', 'ltgt-ne', 'lteq', 'gteq' ]
 
 [composite.--fstar-equality-inequality--]
-buildup = [	'eqeq', 'ltgt-ne', 'eqeqeq', 'eqexeq', 'lteq', 'gteq' ]
+buildup = [ 'eqeq', 'ltgt-ne', 'eqeqeq', 'eqexeq', 'lteq', 'gteq' ]
 
 [composite.--haskell-equality-inequality--]
-buildup = [	'eqeq', 'slasheq', 'lteq', 'gteq' ]
+buildup = [ 'eqeq', 'slasheq', 'lteq', 'gteq' ]
 
 [composite.--matlab-equality-inequality--]
-buildup = [	'eqeq', 'tildeeq', 'lteq', 'gteq' ]
+buildup = [ 'eqeq', 'tildeeq', 'lteq', 'gteq' ]
 
 [composite.--verilog-equality-inequality--]
-buildup = [	'eqeqeq', 'eqeq', 'exeqeq', 'exeq', 'lteq-separate', 'gteq-separate' ]
+buildup = [ 'eqeqeq', 'eqeq', 'exeqeq', 'exeq', 'lteq-separate', 'gteq-separate' ]
 
 [composite.--wolfram-equality-inequality--]
-buildup = [	'eqeq', 'exeq', 'eqexeq-dl', 'lteq', 'gteq' ]
+buildup = [ 'eqeq', 'exeq', 'eqexeq-dl', 'lteq', 'gteq' ]
 
 [composite.--erlang-equality-inequality--]
 buildup = [ 'eqeq', 'exeq', 'eqlt', 'gteq' ]
@@ -314,7 +314,7 @@ buildup = [ 'plus-plus-plus', 'minus-minus-minus', 'underscore-underscore-unders
 buildup = [ 'plus-plus', 'minus-minus', 'underscore-underscore', 'hash-hash', 'tilde-tilde' ]
 
 [composite.--c-like-chaining--]
-buildup = [ 'plus-plus', 'minus-minus', 'underscore-underscore', 'hash-hash-hash', 'tilde-tilde-tilde' ]
+buildup = [ 'plus-plus', 'minus-minus-minus', 'underscore-underscore', 'hash-hash-hash', 'tilde-tilde-tilde' ]
 
 # This feature is on by default by many software
 [composite.default-calt]

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -8607,7 +8607,7 @@ cyrl-capital-ya = "curly-serifed"
 cyrl-ya = "curly-serifed"
 four = "closed-serifed"
 five = "upright-flat-serifed"
-seven = "bend-serifed"
+seven = "curly-serifed"
 micro-sign = "toothed-serifed"
 
 [composite.ss08.slab-override.italic]


### PR DESCRIPTION
* Slightly optimize leaning anchor for gha.
* Cleanup leftover unneeded parentheses anchor code for circumflex tie from when it was just a centered single mark.
* Fix discontinuity for `7` variants for `ss08` between sans and slab.
* Require at least three hyphens to trigger hyphen chain for C-likes for better disambiguation between a decrement operator token and just a continuous horizontal bar.

If possible, it would be nice if this could be merged without squashing, but it's not super important.