### PR TITLE
Clean up handling of pipe characters based on whether they are delimiters or operators.

### DIFF
--- a/changes/29.0.4.md
+++ b/changes/29.0.4.md
@@ -1,0 +1,2 @@
+* Make `U+2980` respond to `VSAM`.
+  - `U+2AFC` will no longer respond to `VSAM`.

--- a/packages/font-glyphs/src/symbol/math/logicals.ptl
+++ b/packages/font-glyphs/src/symbol/math/logicals.ptl
@@ -9,6 +9,7 @@ glyph-block Symbol-Math-Logicals : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Symbol-Math-Relation-Common : IdentHalfSpace
 	glyph-block-import Mark-Shared-Metrics : markStroke
+	glyph-block-import Symbol-Punctuation-Bar : BarShape DoubleBarShape TripleBarShape
 
 	create-glyph 'negate' 0xAC : glyph-proc
 		include : refer-glyph "minus"
@@ -26,13 +27,9 @@ glyph-block Symbol-Math-Logicals : begin
 	create-glyph 'endOfProof' 0x220E : glyph-proc
 		include : Rect top bot SB RightSB
 
-	create-glyph 'stile' 0x2223 : glyph-proc
-		include : VBar.m Middle bot top OperatorStroke
+	create-glyph 'stile' 0x2223 : BarShape Middle top bot OperatorStroke
 
-	create-glyph 'parallel' 0x2225 : glyph-proc
-		local sw : AdviceStroke 3.5
-		include : VBar.m (Middle - Width * 0.175) bot top sw
-		include : VBar.m (Middle + Width * 0.175) bot top sw
+	create-glyph 'parallel' 0x2225 : DoubleBarShape Middle top bot OperatorStroke
 
 	create-glyph 'vdash' 0x22A2 : glyph-proc
 		include : HBar.m SB RightSB SymbolMid OperatorStroke
@@ -209,8 +206,6 @@ glyph-block Symbol-Math-Logicals : begin
 	turned 'barRingBelow' 0x2AF0 'barRingAbove' Middle SymbolMid
 	turned 'topRingBelow' 0x2AF1 'botRingAbove' Middle SymbolMid
 
-	create-glyph 'interleave' 0x2AF4 : glyph-proc
-		local sw : AdviceStroke 4.25
-		include : VBar.m (Middle - Width * 0.2625) bot top sw
-		include : VBar.m  Middle                   bot top sw
-		include : VBar.m (Middle + Width * 0.2625) bot top sw
+	create-glyph 'interleave' 0x2AF4 : TripleBarShape Middle top bot OperatorStroke
+
+	create-glyph 'bigInterleave' 0x2AFC : TripleBarShape Middle ParenTop ParenBot OperatorStroke

--- a/packages/font-glyphs/src/symbol/punctuation/bar.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/bar.ptl
@@ -11,80 +11,92 @@ glyph-block Symbol-Punctuation-Bar : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 
-	define [BarShape x gap] : glyph-proc
-		set-base-anchor 'above' x ParenTop
-		set-base-anchor 'below' x ParenBot
-		include : VBar.m x (ParenBot + gap) (ParenTop - gap)
+	glyph-block-export BarShape
+	define [BarShape x top bot fine] : glyph-proc
+		set-base-anchor 'above' x top
+		set-base-anchor 'below' x bot
+		local sw : fallback fine Stroke
+		include : VBar.m x bot top sw
 
-	create-glyph 'bar.upright' : BarShape Middle 0
-	create-glyph 'bar.slanted.naturalSlope' : BarShape Middle 0
+	create-glyph 'bar.upright'              : BarShape Middle ParenTop ParenBot
+	create-glyph 'bar.slanted.naturalSlope' : BarShape Middle ParenTop ParenBot
 	create-glyph 'bar.slanted.forceUpright' : glyph-proc
 		include : ForceUpright
-		include : BarShape Middle 0
+		include : BarShape Middle ParenTop ParenBot
 
 	create-glyph 'ligBarInsideBracketLeft' : glyph-proc
 		Joining.set currentGlyph Joining.Classes.Left
+		local gap : Stroke + [Math.max [AdviceStroke 5] (XH / 12)]
 		include : BarShape
 			[mix SB RightSB DesignParameters.bracketOutside] + [HSwToV HalfStroke]
-			Stroke + [Math.max [AdviceStroke 5] (XH / 12)]
+			ParenTop - gap
+			ParenBot + gap
 
 	create-glyph 'ligBarInsideBracketRight' : glyph-proc
 		Joining.set currentGlyph Joining.Classes.Right
+		local gap : Stroke + [Math.max [AdviceStroke 5] (XH / 12)]
 		include : BarShape
 			[mix RightSB SB DesignParameters.bracketOutside] - [HSwToV HalfStroke]
-			Stroke + [Math.max [AdviceStroke 5] (XH / 12)]
+			ParenTop - gap
+			ParenBot + gap
 
-	define [DoubleBarShape] : glyph-proc
-		set-base-anchor 'above' Middle ParenTop
-		set-base-anchor 'below' Middle ParenBot
-		local sw : AdviceStroke 3.5
-		include : VBar.m (Middle - Width * 0.175) ParenBot ParenTop sw
-		include : VBar.m (Middle + Width * 0.175) ParenBot ParenTop sw
-
-	create-glyph 'doubleBar.upright'              : DoubleBarShape
-	create-glyph 'doubleBar.slanted.naturalSlope' : DoubleBarShape
-	create-glyph 'doubleBar.slanted.forceUpright' : glyph-proc
-		include : ForceUpright
-		include : DoubleBarShape
-
-	define [TripleBarShape] : glyph-proc
-		set-base-anchor 'above' Middle ParenTop
-		set-base-anchor 'below' Middle ParenBot
-		local sw : AdviceStroke 4.25
-		include : VBar.m (Middle - Width * 0.2625) ParenBot ParenTop sw
-		include : VBar.m  Middle                   ParenBot ParenTop sw
-		include : VBar.m (Middle + Width * 0.2625) ParenBot ParenTop sw
-
-	create-glyph 'tripleBar.upright'              : TripleBarShape
-	create-glyph 'tripleBar.slanted.naturalSlope' : TripleBarShape
-	create-glyph 'tripleBar.slanted.forceUpright' : glyph-proc
-		include : ForceUpright
-		include : TripleBarShape
-
-	define [BrokenBarShape] : glyph-proc
+	define [BrokenBarShape x top bot fine] : glyph-proc
 		local breakDist : Math.max Stroke (CAP / 8)
-		include : VBar.m Middle (SymbolMid + breakDist / 2) ParenTop
-		include : VBar.m Middle ParenBot (SymbolMid - breakDist / 2)
+		local yMid : mix top bot 0.5
+		local sw : fallback fine Stroke
+		include : VBar.m x (yMid + breakDist / 2) top sw
+		include : VBar.m x bot (yMid - breakDist / 2) sw
 
-	create-glyph 'brokenBar.upright'              : BrokenBarShape
-	create-glyph 'brokenBar.slanted.naturalSlope' : BrokenBarShape
+	create-glyph 'brokenBar.upright'              : BrokenBarShape Middle ParenTop ParenBot
+	create-glyph 'brokenBar.slanted.naturalSlope' : BrokenBarShape Middle ParenTop ParenBot
 	create-glyph 'brokenBar.slanted.forceUpright' : glyph-proc
 		include : ForceUpright
-		include : BrokenBarShape
+		include : BrokenBarShape Middle ParenTop ParenBot
 
-	create-glyph 'palatoalveolarclick' 0x1C2 : glyph-proc
-		include [refer-glyph 'bar.upright'] AS_BASE
-		include : HBar.b SB RightSB (SymbolMid + XH * 0.1) OperatorStroke
-		include : HBar.t SB RightSB (SymbolMid - XH * 0.1) OperatorStroke
+	glyph-block-export DoubleBarShape
+	define [DoubleBarShape x top bot fine] : glyph-proc
+		set-base-anchor 'above' x top
+		set-base-anchor 'below' x bot
+		local sw : ([fallback fine Stroke] / Stroke) * [AdviceStroke 3.5]
+		include : VBar.m (x - Width * 0.175) bot top sw
+		include : VBar.m (x + Width * 0.175) bot top sw
+
+	create-glyph 'doubleBar.upright'              : DoubleBarShape Middle ParenTop ParenBot
+	create-glyph 'doubleBar.slanted.naturalSlope' : DoubleBarShape Middle ParenTop ParenBot
+	create-glyph 'doubleBar.slanted.forceUpright' : glyph-proc
+		include : ForceUpright
+		include : DoubleBarShape Middle ParenTop ParenBot
+
+	glyph-block-export TripleBarShape
+	define [TripleBarShape x top bot fine] : glyph-proc
+		set-base-anchor 'above' x top
+		set-base-anchor 'below' x bot
+		local sw : ([fallback fine Stroke] / Stroke) * [AdviceStroke 4.25]
+		include : VBar.m (x - Width * 0.2625) bot top sw
+		include : VBar.m  x                   bot top sw
+		include : VBar.m (x + Width * 0.2625) bot top sw
+
+	create-glyph 'tripleBar.upright'              : TripleBarShape Middle ParenTop ParenBot
+	create-glyph 'tripleBar.slanted.naturalSlope' : TripleBarShape Middle ParenTop ParenBot
+	create-glyph 'tripleBar.slanted.forceUpright' : glyph-proc
+		include : ForceUpright
+		include : TripleBarShape Middle ParenTop ParenBot
 
 	select-variant 'bar.slanted'
 	orthographic-slanted 'bar' '|'
-	select-variant 'doubleBar.slanted' (follow -- 'bar.slanted')
-	orthographic-slanted 'doubleBar' 0x2016
-	select-variant 'tripleBar.slanted' (follow -- 'bar.slanted')
-	orthographic-slanted 'tripleBar' 0x2AFC
+
 	select-variant 'brokenBar.slanted' (follow -- 'bar.slanted')
 	orthographic-slanted 'brokenBar' 0xA6
-	alias 'dentalclick' 0x1C0 'bar.upright'
-	alias 'alveolarlateralclick' 0x1C1 'doubleBar.upright'
-	alias 'retroflexlateralclick' 0x2980 'tripleBar.upright'
+
+	select-variant 'doubleBar.slanted' (follow -- 'bar.slanted')
+	orthographic-slanted 'doubleBar' 0x2016
+
+	select-variant 'tripleBar.slanted' (follow -- 'bar.slanted')
+	orthographic-slanted 'tripleBar' 0x2980
+
+	create-glyph 'dentalclick'          0x1C0 :       BarShape Middle ParenTop ParenBot
+	create-glyph 'alveolarlateralclick' 0x1C1 : DoubleBarShape Middle ParenTop ParenBot
+	create-glyph 'palatoalveolarclick'  0x1C2 : glyph-proc
+		include [refer-glyph 'dentalclick'] AS_BASE
+		include : HBar.b SB RightSB (SymbolMid + XH * 0.1) OverlayStroke
+		include : HBar.t SB RightSB (SymbolMid - XH * 0.1) OverlayStroke


### PR DESCRIPTION
According to [/L2/L2017/17165](http://www.unicode.org/L2/L2017/17165-tr25-15-unicode-math.pdf#page=18), bar characters classified as delimiters and as operators are grouped separately. In this PR, the ones classified as delimiters will follow `VSAM` and the rest will not.

In #1749 , I mistakenly made LARGE TRIPLE VERTICAL BAR OPERATOR follow `VSAM` variants and TRIPLE VERTICAL BAR DELIMITER not follow them, but it should have been the other way around. My prior justification for the latter being used in para-IPA turned out to be only incidental as both happen to be extensions of an ASCII pipe character, which is a similar case to the Ext-IPA usage of the inverted exclamation mark `¡` from Latin-1 rather than having Unicode encode a whole new click letter.

Additionally, the mathematical double/triple stile characters will receive an _extremely subtle_ tweak to their stroke width based on the proportions of `OperatorStroke` compared to `Stroke`.

Finally, the horizontal bars of Alveolar Click (`ǂ`) will use `OverlayStroke` to match the metrics of other related IPA letters (namely `𝼋`, `ⱡ`, etc.).

```
|‖⦀
ǀǁǂ
∣∥⫴⫼
```

Upright with `VSAM` enabled:
![image](https://github.com/be5invis/Iosevka/assets/37010132/b935f018-f9f6-4a3c-897e-ed951b9368f6)
Italic with `VSAM` enabled:
![image](https://github.com/be5invis/Iosevka/assets/37010132/4cec18c8-4bff-423a-b34e-3ef223ecff19)
Thin:
![image](https://github.com/be5invis/Iosevka/assets/37010132/18fa480b-6e30-4049-8686-7555589aaa1d)
Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/d5eec507-b2d1-44c0-8a4e-279f548d26db)
Heavy:
![image](https://github.com/be5invis/Iosevka/assets/37010132/471a5086-028a-4599-92bf-ff2e8c82eb48)
