### PR TITLE
Fix horizontal positioning of multi-dot punctuation under Quasi-Proportional.

### DIFF
--- a/changes/29.0.5.md
+++ b/changes/29.0.5.md
@@ -1,0 +1,1 @@
+* Fix side bearings of multi-dot punctuation (`U+10FB`, `U+2056`, `U+2058`..`205B`, `U+2E2A`..`U+2E2D`) under Quasi-Proportional.

--- a/packages/font-glyphs/src/symbol/punctuation/small.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/small.ptl
@@ -25,21 +25,11 @@ glyph-block Symbol-Punctuation-Small : begin
 			local df : include : DivFrame para.diversityF
 			include : DrawAt df.middle (CAP - PeriodRadius * kDotRadius) (PeriodRadius * kDotRadius - overshoot)
 
-		create-glyph "smallPeriod.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.diversityF
-			include : DrawAt df.middle (DotRadius * kDotRadius) (DotRadius * kDotRadius - overshoot)
-		create-glyph "halfXhSmallPeriod.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.diversityF
-			include : DrawAt df.middle (XH / 2) (DotRadius * kDotRadius - overshoot)
-		create-glyph "halfCapSmallPeriod.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.diversityF
-			include : DrawAt df.middle (CAP / 2) (DotRadius * kDotRadius - overshoot)
-		create-glyph "xhSmallPeriod.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.diversityF
-			include : DrawAt df.middle (XH - DotRadius * kDotRadius) (DotRadius * kDotRadius - overshoot)
-		create-glyph "capSmallPeriod.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.diversityF
-			include : DrawAt df.middle (CAP - DotRadius * kDotRadius) (DotRadius * kDotRadius - overshoot)
+		create-glyph "smallPeriod.\(suffix)"        : DrawAt Middle (DotRadius * kDotRadius)       (DotRadius * kDotRadius - overshoot)
+		create-glyph "halfXhSmallPeriod.\(suffix)"  : DrawAt Middle (XH  / 2)                      (DotRadius * kDotRadius - overshoot)
+		create-glyph "halfCapSmallPeriod.\(suffix)" : DrawAt Middle (CAP / 2)                      (DotRadius * kDotRadius - overshoot)
+		create-glyph "xhSmallPeriod.\(suffix)"      : DrawAt Middle (XH  - DotRadius * kDotRadius) (DotRadius * kDotRadius - overshoot)
+		create-glyph "capSmallPeriod.\(suffix)"     : DrawAt Middle (CAP - DotRadius * kDotRadius) (DotRadius * kDotRadius - overshoot)
 
 	select-variant 'period' '.' (follow -- 'punctuationDot')
 


### PR DESCRIPTION
Basically `smallPeriod` etc. was previously given a divframe despite only ever being used as a radical for these multi-dot marks, and the divframe didn't even match the default width used by the multi-dot marks so it was always shifted to the left by the exact difference between `diversityF` and `1`.

All that needed to be done to fix it was to remove the divframe for _just_ the small dots, and draw them starting from the default center instead.
```
჻  ⁖  ⸪  ⸫
⁘  ⸭  ⸬  ⁙
:  ⁚  ⁘  ⁛
```
Before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/c6562e2e-9752-4756-8d49-5cc5c8595fc6)
After:
![image](https://github.com/be5invis/Iosevka/assets/37010132/dae0097e-9bf3-459f-b92a-8d88bfc5c2b8)
