### PR TITLE
Make the geometry cache more efficient. Bump version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iosevka/monorepo",
-  "version": "29.0.5",
+  "version": "29.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iosevka/monorepo",
-      "version": "29.0.5",
+      "version": "29.0.6",
       "workspaces": [
         "packages/*",
         "tools/*"
@@ -4310,16 +4310,16 @@
     },
     "packages/font": {
       "name": "@iosevka/font",
-      "version": "29.0.5",
+      "version": "29.0.6",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@iosevka/font-glyphs": "29.0.5",
-        "@iosevka/font-otl": "29.0.5",
-        "@iosevka/geometry": "29.0.5",
-        "@iosevka/geometry-cache": "29.0.5",
-        "@iosevka/glyph": "29.0.5",
-        "@iosevka/param": "29.0.5",
-        "@iosevka/util": "29.0.5",
+        "@iosevka/font-glyphs": "29.0.6",
+        "@iosevka/font-otl": "29.0.6",
+        "@iosevka/geometry": "29.0.6",
+        "@iosevka/geometry-cache": "29.0.6",
+        "@iosevka/glyph": "29.0.6",
+        "@iosevka/param": "29.0.6",
+        "@iosevka/util": "29.0.6",
         "harfbuzzjs": "^0.3.4",
         "ot-builder": "^1.7.3",
         "semver": "^7.6.0"
@@ -4327,100 +4327,100 @@
     },
     "packages/font-glyphs": {
       "name": "@iosevka/font-glyphs",
-      "version": "29.0.5",
+      "version": "29.0.6",
       "dependencies": {
-        "@iosevka/font-kits": "29.0.5",
-        "@iosevka/geometry": "29.0.5",
-        "@iosevka/geometry-cache": "29.0.5",
-        "@iosevka/glyph": "29.0.5",
-        "@iosevka/util": "29.0.5",
+        "@iosevka/font-kits": "29.0.6",
+        "@iosevka/geometry": "29.0.6",
+        "@iosevka/geometry-cache": "29.0.6",
+        "@iosevka/glyph": "29.0.6",
+        "@iosevka/util": "29.0.6",
         "typo-geom": "^0.15.1"
       }
     },
     "packages/font-kits": {
       "name": "@iosevka/font-kits",
-      "version": "29.0.5",
+      "version": "29.0.6",
       "dependencies": {
-        "@iosevka/geometry": "29.0.5",
-        "@iosevka/glyph": "29.0.5",
-        "@iosevka/util": "29.0.5"
+        "@iosevka/geometry": "29.0.6",
+        "@iosevka/glyph": "29.0.6",
+        "@iosevka/util": "29.0.6"
       }
     },
     "packages/font-otl": {
       "name": "@iosevka/font-otl",
-      "version": "29.0.5",
+      "version": "29.0.6",
       "dependencies": {
-        "@iosevka/font-glyphs": "29.0.5",
-        "@iosevka/glyph": "29.0.5",
+        "@iosevka/font-glyphs": "29.0.6",
+        "@iosevka/glyph": "29.0.6",
         "toposort": "^2.0.2"
       }
     },
     "packages/geometry": {
       "name": "@iosevka/geometry",
-      "version": "29.0.5",
+      "version": "29.0.6",
       "dependencies": {
-        "@iosevka/util": "29.0.5",
+        "@iosevka/util": "29.0.6",
         "spiro": "^3.0.0",
         "typo-geom": "^0.15.1"
       }
     },
     "packages/geometry-cache": {
       "name": "@iosevka/geometry-cache",
-      "version": "29.0.5",
+      "version": "29.0.6",
       "dependencies": {
-        "@iosevka/geometry": "29.0.5",
+        "@iosevka/geometry": "29.0.6",
         "@msgpack/msgpack": "^2.8.0"
       }
     },
     "packages/glyph": {
       "name": "@iosevka/glyph",
-      "version": "29.0.5",
+      "version": "29.0.6",
       "dependencies": {
-        "@iosevka/geometry": "29.0.5"
+        "@iosevka/geometry": "29.0.6"
       }
     },
     "packages/param": {
       "name": "@iosevka/param",
-      "version": "29.0.5",
+      "version": "29.0.6",
       "dependencies": {
-        "@iosevka/util": "29.0.5"
+        "@iosevka/util": "29.0.6"
       }
     },
     "packages/util": {
       "name": "@iosevka/util",
-      "version": "29.0.5"
+      "version": "29.0.6"
     },
     "tools/amend-readme": {
       "name": "@iosevka/amend-readme",
-      "version": "29.0.5",
+      "version": "29.0.6",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@iosevka/param": "29.0.5",
+        "@iosevka/param": "29.0.6",
         "@unicode/unicode-15.1.0": "^1.5.2"
       }
     },
     "tools/data-export": {
       "name": "@iosevka/data-export",
-      "version": "29.0.5",
+      "version": "29.0.6",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@iosevka/param": "29.0.5",
+        "@iosevka/param": "29.0.6",
         "@unicode/unicode-15.1.0": "^1.5.2",
         "cldr": "^7.5.0"
       }
     },
     "tools/generate-samples": {
       "name": "@iosevka/generate-samples",
-      "version": "29.0.5",
+      "version": "29.0.6",
       "dependencies": {
-        "@iosevka/data-export": "29.0.5"
+        "@iosevka/data-export": "29.0.6"
       }
     },
     "tools/misc": {
       "name": "@iosevka/misc",
-      "version": "29.0.5",
+      "version": "29.0.6",
       "dependencies": {
-        "@iosevka/util": "29.0.5",
+        "@iosevka/util": "29.0.6",
         "semver": "^7.6.0",
         "wawoff2": "^2.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iosevka/monorepo",
-  "version": "29.0.5",
+  "version": "29.0.6",
   "workspaces": [
     "packages/*",
     "tools/*"

--- a/packages/font-glyphs/package.json
+++ b/packages/font-glyphs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iosevka/font-glyphs",
-  "version": "29.0.5",
+  "version": "29.0.6",
   "private": true,
   "exports": {
     ".": "./src/index.mjs",
@@ -8,11 +8,11 @@
     "./unicode-knowledge": "./src/meta/unicode-knowledge.mjs"
   },
   "dependencies": {
-    "@iosevka/font-kits": "29.0.5",
-    "@iosevka/geometry": "29.0.5",
-    "@iosevka/geometry-cache": "29.0.5",
-    "@iosevka/glyph": "29.0.5",
-    "@iosevka/util": "29.0.5",
+    "@iosevka/font-kits": "29.0.6",
+    "@iosevka/geometry": "29.0.6",
+    "@iosevka/geometry-cache": "29.0.6",
+    "@iosevka/glyph": "29.0.6",
+    "@iosevka/util": "29.0.6",
     "typo-geom": "^0.15.1"
   }
 }

--- a/packages/font-kits/package.json
+++ b/packages/font-kits/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@iosevka/font-kits",
-  "version": "29.0.5",
+  "version": "29.0.6",
   "private": true,
   "exports": {
     "./boole-kit": "./src/boole-kit.mjs",
     "./spiro-kit": "./src/spiro-kit.mjs"
   },
   "dependencies": {
-    "@iosevka/geometry": "29.0.5",
-    "@iosevka/glyph": "29.0.5",
-    "@iosevka/util": "29.0.5"
+    "@iosevka/geometry": "29.0.6",
+    "@iosevka/glyph": "29.0.6",
+    "@iosevka/util": "29.0.6"
   }
 }

--- a/packages/font-otl/package.json
+++ b/packages/font-otl/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@iosevka/font-otl",
-  "version": "29.0.5",
+  "version": "29.0.6",
   "private": true,
   "exports": {
     ".": "./src/index.mjs"
   },
   "dependencies": {
-    "@iosevka/font-glyphs": "29.0.5",
-    "@iosevka/glyph": "29.0.5",
+    "@iosevka/font-glyphs": "29.0.6",
+    "@iosevka/glyph": "29.0.6",
     "toposort": "^2.0.2"
   }
 }

--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iosevka/font",
-  "version": "29.0.5",
+  "version": "29.0.6",
   "private": true,
   "exports": {
     ".": "./src/index.mjs",
@@ -10,13 +10,13 @@
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",
-    "@iosevka/font-glyphs": "29.0.5",
-    "@iosevka/font-otl": "29.0.5",
-    "@iosevka/geometry": "29.0.5",
-    "@iosevka/geometry-cache": "29.0.5",
-    "@iosevka/glyph": "29.0.5",
-    "@iosevka/param": "29.0.5",
-    "@iosevka/util": "29.0.5",
+    "@iosevka/font-glyphs": "29.0.6",
+    "@iosevka/font-otl": "29.0.6",
+    "@iosevka/geometry": "29.0.6",
+    "@iosevka/geometry-cache": "29.0.6",
+    "@iosevka/glyph": "29.0.6",
+    "@iosevka/param": "29.0.6",
+    "@iosevka/util": "29.0.6",
     "harfbuzzjs": "^0.3.4",
     "ot-builder": "^1.7.3",
     "semver": "^7.6.0"

--- a/packages/font/src/cleanup/glyphs.mjs
+++ b/packages/font/src/cleanup/glyphs.mjs
@@ -19,19 +19,6 @@ function regulateGlyphStore(cache, skew, glyphStore) {
 }
 
 function flattenSimpleGlyph(cache, skew, g) {
-	// Check if the geometry is already in the cache. If so, use the cached geometry.
-	const ck = Geom.hashGeometry(g.geometry);
-	if (ck && cache) {
-		const cachedGeometry = cache && cache.getGF(ck);
-		if (cachedGeometry) {
-			g.clearGeometry();
-			g.includeContours(cachedGeometry);
-			cache.refreshGF(ck);
-			return;
-		}
-	}
-
-	// Perform the actual simplification
 	try {
 		let gSimplified;
 		if (skew) {
@@ -45,10 +32,9 @@ function flattenSimpleGlyph(cache, skew, g) {
 			gSimplified = new Geom.SimplifyGeometry(g.geometry);
 		}
 
-		const cs = gSimplified.toContours();
+		const cs = gSimplified.toContours({ cache });
 		g.clearGeometry();
 		g.includeContours(cs);
-		if (ck && cache) cache.saveGF(ck, cs);
 	} catch (e) {
 		console.error("Detected broken geometry when processing", g._m_identifier);
 		throw e;

--- a/packages/geometry-cache/package.json
+++ b/packages/geometry-cache/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@iosevka/geometry-cache",
-  "version": "29.0.5",
+  "version": "29.0.6",
   "private": true,
   "exports": {
     ".": "./src/index.mjs"
   },
   "dependencies": {
-    "@iosevka/geometry": "29.0.5",
+    "@iosevka/geometry": "29.0.6",
     "@msgpack/msgpack": "^2.8.0"
   }
 }

--- a/packages/geometry-cache/src/index.mjs
+++ b/packages/geometry-cache/src/index.mjs
@@ -4,7 +4,7 @@ import zlib from "zlib";
 import * as CurveUtil from "@iosevka/geometry/curve-util";
 import { encode, decode } from "@msgpack/msgpack";
 
-const Edition = 37;
+const Edition = 40;
 const MAX_AGE = 16;
 class GfEntry {
 	constructor(age, value) {

--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iosevka/geometry",
-  "version": "29.0.5",
+  "version": "29.0.6",
   "private": true,
   "exports": {
     ".": "./src/index.mjs",
@@ -13,7 +13,7 @@
     "./spiro-control": "./src/spiro-control.mjs"
   },
   "dependencies": {
-    "@iosevka/util": "29.0.5",
+    "@iosevka/util": "29.0.6",
     "spiro": "^3.0.0",
     "typo-geom": "^0.15.1"
   }

--- a/packages/geometry/src/index.mjs
+++ b/packages/geometry/src/index.mjs
@@ -13,11 +13,11 @@ import { Transform } from "./transform.mjs";
 
 export const CPLX_NON_EMPTY = 0x01; // A geometry tree that is not empty
 export const CPLX_NON_SIMPLE = 0x02; // A geometry tree that contains non-simple contours
-export const CPLX_BROKEN = 0x04; // A geometry tree that contains broken contours, like having points with NaN coordinates
+export const CPLX_BROKEN = 0x04; // A geometry tree that contains broken contours
 export const CPLX_UNKNOWN = 0xff;
 
 export class GeometryBase {
-	toContours() {
+	toContours(ctx) {
 		throw new Error("Unimplemented");
 	}
 	toReferences() {
@@ -35,8 +35,9 @@ export class GeometryBase {
 	measureComplexity() {
 		return CPLX_UNKNOWN;
 	}
-	toShapeStringOrNull() {
-		return null;
+
+	hash(h) {
+		return h.invalid();
 	}
 }
 
@@ -47,7 +48,7 @@ export class ContourSetGeometry extends GeometryBase {
 		super();
 		this.m_contours = contours;
 	}
-	toContours() {
+	toContours(ctx) {
 		return this.m_contours;
 	}
 	toReferences() {
@@ -68,26 +69,52 @@ export class ContourSetGeometry extends GeometryBase {
 		}
 		return cp;
 	}
-	toShapeStringOrNull() {
-		return Format.struct(
-			`ContourSetGeometry`,
-			Format.list(this.m_contours.map(c => Format.list(c.map(Format.typedPoint)))),
-		);
+	hash(h) {
+		h.beginStruct("ContourSetGeometry");
+		h.beginArray(this.m_contours.length);
+		for (const c of this.m_contours) {
+			h.beginArray(c.length);
+			for (const z of c) h.typedPoint(z);
+			h.endArray();
+		}
+		h.endArray();
+		h.endStruct();
 	}
 }
 
-export class SpiroGeometry extends GeometryBase {
+// Enabling geometry cache over the deep nodes of the geometry tree
+export class CachedGeometry extends GeometryBase {
+	toContours(ctx) {
+		let ck = null;
+		if (ctx && ctx.cache) {
+			ck = hashGeometry(this);
+			const gf = ctx.cache.getGF(ck);
+			if (gf) {
+				ctx.cache.refreshGF(ck);
+				return gf;
+			}
+		}
+
+		const outline = this.toContoursImpl(ctx);
+		if (ck && ctx && ctx.cache) ctx.cache.saveGF(ck, outline);
+
+		return outline;
+	}
+
+	toContoursImpl() {
+		throw new Error("Unimplemented");
+	}
+}
+
+export class SpiroGeometry extends CachedGeometry {
 	constructor(gizmo, closed, knots) {
 		super();
 		this.m_knots = knots;
 		this.m_closed = closed;
 		this.m_gizmo = gizmo;
-		this.m_cachedContours = null;
 	}
-	toContours() {
-		if (this.m_cachedContours) return this.m_cachedContours;
-		this.m_cachedContours = spiroToOutline(this.m_knots, this.m_closed, this.m_gizmo);
-		return this.m_cachedContours;
+	toContoursImpl() {
+		return spiroToOutline(this.m_knots, this.m_closed, this.m_gizmo);
 	}
 	toReferences() {
 		return null;
@@ -105,28 +132,28 @@ export class SpiroGeometry extends GeometryBase {
 		}
 		return cplx;
 	}
-	toShapeStringOrNull() {
-		return Format.struct(
-			"SpiroGeometry",
-			Format.gizmo(this.m_gizmo),
-			this.m_closed,
-			Format.list(this.m_knots.map(k => k.toShapeString())),
-		);
+
+	hash(h) {
+		h.beginStruct("SpiroGeometry");
+		h.gizmo(this.m_gizmo);
+		h.bool(this.m_closed);
+		h.beginArray(this.m_knots.length);
+		for (const knot of this.m_knots) h.embed(knot);
+		h.endArray();
+		h.endStruct();
 	}
 }
 
-export class DiSpiroGeometry extends GeometryBase {
+export class DiSpiroGeometry extends CachedGeometry {
 	constructor(gizmo, contrast, closed, biKnots) {
 		super();
 		this.m_biKnots = biKnots; // untransformed
 		this.m_closed = closed;
 		this.m_gizmo = gizmo;
 		this.m_contrast = contrast;
-		this.m_cachedExpansionResults = null;
-		this.m_cachedContours = null;
 	}
-	toContours() {
-		if (this.m_cachedContours) return this.m_cachedContours;
+
+	toContoursImpl() {
 		const expandResult = this.expand();
 		const lhs = [...expandResult.lhsUntransformed];
 		const rhs = [...expandResult.rhsUntransformed];
@@ -134,23 +161,20 @@ export class DiSpiroGeometry extends GeometryBase {
 		for (const k of rhs) k.reverseType();
 		rhs.reverse();
 
-		let outlineGeometry;
 		if (this.m_closed) {
-			outlineGeometry = new CombineGeometry([
-				new SpiroGeometry(this.m_gizmo, true, lhs),
-				new SpiroGeometry(this.m_gizmo, true, rhs),
-			]);
+			return [
+				...new SpiroGeometry(this.m_gizmo, true, lhs).toContoursImpl(),
+				...new SpiroGeometry(this.m_gizmo, true, rhs).toContoursImpl(),
+			];
 		} else {
 			lhs[0].type = lhs[lhs.length - 1].type = "corner";
 			rhs[0].type = rhs[rhs.length - 1].type = "corner";
 			const allKnots = lhs.concat(rhs);
-			outlineGeometry = new SpiroGeometry(this.m_gizmo, true, allKnots);
+			return new SpiroGeometry(this.m_gizmo, true, allKnots).toContoursImpl();
 		}
-		this.m_cachedContours = outlineGeometry.toContours();
-		return this.m_cachedContours;
 	}
+
 	expand() {
-		if (this.m_cachedExpansionResults) return this.m_cachedExpansionResults;
 		const expander = new SpiroExpander(
 			this.m_gizmo,
 			this.m_contrast,
@@ -162,8 +186,7 @@ export class DiSpiroGeometry extends GeometryBase {
 		expander.iterateNormals();
 		expander.iterateNormals();
 		expander.iterateNormals();
-		this.m_cachedExpansionResults = expander.expand();
-		return this.m_cachedExpansionResults;
+		return expander.expand();
 	}
 	toReferences() {
 		return null;
@@ -181,14 +204,16 @@ export class DiSpiroGeometry extends GeometryBase {
 		}
 		return cplx;
 	}
-	toShapeStringOrNull() {
-		return Format.struct(
-			"DiSpiroGeometry",
-			Format.gizmo(this.m_gizmo),
-			Format.n(this.m_contrast),
-			this.m_closed,
-			Format.list(this.m_biKnots.map(z => z.toShapeString())),
-		);
+
+	hash(h) {
+		h.beginStruct("DiSpiroGeometry");
+		h.gizmo(this.m_gizmo);
+		h.f64(this.m_contrast);
+		h.bool(this.m_closed);
+		h.beginArray(this.m_biKnots.length);
+		for (const knot of this.m_biKnots) h.embed(knot);
+		h.endArray();
+		h.endStruct();
 	}
 }
 
@@ -206,8 +231,8 @@ export class ReferenceGeometry extends GeometryBase {
 			this.m_glyph.geometry,
 		);
 	}
-	toContours() {
-		return this.unwrap().toContours();
+	toContours(ctx) {
+		return this.unwrap().toContours(ctx);
 	}
 	toReferences() {
 		if (this.m_glyph.geometry.measureComplexity() & CPLX_NON_EMPTY) {
@@ -229,10 +254,13 @@ export class ReferenceGeometry extends GeometryBase {
 	unlinkReferences() {
 		return this.unwrap().unlinkReferences();
 	}
-	toShapeStringOrNull() {
-		let sTarget = this.m_glyph.geometry.toShapeStringOrNull();
-		if (!sTarget) return null;
-		return Format.struct("ReferenceGeometry", sTarget, Format.n(this.m_x), Format.n(this.m_y));
+
+	hash(h) {
+		h.beginStruct("ReferenceGeometry");
+		h.embed(this.m_glyph.geometry);
+		h.f64(this.m_x);
+		h.f64(this.m_y);
+		h.endStruct();
 	}
 }
 
@@ -242,8 +270,8 @@ export class TaggedGeometry extends GeometryBase {
 		this.m_geom = g;
 		this.m_tag = tag;
 	}
-	toContours() {
-		return this.m_geom.toContours();
+	toContours(ctx) {
+		return this.m_geom.toContours(ctx);
 	}
 	toReferences() {
 		return this.m_geom.toReferences();
@@ -261,8 +289,9 @@ export class TaggedGeometry extends GeometryBase {
 	unlinkReferences() {
 		return this.m_geom.unlinkReferences();
 	}
-	toShapeStringOrNull() {
-		return this.m_geom.toShapeStringOrNull();
+
+	hash(h) {
+		this.m_geom.hash(h);
 	}
 }
 
@@ -277,9 +306,9 @@ export class TransformedGeometry extends GeometryBase {
 		return new TransformedGeometry(Transform.Combine(this.m_transform, tfm), this.m_geom);
 	}
 
-	toContours() {
+	toContours(ctx) {
 		let result = [];
-		for (const c of this.m_geom.toContours()) {
+		for (const c of this.m_geom.toContours(ctx)) {
 			let c1 = [];
 			for (const z of c) c1.push(Point.transformed(this.m_transform, z));
 			result.push(c1);
@@ -319,10 +348,13 @@ export class TransformedGeometry extends GeometryBase {
 			return new TransformedGeometry(this.m_transform, unwrapped);
 		}
 	}
-	toShapeStringOrNull() {
-		const sTarget = this.m_geom.toShapeStringOrNull();
-		if (!sTarget) return null;
-		return Format.struct("TransformedGeometry", Format.gizmo(this.m_transform), sTarget);
+
+	hash(h) {
+		h.beginStruct("TransformedGeometry");
+		h.gizmo(this.m_transform);
+		h.embed(this.m_geom);
+		h.endStruct();
+		return h;
 	}
 }
 
@@ -331,8 +363,8 @@ export class RadicalGeometry extends GeometryBase {
 		super();
 		this.m_geom = g;
 	}
-	toContours() {
-		return this.m_geom.toContours();
+	toContours(ctx) {
+		return this.m_geom.toContours(ctx);
 	}
 	toReferences() {
 		return null;
@@ -351,10 +383,9 @@ export class RadicalGeometry extends GeometryBase {
 	unlinkReferences() {
 		return this.m_geom.unlinkReferences();
 	}
-	toShapeStringOrNull() {
-		const sTarget = this.m_geom.toShapeStringOrNull();
-		if (!sTarget) return null;
-		return Format.struct("RadicalGeometry", sTarget);
+
+	hash(h) {
+		this.m_geom.hash(h);
 	}
 }
 
@@ -370,10 +401,10 @@ export class CombineGeometry extends GeometryBase {
 			return new CombineGeometry([...this.m_parts, g]);
 		}
 	}
-	toContours() {
+	toContours(ctx) {
 		let results = [];
 		for (const part of this.m_parts) {
-			for (const c of part.toContours()) {
+			for (const c of part.toContours(ctx)) {
 				results.push(c);
 			}
 		}
@@ -424,30 +455,24 @@ export class CombineGeometry extends GeometryBase {
 		}
 		return new CombineGeometry(parts);
 	}
-	toShapeStringOrNull() {
-		let sParts = [];
-		for (const item of this.m_parts) {
-			const sPart = item.toShapeStringOrNull();
-			if (!sPart) return null;
-			sParts.push(sPart);
-		}
-		return Format.struct("CombineGeometry", Format.list(sParts));
+
+	hash(h) {
+		h.beginStruct("CombineGeometry");
+		h.beginArray(this.m_parts.length);
+		for (const part of this.m_parts) h.embed(part);
+		h.endArray();
+		h.endStruct();
 	}
 }
 
-export class BooleanGeometry extends GeometryBase {
+export class BooleanGeometry extends CachedGeometry {
 	constructor(operator, operands) {
 		super();
 		this.m_operator = operator;
 		this.m_operands = operands;
-		this.m_resolved = null;
 	}
-	toContours() {
-		if (this.m_resolved) return this.m_resolved;
-		this.m_resolved = this.asContoursImpl();
-		return this.m_resolved;
-	}
-	asContoursImpl() {
+
+	toContoursImpl() {
 		if (this.m_operands.length === 0) return [];
 
 		const stack = [];
@@ -516,18 +541,18 @@ export class BooleanGeometry extends GeometryBase {
 		}
 		return new BooleanGeometry(this.m_operator, operands);
 	}
-	toShapeStringOrNull() {
-		let sParts = [];
-		for (const item of this.m_operands) {
-			const sPart = item.toShapeStringOrNull();
-			if (!sPart) return null;
-			sParts.push(sPart);
-		}
-		return Format.struct("BooleanGeometry", this.m_operator, Format.list(sParts));
+
+	hash(h) {
+		h.beginStruct("BooleanGeometry");
+		h.u32(this.m_operator);
+		h.beginArray(this.m_operands.length);
+		for (const operand of this.m_operands) h.embed(operand);
+		h.endArray();
+		h.endStruct();
 	}
 }
 
-export class StrokeGeometry extends GeometryBase {
+export class StrokeGeometry extends CachedGeometry {
 	constructor(geom, gizmo, radius, contrast, fInside) {
 		super();
 		this.m_geom = geom;
@@ -537,11 +562,11 @@ export class StrokeGeometry extends GeometryBase {
 		this.m_fInside = fInside;
 	}
 
-	toContours() {
+	toContoursImpl(ctx) {
 		// Produce simplified arcs
 		const nonTransformedGeometry = new TransformedGeometry(this.m_gizmo.inverse(), this.m_geom);
 		let arcs = TypoGeom.Boolean.removeOverlap(
-			CurveUtil.convertShapeToArcs(nonTransformedGeometry.toContours()),
+			CurveUtil.convertShapeToArcs(nonTransformedGeometry.toContours(ctx)),
 			TypoGeom.Boolean.PolyFillType.pftNonZero,
 			CurveUtil.BOOLE_RESOLUTION,
 		);
@@ -590,29 +615,27 @@ export class StrokeGeometry extends GeometryBase {
 	measureComplexity() {
 		return this.m_geom.measureComplexity() | CPLX_NON_SIMPLE;
 	}
-	toShapeStringOrNull() {
-		const sTarget = this.m_geom.unlinkReferences().toShapeStringOrNull();
-		if (!sTarget) return null;
-		return Format.struct(
-			`StrokeGeometry`,
-			sTarget,
-			Format.gizmo(this.m_gizmo),
-			Format.n(this.m_radius),
-			Format.n(this.m_contrast),
-			this.m_fInside,
-		);
+
+	hash(h) {
+		h.beginStruct("StrokeGeometry");
+		h.embed(this.m_geom);
+		h.gizmo(this.m_gizmo);
+		h.f64(this.m_radius);
+		h.f64(this.m_contrast);
+		h.bool(this.m_fInside);
+		h.endStruct();
 	}
 }
 
 // This special geometry type is used in the finalization phase to create TTF contours.
-export class SimplifyGeometry extends GeometryBase {
+export class SimplifyGeometry extends CachedGeometry {
 	constructor(g) {
 		super();
 		this.m_geom = g;
 	}
-	toContours() {
+	toContoursImpl(ctx) {
 		// Produce simplified arcs
-		let arcs = CurveUtil.convertShapeToArcs(this.m_geom.toContours());
+		let arcs = CurveUtil.convertShapeToArcs(this.m_geom.toContours(ctx));
 		if (this.m_geom.measureComplexity() & CPLX_NON_SIMPLE) {
 			arcs = TypoGeom.Boolean.removeOverlap(
 				arcs,
@@ -645,10 +668,11 @@ export class SimplifyGeometry extends GeometryBase {
 	measureComplexity() {
 		return this.m_geom.measureComplexity();
 	}
-	toShapeStringOrNull() {
-		const sTarget = this.m_geom.unlinkReferences().toShapeStringOrNull();
-		if (!sTarget) return null;
-		return `SimplifyGeometry{${sTarget}}`;
+
+	hash(h) {
+		h.beginStruct("SimplifyGeometry");
+		h.embed(this.m_geom);
+		h.endStruct();
 	}
 }
 
@@ -662,7 +686,7 @@ export function combineWith(a, b) {
 }
 
 export function hashGeometry(geom) {
-	const s = geom.toShapeStringOrNull();
-	if (!s) return null;
-	return crypto.createHash("sha256").update(s).digest("hex");
+	const hasher = new Format.Hasher();
+	geom.hash(hasher);
+	return hasher.digest();
 }

--- a/packages/geometry/src/spiro-control.mjs
+++ b/packages/geometry/src/spiro-control.mjs
@@ -115,9 +115,15 @@ export class MonoKnot {
 		const k1 = new MonoKnot(this.type, this.x, this.y, this.unimportant);
 		return k1;
 	}
-	toShapeString() {
-		return Format.tuple(this.type, this.unimportant, Format.n(this.x), Format.n(this.y));
+	hash(h) {
+		h.beginStruct("MonoKnot");
+		h.str(this.type);
+		h.bool(this.unimportant);
+		h.f64(this.x);
+		h.f64(this.y);
+		h.endStruct();
 	}
+
 	reverseType() {
 		if (this.type === "left") {
 			this.type = "right";
@@ -158,19 +164,26 @@ class BiKnot {
 		k1.unimportant = this.unimportant;
 		return k1;
 	}
-	toShapeString() {
-		return Format.tuple(
-			this.type,
-			this.unimportant,
-			Format.n(this.x),
-			Format.n(this.y),
-			this.d1 == null ? "" : Format.n(this.d1),
-			this.d2 == null ? "" : Format.n(this.d2),
-			this.proposedNormal
-				? Format.tuple(Format.n(this.proposedNormal.x), Format.n(this.proposedNormal.y))
-				: "",
-		);
+	hash(h) {
+		h.beginStruct("BiKnot");
+		h.str(this.type);
+		h.bool(this.unimportant);
+		h.f64(this.x);
+		h.f64(this.y);
+
+		h.bool(this.d1 != null);
+		if (this.d1 != null) h.f64(this.d1);
+		h.bool(this.d2 != null);
+		if (this.d2 != null) h.f64(this.d2);
+
+		h.bool(this.proposedNormal != null);
+		if (this.proposedNormal) {
+			h.f64(this.proposedNormal.x);
+			h.f64(this.proposedNormal.y);
+		}
+		h.endStruct();
 	}
+
 	toMono() {
 		return new MonoKnot(this.type, this.unimportant, this.x, this.y);
 	}

--- a/packages/glyph/package.json
+++ b/packages/glyph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iosevka/glyph",
-  "version": "29.0.5",
+  "version": "29.0.6",
   "private": true,
   "exports": {
     ".": "./src/glyph.mjs",
@@ -9,6 +9,6 @@
     "./relation": "./src/relation.mjs"
   },
   "dependencies": {
-    "@iosevka/geometry": "29.0.5"
+    "@iosevka/geometry": "29.0.6"
   }
 }

--- a/packages/glyph/src/glyph.mjs
+++ b/packages/glyph/src/glyph.mjs
@@ -150,8 +150,8 @@ export class Glyph {
 	tryBecomeMirrorOf(dst, rankSet) {
 		if (rankSet.has(this) || rankSet.has(dst)) return;
 		if (dst.hasDependency(this)) return;
-		const csThis = this.geometry.unlinkReferences().toShapeStringOrNull();
-		const csDst = dst.geometry.unlinkReferences().toShapeStringOrNull();
+		const csThis = Geom.hashGeometry(this.geometry.unlinkReferences());
+		const csDst = Geom.hashGeometry(dst.geometry.unlinkReferences());
 		if (csThis && csDst && csThis === csDst) {
 			this.geometry = new Geom.CombineGeometry([new Geom.ReferenceGeometry(dst, 0, 0)]);
 			rankSet.add(this);

--- a/packages/param/package.json
+++ b/packages/param/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iosevka/param",
-  "version": "29.0.5",
+  "version": "29.0.6",
   "private": true,
   "exports": {
     ".": "./src/index.mjs",
@@ -9,6 +9,6 @@
     "./metric-override": "./src/metric-override.mjs"
   },
   "dependencies": {
-    "@iosevka/util": "29.0.5"
+    "@iosevka/util": "29.0.6"
   }
 }

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iosevka/util",
-  "version": "29.0.5",
+  "version": "29.0.6",
   "private": true,
   "exports": {
     ".": "./src/index.mjs",

--- a/packages/util/src/formatter.mjs
+++ b/packages/util/src/formatter.mjs
@@ -1,18 +1,108 @@
-export function struct(leader, ...items) {
-	return "" + leader + "(" + items.join(";") + ")";
-}
-export function tuple(...items) {
-	return "(" + items.join(";") + ")";
-}
-export function list(items) {
-	return "{" + items.join(";") + "}";
-}
-export function n(x) {
-	return String(Math.round(x * 0x10000));
-}
-export function typedPoint(z) {
-	return tuple(z.type, n(z.x), n(z.y));
-}
-export function gizmo(g) {
-	return tuple(n(g.xx), n(g.xy), n(g.yx), n(g.yy), n(g.tx), n(g.ty));
+import crypto from "crypto";
+
+const TAG_INVALID = 0x11000000;
+const TAG_BEGIN_STRUCT = 0x12340001;
+const TAG_END_STRUCT = 0x12340002;
+const TAG_BEGIN_ARRAY = 0x12340003;
+const TAG_END_ARRAY = 0x12340004;
+const TAG_BEGIN_STR = 0x12340005;
+const TAG_END_STR = 0x12340006;
+const TAG_BEGIN_STRUCT_TYPE = 0x12340007;
+const TAG_END_STRUCT_TYPE = 0x12340008;
+
+const TAG_TYPED_POINT = 0x12340010;
+const TAG_GIZMO = 0x12340011;
+const TAG_LIST_LENGTH = 0x12340012;
+
+const TAG_EMBED_BEGIN = 0x12340020;
+const TAG_EMBED_END = 0x12340021;
+
+export class Hasher {
+	constructor() {
+		this.hash = crypto.createHash("sha256");
+		this.buf4 = Buffer.alloc(4);
+		this.buf8 = Buffer.alloc(8);
+	}
+
+	digest() {
+		return this.hash.digest("hex");
+	}
+
+	invalid() {
+		this.u32(TAG_INVALID);
+		return this;
+	}
+	beginStruct(typeStr) {
+		this.u32(TAG_BEGIN_STRUCT);
+		if (typeStr) {
+			this.u32(TAG_BEGIN_STRUCT_TYPE);
+			this.hash.update(typeStr);
+			this.u32(TAG_END_STRUCT_TYPE);
+		}
+		return this;
+	}
+	endStruct() {
+		this.u32(TAG_END_STRUCT);
+		return this;
+	}
+	beginArray(n) {
+		this.u32(TAG_BEGIN_ARRAY);
+		this.u32(TAG_LIST_LENGTH);
+		this.u32(n);
+		return this;
+	}
+	endArray() {
+		this.u32(TAG_END_ARRAY);
+		return this;
+	}
+	str(s) {
+		this.u32(TAG_BEGIN_STR);
+		this.hash.update(s);
+		this.u32(TAG_END_STR);
+		return this;
+	}
+	embed(other) {
+		this.u32(TAG_EMBED_BEGIN);
+		other.hash(this);
+		this.u32(TAG_EMBED_END);
+		return this;
+	}
+
+	bool(x) {
+		this.u32(x ? 1 : 0);
+		return this;
+	}
+	u32(x) {
+		this.buf4.writeUInt32LE(x, 0);
+		this.hash.update(this.buf4);
+		return this;
+	}
+	i32(x) {
+		this.buf4.writeInt32LE(x, 0);
+		this.hash.update(this.buf4);
+		return this;
+	}
+	f64(x) {
+		this.buf8.writeDoubleLE(x, 0);
+		this.hash.update(this.buf8);
+		return this;
+	}
+
+	typedPoint(z) {
+		this.u32(TAG_TYPED_POINT);
+		this.u32(z.type);
+		this.f64(z.x);
+		this.f64(z.y);
+		return this;
+	}
+	gizmo(g) {
+		this.u32(TAG_GIZMO);
+		this.f64(g.xx);
+		this.f64(g.xy);
+		this.f64(g.yx);
+		this.f64(g.yy);
+		this.f64(g.tx);
+		this.f64(g.ty);
+		return this;
+	}
 }

--- a/tools/amend-readme/package.json
+++ b/tools/amend-readme/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@iosevka/amend-readme",
-  "version": "29.0.5",
+  "version": "29.0.6",
   "private": true,
   "exports": {
     ".": "./src/index.mjs"
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",
-    "@iosevka/param": "29.0.5",
+    "@iosevka/param": "29.0.6",
     "@unicode/unicode-15.1.0": "^1.5.2"
   }
 }

--- a/tools/data-export/package.json
+++ b/tools/data-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iosevka/data-export",
-  "version": "29.0.5",
+  "version": "29.0.6",
   "private": true,
   "exports": {
     ".": "./src/index.mjs",
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",
-    "@iosevka/param": "29.0.5",
+    "@iosevka/param": "29.0.6",
     "@unicode/unicode-15.1.0": "^1.5.2",
     "cldr": "^7.5.0"
   }

--- a/tools/generate-samples/package.json
+++ b/tools/generate-samples/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@iosevka/generate-samples",
-  "version": "29.0.5",
+  "version": "29.0.6",
   "private": true,
   "exports": {
     ".": "./src/index.mjs"
   },
   "dependencies": {
-    "@iosevka/data-export": "29.0.5"
+    "@iosevka/data-export": "29.0.6"
   }
 }

--- a/tools/misc/package.json
+++ b/tools/misc/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@iosevka/misc",
-  "version": "29.0.5",
+  "version": "29.0.6",
   "private": true,
   "dependencies": {
     "semver": "^7.6.0",
     "wawoff2": "^2.0.1",
-    "@iosevka/util": "29.0.5"
+    "@iosevka/util": "29.0.6"
   }
 }


### PR DESCRIPTION
This change allos the geometry cache to be effective when handling the deeper nodes of a geometry tree. As a result it could reduce about 30% of the uncached build time.