### PR TITLE
Three modifier letter additions, slightly adjust Latin-1 Macron.

### DIFF
--- a/changes/29.1.0.md
+++ b/changes/29.1.0.md
@@ -7,3 +7,8 @@
 * Make presence of top-right serif automatic for CYRILLIC SMALL LIGATURE EN GHE (`U+04A5`) under `cyrl/en`=`tailed-top-left-serifed`.
 * Fix broken geometry of tailed `i`/`l` under heavy oblique quasi-proportional.
 * Make Cyrillic Lower Em (`cv74`) use `flat-bottom-serifless` for sans and `flat-bottom-serifed` for slab by default.
+* Make Latin-1 Macron (`U+00AF`) slightly wider.
+* Add characters:
+  - MODIFIER LETTER LOWER RIGHT CORNER ANGLE (`U+A71A`).
+  - MODIFIER LETTER STRESS AND HIGH TONE (`U+A720`).
+  - MODIFIER LETTER STRESS AND LOW TONE (`U+A721`).

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -466,12 +466,17 @@ glyph-block Mark-Above : begin
 		set-width 0
 		include : StdAnchors.wide
 
-		local leftEnd (markMiddle - markExtend * 1.5)
+		local leftEnd  (markMiddle - markExtend * 1.5)
 		local rightEnd (markMiddle + markExtend * 1.5)
 
 		include : dispiro
-			flat leftEnd aboveMarkMid [widths.center : 2 * markHalfStroke]
+			flat leftEnd  aboveMarkMid [widths.center : 2 * markHalfStroke]
 			curl rightEnd aboveMarkMid
+
+	create-glyph 'latin1macron' 0xAF : glyph-proc
+		include : dispiro
+			flat SB      aboveMarkMid [widths.center : 2 * markHalfStroke]
+			curl RightSB aboveMarkMid
 
 	create-glyph 'overlineAbove' 0x305 : glyph-proc
 		set-width 0
@@ -700,8 +705,23 @@ glyph-block Mark-Above : begin
 		set-width 0
 		include : StdAnchors.impl 'above' 0 1.5
 
-		include : VBar.m (SB - Width) aboveMarkBot aboveMarkTop (markFine * 2)
+		include : VBar.m (SB - Width)      aboveMarkBot aboveMarkTop (markFine * 2)
 		include : VBar.m (RightSB - Width) aboveMarkBot aboveMarkTop (markFine * 2)
+		include : HBar.t (SB - Width) (RightSB - Width) aboveMarkTop (markFine * 2)
+
+	create-glyph 'lowerRightAngleAbove' : glyph-proc
+		set-width 0
+		include : StdAnchors.mediumWide
+
+		include : VBar.r (markMiddle + markExtend) aboveMarkBot aboveMarkTop (markFine * 2)
+		include : HBar.b (markMiddle - markExtend) (markMiddle + markExtend) aboveMarkBot (markFine * 2)
+
+	create-glyph 'stressAndHighToneAbove' : glyph-proc
+		set-width 0
+		include : StdAnchors.impl 'above' 0 1.5
+
+		include : VBar.m (SB - Width)      aboveMarkBot aboveMarkTop (markFine * 2)
+		include : VBar.m (Middle - Width)  aboveMarkBot aboveMarkTop (markFine * 2)
 		include : HBar.t (SB - Width) (RightSB - Width) aboveMarkTop (markFine * 2)
 
 	create-glyph 'yerikAbove' 0x33E : glyph-proc

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -473,11 +473,6 @@ glyph-block Mark-Above : begin
 			flat leftEnd  aboveMarkMid [widths.center : 2 * markHalfStroke]
 			curl rightEnd aboveMarkMid
 
-	create-glyph 'latin1macron' 0xAF : glyph-proc
-		include : dispiro
-			flat SB      aboveMarkMid [widths.center : 2 * markHalfStroke]
-			curl RightSB aboveMarkMid
-
 	create-glyph 'overlineAbove' 0x305 : glyph-proc
 		set-width 0
 		include : StdAnchors.impl 'above' 0 2

--- a/packages/font-glyphs/src/marks/below.ptl
+++ b/packages/font-glyphs/src/marks/below.ptl
@@ -140,7 +140,7 @@ glyph-block Mark-Below : begin
 		set-width 0
 		include : StdAnchors.impl 0 1.5
 
-		include : VBar.m (SB - Width) belowMarkBot belowMarkTop (markFine * 2)
+		include : VBar.m (SB - Width)      belowMarkBot belowMarkTop (markFine * 2)
 		include : VBar.m (RightSB - Width) belowMarkBot belowMarkTop (markFine * 2)
 		include : HBar.b (SB - Width) (RightSB - Width) belowMarkBot (markFine * 2)
 
@@ -149,6 +149,14 @@ glyph-block Mark-Below : begin
 		include : StdAnchors.impl 0 1.5
 
 		include : VBar.m (SB - Width) belowMarkBot belowMarkTop (markFine * 2)
+		include : HBar.b (SB - Width) (RightSB - Width) belowMarkBot (markFine * 2)
+
+	create-glyph 'stressAndLowToneBelow' : glyph-proc
+		set-width 0
+		include : StdAnchors.impl 0 1.5
+
+		include : VBar.m (SB - Width)      belowMarkBot belowMarkTop (markFine * 2)
+		include : VBar.m (Middle - Width)  belowMarkBot belowMarkTop (markFine * 2)
 		include : HBar.b (SB - Width) (RightSB - Width) belowMarkBot (markFine * 2)
 
 	define [mirrorAnchor gs gt srcCls dstCls] : begin

--- a/packages/font-glyphs/src/meta/unicode-knowledge.ptl
+++ b/packages/font-glyphs/src/meta/unicode-knowledge.ptl
@@ -52,7 +52,6 @@ export : define decompOverrides : object
 
 	# Spacing marks
 	0xA8   { 'markBaseSpace' 'dieresisAbove' }
-	0xAF   { 'markBaseSpace' 'macronAbove' }
 	0xB8   { 'markBaseSpace' 'cedillaBelow' }
 	0x2C2  { 'markBaseSpace' 'lessAbove' }
 	0x2C3  { 'markBaseSpace' 'greaterAbove' }
@@ -102,6 +101,7 @@ export : define decompOverrides : object
 	0x1FFD { 'markBaseSpace' 'acuteAbove' }
 	0x1FFE { 'markBaseSpace' 'revCommaAbove' }
 	0x2E2F { 'markBaseSpace' 'yerikAbove' }
+	0xA71A { 'markBaseSpace' 'lowerRightAngleAbove' }
 	0xA788 { 'markBaseSpace' 'circumflexBelow' }
 	0xA78A { 'markBaseSpace' 'equalOver' }
 	0xAB6A { 'markBaseSpace' 'leftTackOver' }

--- a/packages/font-glyphs/src/meta/unicode-knowledge.ptl
+++ b/packages/font-glyphs/src/meta/unicode-knowledge.ptl
@@ -52,6 +52,7 @@ export : define decompOverrides : object
 
 	# Spacing marks
 	0xA8   { 'markBaseSpace' 'dieresisAbove' }
+	0xAF   { 'markBaseSpace' 'sbRsbOverlineAbove' }
 	0xB8   { 'markBaseSpace' 'cedillaBelow' }
 	0x2C2  { 'markBaseSpace' 'lessAbove' }
 	0x2C3  { 'markBaseSpace' 'greaterAbove' }

--- a/packages/font-glyphs/src/symbol/punctuation/ascii-marks.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/ascii-marks.ptl
@@ -54,10 +54,6 @@ glyph-block Symbol-Punctuation-Ascii-Marks : begin
 			include [refer-glyph : MangleName 'swungDash.high'] AS_BASE ALSO_METRICS
 			include : ApparentTranslate 0 (SymbolMid - XH - AccentStackOffset)
 
-	create-glyph 'latin1macron' 0xAF : glyph-proc
-		include [refer-glyph 'markBaseSpace'] AS_BASE ALSO_METRICS
-		include [refer-glyph 'sbRsbOverlineAbove']
-
 	create-glyph 'degree' 0xB0 : glyph-proc
 		include [refer-glyph 'markBaseSpace'] AS_BASE ALSO_METRICS
 		include [refer-glyph 'ringAbove']

--- a/packages/font-glyphs/src/symbol/punctuation/ascii-marks.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/ascii-marks.ptl
@@ -54,6 +54,10 @@ glyph-block Symbol-Punctuation-Ascii-Marks : begin
 			include [refer-glyph : MangleName 'swungDash.high'] AS_BASE ALSO_METRICS
 			include : ApparentTranslate 0 (SymbolMid - XH - AccentStackOffset)
 
+	create-glyph 'latin1macron' 0xAF : glyph-proc
+		include [refer-glyph 'markBaseSpace'] AS_BASE ALSO_METRICS
+		include [refer-glyph 'sbRsbOverlineAbove']
+
 	create-glyph 'degree' 0xB0 : glyph-proc
 		include [refer-glyph 'markBaseSpace'] AS_BASE ALSO_METRICS
 		include [refer-glyph 'ringAbove']

--- a/packages/font-glyphs/src/symbol/punctuation/ascii-marks.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/ascii-marks.ptl
@@ -67,3 +67,6 @@ glyph-block Symbol-Punctuation-Ascii-Marks : begin
 
 		derive-composites 'mdfShelf'     0x2FD 'markBaseSpace' 'shelfBelow'
 		derive-composites 'mdfOpenShelf' 0x2FE 'markBaseSpace' 'openShelfBelow'
+
+		derive-composites 'mdfStressAndHighTone' 0xA720 'markBaseSpace' 'stressAndHighToneAbove'
+		derive-composites 'mdfStressAndLowTone'  0xA721 'markBaseSpace' 'stressAndLowToneBelow'


### PR DESCRIPTION
First, a demonstration of Latin-1 Macron next to Modifier Letter macron:
`x¯ˉ`
![image](https://github.com/be5invis/Iosevka/assets/37010132/45b6cc34-d120-490f-a73c-e1df4804205d)
The Latin-1 version is adjusted to extend to the side bearings of `n` for disambiguation, which is a similar distinction to how Ascii Grave and Latin-1 acute are made slightly larger than a true diacritical grave/acute.

Secondly, three additional modifier characters are added:
`꜠꜡ꜚ`
![image](https://github.com/be5invis/Iosevka/assets/37010132/2e7dc05d-53f6-44d6-91cd-eb108e4bf9e3)

I modeled them after Liberation Mono:
![image](https://github.com/be5invis/Iosevka/assets/37010132/6e660e75-4122-45b0-b6b0-ae6b0022f849)
