### PR TITLE
Adjust Latin-1 Macron, add one modifier letter.

### DIFF
--- a/changes/29.1.0.md
+++ b/changes/29.1.0.md
@@ -7,3 +7,6 @@
 * Make presence of top-right serif automatic for CYRILLIC SMALL LIGATURE EN GHE (`U+04A5`) under `cyrl/en`=`tailed-top-left-serifed`.
 * Fix broken geometry of tailed `i`/`l` under heavy oblique quasi-proportional.
 * Make Cyrillic Lower Em (`cv74`) use `flat-bottom-serifless` for sans and `flat-bottom-serifed` for slab by default.
+* Make Latin-1 Macron (`U+00AF`) slightly wider.
+* Add characters:
+  - MODIFIER LETTER LOWER RIGHT CORNER ANGLE (`U+A71A`).

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -466,11 +466,11 @@ glyph-block Mark-Above : begin
 		set-width 0
 		include : StdAnchors.wide
 
-		local leftEnd (markMiddle - markExtend * 1.5)
+		local leftEnd  (markMiddle - markExtend * 1.5)
 		local rightEnd (markMiddle + markExtend * 1.5)
 
 		include : dispiro
-			flat leftEnd aboveMarkMid [widths.center : 2 * markHalfStroke]
+			flat leftEnd  aboveMarkMid [widths.center : 2 * markHalfStroke]
 			curl rightEnd aboveMarkMid
 
 	create-glyph 'overlineAbove' 0x305 : glyph-proc
@@ -700,9 +700,16 @@ glyph-block Mark-Above : begin
 		set-width 0
 		include : StdAnchors.impl 'above' 0 1.5
 
-		include : VBar.m (SB - Width) aboveMarkBot aboveMarkTop (markFine * 2)
+		include : VBar.m (SB - Width)      aboveMarkBot aboveMarkTop (markFine * 2)
 		include : VBar.m (RightSB - Width) aboveMarkBot aboveMarkTop (markFine * 2)
 		include : HBar.t (SB - Width) (RightSB - Width) aboveMarkTop (markFine * 2)
+
+	create-glyph 'lowerRightAngleAbove' : glyph-proc
+		set-width 0
+		include : StdAnchors.mediumWide
+
+		include : VBar.r (markMiddle + markExtend) aboveMarkBot aboveMarkTop (markFine * 2)
+		include : HBar.b (markMiddle - markExtend) (markMiddle + markExtend) aboveMarkBot (markFine * 2)
 
 	create-glyph 'yerikAbove' 0x33E : glyph-proc
 		set-width 0

--- a/packages/font-glyphs/src/meta/unicode-knowledge.ptl
+++ b/packages/font-glyphs/src/meta/unicode-knowledge.ptl
@@ -52,7 +52,7 @@ export : define decompOverrides : object
 
 	# Spacing marks
 	0xA8   { 'markBaseSpace' 'dieresisAbove' }
-	0xAF   { 'markBaseSpace' 'macronAbove' }
+	0xAF   { 'markBaseSpace' 'sbRsbOverlineAbove' }
 	0xB8   { 'markBaseSpace' 'cedillaBelow' }
 	0x2C2  { 'markBaseSpace' 'lessAbove' }
 	0x2C3  { 'markBaseSpace' 'greaterAbove' }
@@ -102,6 +102,7 @@ export : define decompOverrides : object
 	0x1FFD { 'markBaseSpace' 'acuteAbove' }
 	0x1FFE { 'markBaseSpace' 'revCommaAbove' }
 	0x2E2F { 'markBaseSpace' 'yerikAbove' }
+	0xA71A { 'markBaseSpace' 'lowerRightAngleAbove' }
 	0xA788 { 'markBaseSpace' 'circumflexBelow' }
 	0xA78A { 'markBaseSpace' 'equalOver' }
 	0xAB6A { 'markBaseSpace' 'leftTackOver' }


### PR DESCRIPTION
Latin-1 Macron is made slightly wider than modifier letter macron for disambiguation, similar to the handling of ASCII Grave and Latin-1 Acute against proper diacritical grave/acute marks.
Additionally, one character is added based on a spacing right angle mark, used as a tone mark in the Chinatec languages of Mexico.
`x¯ˉꜚ`
![image](https://github.com/be5invis/Iosevka/assets/37010132/8b77d841-109c-4167-a328-dc5276186b56)
