### PR TITLE
Make serifs of attachment parts automatic for three `K`-derived characters.

### DIFF
--- a/changes/29.1.1.md
+++ b/changes/29.1.1.md
@@ -1,0 +1,2 @@
+* Make presence of descender serif automatic for GREEK CAPITAL KAI SYMBOL (`U+03CF`).
+* Make presence of top-left serif automatic for CYRILLIC {CAPITAL|SMALL} LETTER BASHKIR KA (`U+04A0`..`U+04A1`).

--- a/packages/font-glyphs/src/letter/latin/k.ptl
+++ b/packages/font-glyphs/src/letter/latin/k.ptl
@@ -340,20 +340,18 @@ glyph-block Letter-Latin-K : begin
 			curly                 KLegs.Curly
 			symmetricTouching    [KLegs.Symmetric 0]
 			symmetricConnected   [KLegs.Symmetric : AdviceStroke 6]
-			symmetricConnectedKH [KLegs.Symmetric [AdviceStroke 6] Descender]
+			symmetricConnectedKH [KLegs.Symmetric  [AdviceStroke 6] Descender]
 			symmetricConnectedVB [KLegs.Symmetric CyrlVbGap]
-		object # serifs
-			serifless                     { 0 0 0 0 }
-			topLeftSerifed                { 2 0 0 0 }
-			bottomRightSerifed            { 0 0 1 0 }
-			bottomRightSerifed2           { 0 0 0 1 }
-			topLeftAndBottomRightSerifed  { 2 0 1 0 }
-			topLeftAndBottomRightSerifed2 { 2 0 0 1 }
-			serifed                       { 1 1 3 0 }
-			serifedKH                     { 1 1 2 0 }
-			serifed2                      { 1 1 2 1 }
-			serifedKra                    { 2 1 3 0 }
-			serifedKappa                  { 2 0 3 0 }
+		function [body] : object # serifs
+			serifless                     { 0 0 0 }
+			topLeftSerifed                { 2 0 0 }
+			bottomRightSerifed            { 0 0 1 }
+			topLeftAndBottomRightSerifed  { 2 0 1 }
+			serifedKra                    { 2 1 3 }
+			serifedKappa                  { 2 0 3 }
+			serifed : match body
+				[Just 'symmetricConnectedKH']  { 1 1 2 }
+				__                             { 1 1 3 }
 
 	define [UpperKLTSerif top sw xBarLeft slabType] : match slabType
 		2 : HSerif.lt xBarLeft top SideJut
@@ -371,31 +369,26 @@ glyph-block Letter-Latin-K : begin
 		top / 2 + [CyrlVbLength top] / 2
 		Math.min [AdviceStroke 5] (CyrlVbGap * 0.5)
 
-	# Attachment glyphs used for Greek Kai Symbol
-	define [GrekKaiAttachmentshape fSerif] : begin
+	# Attachment glyph used for Greek Kai Symbol
+	create-glyph 'UpperKaiSymbolAttachment' : glyph-proc
+		set-width 0
+		set-mark-anchor 'trailing' 0 0
 		define shapeDepth : 0.8 * Descender - 0.25 * Stroke
-		return : PointingTo 0 0 shapeDepth shapeDepth : function [mag] : glyph-proc
-			define kSw : mix 1 HVContrast ([Math.sqrt 2] / 2)
-			include : dispiro
+		define kSw : mix 1 HVContrast Math.SQRT1_2
+		include : PointingTo 0 0 shapeDepth shapeDepth : function [mag] : union
+			dispiro
 				widths.lhs (Stroke * kSw)
 				flat 0   0
 				curl mag 0
-			if fSerif : include : dispiro
-				widths.center (Stroke / kSw)
-				flat 0 (Stroke * kSw + SideJut)
-				curl 0 (0 - SideJut)
-
-	create-glyph 'UpperKaiSymbolAttachment/sans' : glyph-proc
-		set-width 0
-		set-mark-anchor 'trailing' 0 0
-		include : GrekKaiAttachmentshape false
-	create-glyph 'UpperKaiSymbolAttachment/serifed' : glyph-proc
-		set-width 0
-		set-mark-anchor 'trailing' 0 0
-		include : GrekKaiAttachmentshape true
+			if SLAB
+				dispiro
+					widths.center (Stroke / kSw)
+					flat 0 (Stroke * kSw + SideJut)
+					curl 0 (0 - SideJut)
+				no-shape
 
 	# Main building
-	foreach { suffix { LegsImpl {slabLT slabLB slabLegs slabKS} } } [pairs-of UpperKConfig] : do
+	foreach { suffix { LegsImpl {slabLT slabLB slabLegs} } } [pairs-of UpperKConfig] : do
 		local straightBar : LegsImpl !== KLegs.Curly
 		local xBarLeft : SB + [KBalance slabLT straightBar]
 
@@ -429,10 +422,9 @@ glyph-block Letter-Latin-K : begin
 
 		create-glyph "grek/KaiSymbol.\(suffix)" : glyph-proc
 			include [refer-glyph "K.\(suffix)"] AS_BASE ALSO_METRICS
+			eject-contour 'serifRB'
 			include : ExtendBelowBaseAnchors Descender
-			include : refer-glyph : match slabKS
-				0 'UpperKaiSymbolAttachment/sans'
-				1 'UpperKaiSymbolAttachment/serifed'
+			include [refer-glyph "UpperKaiSymbolAttachment"]
 
 		create-glyph "smcpK.\(suffix)" : glyph-proc
 			include : MarkSet.e
@@ -457,25 +449,26 @@ glyph-block Letter-Latin-K : begin
 			if slabLB : include : UpperKLBSerif CAP Stroke xBarLeft slabLB
 
 		define [BashkirKaShape df top] : glyph-proc
-			local left : if slabLT ([mix SB RightSB 0.35] - [HSwToV : 0.5 * df.mvs]) [mix SB RightSB 0.2]
-			local leftNB : left - [KBalance slabLT straightBar]
-			local xTopBarLeftEnd : mix 0 SB [if slabLT 0.25 0.375]
+			local left : if SLAB ([mix SB RightSB 0.35] - [HSwToV : 0.5 * df.mvs]) [mix SB RightSB 0.2]
+			local leftNB : left - [KBalance SLAB straightBar]
+			local xTopBarLeftEnd : mix 0 SB [if SLAB 0.25 0.375]
 			local sw : AdviceStroke 3
 
 			include : HBar.t xTopBarLeftEnd (Stroke * 0.1 + left) top
 			include : VBar.l left 0 top sw
-			include : LegsImpl false leftNB RightSB sw top slabLT slabLegs
-			if slabLT : include : VSerif.dl xTopBarLeftEnd top VJut
-				Math.min (VJutStroke * df.mvs / Stroke) (0.625 * (left - xTopBarLeftEnd))
-			if slabLB : begin
-				include : HSerif.mb (left + [HSwToV : 0.5 * sw]) 0 Jut
+			include : LegsImpl false leftNB RightSB sw top SLAB slabLegs
+			if SLAB : begin
+				include : VSerif.dl xTopBarLeftEnd top VJut
+					Math.min (VJutStroke * df.mvs / Stroke) (0.625 * (left - xTopBarLeftEnd))
+				if slabLT : include : UpperKLTSerif top sw left slabLT
+			if slabLB : include : UpperKLBSerif top sw left slabLB
 
-		create-glyph "cyrl/BashkirUpperKa.\(suffix)" : glyph-proc
+		create-glyph "cyrl/KaBashkir.\(suffix)" : glyph-proc
 			define df : include : DivFrame 1
 			include : df.markSet.capital
 			include : BashkirKaShape df CAP
 
-		create-glyph "cyrl/BashkirKa.\(suffix)" : glyph-proc
+		create-glyph "cyrl/kaBashkir.\(suffix)" : glyph-proc
 			define df : include : DivFrame 1
 			include : df.markSet.e
 			include : BashkirKaShape df XH
@@ -592,10 +585,10 @@ glyph-block Letter-Latin-K : begin
 
 	select-variant 'turnk' 0x29E (follow -- 'k')
 
-	select-variant 'cyrl/BashkirUpperKa' 0x4A0 (follow -- 'cyrl/Ka')
-	select-variant 'cyrl/BashkirKa'      0x4A1 (follow -- 'cyrl/ka')
+	select-variant 'cyrl/KaBashkir' 0x4A0
+	select-variant 'cyrl/kaBashkir' 0x4A1
 
-	select-variant 'grek/KaiSymbol' 0x3CF
+	select-variant 'grek/KaiSymbol' 0x3CF (follow -- 'KDescender')
 
 	derive-multi-part-glyphs 'kDot' null {'k' 'dotAbove'} : lambda [srcs gr] : glyph-proc
 		local { base mark } srcs

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -566,7 +566,6 @@ rank = 1
 descriptionAffix = "straight shape"
 selectorAffix.K = "straight"
 selectorAffix."K/sansSerif" = "straight"
-selectorAffix."grek/KaiSymbol" = "straight"
 selectorAffix.KDescender = "straight"
 
 [prime.capital-k.variants-buildup.stages.body.curly]
@@ -574,7 +573,6 @@ rank = 2
 descriptionAffix = "curly shape"
 selectorAffix.K = "curly"
 selectorAffix."K/sansSerif" = "curly"
-selectorAffix."grek/KaiSymbol" = "curly"
 selectorAffix.KDescender = "curly"
 
 [prime.capital-k.variants-buildup.stages.body.symmetric-touching]
@@ -582,7 +580,6 @@ rank = 3
 descriptionAffix = "symmetric legs touching the vertical bar"
 selectorAffix.K = "symmetricTouching"
 selectorAffix."K/sansSerif" = "symmetricTouching"
-selectorAffix."grek/KaiSymbol" = "symmetricTouching"
 selectorAffix.KDescender = "symmetricTouching"
 
 [prime.capital-k.variants-buildup.stages.body.symmetric-connected]
@@ -590,7 +587,6 @@ rank = 4
 descriptionAffix = "symmetric legs connected to the vertical bar"
 selectorAffix.K = "symmetricConnected"
 selectorAffix."K/sansSerif" = "symmetricConnected"
-selectorAffix."grek/KaiSymbol" = "symmetricConnected"
 selectorAffix.KDescender = "symmetricConnected"
 
 [prime.capital-k.variants-buildup.stages.serifs.serifless]
@@ -599,7 +595,6 @@ descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix.K = "serifless"
 selectorAffix."K/sansSerif" = "serifless"
-selectorAffix."grek/KaiSymbol" = "serifless"
 selectorAffix.KDescender = "serifless"
 
 [prime.capital-k.variants-buildup.stages.serifs.top-left-serifed]
@@ -607,7 +602,6 @@ rank = 2
 descriptionAffix = "serifs at top left"
 selectorAffix.K = "topLeftSerifed"
 selectorAffix."K/sansSerif" = "serifless"
-selectorAffix."grek/KaiSymbol" = "topLeftSerifed"
 selectorAffix.KDescender = "topLeftSerifed"
 
 [prime.capital-k.variants-buildup.stages.serifs.bottom-right-serifed]
@@ -615,7 +609,6 @@ rank = 3
 descriptionAffix = "serifs at bottom right"
 selectorAffix.K = "bottomRightSerifed"
 selectorAffix."K/sansSerif" = "serifless"
-selectorAffix."grek/KaiSymbol" = "bottomRightSerifed2"
 selectorAffix.KDescender = "serifless"
 
 [prime.capital-k.variants-buildup.stages.serifs.top-left-and-bottom-right-serifed]
@@ -623,7 +616,6 @@ rank = 4
 descriptionAffix = "serifs at top left and bottom right"
 selectorAffix.K = "topLeftAndBottomRightSerifed"
 selectorAffix."K/sansSerif" = "serifless"
-selectorAffix."grek/KaiSymbol" = "topLeftAndBottomRightSerifed2"
 selectorAffix.KDescender = "topLeftSerifed"
 
 [prime.capital-k.variants-buildup.stages.serifs.serifed]
@@ -631,7 +623,6 @@ rank = 5
 descriptionAffix = "serifs"
 selectorAffix.K = "serifed"
 selectorAffix."K/sansSerif" = "serifless"
-selectorAffix."grek/KaiSymbol" = "serifed2"
 selectorAffix.KDescender = "serifed"
 
 
@@ -5374,6 +5365,7 @@ selectorAffix."cyrl/Ka" = "straight"
 selectorAffix."cyrl/KaDescender" = "straight"
 selectorAffix."cyrl/KaVBar" = "symmetricConnectedVB"
 selectorAffix."cyrl/KaHook" = "symmetricConnectedKH"
+selectorAffix."cyrl/KaBashkir" = "straight"
 
 [prime.cyrl-capital-ka.variants-buildup.stages.body.curly]
 rank = 2
@@ -5382,6 +5374,7 @@ selectorAffix."cyrl/Ka" = "curly"
 selectorAffix."cyrl/KaDescender" = "curly"
 selectorAffix."cyrl/KaVBar" = "symmetricConnectedVB"
 selectorAffix."cyrl/KaHook" = "symmetricConnectedKH"
+selectorAffix."cyrl/KaBashkir" = "curly"
 
 [prime.cyrl-capital-ka.variants-buildup.stages.body.symmetric-touching]
 rank = 3
@@ -5390,6 +5383,7 @@ selectorAffix."cyrl/Ka" = "symmetricTouching"
 selectorAffix."cyrl/KaDescender" = "symmetricTouching"
 selectorAffix."cyrl/KaVBar" = "symmetricConnectedVB"
 selectorAffix."cyrl/KaHook" = "symmetricConnectedKH"
+selectorAffix."cyrl/KaBashkir" = "symmetricTouching"
 
 [prime.cyrl-capital-ka.variants-buildup.stages.body.symmetric-connected]
 rank = 4
@@ -5398,6 +5392,7 @@ selectorAffix."cyrl/Ka" = "symmetricConnected"
 selectorAffix."cyrl/KaDescender" = "symmetricConnected"
 selectorAffix."cyrl/KaVBar" = "symmetricConnectedVB"
 selectorAffix."cyrl/KaHook" = "symmetricConnectedKH"
+selectorAffix."cyrl/KaBashkir" = "symmetricConnected"
 
 [prime.cyrl-capital-ka.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -5407,6 +5402,7 @@ selectorAffix."cyrl/Ka" = "serifless"
 selectorAffix."cyrl/KaDescender" = "serifless"
 selectorAffix."cyrl/KaVBar" = "serifless"
 selectorAffix."cyrl/KaHook" = "serifless"
+selectorAffix."cyrl/KaBashkir" = "serifless"
 
 [prime.cyrl-capital-ka.variants-buildup.stages.serifs.top-left-serifed]
 rank = 2
@@ -5415,6 +5411,7 @@ selectorAffix."cyrl/Ka" = "topLeftSerifed"
 selectorAffix."cyrl/KaDescender" = "topLeftSerifed"
 selectorAffix."cyrl/KaVBar" = "topLeftSerifed"
 selectorAffix."cyrl/KaHook" = "topLeftSerifed"
+selectorAffix."cyrl/KaBashkir" = "serifless"
 
 [prime.cyrl-capital-ka.variants-buildup.stages.serifs.bottom-right-serifed]
 rank = 3
@@ -5423,6 +5420,7 @@ selectorAffix."cyrl/Ka" = "bottomRightSerifed"
 selectorAffix."cyrl/KaDescender" = "serifless"
 selectorAffix."cyrl/KaVBar" = "bottomRightSerifed"
 selectorAffix."cyrl/KaHook" = "serifless"
+selectorAffix."cyrl/KaBashkir" = "bottomRightSerifed"
 
 [prime.cyrl-capital-ka.variants-buildup.stages.serifs.top-left-and-bottom-right-serifed]
 rank = 4
@@ -5431,6 +5429,7 @@ selectorAffix."cyrl/Ka" = "topLeftAndBottomRightSerifed"
 selectorAffix."cyrl/KaDescender" = "topLeftSerifed"
 selectorAffix."cyrl/KaVBar" = "topLeftAndBottomRightSerifed"
 selectorAffix."cyrl/KaHook" = "topLeftSerifed"
+selectorAffix."cyrl/KaBashkir" = "bottomRightSerifed"
 
 [prime.cyrl-capital-ka.variants-buildup.stages.serifs.serifed]
 rank = 5
@@ -5438,7 +5437,8 @@ descriptionAffix = "serifs"
 selectorAffix."cyrl/Ka" = "serifed"
 selectorAffix."cyrl/KaDescender" = "serifed"
 selectorAffix."cyrl/KaVBar" = "serifed"
-selectorAffix."cyrl/KaHook" = "serifedKH"
+selectorAffix."cyrl/KaHook" = "serifed"
+selectorAffix."cyrl/KaBashkir" = "serifed"
 
 
 
@@ -5461,6 +5461,7 @@ selectorAffix."cyrl/ka" = "straight"
 selectorAffix."cyrl/kaDescender" = "straight"
 selectorAffix."cyrl/kaVBar" = "symmetricConnectedVB"
 selectorAffix."cyrl/kaHook" = "symmetricConnectedKH"
+selectorAffix."cyrl/kaBashkir" = "straight"
 
 [prime.cyrl-ka.variants-buildup.stages.body.curly]
 rank = 2
@@ -5469,6 +5470,7 @@ selectorAffix."cyrl/ka" = "curly"
 selectorAffix."cyrl/kaDescender" = "curly"
 selectorAffix."cyrl/kaVBar" = "symmetricConnectedVB"
 selectorAffix."cyrl/kaHook" = "symmetricConnectedKH"
+selectorAffix."cyrl/kaBashkir" = "curly"
 
 [prime.cyrl-ka.variants-buildup.stages.body.symmetric-touching]
 rank = 3
@@ -5477,6 +5479,7 @@ selectorAffix."cyrl/ka" = "symmetricTouching"
 selectorAffix."cyrl/kaDescender" = "symmetricTouching"
 selectorAffix."cyrl/kaVBar" = "symmetricConnectedVB"
 selectorAffix."cyrl/kaHook" = "symmetricConnectedKH"
+selectorAffix."cyrl/kaBashkir" = "symmetricTouching"
 
 [prime.cyrl-ka.variants-buildup.stages.body.symmetric-connected]
 rank = 4
@@ -5485,6 +5488,7 @@ selectorAffix."cyrl/ka" = "symmetricConnected"
 selectorAffix."cyrl/kaDescender" = "symmetricConnected"
 selectorAffix."cyrl/kaVBar" = "symmetricConnectedVB"
 selectorAffix."cyrl/kaHook" = "symmetricConnectedKH"
+selectorAffix."cyrl/kaBashkir" = "symmetricConnected"
 
 [prime.cyrl-ka.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -5494,6 +5498,7 @@ selectorAffix."cyrl/ka" = "serifless"
 selectorAffix."cyrl/kaDescender" = "serifless"
 selectorAffix."cyrl/kaVBar" = "serifless"
 selectorAffix."cyrl/kaHook" = "serifless"
+selectorAffix."cyrl/kaBashkir" = "serifless"
 
 [prime.cyrl-ka.variants-buildup.stages.serifs.top-left-serifed]
 rank = 2
@@ -5502,6 +5507,7 @@ selectorAffix."cyrl/ka" = "topLeftSerifed"
 selectorAffix."cyrl/kaDescender" = "topLeftSerifed"
 selectorAffix."cyrl/kaVBar" = "topLeftSerifed"
 selectorAffix."cyrl/kaHook" = "topLeftSerifed"
+selectorAffix."cyrl/kaBashkir" = "serifless"
 
 [prime.cyrl-ka.variants-buildup.stages.serifs.bottom-right-serifed]
 rank = 3
@@ -5510,6 +5516,7 @@ selectorAffix."cyrl/ka" = "bottomRightSerifed"
 selectorAffix."cyrl/kaDescender" = "serifless"
 selectorAffix."cyrl/kaVBar" = "bottomRightSerifed"
 selectorAffix."cyrl/kaHook" = "serifless"
+selectorAffix."cyrl/kaBashkir" = "bottomRightSerifed"
 
 [prime.cyrl-ka.variants-buildup.stages.serifs.top-left-and-bottom-right-serifed]
 rank = 4
@@ -5518,6 +5525,7 @@ selectorAffix."cyrl/ka" = "topLeftAndBottomRightSerifed"
 selectorAffix."cyrl/kaDescender" = "topLeftSerifed"
 selectorAffix."cyrl/kaVBar" = "topLeftAndBottomRightSerifed"
 selectorAffix."cyrl/kaHook" = "topLeftSerifed"
+selectorAffix."cyrl/kaBashkir" = "bottomRightSerifed"
 
 [prime.cyrl-ka.variants-buildup.stages.serifs.serifed]
 rank = 5
@@ -5525,7 +5533,8 @@ descriptionAffix = "serifs"
 selectorAffix."cyrl/ka" = "serifed"
 selectorAffix."cyrl/kaDescender" = "serifed"
 selectorAffix."cyrl/kaVBar" = "serifed"
-selectorAffix."cyrl/kaHook" = "serifedKH"
+selectorAffix."cyrl/kaHook" = "serifed"
+selectorAffix."cyrl/kaBashkir" = "serifed"
 
 
 


### PR DESCRIPTION
Firstly, for Greek&nbsp;Capital&nbsp;Kai&nbsp;Symbol, the attachment part is loosely based on an Iota, but rather than make it controlled by the serifs of capital `I` (which would make it serifed almost all the time) or of lowercase iota (which would make it rarely ever serifed), it's done automatically (when the font is compiled as slab).
Outsourcing the behavior of the attachment serif to slab builds also reduces the glyph count by a lot.
On a side note, fun fact: Apparently Javascript's Math library has predefined constants for Root2 and Root2&nbsp;over&nbsp;2.
`K𝖪ϏⱩ`
sans:
![image](https://github.com/be5invis/Iosevka/assets/37010132/0a828f20-5253-4432-ad2f-b39e5b49b39f)
slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/c601bbfa-9927-4020-ab7a-0adada634e97)
Secondly, for Bashkir&nbsp;Ka, the serif of the top-left attachment is made automatic to match with graphically related letters like hard&nbsp;sign. Additionally, the fully-serifed form will now show its top-left serif since it apparently has one when it protrudes inward, but only when the font is slab as to again still match hard&nbsp;sign.
Thirdly, to further reduce the glyph count, the fully serifed variant for Ka&nbsp;with&nbsp;Hook now requires the body variant to _literally be_ Ka&nbsp;with&nbsp;Hook, reducing that whole extra serif variant that was previously being created for all other `K` characters under the hood, but not used.
`КҚҜӃҠЪ`
sans:
![image](https://github.com/be5invis/Iosevka/assets/37010132/ddb16bd3-8060-4afb-a224-82dcc2110d22)
slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/ca03299a-3f4d-4335-8576-dab0d27bd2f8)
`кқҝӄҡъ`
sans:
![image](https://github.com/be5invis/Iosevka/assets/37010132/5c7df2e1-36d6-403b-b0d3-70bd2eae0193)
slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/401c0b41-a381-456e-8620-96e6c95efc55)
