### PR TITLE
Harmonize glyphs/variants of three non-slavic Cyrillic letters.

### DIFF
--- a/changes/29.1.1.md
+++ b/changes/29.1.1.md
@@ -3,3 +3,4 @@
 * Make GREEK SMALL LETTER DIGAMMA (`U+03DD`) respond to top-right serif variants of Greek Capital Gamma (`cv56`).
 * Make GREEK SMALL LETTER HETA (`U+0371`) respond to top-left serif variants of `H` (`cv08`).
 * Make CYRILLIC {CAPITAL|SMALL} LIGATURE EN GHE (`U+04A4`..`U+04A5`) respond to top-right serif variants of Greek Capital Gamma (`cv56`).
+* Make CYRILLIC {CAPITAL|SMALL} LETTER STRAIGHT U (`U+04AE`..`U+04B1`) follow variants of Cyrillic Capital/Small U (`cv77`..`cv78`).

--- a/changes/29.1.1.md
+++ b/changes/29.1.1.md
@@ -4,3 +4,4 @@
 * Make GREEK SMALL LETTER HETA (`U+0371`) respond to top-left serif variants of `H` (`cv08`).
 * Make CYRILLIC {CAPITAL|SMALL} LIGATURE EN GHE (`U+04A4`..`U+04A5`) respond to top-right serif variants of Greek Capital Gamma (`cv56`).
 * Make CYRILLIC {CAPITAL|SMALL} LETTER STRAIGHT U (`U+04AE`..`U+04B1`) follow variants of Cyrillic Capital/Small U (`cv77`..`cv78`).
+* Make the descender part of CYRILLIC {CAPITAL|SMALL} LETTER {ZE|ES} WITH DESCENDER (`U+0498`..`U+0499`, `U+04AA`..`U+04AB`) visually distinct from a cedilla, and curling right instead of left.

--- a/changes/29.1.1.md
+++ b/changes/29.1.1.md
@@ -4,5 +4,4 @@
 * Make GREEK SMALL LETTER HETA (`U+0371`) respond to top-left serif variants of `H` (`cv08`).
 * Make CYRILLIC {CAPITAL|SMALL} LIGATURE EN GHE (`U+04A4`..`U+04A5`) respond to top-right serif variants of Greek Capital Gamma (`cv56`).
 * Make CYRILLIC {CAPITAL|SMALL} LETTER STRAIGHT U (`U+04AE`..`U+04B1`) follow variants of Cyrillic Capital/Small U (`cv77`..`cv78`).
-* Make the descender part of CYRILLIC {CAPITAL|SMALL} LETTER {ZE|ES} WITH DESCENDER (`U+0498`..`U+0499`, `U+04AA`..`U+04AB`) visually distinct from a cedilla, and curling right instead of left.
 * Make the terminal of {LATIN|CYRILLIC} {CAPITAL|SMALL} LETTER SCHWA (`U+018F`, `U+0259`, `U+04D8`..`U+04D9`) a full hook under italics to match CYRILLIC {CAPITAL|SMALL} LETTER E (`U+042D`, `U+044D`).

--- a/changes/29.1.1.md
+++ b/changes/29.1.1.md
@@ -5,5 +5,4 @@
 * Make CYRILLIC {CAPITAL|SMALL} LIGATURE EN GHE (`U+04A4`..`U+04A5`) respond to top-right serif variants of Greek Capital Gamma (`cv56`).
 * Make CYRILLIC {CAPITAL|SMALL} LETTER STRAIGHT U (`U+04AE`..`U+04B1`) follow variants of Cyrillic Capital/Small U (`cv77`..`cv78`).
 * Make the descender part of CYRILLIC {CAPITAL|SMALL} LETTER {ZE|ES} WITH DESCENDER (`U+0498`..`U+0499`, `U+04AA`..`U+04AB`) visually distinct from a cedilla, and curling right instead of left.
-  - Harmonize the descender part of CYRILLIC {CAPITAL|SMALL} LETTER ABKHASIAN CHE WITH DESCENDER (`U+04BE`..`U+04BF`) with CYRILLIC {CAPITAL|SMALL} LETTER ES WITH DESCENDER (`U+04AA`..`U+04AB`).
 * Make the terminal of {LATIN|CYRILLIC} {CAPITAL|SMALL} LETTER SCHWA (`U+018F`, `U+0259`, `U+04D8`..`U+04D9`) a full hook under italics to match CYRILLIC {CAPITAL|SMALL} LETTER E (`U+042D`, `U+044D`).

--- a/changes/29.1.1.md
+++ b/changes/29.1.1.md
@@ -5,3 +5,5 @@
 * Make CYRILLIC {CAPITAL|SMALL} LIGATURE EN GHE (`U+04A4`..`U+04A5`) respond to top-right serif variants of Greek Capital Gamma (`cv56`).
 * Make CYRILLIC {CAPITAL|SMALL} LETTER STRAIGHT U (`U+04AE`..`U+04B1`) follow variants of Cyrillic Capital/Small U (`cv77`..`cv78`).
 * Make the descender part of CYRILLIC {CAPITAL|SMALL} LETTER {ZE|ES} WITH DESCENDER (`U+0498`..`U+0499`, `U+04AA`..`U+04AB`) visually distinct from a cedilla, and curling right instead of left.
+  - Harmonize the descender part of CYRILLIC {CAPITAL|SMALL} LETTER ABKHASIAN CHE WITH DESCENDER (`U+04BE`..`U+04BF`) with CYRILLIC {CAPITAL|SMALL} LETTER ES WITH DESCENDER (`U+04AA`..`U+04AB`).
+* Make the terminal of {LATIN|CYRILLIC} {CAPITAL|SMALL} LETTER SCHWA (`U+018F`, `U+0259`, `U+04D8`..`U+04D9`) a full hook under italics to match CYRILLIC {CAPITAL|SMALL} LETTER E (`U+042D`, `U+044D`).

--- a/packages/font-glyphs/src/common/shapes.ptl
+++ b/packages/font-glyphs/src/common/shapes.ptl
@@ -430,12 +430,12 @@ glyph-block CommonShapes : begin
 
 	define nHookSegments 12
 	define [HookShape toStraight toFinish isStart args] : begin
-		local [object y tight sw swItalicAdj noAdjTerminalY turnSlope isTail] args
+		local [object y tight sw swItalicAdj noAdjTerminalY turnSlope isTail suppressSwash] args
 
 		local atBottom : toStraight.y > y
 		local ltr : if isStart (toFinish.x < toStraight.x) (toFinish.x > toStraight.x)
 		local dtu : if isStart (y > toFinish.y) (y < toFinish.y)
-		local doSwash : !tight && !isStart && atBottom && (para.isItalic || isTail) && [if (para.slopeAngle >= 0) ltr [not ltr]]
+		local doSwash : !suppressSwash && !tight && !isStart && atBottom && (para.isItalic || isTail) && [if (para.slopeAngle >= 0) ltr [not ltr]]
 		local superness : if tight DesignParameters.tightHookSuperness DesignParameters.superness
 
 		# Adjust terminal's position if necessary
@@ -528,8 +528,9 @@ glyph-block CommonShapes : begin
 		local-parameter : noAdjTerminalY -- false
 		local-parameter : turnSlope      -- nothing
 		local-parameter : isTail         -- false
+		local-parameter : suppressSwash  -- false
 		return : Interpolator hookStartBlender
-			object y tight sw swItalicAdj noAdjTerminalY turnSlope isTail
+			object y tight sw swItalicAdj noAdjTerminalY turnSlope isTail suppressSwash
 
 	glyph-block-export hookend
 	define flex-params [hookend] : begin
@@ -540,8 +541,9 @@ glyph-block CommonShapes : begin
 		local-parameter : noAdjTerminalY -- false
 		local-parameter : turnSlope      -- nothing
 		local-parameter : isTail         -- false
+		local-parameter : suppressSwash  -- false
 		return : Interpolator hookEndBlender
-			object y tight sw swItalicAdj noAdjTerminalY turnSlope isTail
+			object y tight sw swItalicAdj noAdjTerminalY turnSlope isTail suppressSwash
 
 	glyph-block-export Ungizmo
 	define [Ungizmo] : glyph-proc

--- a/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
@@ -490,8 +490,8 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 	select-variant 'cyrl/DzjeKomi' 0x506 (follow -- 'cyrl/Ksi')
 	select-variant 'cyrl/dzjeKomi' 0x507 (follow -- 'cyrl/ksi')
 
-	derive-composites 'cyrl/ZeCedilla' 0x498 'cyrl/Ze' 'cedillaExtShapeBelowOArc'
-	derive-composites 'cyrl/zeCedilla' 0x499 'cyrl/ze' 'cedillaExtShapeBelowSOArc'
+	derive-composites 'cyrl/Dhe' 0x498 'cyrl/Ze' 'ogonekBelow'
+	derive-composites 'cyrl/dhe' 0x499 'cyrl/ze' 'ogonekBelow'
 
 	select-variant 'latn/epsilon/descBase' (shapeFrom -- 'latn/epsilon')
 	select-variant 'latn/epsilonRev/descBase' (shapeFrom -- 'cyrl/ze') (follow -- 'latn/epsilon/descBase')

--- a/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
@@ -490,7 +490,7 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 	select-variant 'cyrl/DzjeKomi' 0x506 (follow -- 'cyrl/Ksi')
 	select-variant 'cyrl/dzjeKomi' 0x507 (follow -- 'cyrl/ksi')
 
-	derive-composites 'cyrl/Dhe' 0x498 'cyrl/Ze' 'cedillaExtShapeBelowSOArc'
+	derive-composites 'cyrl/Dhe' 0x498 'cyrl/Ze' 'cedillaExtShapeBelowOArc'
 	derive-composites 'cyrl/dhe' 0x499 'cyrl/ze' 'cedillaExtShapeBelowSOArc'
 
 	select-variant 'latn/epsilon/descBase' (shapeFrom -- 'latn/epsilon')

--- a/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
@@ -490,8 +490,8 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 	select-variant 'cyrl/DzjeKomi' 0x506 (follow -- 'cyrl/Ksi')
 	select-variant 'cyrl/dzjeKomi' 0x507 (follow -- 'cyrl/ksi')
 
-	derive-composites 'cyrl/Dhe' 0x498 'cyrl/Ze' 'ogonekBelow'
-	derive-composites 'cyrl/dhe' 0x499 'cyrl/ze' 'ogonekBelow'
+	derive-composites 'cyrl/Dhe' 0x498 'cyrl/Ze' 'cedillaExtShapeBelowSOArc'
+	derive-composites 'cyrl/dhe' 0x499 'cyrl/ze' 'cedillaExtShapeBelowSOArc'
 
 	select-variant 'latn/epsilon/descBase' (shapeFrom -- 'latn/epsilon')
 	select-variant 'latn/epsilonRev/descBase' (shapeFrom -- 'cyrl/ze') (follow -- 'latn/epsilon/descBase')

--- a/packages/font-glyphs/src/letter/latin/c.ptl
+++ b/packages/font-glyphs/src/letter/latin/c.ptl
@@ -414,7 +414,5 @@ glyph-block Letter-Latin-C : begin
 
 	derive-composites 'CCedilla' 0xC7 'C' 'cedillaExtShapeBelowOArc'
 	derive-composites 'cCedilla' 0xE7 'c' 'cedillaExtShapeBelowOArc'
-	derive-composites 'CCedillaAcute' 0x1E08 'C' 'cedillaExtShapeBelowOArc' 'acuteAbove'
-	derive-composites 'cCedillaAcute' 0x1E09 'c' 'cedillaExtShapeBelowOArc' 'acuteAbove'
-	derive-composites 'cyrl/The' 0x4AA 'cyrl/Es' 'cedillaExtShapeBelowOArc'
-	derive-composites 'cyrl/the' 0x4AB 'cyrl/es' 'cedillaExtShapeBelowOArc'
+	derive-composites 'cyrl/The' 0x4AA 'cyrl/Es' 'ogonekBelow'
+	derive-composites 'cyrl/the' 0x4AB 'cyrl/es' 'ogonekBelow'

--- a/packages/font-glyphs/src/letter/latin/c.ptl
+++ b/packages/font-glyphs/src/letter/latin/c.ptl
@@ -414,5 +414,5 @@ glyph-block Letter-Latin-C : begin
 
 	derive-composites 'CCedilla' 0xC7 'C' 'cedillaExtShapeBelowOArc'
 	derive-composites 'cCedilla' 0xE7 'c' 'cedillaExtShapeBelowOArc'
-	derive-composites 'cyrl/The' 0x4AA 'cyrl/Es' 'ogonekBelow'
-	derive-composites 'cyrl/the' 0x4AB 'cyrl/es' 'ogonekBelow'
+	derive-composites 'cyrl/The' 0x4AA 'cyrl/Es' 'cedillaExtShapeBelowOArc'
+	derive-composites 'cyrl/the' 0x4AB 'cyrl/es' 'cedillaExtShapeBelowOArc'

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -131,16 +131,18 @@ glyph-block Letter-Latin-Lower-E : begin
 			hookend O (sw -- stroke)
 			g4 (df.width - [xTerminalR df]) [HookHeight top stroke]
 
-	define [AbkCheShape] : with-params [Body df top tailSlab] : glyph-proc
+	define [AbkCheShape] : with-params [fDesc Body df top tailSlab] : glyph-proc
 		local gap : (df.width - 2 * df.leftSB - 2.5 * df.mvs) * 0.375 - [HSwToV : 0.25 * df.mvs]
 		define divSub : (df.width - gap - df.mvs) / Width
 		define dfSub : DivFrame divSub 2
 		include : Body dfSub top df.mvs (tailSlab -- tailSlab)
 		define offset : Width * (df.div - divSub)
+		if fDesc : begin
+			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
+			include : difference
+				VBar.m dfSub.middle (-LongJut + 0.5 * Stroke) (df.mvs + O) [AdviceStroke 3.5 df.div]
+				OShapeOutline.NoOvershoot top 0 dfSub.leftSB dfSub.rightSB df.mvs
 		include : Translate offset 0
-
-		set-base-anchor 'above' (dfSub.middle + offset) top
-		set-base-anchor 'below' (dfSub.middle + offset) 0
 
 		local hd : FlatHookDepth df
 		local yBar : top * DesignParameters.eBarPos - 0.5 * df.mvs
@@ -231,6 +233,8 @@ glyph-block Letter-Latin-Lower-E : begin
 
 		DefineSelectorGlyph "cyrl/abk/Che" suffix [abkCheDf.markSet.capital]
 		DefineSelectorGlyph "cyrl/abk/che" suffix [abkCheDf.markSet.e]
+		DefineSelectorGlyph "cyrl/abk/CheDescender" suffix [abkCheDf.markSet.capDesc]
+		DefineSelectorGlyph "cyrl/abk/cheDescender" suffix [abkCheDf.markSet.p]
 
 		foreach { suffixSerif { styTop styBot } } [Object.entries CConfig] : do
 			create-glyph "Schwa.\(suffix).\(suffixSerif)" : glyph-proc
@@ -247,16 +251,26 @@ glyph-block Letter-Latin-Lower-E : begin
 			create-glyph "cyrl/abk/Che.\(suffix).\(suffixSerif)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
-				include : AbkCheShape Body abkCheDf CAP (tailSlab -- styBot)
+				include : AbkCheShape 0 Body abkCheDf CAP (tailSlab -- styBot)
 			create-glyph "cyrl/abk/che.\(suffix).\(suffixSerif)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
-				include : AbkCheShape Body abkCheDf XH (tailSlab -- styBot)
+				include : AbkCheShape 0 Body abkCheDf XH (tailSlab -- styBot)
+			create-glyph "cyrl/abk/CheDescender.\(suffix).\(suffixSerif)" : glyph-proc
+				set-width 0
+				set-mark-anchor 'cvDecompose' 0 0
+				include : AbkCheShape 1 Body abkCheDf CAP (tailSlab -- styBot)
+			create-glyph "cyrl/abk/cheDescender.\(suffix).\(suffixSerif)" : glyph-proc
+				set-width 0
+				set-mark-anchor 'cvDecompose' 0 0
+				include : AbkCheShape 1 Body abkCheDf XH (tailSlab -- styBot)
 
 		select-variant "Schwa.\(suffix)" (follow -- "CTopSerifOnly")
 		select-variant "schwa.\(suffix)" (follow -- "cTopSerifOnly")
 		select-variant "cyrl/abk/Che.\(suffix)" (follow -- 'CBottomSerifOnly')
 		select-variant "cyrl/abk/che.\(suffix)" (follow -- 'cBottomSerifOnly')
+		select-variant "cyrl/abk/CheDescender.\(suffix)" (follow -- 'CBottomSerifOnly')
+		select-variant "cyrl/abk/cheDescender.\(suffix)" (follow -- 'cBottomSerifOnly')
 
 	select-variant 'e' 'e'
 	alias 'cyrl/ie' 0x435 'e'
@@ -278,8 +292,8 @@ glyph-block Letter-Latin-Lower-E : begin
 
 	CreateSelectorVariants 'cyrl/abk/Che' 0x4BC [Object.keys SmallEConfig] (follow -- 'e')
 	CreateSelectorVariants 'cyrl/abk/che' 0x4BD [Object.keys SmallEConfig] (follow -- 'e')
-	derive-composites 'cyrl/abk/CheDescender' 0x4BE 'cyrl/abk/Che' 'ogonekBelow'
-	derive-composites 'cyrl/abk/cheDescender' 0x4BF 'cyrl/abk/che' 'ogonekBelow'
+	CreateSelectorVariants 'cyrl/abk/CheDescender' 0x4BE [Object.keys SmallEConfig] (follow -- 'e')
+	CreateSelectorVariants 'cyrl/abk/cheDescender' 0x4BF [Object.keys SmallEConfig] (follow -- 'e')
 
 	glyph-block-import Letter-Blackboard : BBS BBD
 	create-glyph 'mathbb/e' 0x1D556 : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -25,7 +25,7 @@ glyph-block Letter-Latin-Lower-E : begin
 	define SLAB-CLASSICAL  1
 	define SLAB-INWARD     2
 
-	define [SmallESerifedTerminalShape df top stroke tailSlab] : match tailSlab
+	define [SmallESerifedTerminalShape df top stroke tailSlab schwaTail] : match tailSlab
 		[Just SLAB-CLASSICAL] : begin
 			SerifedArcEnd.LtrLhs df.rightSB df.middle 0 stroke [HookHeight top stroke]
 		[Just SLAB-INWARD] : list
@@ -33,16 +33,16 @@ glyph-block Letter-Latin-Lower-E : begin
 			g4 (df.middle + CorrectionOMidX * stroke) O
 			g4 df.rightSB (DToothlessRise)
 		__ : list
-			hookend O (sw -- stroke)
+			hookend O (sw -- stroke) (suppressSwash -- schwaTail)
 			g4 [xTerminalR df] [HookHeight top stroke]
 
-	define [SmallETerminalSerif df top stroke tailSlab] : match tailSlab
+	define [SmallETerminalSerif df top stroke tailSlab schwaTail] : match tailSlab
 		[Just SLAB-CLASSICAL] : ArcEndSerif.R df.rightSB 0 stroke [HookHeight top stroke]
 		[Just SLAB-INWARD] : ArcEndSerif.InwardR df.rightSB 0 stroke [HookHeight top stroke]
 		__ : no-shape
 
 	glyph-block-export SmallEShape
-	define [SmallEShape] : with-params [df top stroke barpos [bbd 0] tailSlab] : glyph-proc
+	define [SmallEShape] : with-params [df top stroke barpos [bbd 0] tailSlab schwaTail] : glyph-proc
 		local barbottom : top * [fallback barpos DesignParameters.eBarPos] - (stroke / 2)
 
 		include : HBar.b (df.leftSB + (stroke / 2) + OX + bbd) (df.rightSB - (stroke / 2) - OX) barbottom stroke
@@ -55,9 +55,9 @@ glyph-block Letter-Latin-Lower-E : begin
 			archv
 			flat (df.leftSB + OX) (top - [df.archDepthA SmallArchDepth])
 			curl (df.leftSB + OX) (0 + [df.archDepthB SmallArchDepth])
-			SmallESerifedTerminalShape df top stroke tailSlab
+			SmallESerifedTerminalShape df top stroke tailSlab schwaTail
 
-		include : SmallETerminalSerif df top stroke tailSlab
+		include : SmallETerminalSerif df top stroke tailSlab schwaTail
 
 		return path.rhsKnots.[path.rhsKnots.length - 1]
 
@@ -81,7 +81,7 @@ glyph-block Letter-Latin-Lower-E : begin
 			g4 (df.width - [xTerminalR df]) [HookHeight top stroke]
 
 	glyph-block-export SmallERoundedShape
-	define [SmallERoundedShape] : with-params [df top stroke barpos tailSlab] : glyph-proc
+	define [SmallERoundedShape] : with-params [df top stroke barpos tailSlab schwaTail] : glyph-proc
 		local barbottom : top * [fallback barpos : if para.isItalic 0.500 0.475] - (stroke / 2)
 
 		local pBarRight : 0.475 - TanSlope * 0.5
@@ -93,7 +93,7 @@ glyph-block Letter-Latin-Lower-E : begin
 			widths.lhs stroke
 			[if para.isItalic g2 flat] xStart (barbottom - pfIt * [StrokeWidthBlend 2 3] * O)
 			if para.isItalic [alsoThru.g2 0.5 0.8] [list]
-			[if para.isItalic g2 curl] [mix (xStart + [if para.isItalic 0.25 0.0] * [HSwToV stroke]) df.rightSB pBarRight] (barbottom + pfIt * [StrokeWidthBlend 0.25 1] * O)
+			[if para.isItalic g2 curl] [mix (xStart + pfIt * 0.25 * [HSwToV stroke]) df.rightSB pBarRight] (barbottom + pfIt * [StrokeWidthBlend 0.25 1] * O)
 			if para.isItalic {} [archv]
 			g4 (df.rightSB - OX) [mix barbottom top pArcRight]
 			arcvh
@@ -101,9 +101,9 @@ glyph-block Letter-Latin-Lower-E : begin
 			archv
 			flat (df.leftSB + OX) (top - [df.archDepthA SmallArchDepth])
 			curl (df.leftSB + OX) (0 + [df.archDepthB SmallArchDepth])
-			SmallESerifedTerminalShape df top stroke tailSlab
+			SmallESerifedTerminalShape df top stroke tailSlab schwaTail
 
-		include : SmallETerminalSerif df top stroke tailSlab
+		include : SmallETerminalSerif df top stroke tailSlab schwaTail
 
 		return path.rhsKnots.[path.rhsKnots.length - 1]
 
@@ -131,26 +131,25 @@ glyph-block Letter-Latin-Lower-E : begin
 			hookend O (sw -- stroke)
 			g4 (df.width - [xTerminalR df]) [HookHeight top stroke]
 
-	define [AbkCheShape] : with-params [fDesc Body df top tailSlab] : glyph-proc
+	define [AbkCheShape] : with-params [Body df top tailSlab] : glyph-proc
 		local gap : (df.width - 2 * df.leftSB - 2.5 * df.mvs) * 0.375 - [HSwToV : 0.25 * df.mvs]
 		define divSub : (df.width - gap - df.mvs) / Width
 		define dfSub : DivFrame divSub 2
 		include : Body dfSub top df.mvs (tailSlab -- tailSlab)
-		if fDesc : begin
-			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
-			include : difference
-				VBar.m dfSub.middle (-LongJut + 0.5 * Stroke) (df.mvs + O) [AdviceStroke 3.5 df.div]
-				OShapeOutline.NoOvershoot top 0 dfSub.leftSB dfSub.rightSB df.mvs
-		include : Translate (Width * (df.div - divSub)) 0
+		define offset : Width * (df.div - divSub)
+		include : Translate offset 0
+
+		set-base-anchor 'above' (dfSub.middle + offset) top
+		set-base-anchor 'below' (dfSub.middle + offset) 0
 
 		local hd : FlatHookDepth df
 		local yBar : top * DesignParameters.eBarPos - 0.5 * df.mvs
-		include : intersection [MaskLeft (dfSub.leftSB + Width * (df.div - divSub))] : dispiro
+		include : intersection [MaskLeft : dfSub.leftSB + offset] : dispiro
 			flat (df.leftSB - [HSwToV : 0.25 * df.mvs]) (yBar + Hook) [widths.lhs.heading df.mvs Downward]
 			curl (df.leftSB - [HSwToV : 0.25 * df.mvs]) (yBar + [Math.min Hook hd.y] - df.mvs * 0.25) [heading Downward]
 			arcvh
-			flat [Math.min (df.leftSB + hd.x - [HSwToV : 0.5 * df.mvs]) (dfSub.leftSB + Width * (df.div - divSub))] yBar
-			curl (dfSub.middle + Width * (df.div - divSub)) yBar
+			flat [Math.min (df.leftSB + hd.x - [HSwToV : 0.5 * df.mvs]) (dfSub.leftSB + offset)] yBar
+			curl (dfSub.middle + offset) yBar
 
 	define SmallEConfig : object
 		flatCrossbar { SmallEShape        RevSmallEShape        }
@@ -232,44 +231,32 @@ glyph-block Letter-Latin-Lower-E : begin
 
 		DefineSelectorGlyph "cyrl/abk/Che" suffix [abkCheDf.markSet.capital]
 		DefineSelectorGlyph "cyrl/abk/che" suffix [abkCheDf.markSet.e]
-		DefineSelectorGlyph "cyrl/abk/CheDescender" suffix [abkCheDf.markSet.capDesc]
-		DefineSelectorGlyph "cyrl/abk/cheDescender" suffix [abkCheDf.markSet.p]
 
 		foreach { suffixSerif { styTop styBot } } [Object.entries CConfig] : do
 			create-glyph "Schwa.\(suffix).\(suffixSerif)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
-				include : Body [DivFrame 1] CAP [AdviceStroke2 2 3 CAP] (tailSlab -- styTop)
+				include : Body [DivFrame 1] CAP [AdviceStroke2 2 3 CAP] (tailSlab -- styTop) (schwaTail -- true)
 				include : FlipAround Middle (CAP / 2)
 			create-glyph "schwa.\(suffix).\(suffixSerif)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
-				include : Body [DivFrame 1] XH [AdviceStroke2 2 3 XH] (tailSlab -- styTop)
+				include : Body [DivFrame 1] XH [AdviceStroke2 2 3 XH] (tailSlab -- styTop) (schwaTail -- true)
 				include : FlipAround Middle (XH / 2)
 
 			create-glyph "cyrl/abk/Che.\(suffix).\(suffixSerif)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
-				include : AbkCheShape 0 Body abkCheDf CAP (tailSlab -- styBot)
+				include : AbkCheShape Body abkCheDf CAP (tailSlab -- styBot)
 			create-glyph "cyrl/abk/che.\(suffix).\(suffixSerif)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
-				include : AbkCheShape 0 Body abkCheDf XH (tailSlab -- styBot)
-			create-glyph "cyrl/abk/CheDescender.\(suffix).\(suffixSerif)" : glyph-proc
-				set-width 0
-				set-mark-anchor 'cvDecompose' 0 0
-				include : AbkCheShape 1 Body abkCheDf CAP (tailSlab -- styBot)
-			create-glyph "cyrl/abk/cheDescender.\(suffix).\(suffixSerif)" : glyph-proc
-				set-width 0
-				set-mark-anchor 'cvDecompose' 0 0
-				include : AbkCheShape 1 Body abkCheDf XH (tailSlab -- styBot)
+				include : AbkCheShape Body abkCheDf XH (tailSlab -- styBot)
 
 		select-variant "Schwa.\(suffix)" (follow -- "CTopSerifOnly")
 		select-variant "schwa.\(suffix)" (follow -- "cTopSerifOnly")
 		select-variant "cyrl/abk/Che.\(suffix)" (follow -- 'CBottomSerifOnly')
 		select-variant "cyrl/abk/che.\(suffix)" (follow -- 'cBottomSerifOnly')
-		select-variant "cyrl/abk/CheDescender.\(suffix)" (follow -- 'CBottomSerifOnly')
-		select-variant "cyrl/abk/cheDescender.\(suffix)" (follow -- 'cBottomSerifOnly')
 
 	select-variant 'e' 'e'
 	alias 'cyrl/ie' 0x435 'e'
@@ -291,8 +278,8 @@ glyph-block Letter-Latin-Lower-E : begin
 
 	CreateSelectorVariants 'cyrl/abk/Che' 0x4BC [Object.keys SmallEConfig] (follow -- 'e')
 	CreateSelectorVariants 'cyrl/abk/che' 0x4BD [Object.keys SmallEConfig] (follow -- 'e')
-	CreateSelectorVariants 'cyrl/abk/CheDescender' 0x4BE [Object.keys SmallEConfig] (follow -- 'e')
-	CreateSelectorVariants 'cyrl/abk/cheDescender' 0x4BF [Object.keys SmallEConfig] (follow -- 'e')
+	derive-composites 'cyrl/abk/CheDescender' 0x4BE 'cyrl/abk/Che' 'ogonekBelow'
+	derive-composites 'cyrl/abk/cheDescender' 0x4BF 'cyrl/abk/che' 'ogonekBelow'
 
 	glyph-block-import Letter-Blackboard : BBS BBD
 	create-glyph 'mathbb/e' 0x1D556 : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/upper-y.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-y.ptl
@@ -20,7 +20,6 @@ glyph-block Letter-Latin-Upper-Y : begin
 	define SLAB-ALL    1
 	define SLAB-BASE   2
 	define SLAB-MOTION 3
-	define SLAB-CYRL   4
 
 	define [YCrossPos top bot] : mix bot top 0.4
 
@@ -32,9 +31,6 @@ glyph-block Letter-Latin-Upper-Y : begin
 				include : HSerif.mb Middle bot MidJutSide
 			[Just SLAB-MOTION] : include sf.lt.outer
 			[Just SLAB-BASE] : include : HSerif.mb Middle bot MidJutSide
-			[Just SLAB-CYRL] : begin
-				include : if para.isItalic sf.lt.outer [composite-proc sf.lt.full sf.rt.full]
-				include : HSerif.mb Middle bot MidJutSide
 
 	define [YShape bodyType slabType top bot] : glyph-proc
 		local cross : YCrossPos top bot
@@ -94,8 +90,6 @@ glyph-block Letter-Latin-Upper-Y : begin
 		curlyMotionSerifed    { BODY-CURLY    SLAB-MOTION }
 		straightSerifed       { BODY-STRAIGHT SLAB-ALL    }
 		curlySerifed          { BODY-CURLY    SLAB-ALL    }
-		straightSmallCyrl     { BODY-STRAIGHT SLAB-CYRL   }
-		curlySmallCyrl        { BODY-CURLY    SLAB-CYRL   }
 
 	foreach { suffix { bodyType slabType } } [Object.entries YConfig] : do
 		create-glyph "Y.\(suffix)" : glyph-proc
@@ -149,7 +143,7 @@ glyph-block Letter-Latin-Upper-Y : begin
 	link-reduced-variant 'grek/Upsilon/sansSerif' 'grek/Upsilon' MathSansSerif (follow -- 'Y/sansSerif')
 	select-variant 'grek/UpsilonHookTop' 0x3D2
 
-	alias 'cyrl/Ue' 0x4AE 'Y'
+	select-variant 'cyrl/Ue' 0x4AE (shapeFrom -- 'Y')
 	select-variant 'cyrl/ue' 0x4AF
 	CreateAccentedComposition 'cyrl/UShortKazakh' 0x4B0 'cyrl/Ue' 'barOver'
 	CreateAccentedComposition 'cyrl/uShortKazakh' 0x4B1 'cyrl/ue' 'barOver'

--- a/packages/font-glyphs/src/meta/unicode-knowledge.ptl
+++ b/packages/font-glyphs/src/meta/unicode-knowledge.ptl
@@ -162,6 +162,8 @@ export : define decompOverrides : object
 	0x1D7D { 'p' 'hStrike' }
 	0x1D7F { 'latn/upsilon' 'hStrike' }
 
+	0x1E08 { 'CCedilla' 'acuteAbove' }
+	0x1E09 { 'cCedilla' 'acuteAbove' }
 	0x1E9C { 'longs' 'shortSlashOver' }
 	0x1EDA { 'OHorn' 'acuteAbove' }
 	0x1EDB { 'oHorn' 'acuteAbove' }

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1353,7 +1353,6 @@ selectorAffix.Y = "straight"
 selectorAffix."Y/sansSerif" = "straight"
 selectorAffix.YLoop = "straightLoop"
 selectorAffix."grek/UpsilonHookTop" = "straight"
-selectorAffix."cyrl/ue" = "straight"
 
 [prime.capital-y.variants-buildup.stages.body.curly]
 rank = 2
@@ -1362,7 +1361,6 @@ selectorAffix.Y = "curly"
 selectorAffix."Y/sansSerif" = "curly"
 selectorAffix.YLoop = "curlyLoop"
 selectorAffix."grek/UpsilonHookTop" = "straight"
-selectorAffix."cyrl/ue" = "curly"
 
 [prime.capital-y.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -1372,7 +1370,6 @@ selectorAffix.Y = "serifless"
 selectorAffix."Y/sansSerif" = "serifless"
 selectorAffix.YLoop = "serifless"
 selectorAffix."grek/UpsilonHookTop" = "serifless"
-selectorAffix."cyrl/ue" = "serifless"
 
 [prime.capital-y.variants-buildup.stages.serifs.base-serifed]
 rank = 2
@@ -1381,7 +1378,6 @@ selectorAffix.Y = "baseSerifed"
 selectorAffix."Y/sansSerif" = "serifless"
 selectorAffix.YLoop = "serifless"
 selectorAffix."grek/UpsilonHookTop" = "BaseSerifed"
-selectorAffix."cyrl/ue" = "serifless"
 
 [prime.capital-y.variants-buildup.stages.serifs.motion-serifed]
 rank = 3
@@ -1390,7 +1386,6 @@ selectorAffix.Y = "motionSerifed"
 selectorAffix."Y/sansSerif" = "serifless"
 selectorAffix.YLoop = "motionSerifed"
 selectorAffix."grek/UpsilonHookTop" = "serifless"
-selectorAffix."cyrl/ue" = "motionSerifed"
 
 [prime.capital-y.variants-buildup.stages.serifs.serifed]
 rank = 4
@@ -1399,7 +1394,6 @@ selectorAffix.Y = "serifed"
 selectorAffix."Y/sansSerif" = "serifless"
 selectorAffix.YLoop = "serifed"
 selectorAffix."grek/UpsilonHookTop" = "BaseSerifed"
-selectorAffix."cyrl/ue" = "smallCyrl"
 
 
 
@@ -5779,16 +5773,19 @@ next = "hook"
 rank = 1
 descriptionAffix = "straight shape"
 selectorAffix."cyrl/U" = "straight"
+selectorAffix."cyrl/Ue" = "straight"
 
 [prime.cyrl-capital-u.variants-buildup.stages.body.curly]
 rank = 2
 descriptionAffix = "curly shape"
 selectorAffix."cyrl/U" = "curly"
+selectorAffix."cyrl/Ue" = "curly"
 
 [prime.cyrl-capital-u.variants-buildup.stages.body.cursive]
 rank = 3
 descriptionAffix = "cursive shape"
 selectorAffix."cyrl/U" = "cursive"
+selectorAffix."cyrl/Ue" = "straight"
 
 [prime.cyrl-capital-u.variants-buildup.stages.hook."*"]
 next = "serifs"
@@ -5797,34 +5794,40 @@ next = "serifs"
 rank = 1
 keyAffix = ""
 selectorAffix."cyrl/U" = ""
+selectorAffix."cyrl/Ue" = ""
 
 [prime.cyrl-capital-u.variants-buildup.stages.hook.turn]
 rank = 2
 disableIf = [{ body = "cursive" }]
 descriptionAffix = "a tail turns leftward"
 selectorAffix."cyrl/U" = "turn"
+selectorAffix."cyrl/Ue" = ""
 
 [prime.cyrl-capital-u.variants-buildup.stages.hook.flat-hook]
 rank = 3
 disableIf = [{ body = "NOT cursive" }]
 descriptionAffix = "a flat terminal hook"
 selectorAffix."cyrl/U" = "flatHook"
+selectorAffix."cyrl/Ue" = ""
 
 [prime.cyrl-capital-u.variants-buildup.stages.serifs.serifless]
 rank = 1
 descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix."cyrl/U" = "serifless"
+selectorAffix."cyrl/Ue" = "serifless"
 
 [prime.cyrl-capital-u.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
 descriptionAffix = "motion serifs"
 selectorAffix."cyrl/U" = "motionSerifed"
+selectorAffix."cyrl/Ue" = "motionSerifed"
 
 [prime.cyrl-capital-u.variants-buildup.stages.serifs.serifed]
 rank = 3
 descriptionAffix = "serifs"
 selectorAffix."cyrl/U" = "serifed"
+selectorAffix."cyrl/Ue" = "serifed"
 
 
 
@@ -5844,16 +5847,19 @@ next = "hook"
 rank = 1
 descriptionAffix = "straight shape"
 selectorAffix."cyrl/u" = "straight"
+selectorAffix."cyrl/ue" = "straight"
 
 [prime.cyrl-u.variants-buildup.stages.body.curly]
 rank = 2
 descriptionAffix = "curly shape"
 selectorAffix."cyrl/u" = "curly"
+selectorAffix."cyrl/ue" = "curly"
 
 [prime.cyrl-u.variants-buildup.stages.body.cursive]
 rank = 3
 descriptionAffix = "cursive shape"
 selectorAffix."cyrl/u" = "cursive"
+selectorAffix."cyrl/ue" = "straight"
 
 [prime.cyrl-u.variants-buildup.stages.hook."*"]
 next = "serifs"
@@ -5862,34 +5868,40 @@ next = "serifs"
 rank = 1
 keyAffix = ""
 selectorAffix."cyrl/u" = ""
+selectorAffix."cyrl/ue" = ""
 
 [prime.cyrl-u.variants-buildup.stages.hook.turn]
 rank = 2
 disableIf = [{ body = "cursive" }]
 descriptionAffix = "a tail turns leftward"
 selectorAffix."cyrl/u" = "turn"
+selectorAffix."cyrl/ue" = ""
 
 [prime.cyrl-u.variants-buildup.stages.hook.flat-hook]
 rank = 3
 disableIf = [{ body = "NOT cursive" }]
 descriptionAffix = "a flat terminal hook"
 selectorAffix."cyrl/u" = "flatHook"
+selectorAffix."cyrl/ue" = ""
 
 [prime.cyrl-u.variants-buildup.stages.serifs.serifless]
 rank = 1
 descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix."cyrl/u" = "serifless"
+selectorAffix."cyrl/ue" = "serifless"
 
 [prime.cyrl-u.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
 descriptionAffix = "motion serifs"
 selectorAffix."cyrl/u" = "motionSerifed"
+selectorAffix."cyrl/ue" = "motionSerifed"
 
 [prime.cyrl-u.variants-buildup.stages.serifs.serifed]
 rank = 3
 descriptionAffix = "serifs"
 selectorAffix."cyrl/u" = "serifed"
+selectorAffix."cyrl/ue" = "serifed"
 
 
 
@@ -8182,6 +8194,7 @@ long-s = "flat-hook-descending"
 eszet = "longs-s-lig-descending-serifless"
 cyrl-ka = "symmetric-connected-top-left-serifed"
 cyrl-u = "straight-turn-motion-serifed"
+cyrl-ef = "serifless"
 micro-sign = "tailed-motion-serifed"
 
 


### PR DESCRIPTION
Schwa top hook behavior:
`ОоӨөЭэӘә`
(not shown is real turned e which is unchanged).
Upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/5d7dc112-07d5-4b08-be47-68d5d0f692d6)
Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/d178ea68-642b-4686-8cf1-7fd95d90db5d)
Compared to slab:
Upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/9cfc1217-6cc1-4a3d-8162-f774ba6eee0d)
Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/0b7bad26-acda-4f6d-9af0-b84341fa7081)
Cyrillic Straight U behavior:
All Capital U variants:
`УЎҮҰ`
![image](https://github.com/be5invis/Iosevka/assets/37010132/1078b8be-61eb-421b-a41d-e9b610bf2d66)
All Lower U variants:
`уўүұ`
![image](https://github.com/be5invis/Iosevka/assets/37010132/7f098a60-39e1-49f0-af8b-3d051995681f)
