### PR TITLE
Refine tails of Schwa and Reversed Lower E under italics

### DIFF
--- a/changes/29.2.1.md
+++ b/changes/29.2.1.md
@@ -1,4 +1,5 @@
 * Refine shape of `U+1CC09`, `U+1CC0A`, `U+1CC10` and `U+1CC11`.
+* Refine terminal shape of Schwa and Reversed Lower E (`U+018F`, `U+0258`..`U+025A`, `U+04D8`..`U+04D9`) under italics.
 * Add characters:
   - LEFT-FACING SNAKE HEAD WITH OPEN MOUTH (`U+1CC70`) ... DOWN-FACING SNAKE HEAD WITH CLOSED MOUTH (`U+1CC77`)  (Proposed for Unicode 16; L2/21-235).
   - UPPER LEFT QUADRANT FACE WITH OPEN EYES (`U+1CCA6`) ... BOTTOM HALF FORWARD-FACING RUNNER FRAME-4 (`U+1CDF4`)  (Proposed for Unicode 16; L2/21-235).

--- a/packages/font-glyphs/src/common/shapes.ptl
+++ b/packages/font-glyphs/src/common/shapes.ptl
@@ -430,12 +430,12 @@ glyph-block CommonShapes : begin
 
 	define nHookSegments 12
 	define [HookShape toStraight toFinish isStart args] : begin
-		local [object y tight sw swItalicAdj noAdjTerminalY turnSlope isTail suppressSwash] args
+		local [object y tight sw swItalicAdj noAdjTerminalY turnSlope isTail noSwash] args
 
 		local atBottom : toStraight.y > y
 		local ltr : if isStart (toFinish.x < toStraight.x) (toFinish.x > toStraight.x)
 		local dtu : if isStart (y > toFinish.y) (y < toFinish.y)
-		local doSwash : !suppressSwash && !tight && !isStart && atBottom && (para.isItalic || isTail) && [if (para.slopeAngle >= 0) ltr [not ltr]]
+		local doSwash : !noSwash && !tight && !isStart && atBottom && (para.isItalic || isTail) && [if (para.slopeAngle >= 0) ltr [not ltr]]
 		local superness : if tight DesignParameters.tightHookSuperness DesignParameters.superness
 
 		# Adjust terminal's position if necessary
@@ -528,9 +528,9 @@ glyph-block CommonShapes : begin
 		local-parameter : noAdjTerminalY -- false
 		local-parameter : turnSlope      -- nothing
 		local-parameter : isTail         -- false
-		local-parameter : suppressSwash  -- false
+		local-parameter : noSwash        -- false
 		return : Interpolator hookStartBlender
-			object y tight sw swItalicAdj noAdjTerminalY turnSlope isTail suppressSwash
+			object y tight sw swItalicAdj noAdjTerminalY turnSlope isTail noSwash
 
 	glyph-block-export hookend
 	define flex-params [hookend] : begin
@@ -541,9 +541,9 @@ glyph-block CommonShapes : begin
 		local-parameter : noAdjTerminalY -- false
 		local-parameter : turnSlope      -- nothing
 		local-parameter : isTail         -- false
-		local-parameter : suppressSwash  -- false
+		local-parameter : noSwash        -- false
 		return : Interpolator hookEndBlender
-			object y tight sw swItalicAdj noAdjTerminalY turnSlope isTail suppressSwash
+			object y tight sw swItalicAdj noAdjTerminalY turnSlope isTail noSwash
 
 	glyph-block-export Ungizmo
 	define [Ungizmo] : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -10,7 +10,7 @@ glyph-block Letter-Latin-Lower-E : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared : CreateSelectorVariants DefineSelectorGlyph CreateTurnedLetter
 	glyph-block-import Letter-Shared-Shapes : FlatHookDepth RetroflexHook
-	glyph-block-import Letter-Shared-Shapes : SerifedArcEnd ArcEndSerif DToothlessRise
+	glyph-block-import Letter-Shared-Shapes : SerifedArcEnd InwardSlabArcEnd ArcEndSerif
 	glyph-block-import Mark-Shared-Metrics : markExtend markStroke markStress markFine
 	glyph-block-import Mark-Above : aboveMarkTop aboveMarkBot aboveMarkMid aboveMarkStack
 	glyph-block-import Mark-Adjustment : ExtendBelowBaseAnchors
@@ -26,10 +26,8 @@ glyph-block Letter-Latin-Lower-E : begin
 	define [SmallESerifedTerminalShape df top stroke tailSlab schwaTail] : match tailSlab
 		[Just SLAB-CLASSICAL] : begin
 			SerifedArcEnd.LtrLhs df.rightSB df.middle 0 stroke [HookHeight top stroke schwaTail]
-		[Just SLAB-INWARD] : list
-			arcvh
-			g4 (df.middle + CorrectionOMidX * stroke) O
-			g4 df.rightSB (DToothlessRise)
+		[Just SLAB-INWARD] : begin
+			InwardSlabArcEnd.LtrLhs df.rightSB df.middle 0 stroke [HookHeight top stroke schwaTail]
 		__ : list
 			hookend O (sw -- stroke) (noSwash -- schwaTail)
 			g4 (df.rightSB - [if (para.isItalic && !schwaTail) 0 0.5] * OX) [HookHeight top stroke schwaTail]

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -16,10 +16,8 @@ glyph-block Letter-Latin-Lower-E : begin
 	glyph-block-import Mark-Adjustment : ExtendBelowBaseAnchors
 	glyph-block-import Letter-Latin-C : CConfig
 
-	define [xTerminalR df] : df.rightSB - OX * [if para.isItalic 0 0.5]
-
-	define [HookHeight top stroke] : Math.min Hook (AHook / XH * top)
-		if para.isItalic top (stroke / 2 + (top - stroke * 3) / 4)
+	define [HookHeight top stroke noItalicAdj] : Math.min Hook (AHook / XH * top)
+		if (para.isItalic && !noItalicAdj) top (stroke / 2 + (top - stroke * 3) / 4)
 
 	define SLAB-NONE       0
 	define SLAB-CLASSICAL  1
@@ -27,18 +25,18 @@ glyph-block Letter-Latin-Lower-E : begin
 
 	define [SmallESerifedTerminalShape df top stroke tailSlab schwaTail] : match tailSlab
 		[Just SLAB-CLASSICAL] : begin
-			SerifedArcEnd.LtrLhs df.rightSB df.middle 0 stroke [HookHeight top stroke]
+			SerifedArcEnd.LtrLhs df.rightSB df.middle 0 stroke [HookHeight top stroke schwaTail]
 		[Just SLAB-INWARD] : list
 			arcvh
 			g4 (df.middle + CorrectionOMidX * stroke) O
 			g4 df.rightSB (DToothlessRise)
 		__ : list
-			hookend O (sw -- stroke) (suppressSwash -- schwaTail)
-			g4 [xTerminalR df] [HookHeight top stroke]
+			hookend O (sw -- stroke) (noSwash -- schwaTail)
+			g4 (df.rightSB - [if (para.isItalic && !schwaTail) 0 0.5] * OX) [HookHeight top stroke schwaTail]
 
 	define [SmallETerminalSerif df top stroke tailSlab schwaTail] : match tailSlab
-		[Just SLAB-CLASSICAL] : ArcEndSerif.R df.rightSB 0 stroke [HookHeight top stroke]
-		[Just SLAB-INWARD] : ArcEndSerif.InwardR df.rightSB 0 stroke [HookHeight top stroke]
+		[Just SLAB-CLASSICAL] : ArcEndSerif.R df.rightSB 0 stroke [HookHeight top stroke schwaTail]
+		[Just SLAB-INWARD] : ArcEndSerif.InwardR df.rightSB 0 stroke [HookHeight top stroke schwaTail]
 		__ : no-shape
 
 	glyph-block-export SmallEShape
@@ -78,7 +76,7 @@ glyph-block Letter-Latin-Lower-E : begin
 			flat (df.rightSB - OX) (top - [df.archDepthB SmallArchDepth])
 			curl (df.rightSB - OX) [df.archDepthA SmallArchDepth]
 			hookend O (sw -- stroke)
-			g4 (df.width - [xTerminalR df]) [HookHeight top stroke]
+			g4 (df.leftSB + 0.5 * OX) [HookHeight top stroke true]
 
 	glyph-block-export SmallERoundedShape
 	define [SmallERoundedShape] : with-params [df top stroke barpos tailSlab schwaTail] : glyph-proc
@@ -120,7 +118,7 @@ glyph-block Letter-Latin-Lower-E : begin
 			widths.rhs stroke
 			[if para.isItalic g2 flat] xStart (barbottom - pfIt * [StrokeWidthBlend 2 3] * O)
 			if para.isItalic [alsoThru.g2 0.5 0.8] [list]
-			[if para.isItalic g2 curl] [mix (xStart - [if para.isItalic 0.25 0.0] * [HSwToV stroke]) df.leftSB pBarRight] (barbottom + pfIt * [StrokeWidthBlend 0.25 1] * O)
+			[if para.isItalic g2 curl] [mix (xStart - pfIt * 0.25 * [HSwToV stroke]) df.leftSB pBarRight] (barbottom + pfIt * [StrokeWidthBlend 0.25 1] * O)
 			if para.isItalic {} [archv]
 			g4 (df.leftSB + OX) [mix barbottom top pArcRight]
 			arcvh
@@ -129,7 +127,7 @@ glyph-block Letter-Latin-Lower-E : begin
 			flat (df.rightSB - OX) (top - [df.archDepthB SmallArchDepth])
 			curl (df.rightSB - OX) (0 + [df.archDepthA SmallArchDepth])
 			hookend O (sw -- stroke)
-			g4 (df.width - [xTerminalR df]) [HookHeight top stroke]
+			g4 (df.leftSB + 0.5 * OX) [HookHeight top stroke true]
 
 	define [AbkCheShape] : with-params [fDesc Body df top tailSlab] : glyph-proc
 		local gap : (df.width - 2 * df.leftSB - 2.5 * df.mvs) * 0.375 - [HSwToV : 0.25 * df.mvs]

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -16,7 +16,9 @@ glyph-block Letter-Latin-Lower-E : begin
 	glyph-block-import Mark-Adjustment : ExtendBelowBaseAnchors
 	glyph-block-import Letter-Latin-C : CConfig
 
-	define [HookHeight top stroke noItalicAdj] : Math.min Hook (AHook / XH * top)
+	define [HookHeight top] : Math.min Hook (AHook / XH * top)
+
+	define [HookHeightTight top stroke noItalicAdj] : Math.min [HookHeight top]
 		if (para.isItalic && !noItalicAdj) top (stroke / 2 + (top - stroke * 3) / 4)
 
 	define SLAB-NONE       0
@@ -25,16 +27,16 @@ glyph-block Letter-Latin-Lower-E : begin
 
 	define [SmallESerifedTerminalShape df top stroke tailSlab schwaTail] : match tailSlab
 		[Just SLAB-CLASSICAL] : begin
-			SerifedArcEnd.LtrLhs df.rightSB df.middle 0 stroke [HookHeight top stroke schwaTail]
+			SerifedArcEnd.LtrLhs df.rightSB df.middle 0 stroke [HookHeight top]
 		[Just SLAB-INWARD] : begin
-			InwardSlabArcEnd.LtrLhs df.rightSB df.middle 0 stroke [HookHeight top stroke schwaTail]
+			InwardSlabArcEnd.LtrLhs df.rightSB df.middle 0 stroke [HookHeight top]
 		__ : list
 			hookend O (sw -- stroke) (noSwash -- schwaTail)
-			g4 (df.rightSB - [if (para.isItalic && !schwaTail) 0 0.5] * OX) [HookHeight top stroke schwaTail]
+			g4 (df.rightSB - [if (para.isItalic && !schwaTail) 0 0.5] * OX) [HookHeightTight top stroke schwaTail]
 
 	define [SmallETerminalSerif df top stroke tailSlab schwaTail] : match tailSlab
-		[Just SLAB-CLASSICAL] : ArcEndSerif.R df.rightSB 0 stroke [HookHeight top stroke schwaTail]
-		[Just SLAB-INWARD] : ArcEndSerif.InwardR df.rightSB 0 stroke [HookHeight top stroke schwaTail]
+		[Just SLAB-CLASSICAL] : ArcEndSerif.R df.rightSB 0 stroke [HookHeight top]
+		[Just SLAB-INWARD] : ArcEndSerif.InwardR df.rightSB 0 stroke [HookHeight top]
 		__ : no-shape
 
 	glyph-block-export SmallEShape
@@ -60,8 +62,6 @@ glyph-block Letter-Latin-Lower-E : begin
 	glyph-block-export RevSmallEShape
 	define [RevSmallEShape] : with-params [df top stroke barpos] : glyph-proc
 		local barbottom (top * [fallback barpos DesignParameters.eBarPos] - HalfStroke)
-		local hookx df.leftSB
-		local hookmiddle : [mix (df.rightSB - O) hookx 0.55] + CorrectionOMidS
 
 		include : HBar.b (df.leftSB + (stroke / 2)) (df.rightSB - (stroke / 2)) barbottom stroke
 		include : dispiro
@@ -74,7 +74,7 @@ glyph-block Letter-Latin-Lower-E : begin
 			flat (df.rightSB - OX) (top - [df.archDepthB SmallArchDepth])
 			curl (df.rightSB - OX) [df.archDepthA SmallArchDepth]
 			hookend O (sw -- stroke)
-			g4 (df.leftSB + 0.5 * OX) [HookHeight top stroke true]
+			g4 (df.leftSB + 0.5 * OX) [HookHeightTight top stroke true]
 
 	glyph-block-export SmallERoundedShape
 	define [SmallERoundedShape] : with-params [df top stroke barpos tailSlab schwaTail] : glyph-proc
@@ -125,7 +125,7 @@ glyph-block Letter-Latin-Lower-E : begin
 			flat (df.rightSB - OX) (top - [df.archDepthB SmallArchDepth])
 			curl (df.rightSB - OX) (0 + [df.archDepthA SmallArchDepth])
 			hookend O (sw -- stroke)
-			g4 (df.leftSB + 0.5 * OX) [HookHeight top stroke true]
+			g4 (df.leftSB + 0.5 * OX) [HookHeightTight top stroke true]
 
 	define [AbkCheShape] : with-params [fDesc Body df top tailSlab] : glyph-proc
 		local gap : (df.width - 2 * df.leftSB - 2.5 * df.mvs) * 0.375 - [HSwToV : 0.25 * df.mvs]


### PR DESCRIPTION
Basically, because they all bypass the swash code (including incidentally reversed e, even before the schwa serif code, simply due to having to redraw it mirrored), they shouldn't need to correct the tail metrics externally because they just end up hypercorrecting for nothing, causing it to curl too far inward, which may be problematic in the upper extremes.

Additionally, my `suppressSwash` parameter is renamed to `noSwash` for brevity.

Also, since Reversed e would now assume upright/oblique hook metrics all the time (because the hook being on the left means it can't have a swash), it shouldn't need to call the entire `xTerminalR` function in its entirety, especially since it has to add code to account for it being on the left side. Replacing it with an exact expression means `SmallESerifedTerminalShape` would be the only place left that calls the function earnestly, so I just combined `xTerminalR` into into that function inline for simplicity, including an extra `&& !schwaTail` clause that goes with `noSwash`, which Reversed e would just send `true` to at all times if it were still a function.

```
ЭƏЗэəз
Cce Ↄↄɘ Ɔɔǝ
```
sans upright (for comparison; effectively unchanged):
![image](https://github.com/be5invis/Iosevka/assets/37010132/f3f88afd-1b0a-4446-9343-368988b3f717)
sans italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/b7cadd8b-93ec-4c8c-af8f-c7477fab8149)
slab upright (effectively unchanged):
![image](https://github.com/be5invis/Iosevka/assets/37010132/2f8831a5-962a-4b49-a560-ef397f36eddf)
slab italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/652f54a4-50ae-4846-84e5-67960672fb0b)
