### PR TITLE
Fix bar position of En part of Cyrillic Nje.

### DIFF
--- a/changes/29.2.2.md
+++ b/changes/29.2.2.md
@@ -1,3 +1,4 @@
 * Refine shape of CYRILLIC CAPITAL LETTER SHHA (`U+04BA`).
+* Fix H bar position of CYRILLIC {CAPITAL|SMALL} LETTER NJE (`U+040A`, `U+045A`).
 * Add characters:
   - KEYBOARD (`U+2328`).

--- a/packages/font-glyphs/src/letter/cyrillic/nje.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/nje.ptl
@@ -21,7 +21,7 @@ glyph-block Letter-Cyrillic-Nje : begin
 	define [LeftHalf slabType df top] : glyph-proc
 		local dfSub : df.slice 3 2
 		include : VBar.l dfSub.leftSB 0 top dfSub.mvs
-		include : HBar.m dfSub.leftSB dfSub.rightSB (top / 2)
+		include : HBar.m dfSub.leftSB dfSub.rightSB (top * HBarPos)
 
 		local sf : SerifFrame.fromDf dfSub top 0
 		include : match slabType


### PR DESCRIPTION
`НЊнњ`
before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/06a72a01-f49d-41bf-846a-f036fe592762)
after:
![image](https://github.com/be5invis/Iosevka/assets/37010132/0a70c881-4fad-4dcb-80e8-af5e8a7bf066)
