### PR TITLE
Finish work started by #2310 including important fixes.

### DIFF
--- a/changes/30.0.0.md
+++ b/changes/30.0.0.md
@@ -1,4 +1,4 @@
-* \[**Breaking**\] A separate variant selector, `ij-dot`, was added to allow users to configure the shape of the dots in `i` and `j` separately.
+* \[**Breaking**\] A separate variant selector, `tittle`, was added to allow users to configure the shape of the dots in `i` and `j` separately.
   - As a result, feature tags for `cv95` ... `cv99`, `VSAA` ... `VSAQ` are shifted by one place to `cv96` ... `cv99` `VSAA`, `VSAB` ... `VSAR`.
 * Refine shape of CYRILLIC CAPITAL LETTER SHHA (`U+04BA`).
 * Fix H bar position of CYRILLIC {CAPITAL|SMALL} LETTER NJE (`U+040A`, `U+045A`).

--- a/packages/font-glyphs/src/letter/latin/lower-il.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-il.ptl
@@ -301,10 +301,12 @@ glyph-block Letter-Latin-Lower-I : begin
 		select-variant 'dotlessiRetroflexHook' (follow -- 'dotlessi')
 		CreateOgonekComposition 'iOgonek.dotless' null 'dotlessi'
 
-		CreateAccentedComposition 'i' 'i' 'dotlessi' 'dotAboveIJ'
-		CreateAccentedComposition 'i/sansSerif' null 'dotlessi/sansSerif' 'dotAboveIJ'
-		CreateAccentedComposition 'i/compLigRight' null 'dotlessi/compLigRight' 'dotAboveIJ'
+		CreateAccentedComposition 'i' 'i' 'dotlessi' 'tittleAbove'
+		CreateAccentedComposition 'i/sansSerif' null 'dotlessi/sansSerif' 'tittleAbove'
+		CreateAccentedComposition 'i/compLigRight' null 'dotlessi/compLigRight' 'tittleAbove'
 		link-reduced-variant 'i/sansSerif' 'i' MathSansSerif
+
+		CreateAccentedComposition 'i.TRK' null 'dotlessi' 'dotAbove'
 
 		alias 'cyrl/iUkrainian' 0x456 'i'
 		CreateAccentedComposition 'cyrl/yi' 0x457 'dotlessi' 'dieresisAbove'
@@ -324,9 +326,9 @@ glyph-block Letter-Latin-Lower-I : begin
 		CreateAccentedComposition      'cyrl/ghe.SRB' null 'dotlessi/tailed'   'macronAbove'
 		CreateMultiAccentedComposition 'cyrl/gje.SRB' null 'dotlessi/tailed' { 'macronAbove' 'acuteAbove' }
 		CreateAccentedComposition 'dotlessiBarOver' null 'dotlessi' 'barOver'
-		CreateAccentedComposition 'iBarOver' 0x268 'dotlessiBarOver' 'dotAbove'
-		CreateAccentedComposition 'iOgonek' 0x12F 'iOgonek.dotless' 'dotAbove'
-		CreateAccentedComposition 'iRetroflexHook' 0x1D96 'dotlessiRetroflexHook' 'dotAbove'
+		CreateAccentedComposition 'iBarOver' 0x268 'dotlessiBarOver' 'tittleAbove'
+		CreateAccentedComposition 'iOgonek' 0x12F 'iOgonek.dotless' 'tittleAbove'
+		CreateAccentedComposition 'iRetroflexHook' 0x1D96 'dotlessiRetroflexHook' 'tittleAbove'
 
 	do "l glyphs"
 		select-variant 'l' 'l'

--- a/packages/font-glyphs/src/letter/latin/lower-j.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-j.ptl
@@ -115,14 +115,18 @@ glyph-block Letter-Latin-Lower-J : begin
 			include : TopHook.mBarOuter xMiddle (XH + O) XH
 
 	select-variant 'dotlessj' 0x237
-	select-variant 'dotlessjBar' 0x25F (follow -- 'dotlessj')
-	select-variant 'dotlessjBarHookTop' 0x284 (follow -- 'dotlessj/sansSerif')
+
 	link-reduced-variant 'dotlessj/sansSerif' 'dotlessj' MathSansSerif
-	CreateAccentedComposition 'j'           'j'   'dotlessj'           'dotAboveIJ'
-	CreateAccentedComposition 'j/sansSerif' null  'dotlessj/sansSerif' 'dotAboveIJ'
-	CreateAccentedComposition 'grek/yot'    0x3F3 'dotlessj'           'dotAbove'
-	CreateAccentedComposition 'cyrl/je'     0x458 'dotlessj'           'dotAbove'
+	CreateAccentedComposition 'j'           'j'   'dotlessj'           'tittleAbove'
+	CreateAccentedComposition 'j/sansSerif' null  'dotlessj/sansSerif' 'tittleAbove'
 	link-reduced-variant 'j/sansSerif' 'j' MathSansSerif
+
+	select-variant 'dotlessjBar'        0x25F (follow -- 'dotlessj')
+	select-variant 'dotlessjBarHookTop' 0x284 (follow -- 'dotlessj/sansSerif')
+	CreateAccentedComposition 'jBar'    0x249 'dotlessjBar' 'tittleAbove'
+
+	alias 'grek/yot' 0x3F3 'j'
+	alias 'cyrl/je'  0x458 'j'
 
 	create-glyph 'dotlessjCurlyTail.serifless' : glyph-proc
 		include : MarkSet.p
@@ -143,7 +147,7 @@ glyph-block Letter-Latin-Lower-J : begin
 		include : HSerif.lt (Middle + JBalance) XH LongJut
 
 	select-variant 'dotlessjCurlyTail'
-	CreateAccentedComposition 'jCurlyTail' 0x29D 'dotlessjCurlyTail' 'dotAbove'
+	CreateAccentedComposition 'jCurlyTail' 0x29D 'dotlessjCurlyTail' 'tittleAbove'
 
 	create-glyph 'mathbb/dotlessj' : glyph-proc
 		include : MarkSet.p

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -23,7 +23,7 @@ glyph-block Letter-Shared : begin
 				currentGlyph.includeMarkWithLeaningSupport gAccent LeaningAnchorMap
 
 			if (!gr) : begin
-				if (gnAccents.length === 1 && gnAccents.0 === 'dotAbove')
+				if (gnAccents.length === 1 && gnAccents.0 === 'tittleAbove')
 				: then : Dotless.set currentGlyph gnBase
 				: else : CvDecompose.set currentGlyph { gnSrc :: gnAccents }
 

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -108,7 +108,7 @@ glyph-block Mark-Above : begin
 	select-variant 'tripleDotAbove'      0x1AB4 (follow -- 'diacriticDot')
 	select-variant 'elipsisAbove'        0x20DB (follow -- 'diacriticDot')
 	select-variant 'fourDotsAbove'       0x20DC (follow -- 'diacriticDot')
-	select-variant 'dotAboveIJ' (shapeFrom -- "dotAbove") (follow -- 'ijDot')
+	select-variant 'tittleAbove' (shapeFrom -- "dotAbove") (follow -- 'tittle')
 
 	glyph-block-export RingDims RingShape
 	define [RingDims _radiusOut] : begin

--- a/packages/font-glyphs/src/meta/unicode-knowledge.ptl
+++ b/packages/font-glyphs/src/meta/unicode-knowledge.ptl
@@ -121,7 +121,6 @@ export : define decompOverrides : object
 	0x246  { 'E' 'longSlash' }
 	0x247  { 'e' 'shortSlash' }
 	0x248  { 'J' 'barOver' }
-	0x249  { 'j' 'barOver' }
 	0x24D  { 'r' 'barOver' }
 	0x24F  { 'y' 'hStrike' }
 

--- a/packages/font-otl/src/gsub-locl.ptl
+++ b/packages/font-otl/src/gsub-locl.ptl
@@ -14,6 +14,8 @@ export : define [buildLOCL gsub para glyphStore] : begin
 	define cyrlMKD  : gsub.copyLanguage 'cyrl_MKD ' 'cyrl_DFLT'
 	define cyrlBOS  : gsub.copyLanguage 'cyrl_BOS ' 'cyrl_DFLT'
 	define cyrlBGR  : gsub.copyLanguage 'cyrl_BGR ' 'cyrl_DFLT'
+	define latnTRK  : gsub.copyLanguage 'latn_TRK ' 'latn_DFLT'
+	define latnAZE  : gsub.copyLanguage 'latn_AZE ' 'latn_DFLT'
 	define latnVIT  : gsub.copyLanguage 'latn_VIT ' 'latn_DFLT'
 	define grekIPPH : gsub.copyLanguage 'grek_IPPH ' 'grek_DFLT'
 	define grekAPPH : gsub.copyLanguage 'grek_APPH ' 'grek_DFLT'
@@ -29,6 +31,15 @@ export : define [buildLOCL gsub para glyphStore] : begin
 	# BGR
 	define loclBGR : cyrlBGR.addFeature : gsub.createFeature 'locl'
 	loclBGR.addLookup : createGsubLookupFromGr gsub glyphStore LocalizedForm.BGR
+
+	# TRK
+	define loclTRK : gsub.createFeature 'locl'
+	latnTRK.addFeature loclTRK
+	latnAZE.addFeature loclTRK
+	loclTRK.addLookup : gsub.createLookup
+		.type 'gsub_single'
+		.substitutions : object
+			'i' : glyphStore.ensureExists 'i.TRK'
 
 	# VIT
 	define loclVIT : latnVIT.addFeature : gsub.createFeature 'locl'

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -6784,21 +6784,21 @@ selector.nine = "straightBar"
 
 
 
-[prime.ij-dot]
+[prime.tittle]
 sampler = "ij "
 hotChars = "ij"
 samplerExplain = "Dots in letters “i” and “j” in particular (not including dots in other letters, even if they are similar)"
 tagKind = "dot"
 
-[prime.ij-dot.variants.round]
+[prime.tittle.variants.round]
 rank = 1
-description = "Dots and Commas in i/j are round"
-selector.ijDot = "round"
+description = "Dots in i/j are round"
+selector.tittle = "round"
 
-[prime.ij-dot.variants.square]
+[prime.tittle.variants.square]
 rank = 2
-description = "Dots and Commas in i/j are square"
-selector.ijDot = "square"
+description = "Dots in i/j are square"
+selector.tittle = "square"
 
 
 
@@ -7750,7 +7750,7 @@ seven = "straight-serifless"
 eight = "crossing"
 nine = "straight-bar"
 # Dots
-ij-dot = "round"
+tittle = "round"
 punctuation-dot = "round"
 diacritic-dot = "round"
 # Symbols
@@ -8062,7 +8062,7 @@ six = "closed-contour"
 seven = "bend-serifed"
 eight = "two-circles"
 nine = "closed-contour"
-ij-dot = "square"
+tittle = "square"
 punctuation-dot = "square"
 diacritic-dot = "square"
 asterisk = "hex-low"
@@ -8249,7 +8249,7 @@ four = "closed-serifless"
 six = "closed-contour"
 eight = "two-circles"
 nine = "closed-contour"
-ij-dot = "square"
+tittle = "square"
 punctuation-dot = "square"
 diacritic-dot = "square"
 asterisk = "hex-low"
@@ -8427,7 +8427,7 @@ six = "closed-contour"
 seven = "bend-serifless"
 eight = "two-circles"
 nine = "closed-contour"
-ij-dot = "square"
+tittle = "square"
 punctuation-dot = "square"
 diacritic-dot = "square"
 brace = "straight"
@@ -8811,6 +8811,7 @@ lower-tau = "flat-tailed"
 one = "base-flat-top-serif"
 four = "closed-serifless"
 eight = "two-circles"
+tittle = "square"
 underscore = "low"
 guillemet = "straight"
 dollar = "through-cap"
@@ -9039,7 +9040,7 @@ six = "closed-contour"
 seven = "bend-serifless"
 eight = "crossing-asymmetric"
 nine = "closed-contour"
-ij-dot = "square"
+tittle = "square"
 punctuation-dot = "square"
 diacritic-dot = "square"
 paren = "large-contour"
@@ -9449,7 +9450,7 @@ five = "oblique-arched-serifless"
 six = "closed-contour"
 seven = "straight-serifed"
 nine = "closed-contour"
-ij-dot = "square"
+tittle = "square"
 punctuation-dot = "square"
 diacritic-dot = "square"
 asterisk = "hex-low"

--- a/tools/generate-samples/src/templates/languages.mjs
+++ b/tools/generate-samples/src/templates/languages.mjs
@@ -4,7 +4,7 @@ import * as themes from "../themes/index.mjs";
 const languages = [
     { lang: 'English', sample: 'Shaw, those twelve beige hooks are joined if I patch a young, gooey mouth.' },
     { lang: 'IPA', sample: '[ɢʷɯʔ.nas.doːŋ.kʰlja] [ŋan.ȵʑi̯wo.ɕi̯uĕn.ɣwa]', localeId :'en-fonipa' },
-    { lang: 'Azerbaijani', sample: 'Zəfər, jaketini də papağını da götür, bu axşam hava çox soyuq olacaq.' },
+    { lang: 'Azerbaijani', sample: 'Zəfər, jaketini də papağını da götür, bu axşam hava çox soyuq olacaq.', localeId :'az' },
     { lang: 'Belarusian', sample: 'У Іўі худы жвавы чорт у зялёнай камізэльцы пабег пад’есці фаршу з юшкай.' },
     { lang: 'Bulgarian', sample: 'Я, пазачът Вальо уж бди, а скришом хапва кюфтенца зад щайгите.', localeId :'bg' },
     { lang: 'Catalan', sample: '«Dóna amor que seràs feliç!». Això, iŀlús company geniüt, ja és un lluït rètol blavís d’onze kWh.' },
@@ -35,7 +35,7 @@ const languages = [
     { lang: 'Slovak', sample: 'Kŕdeľ šťastných ďatľov učí pri ústí Váhu mĺkveho koňa obhrýzať kôru a žrať čerstvé mäso.' },
     { lang: 'Spanish', sample: 'Benjamín pidió una bebida de kiwi y fresa; Noé, sin vergüenza, la más exquisita champaña del menú.' },
     { lang: 'Swedish', sample: 'Yxmördaren Julia Blomqvist på fäktning i Schweiz.' },
-    { lang: 'Turkish', sample: 'Pijamalı hasta yağız şoföre çabucak güvendi.' },
+    { lang: 'Turkish', sample: 'Pijamalı hasta yağız şoföre çabucak güvendi.', localeId :'tr' },
     { lang: 'Ukrainian', sample: 'Чуєш їх, доцю, га? Кумедна ж ти, прощайся без ґольфів!' },
     { lang: 'Vietnamese', sample: 'Do bạch kim rất quý nên sẽ dùng để lắp vô xương.', localeId :'vi' },
     { lang: 'Volapük', sample: 'Ꞝrꞛtom jofazaris hodagudik ꞟf binoy ve cꞛl ad xilapel.' },


### PR DESCRIPTION
* Fix soft dotting of all `i`/`j`-derived characters.
* Use a better name for the tittle variant selector.
* Finish tittle composition for the rest of the `i`/`j`-derived letters.
* Make `ss10` use square tittle.
* Add Turkish/Azerbaijani locales which use original diacritical dot behavior for `i` in particular.

```
<span style="font-family:'Iosevka Custom';font-feature-settings:'ss10';">
<p lang="tr">
Pijamalı hasta yağız şoföre çabucak güvendi.
</p>
<p lang="az">
Zəfər, jaketini də papağını da götür, bu axşam hava çox soyuq olacaq.
</p>
</span>
```
![image](https://github.com/be5invis/Iosevka/assets/37010132/1e03b069-d857-40e4-8a0e-a8945e221771)
