### PR TITLE
Cleanup of #2306 .

### DIFF
--- a/packages/font-glyphs/src/symbol/pictograph.ptl
+++ b/packages/font-glyphs/src/symbol/pictograph.ptl
@@ -15,6 +15,7 @@ export : define [apply] : begin
 	run-glyph-module "./pictograph/heart.mjs"
 	run-glyph-module "./pictograph/i-ching.mjs"
 	run-glyph-module "./pictograph/iec-power-and-playback.mjs"
+	run-glyph-module "./pictograph/keyboard.mjs"
 	run-glyph-module "./pictograph/kome.mjs"
 	run-glyph-module "./pictograph/metric-marks.mjs"
 	run-glyph-module "./pictograph/musical.mjs"
@@ -24,4 +25,3 @@ export : define [apply] : begin
 	run-glyph-module "./pictograph/stick-figure.mjs"
 	run-glyph-module "./pictograph/suit.mjs"
 	run-glyph-module "./pictograph/telephone-recorder.mjs"
-	run-glyph-module "./pictograph/keyboard.mjs"

--- a/packages/font-glyphs/src/symbol/pictograph/keyboard.ptl
+++ b/packages/font-glyphs/src/symbol/pictograph/keyboard.ptl
@@ -1,27 +1,25 @@
 $$include '../../meta/macros.ptl'
 
 import [mix linreg clamp fallback] from "@iosevka/util"
-import [Box] from "@iosevka/geometry/box"
 
 glyph-module
 
 glyph-block Symbol-Pictograph-Keyboard : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim GeometricSizes 
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim
 
 	glyph-block-export KeyGen
-	define [KeyGen top bot left right nRows nCols sw keys] : glyph-proc
+	define [KeyGen top bot left right nCols nRows sw keys] : glyph-proc
 		foreach {yp xp1 xp2} [items-of keys] : begin
 			include : HBar.m
-				mix left right (xp1 / nRows)
-				mix left right (xp2 / nRows)
-				mix (bot + sw) (top - sw) ((yp + 0.5) / nCols)
+				mix left right (xp1 / nCols)
+				mix left right (xp2 / nCols)
+				mix (bot + sw) (top - sw) ((yp + 0.5) / nRows)
 				* sw
 
 	for-width-kinds WideWidth1
 		define Geom : GeometricDim MosaicUnitWidth MosaicWidth
-		define Size : GeometricSizes Geom
 
 		do "Keyboard"
 			define [KeyboardShape top bot left right sw] : glyph-proc


### PR DESCRIPTION
Drop unused imports and also fix labeling of `nCols` and `nRows` parameters for `KeyGen` function (the names were swapped they were still being used as intended, so technically nothing was broken; It was just bothering me).

Functionally, nothing has changed.