### PR TITLE
Add four locales that use dotted/dotless i.

### DIFF
--- a/packages/font-otl/src/gsub-locl.ptl
+++ b/packages/font-otl/src/gsub-locl.ptl
@@ -16,6 +16,10 @@ export : define [buildLOCL gsub para glyphStore] : begin
 	define cyrlBGR  : gsub.copyLanguage 'cyrl_BGR ' 'cyrl_DFLT'
 	define latnTRK  : gsub.copyLanguage 'latn_TRK ' 'latn_DFLT'
 	define latnAZE  : gsub.copyLanguage 'latn_AZE ' 'latn_DFLT'
+	define latnGAG  : gsub.copyLanguage 'latn_GAG ' 'latn_DFLT'
+	define latnKAZ  : gsub.copyLanguage 'latn_KAZ ' 'latn_DFLT'
+	define latnTAT  : gsub.copyLanguage 'latn_TAT ' 'latn_DFLT'
+	define latnCRT  : gsub.copyLanguage 'latn_CRT ' 'latn_DFLT'
 	define latnVIT  : gsub.copyLanguage 'latn_VIT ' 'latn_DFLT'
 	define grekIPPH : gsub.copyLanguage 'grek_IPPH ' 'grek_DFLT'
 	define grekAPPH : gsub.copyLanguage 'grek_APPH ' 'grek_DFLT'
@@ -36,6 +40,10 @@ export : define [buildLOCL gsub para glyphStore] : begin
 	define loclTRK : gsub.createFeature 'locl'
 	latnTRK.addFeature loclTRK
 	latnAZE.addFeature loclTRK
+	latnGAG.addFeature loclTRK
+	latnKAZ.addFeature loclTRK
+	latnTAT.addFeature loclTRK
+	latnCRT.addFeature loclTRK
 	loclTRK.addLookup : gsub.createLookup
 		.type 'gsub_single'
 		.substitutions : object


### PR DESCRIPTION
It is possible that this may actually be exhaustive.
All four of these languages also happen to be Turkic.

The languages are Gagauz, Kazakh&nbsp;(Latin), Tatar, and Crimean&nbsp;Tatar.