### PR TITLE
fix git ignore macos ds store file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ private-build-plans.toml
 .next
 out
 shared/fonts/imports/*/TTF/*
+
+# Platform specified files
+.DS_store


### PR DESCRIPTION
The desktop service store file (`.DS_store`) on macOS will usually been created during the build process. Ignore such file makes the code base tidy.