### PR TITLE
fix git ignore macos ds store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ private-build-plans.toml
 .next
 out
 shared/fonts/imports/*/TTF/*
+
+# Platform specified files
+.DS_store


### PR DESCRIPTION
Once building on macOS, it will usually create `.DS_store` files. Ignore such file will make git repo tidy.