### PR TITLE
Add `semi-chancery-{straight|curly}-serifed` variants for `x`.

### DIFF
--- a/changes/30.0.0.md
+++ b/changes/30.0.0.md
@@ -1,5 +1,8 @@
 * \[**Breaking**\] A separate variant selector, `tittle`, was added to allow users to configure the shape of the dots in `i` and `j` separately.
   - As a result, feature tags for `cv95` ... `cv99`, `VSAA` ... `VSAQ` are shifted by one place to `cv96` ... `cv99` `VSAA`, `VSAB` ... `VSAR`.
+* \[**BREAKING**\] Add `semi-chancery-straight-serifed` and `semi-chancery-curly-serifed` variants for `x` (`cv48`). As a result, variants of `x` are reordered. Change of variant names:
+  - `x`.`semi-chancery-straight` → `x`.`semi-chancery-straight-serifless`
+  - `x`.`semi-chancery-curly` → `x`.`semi-chancery-curly-serifless`
 * Refine shape of CYRILLIC CAPITAL LETTER SHHA (`U+04BA`).
 * Fix H bar position of CYRILLIC {CAPITAL|SMALL} LETTER NJE (`U+040A`, `U+045A`).
 * Fix mapping of LEFT-FACING SNAKE HEAD WITH OPEN MOUTH (`U+1CC70`) ... DOWN-FACING SNAKE HEAD WITH CLOSED MOUTH (`U+1CC77`).

--- a/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
@@ -263,6 +263,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 					local sf : SerifFrame.fromDf df top bot
 					include : match serifShape
 						[Just XSerifs.Full] : composite-proc sf.rt.full sf.rb.full
+						[Just XSerifs.SemiChancery] : composite-proc sf.rt.full
 						[Just XSerifs.BilateralMotion] : composite-proc sf.rb.outer
 						__ : glyph-proc
 
@@ -278,6 +279,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 					local sf : SerifFrame.fromDf df top bot
 					include : match serifShape
 						[Just XSerifs.Full] : composite-proc sf.rt.full sf.lb.full sf.rb.full
+						[Just XSerifs.SemiChancery] : composite-proc sf.rt.full sf.lb.full
 						[Just XSerifs.BilateralMotion] : composite-proc sf.rb.outer
 						__ : glyph-proc
 

--- a/packages/font-glyphs/src/letter/latin/x.ptl
+++ b/packages/font-glyphs/src/letter/latin/x.ptl
@@ -184,6 +184,7 @@ glyph-block Letter-Latin-X : begin
 	glyph-block-export XSerifs
 	define XSerifs : namespace
 		export : define [Full sf] : composite-proc sf.lt.full sf.rt.full sf.lb.full sf.rb.full
+		export : define [SemiChancery sf] : composite-proc sf.rt.full sf.lb.full
 		export : define [Motion sf] : composite-proc sf.lt.outer
 		export : define [BilateralMotion sf] : composite-proc sf.lt.outer sf.rb.outer
 
@@ -192,11 +193,13 @@ glyph-block Letter-Latin-X : begin
 		straightSerifless              { STROKE-STRAIGHT STROKE-STRAIGHT null                    false }
 		curlySerifless                 { STROKE-CURLY    STROKE-CURLY    null                    false }
 		cursive                        { STROKE-CURSIVE  STROKE-CURSIVE  null                    false }
-		semiChanceryStraight           { STROKE-STRAIGHT STROKE-CHANCERY null                    false }
-		semiChanceryCurly              { STROKE-CURLY    STROKE-CHANCERY null                    false }
+		semiChanceryStraightSerifless  { STROKE-STRAIGHT STROKE-CHANCERY null                    false }
+		semiChanceryCurlySerifless     { STROKE-CURLY    STROKE-CHANCERY null                    false }
 		chancery                       { STROKE-CHANCERY STROKE-CHANCERY null                    false }
 		straightSerifed                { STROKE-STRAIGHT STROKE-STRAIGHT XSerifs.Full            true  }
 		curlySerifed                   { STROKE-CURLY    STROKE-CURLY    XSerifs.Full            true  }
+		semiChanceryStraightSerifed    { STROKE-STRAIGHT STROKE-CHANCERY XSerifs.SemiChancery    true  }
+		semiChanceryCurlySerifed       { STROKE-CURLY    STROKE-CHANCERY XSerifs.SemiChancery    true  }
 		straightMotionSerifed          { STROKE-STRAIGHT STROKE-STRAIGHT XSerifs.Motion          false }
 		curlyMotionSerifed             { STROKE-CURLY    STROKE-CURLY    XSerifs.Motion          false }
 		straightBilateralMotionSerifed { STROKE-STRAIGHT STROKE-STRAIGHT XSerifs.BilateralMotion false }

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -4092,7 +4092,6 @@ selectorAffix."cyrl/rha/right" = "cursive"
 
 [prime.x.variants-buildup.stages.body.semi-chancery-straight]
 rank = 4
-next = "END"
 descriptionAffix = "Semi-chancery shape with straight counter-leg"
 selectorAffix.x = "semiChanceryStraight"
 selectorAffix."x/sansSerif" = "semiChanceryStraight"
@@ -4100,7 +4099,6 @@ selectorAffix."cyrl/rha/right" = "semiChanceryStraight"
 
 [prime.x.variants-buildup.stages.body.semi-chancery-curly]
 rank = 5
-next = "END"
 descriptionAffix = "Semi-chancery shape with curly counter-leg"
 selectorAffix.x = "semiChanceryCurly"
 selectorAffix."x/sansSerif" = "semiChanceryCurly"
@@ -4124,6 +4122,7 @@ selectorAffix."cyrl/rha/right" = "serifless"
 
 [prime.x.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
+disableIf = [{body = "semi-chancery-straight"}, {body = "semi-chancery-curly"}]
 descriptionAffix = "motion serifs"
 selectorAffix.x = "motionSerifed"
 selectorAffix."x/sansSerif" = "serifless"
@@ -5145,15 +5144,15 @@ selectorAffix."grek/chi/sansSerif" = "curly"
 rank = 3
 next = "END"
 descriptionAffix = "Semi-chancery shape with straight counter-leg"
-selectorAffix."grek/chi" = "semiChanceryStraight"
-selectorAffix."grek/chi/sansSerif" = "semiChanceryStraight"
+selectorAffix."grek/chi" = "semiChanceryStraightSerifless"
+selectorAffix."grek/chi/sansSerif" = "semiChanceryStraightSerifless"
 
 [prime.lower-chi.variants-buildup.stages.body.semi-chancery-curly]
 rank = 4
 next = "END"
 descriptionAffix = "Semi-chancery shape with curly counter-leg"
-selectorAffix."grek/chi" = "semiChanceryCurly"
-selectorAffix."grek/chi/sansSerif" = "semiChanceryCurly"
+selectorAffix."grek/chi" = "semiChanceryCurlySerifless"
+selectorAffix."grek/chi/sansSerif" = "semiChanceryCurlySerifless"
 
 [prime.lower-chi.variants-buildup.stages.body.chancery]
 rank = 5

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -4082,35 +4082,35 @@ selectorAffix.x = "curly"
 selectorAffix."x/sansSerif" = "curly"
 selectorAffix."cyrl/rha/right" = "curly"
 
-[prime.x.variants-buildup.stages.body.cursive]
-rank = 3
-next = "END"
-descriptionAffix = "cursive shape"
-selectorAffix.x = "cursive"
-selectorAffix."x/sansSerif" = "cursive"
-selectorAffix."cyrl/rha/right" = "cursive"
-
 [prime.x.variants-buildup.stages.body.semi-chancery-straight]
-rank = 4
+rank = 3
 descriptionAffix = "Semi-chancery shape with straight counter-leg"
 selectorAffix.x = "semiChanceryStraight"
 selectorAffix."x/sansSerif" = "semiChanceryStraight"
 selectorAffix."cyrl/rha/right" = "semiChanceryStraight"
 
 [prime.x.variants-buildup.stages.body.semi-chancery-curly]
-rank = 5
+rank = 4
 descriptionAffix = "Semi-chancery shape with curly counter-leg"
 selectorAffix.x = "semiChanceryCurly"
 selectorAffix."x/sansSerif" = "semiChanceryCurly"
 selectorAffix."cyrl/rha/right" = "semiChanceryCurly"
 
 [prime.x.variants-buildup.stages.body.chancery]
-rank = 6
+rank = 5
 next = "END"
 descriptionAffix = "Chancery shape"
 selectorAffix.x = "chancery"
 selectorAffix."x/sansSerif" = "chancery"
 selectorAffix."cyrl/rha/right" = "chancery"
+
+[prime.x.variants-buildup.stages.body.cursive]
+rank = 6
+next = "END"
+descriptionAffix = "cursive shape"
+selectorAffix.x = "cursive"
+selectorAffix."x/sansSerif" = "cursive"
+selectorAffix."cyrl/rha/right" = "cursive"
 
 [prime.x.variants-buildup.stages.serifs.serifless]
 rank = 1


### PR DESCRIPTION
This is a common variant, especially for italics (under serif fonts).
This also renames `x`.`semi-chancery-{straight|curly}` to `x`.`semi-chancery-{straight|curly}-serifless` for consistency.

Greek Chi (`χ`) is unaffected because its serifs would be overrode by the chancery leg(s) anyway.
Its respective `semi-chancery-{straight|curly}` variants' names are unchanged as a result.

All `x` variants:
`x𝗑хԕԗ`
![image](https://github.com/be5invis/Iosevka/assets/37010132/33ff1af8-05f1-41cf-9060-c72b69aff904)
