### PR TITLE
Fix leaning mark anchors for IPA implosive consonants & similar letters.

### DIFF
--- a/changes/30.0.0.md
+++ b/changes/30.0.0.md
@@ -4,6 +4,7 @@
   - `x`.`semi-chancery-straight` → `x`.`semi-chancery-straight-serifless`
   - `x`.`semi-chancery-curly` → `x`.`semi-chancery-curly-serifless`
 * Refine shape of CYRILLIC CAPITAL LETTER SHHA (`U+04BA`).
+* Fix leaning mark anchors for letters with top hooks (`U+0187`, `U+0188`, `U+0193`, `U+0199`, `U+01A5`, `U+01AD`, `U+0253`, `U+0257`, `U+0260`, `U+0266`, `U+0267`, `U+0284`, `U+029B`, `U+0280`, `U+1D91`, `U+1DF09`).
 * Fix H bar position of CYRILLIC {CAPITAL|SMALL} LETTER NJE (`U+040A`, `U+045A`).
 * Fix mapping of LEFT-FACING SNAKE HEAD WITH OPEN MOUTH (`U+1CC70`) ... DOWN-FACING SNAKE HEAD WITH CLOSED MOUTH (`U+1CC77`).
 * Add characters:

--- a/packages/font-glyphs/src/auto-build/transformed.ptl
+++ b/packages/font-glyphs/src/auto-build/transformed.ptl
@@ -263,7 +263,7 @@ glyph-block Autobuild-Transformed : begin
 			list 0x1078F 'epsilonRevClosed'
 			list 0x10791 'ramshorn'
 			list 0x10792 'smcpG'
-			list 0x10793 'gScriptHookTop'
+			list 0x10793 'gHookTop'
 			list 0x10794 'smcpGHookTop'
 			list 0x10795 'hStroke'
 			list 0x10796 'smcpH'
@@ -655,7 +655,7 @@ glyph-block Autobuild-Transformed : begin
 		createReversed : list
 			list 0x1B8   'Ezh'
 			list 0x1B9   'ezh'
-			list 0x2143  'L.serifless'
+			list 0x2143  'L/sansSerif'
 			list 0xA7FB  'F'
 			list 0xA7FC  'P'
 			list 0xA7FD  'turnM'

--- a/packages/font-glyphs/src/letter/latin/c.ptl
+++ b/packages/font-glyphs/src/letter/latin/c.ptl
@@ -8,8 +8,7 @@ glyph-module
 glyph-block Letter-Latin-C : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors ExtendBelowBaseAnchors
-	glyph-block-import Mark-Shared-Metrics : markStroke
+	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors ExtendBelowBaseAnchors LeaningAnchor
 	glyph-block-import Letter-Shared : CreateDependentComposite CreateTurnedLetter
 	glyph-block-import Letter-Shared-Shapes : SerifFrame CurlyTail DToothlessRise
 	glyph-block-import Letter-Shared-Shapes : SerifedArcStart SerifedArcEnd
@@ -167,6 +166,7 @@ glyph-block Letter-Latin-C : begin
 			local lf : CLetterForm [DivFrame 1] sty styBot CAP 0
 			include : union [lf.base] [lf.hookTop] [lf.botSerif]
 			include : ExtendAboveBaseAnchors (CAP + Ascender - XH)
+			include : LeaningAnchor.Above.VBar.r RightSB
 
 		create-glyph "c.\(suffix)" : glyph-proc
 			include : MarkSet.e
@@ -228,6 +228,7 @@ glyph-block Letter-Latin-C : begin
 				adb -- SmallArchDepthB
 			include : union [lf.base] [lf.hookTop] [lf.botSerif]
 			include : ExtendAboveBaseAnchors Ascender
+			include : LeaningAnchor.Above.VBar.r RightSB
 
 		create-glyph "cCurlyTail.\(suffix)" : glyph-proc
 			include : MarkSet.e

--- a/packages/font-glyphs/src/letter/latin/k.ptl
+++ b/packages/font-glyphs/src/letter/latin/k.ptl
@@ -527,6 +527,7 @@ glyph-block Letter-Latin-K : begin
 			include : KHookTopBar xBarLeft
 			if slabLB : include : tagged 'serifLB'
 				HSerif.mb (xBarLeft + [HSwToV HalfStroke]) 0 Jut
+			include : LeaningAnchor.Above.VBar.l xBarLeft
 
 		create-glyph "turnk.\(suffix)" : glyph-proc
 			include : VBar.l xBarLeft 0 Ascender

--- a/packages/font-glyphs/src/letter/latin/lower-b.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-b.ptl
@@ -59,16 +59,21 @@ glyph-block Letter-Latin-Lower-B : begin
 				curl [mix SB RightSB 0.625] (yOverlay + Ascender * 0.05)
 
 		create-glyph "latn/be.\(suffix)" : glyph-proc
-			include [refer-glyph "b.\(suffix)"] AS_BASE ALSO_METRICS
-			include : HBar.t (SB - O) [mix SB RightSB 0.9] Ascender
+			include : MarkSet.b
+			include : Body Ascender
+			local xLeft : SB - O
+			local xRight : mix SB RightSB 0.9
+			include : HBar.t xLeft xRight Ascender
+			include : Serifs
 			if doTS : include : VSerif.dr [mix SB RightSB 0.9] Ascender VJut
+			include : LeaningAnchor.Above.VBar.m [mix xLeft xRight 0.5]
 
-		create-glyph "bHookTop.\(suffix)" : glyph-proc
+		if [not doTS] : create-glyph "bHookTop.\(suffix)" : glyph-proc
 			include : MarkSet.b
 			include : Body XH
 			include : TopHook.lBarInner SB (XH / 2) Ascender
 			include : Serifs
-			eject-contour 'serifLT'
+			include : LeaningAnchor.Above.VBar.l SB
 
 	select-variant 'b'       'b'
 	select-variant 'bStroke' 0x180  (follow -- 'b')

--- a/packages/font-glyphs/src/letter/latin/lower-d.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-d.ptl
@@ -104,21 +104,26 @@ glyph-block Letter-Latin-Lower-D : begin
 
 		create-glyph "latn/de.\(suffix)" : glyph-proc
 			local df : DivFrame 1
-			include [refer-glyph "d.\(suffix)"] AS_BASE ALSO_METRICS
+			include : df.markSet.b
+			include : Body df Ascender
 			local xLeft : mix df.rightSB df.leftSB 0.9
-			include : HBar.t xLeft (df.rightSB + O) Ascender
+			local xRight : df.rightSB + O
+			include : HBar.t xLeft xRight Ascender
 			if topSerif : begin
 				include : VSerif.dl xLeft Ascender : Math.min VJut (0.8 * (Ascender - XH))
 				if [not para.isItalic] : include : HSerif.rt df.rightSB Ascender SideJut
+			if bottomSerif : include : bottomSerif df Ascender
+			include : LeaningAnchor.Above.VBar.m [mix xLeft xRight 0.5]
 
-		create-glyph "dHookTop.\(suffix)" : glyph-proc
+		if [not topSerif] : create-glyph "dHookTop.\(suffix)" : glyph-proc
 			local df : DivFrame 1
 			include : df.markSet.b
 			include : Body df (Ascender - Hook - HalfStroke)
 			include : TopHook.rBarInner df.rightSB (XH / 2) Ascender
 			if bottomSerif : include : bottomSerif df Ascender
+			include : LeaningAnchor.Above.VBar.r df.rightSB
 
-		create-glyph "cyrl/djeKomi.\(suffix)" : glyph-proc
+		if [not bottomSerif] : create-glyph "cyrl/djeKomi.\(suffix)" : glyph-proc
 			local df : DivFrame 1 3
 			include : df.markSet.b
 
@@ -160,10 +165,15 @@ glyph-block Letter-Latin-Lower-D : begin
 		x -- (RightSB + SideJut)
 		y -- 0
 
-	derive-composites 'dHookBottom' 0x256 'd/hookBottomBase'
-		RetroflexHook.rExt RightSB 0
-	derive-composites 'dHookTopBottom' 0x1D91 'dHookTop/hookBottomBase'
-		RetroflexHook.rExt RightSB 0
+	derive-glyphs 'dHookBottom' 0x256 "d/hookBottomBase" : function [src gr] : glyph-proc
+		include [refer-glyph src] AS_BASE ALSO_METRICS
+		include : RetroflexHook.rExt RightSB 0
+		include : LeaningAnchor.Below.VBar.r RightSB
+
+	derive-glyphs 'dHookTopBottom' 0x1D91 "dHookTop/hookBottomBase" : function [src gr] : glyph-proc
+		include [refer-glyph src] AS_BASE ALSO_METRICS
+		include : RetroflexHook.rExt RightSB 0
+		include : LeaningAnchor.Below.VBar.r RightSB
 
 	CreateCommaCaronComposition 'dCaron' 0x10F 'dCaronBase' (Width - [HSwToV : 0.25 * Stroke])
 
@@ -197,6 +207,7 @@ glyph-block Letter-Latin-Lower-D : begin
 				curl m1 (rinner * 2 + fine)
 				CurlyTail fine rinner m1 0 (m1 + rinner * 2 + fine) x2 y2
 			if fSerif : include : HSerif.lt (m1 - [HSwToV Stroke]) Ascender SideJut
+			include : LeaningAnchor.Above.VBar.r m1
 
 	select-variant 'dCurlyTail' 0x221
 

--- a/packages/font-glyphs/src/letter/latin/lower-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-g.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Letter-Latin-Lower-G : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors
+	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors LeaningAnchor
 	glyph-block-import Letter-Shared : CreateTurnedLetter
 	glyph-block-import Letter-Shared-Shapes : OBarLeft OBarRight DToothlessRise DMBlend
 	glyph-block-import Letter-Shared-Shapes : FlatHookDepth CurlyTail PalatalHook TopHook
@@ -183,7 +183,7 @@ glyph-block Letter-Latin-Lower-G : begin
 			include : bodyShape df CAP
 			include : hookShape df (CAP - hookStart)
 
-		create-glyph "gPalatalHook.\(suffix)" : glyph-proc
+		create-glyph "gScriptPalatalHook.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 1
 			include : df.markSet.p
 			set-base-anchor 'overlay' Middle (XH / 2)
@@ -214,17 +214,20 @@ glyph-block Letter-Latin-Lower-G : begin
 	select-variant "gBar" 0x1E5 (follow -- 'g')
 	select-variant 'g/single' null (shapeFrom -- 'g')
 
-	select-variant 'gScript/hookTopBase' null (shapeFrom -- 'g')
+	select-variant 'g/hookTopBase' null (shapeFrom -- 'g')
+
 	select-variant 'gScript' 0x261 (shapeFrom -- 'g') (follow -- 'gScript')
 	select-variant 'GScript' 0xA7AC (follow -- 'gScript')
-	select-variant 'gPalatalHook' 0x1D83 (follow -- 'gScript')
+	select-variant 'gScriptPalatalHook' 0x1D83 (follow -- 'gScript')
 	select-variant 'gScriptCrossedTail' 0xAB36
 
 	alias 'cyrl/de.BGR' null 'g/single'
 	alias 'cyrl/de.SRB' null 'g/single'
 
-	derive-composites 'gScriptHookTop' 0x260 'gScript/hookTopBase'
-		TopHook.rBarOuter RightSB 0 XH
+	derive-glyphs 'gHookTop' 0x260 "g/hookTopBase" : function [src gr] : glyph-proc
+		include [refer-glyph src] AS_BASE ALSO_METRICS
+		include : TopHook.rBarOuter RightSB 0 XH
+		include : LeaningAnchor.Above.VBar.r RightSB
 
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarRight
 	create-glyph 'mathbb/g' 0x1D558 : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/lower-h.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-h.ptl
@@ -50,12 +50,12 @@ glyph-block Letter-Latin-Lower-H : begin
 			straight false
 			tailed   true
 		object # serifs
-			serifless      { false no-shape            }
-			serifed        { true  SmallHSerifs        }
-			motionSerifed  { true  SmallHMotionSerifs  }
-			topLeftSerifed { true  SmallHTopLeftSerifs }
+			serifless      { no-shape            false }
+			serifed        { SmallHSerifs        true  }
+			motionSerifed  { SmallHMotionSerifs  true  }
+			topLeftSerifed { SmallHTopLeftSerifs true  }
 
-	foreach { suffix { fTailed {fHasTopSerif Serifs} } } [Object.entries HConfig] : do
+	foreach { suffix { fTailed {Serifs fHasTopSerif} } } [Object.entries HConfig] : do
 		create-glyph "h.\(suffix)" : glyph-proc
 			include : MarkSet.b
 			include : LeaningAnchor.Above.VBar.l SB
@@ -73,6 +73,7 @@ glyph-block Letter-Latin-Lower-H : begin
 
 		create-glyph "hHookTop.\(suffix)" : glyph-proc
 			include : MarkSet.b
+			include : LeaningAnchor.Above.VBar.l SB
 			include : TopHook.lBarInner SB 0 Ascender
 			include : nShoulder
 				left -- (SB + [HSwToV Stroke])
@@ -81,21 +82,32 @@ glyph-block Letter-Latin-Lower-H : begin
 			if fTailed : include : RightwardTailedBar RightSB 0 (XH - SmallArchDepthB)
 			include : Serifs fTailed true
 
-		create-glyph "hengHookTop.\(suffix)" : glyph-proc
-			include : MarkSet.bp
-			include : refer-glyph "hHookTop.\(suffix)"
-			eject-contour 'serifRB'
-			include : EngHook RightSB 0 Descender
+		if [not fTailed] : begin
+			create-glyph "heng.\(suffix)" : glyph-proc
+				include : MarkSet.bp
+				include : LeaningAnchor.Above.VBar.l SB
+				include : VBar.l SB 0 Ascender
+				include : nShoulder
+					left -- (SB + [HSwToV Stroke])
+					right -- RightSB
+					bottom -- 0
+				include : Serifs true false
+				include : EngHook RightSB 0 Descender
 
-		create-glyph "heng.\(suffix)" : glyph-proc
-			include : MarkSet.bp
-			include : refer-glyph "h.\(suffix)"
-			eject-contour 'serifRB'
-			include : EngHook RightSB 0 Descender
+			create-glyph "hengStroke.\(suffix)" : glyph-proc
+				include [refer-glyph "heng.\(suffix)"] AS_BASE ALSO_METRICS
+				include : HBar.mOverlay fHasTopSerif
 
-		create-glyph "hengStroke.\(suffix)" : glyph-proc
-			include [refer-glyph "heng.\(suffix)"] AS_BASE ALSO_METRICS
-			include : HBar.mOverlay fHasTopSerif
+			create-glyph "hengHookTop.\(suffix)" : glyph-proc
+				include : MarkSet.bp
+				include : LeaningAnchor.Above.VBar.l SB
+				include : TopHook.lBarInner SB 0 Ascender
+				include : nShoulder
+					left -- (SB + [HSwToV Stroke])
+					right -- RightSB
+					bottom -- 0
+				include : Serifs true true
+				include : EngHook RightSB 0 Descender
 
 	select-variant 'h' 'h'
 	link-reduced-variant 'h/descBase' 'h'
@@ -104,9 +116,10 @@ glyph-block Letter-Latin-Lower-H : begin
 	select-variant 'hStroke' 0x127 (follow -- 'h')
 
 	select-variant 'hHookTop' 0x266
-	select-variant 'hengHookTop' 0x267
+
 	select-variant 'heng' 0xA727
 	select-variant 'cyrl/dje' 0x452 (follow -- 'heng') (shapeFrom -- 'hengStroke')
+	select-variant 'hengHookTop' 0x267
 
 	alias 'cyrl/shha' 0x4BB 'h'
 	alias 'cyrl/tshe' 0x45B 'hStroke'

--- a/packages/font-glyphs/src/letter/latin/lower-p.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-p.ptl
@@ -143,6 +143,7 @@ glyph-block Letter-Latin-Lower-P : begin
 		eject-contour 'serifLT'
 		eject-contour 'stemLeft'
 		include : TopHook.lBarOuter SB Descender XH
+		include : LeaningAnchor.Above.VBar.l SB
 
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarLeft
 	create-glyph 'mathbb/p' 0x1D561 : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/lower-q.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-q.ptl
@@ -88,12 +88,14 @@ glyph-block Letter-Latin-Lower-Q : begin
 			include : Body terminal CAP 0
 			include : RetroflexHook.rExt RightSB 0
 			if sRT : include : sRT CAP
+			include : LeaningAnchor.Below.VBar.r RightSB
 
 		create-glyph "qRTail.\(suffix)" : glyph-proc
 			include : MarkSet.p
 			include : Body terminal XH 0
 			include : RetroflexHook.rExt RightSB 0
 			if sRT : include : sRT XH
+			include : LeaningAnchor.Below.VBar.r RightSB
 
 	select-variant 'q' 'q'
 	link-reduced-variant 'q/sansSerif' 'q' MathSansSerif
@@ -106,6 +108,7 @@ glyph-block Letter-Latin-Lower-Q : begin
 		include [refer-glyph src] AS_BASE ALSO_METRICS
 		include : VBar.r RightSB 0 XH
 		include : TopHook.rBarOuter RightSB 0 XH
+		include : LeaningAnchor.Above.VBar.r RightSB
 
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarRight
 	create-glyph 'mathbb/q' 0x1D562 : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/upper-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-g.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Letter-Latin-Upper-G : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors
+	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors LeaningAnchor
 	glyph-block-import Letter-Shared : CreateTurnedLetter
 	glyph-block-import Letter-Shared-Shapes : DToothlessRise ShoulderMidKnotLhs
 	glyph-block-import Letter-Shared-Shapes : SerifedArcStart TopHook
@@ -98,6 +98,7 @@ glyph-block Letter-Latin-Upper-G : begin
 			include : GShape shape SLAB-HOOK-TOP crossBarShape CAP ArchDepthA ArchDepthB
 			include : TopHook.arcStart RightSB CAP Hook
 			include : ExtendAboveBaseAnchors (CAP + Ascender - XH)
+			include : LeaningAnchor.Above.VBar.r RightSB
 		create-glyph "smcpG.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : GShape shape slabType crossBarShape XH ArchDepthA ArchDepthB
@@ -106,6 +107,7 @@ glyph-block Letter-Latin-Upper-G : begin
 			include : GShape shape SLAB-HOOK-TOP crossBarShape XH ArchDepthA ArchDepthB
 			include : TopHook.arcStart RightSB XH Hook
 			include : ExtendAboveBaseAnchors Ascender
+			include : LeaningAnchor.Above.VBar.r RightSB
 
 	select-variant 'G' 'G'
 	link-reduced-variant 'G/sansSerif' 'G' MathSansSerif

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2139,8 +2139,8 @@ rank = 1
 descriptionAffix = "double-storey shape"
 selectorAffix.g = ""
 selectorAffix."g/sansSerif" = ""
+selectorAffix."g/hookTopBase" = ""
 selectorAffix."gScript" = ""
-selectorAffix."gScript/hookTopBase" = ""
 selectorAffix."gScriptCrossedTail" = ""
 selectorAffix."g/single" = ""
 
@@ -2152,8 +2152,8 @@ rank = 1
 keyAffix = ""
 selectorAffix.g = "doubleStorey"
 selectorAffix."g/sansSerif" = "doubleStorey"
+selectorAffix."g/hookTopBase" = "singleStoreySerifless"
 selectorAffix."gScript" = "singleStoreyScriptCut"
-selectorAffix."gScript/hookTopBase" = "singleStoreySerifless"
 selectorAffix."gScriptCrossedTail" = "singleStoreyScriptCut"
 selectorAffix."g/single" = "singleStoreyAutoSerifed"
 
@@ -2162,8 +2162,8 @@ rank = 1
 descriptionAffix = "open contour"
 selectorAffix.g = "openDoubleStorey"
 selectorAffix."g/sansSerif" = "openDoubleStorey"
+selectorAffix."g/hookTopBase" = "singleStoreySerifless"
 selectorAffix."gScript" = "singleStoreyScriptCut"
-selectorAffix."gScript/hookTopBase" = "singleStoreySerifless"
 selectorAffix."gScriptCrossedTail" = "singleStoreyScriptCut"
 selectorAffix."g/single" = "singleStoreyAutoSerifed"
 
@@ -2173,8 +2173,8 @@ rank = 2
 descriptionAffix = "single-storey shape"
 selectorAffix.g = "singleStorey"
 selectorAffix."g/sansSerif" = "singleStorey"
+selectorAffix."g/hookTopBase" = "singleStorey"
 selectorAffix."gScript" = "singleStorey"
-selectorAffix."gScript/hookTopBase" = "singleStorey"
 selectorAffix."gScriptCrossedTail" = "singleStorey"
 selectorAffix."g/single" = "singleStorey"
 
@@ -2186,8 +2186,8 @@ rank = 1
 keyAffix = ""
 selectorAffix.g = ""
 selectorAffix."g/sansSerif" = ""
+selectorAffix."g/hookTopBase" = ""
 selectorAffix."gScript" = ""
-selectorAffix."gScript/hookTopBase" = ""
 selectorAffix."gScriptCrossedTail" = ""
 selectorAffix."g/single" = ""
 
@@ -2196,8 +2196,8 @@ rank = 2
 descriptionAffix = "flat bottom hook"
 selectorAffix.g = "flatHook"
 selectorAffix."g/sansSerif" = "flatHook"
+selectorAffix."g/hookTopBase" = "flatHook"
 selectorAffix."gScript" = "flatHook"
-selectorAffix."gScript/hookTopBase" = "flatHook"
 selectorAffix."gScriptCrossedTail" = ""
 selectorAffix."g/single" = "flatHook"
 
@@ -2205,8 +2205,8 @@ selectorAffix."g/single" = "flatHook"
 rank = 1
 selectorAffix.g = "serifless"
 selectorAffix."g/sansSerif" = "serifless"
+selectorAffix."g/hookTopBase" = "serifless"
 selectorAffix."gScript" = "scriptCut"
-selectorAffix."gScript/hookTopBase" = "serifless"
 selectorAffix."gScriptCrossedTail" = "scriptCut"
 selectorAffix."g/single" = "serifless"
 
@@ -2215,8 +2215,8 @@ rank = 2
 descriptionAffix = "top-right serif"
 selectorAffix.g = "serifed"
 selectorAffix."g/sansSerif" = "serifless"
+selectorAffix."g/hookTopBase" = "serifless"
 selectorAffix."gScript" = "scriptCut"
-selectorAffix."gScript/hookTopBase" = "serifless"
 selectorAffix."gScriptCrossedTail" = "scriptCut"
 selectorAffix."g/single" = "serifed"
 
@@ -2225,8 +2225,8 @@ rank = 3
 descriptionAffix = "earless (cornered top-right)"
 selectorAffix.g = "earlessCorner"
 selectorAffix."g/sansSerif" = "earlessCorner"
+selectorAffix."g/hookTopBase" = "earlessCornerHTB"
 selectorAffix."gScript" = "scriptCut"
-selectorAffix."gScript/hookTopBase" = "earlessCornerHTB"
 selectorAffix."gScriptCrossedTail" = "scriptCut"
 selectorAffix."g/single" = "earlessCorner"
 
@@ -2235,8 +2235,8 @@ rank = 4
 descriptionAffix = "earless (rounded top-right)"
 selectorAffix.g = "earlessRounded"
 selectorAffix."g/sansSerif" = "earlessRounded"
+selectorAffix."g/hookTopBase" = "serifless"
 selectorAffix."gScript" = "scriptCut"
-selectorAffix."gScript/hookTopBase" = "serifless"
 selectorAffix."gScriptCrossedTail" = "scriptCut"
 selectorAffix."g/single" = "earlessRounded"
 
@@ -2257,63 +2257,63 @@ next = "serifs"
 rank = 1
 descriptionAffix = "straight terminal"
 selectorAffix.h = "straight"
-selectorAffix."h/descBase" = "straight"
 selectorAffix."h/sansSerif" = "straight"
+selectorAffix."h/descBase" = "straight"
 selectorAffix.hHookTop = "straight"
-selectorAffix.hengHookTop = "straight"
 selectorAffix.heng = "straight"
+selectorAffix.hengHookTop = "straight"
 
 [prime.h.variants-buildup.stages.tail.tailed]
 rank = 2
 descriptionAffix = "curly tailed terminal"
 selectorAffix.h = "tailed"
-selectorAffix."h/descBase" = "straight"
 selectorAffix."h/sansSerif" = "tailed"
+selectorAffix."h/descBase" = "straight"
 selectorAffix.hHookTop = "tailed"
-selectorAffix.hengHookTop = "straight"
 selectorAffix.heng = "straight"
+selectorAffix.hengHookTop = "straight"
 
 [prime.h.variants-buildup.stages.serifs.serifless]
 rank = 1
 descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix.h = "serifless"
-selectorAffix."h/descBase" = "serifless"
 selectorAffix."h/sansSerif" = "serifless"
+selectorAffix."h/descBase" = "serifless"
 selectorAffix.hHookTop = "serifless"
-selectorAffix.hengHookTop = "serifless"
 selectorAffix.heng = "serifless"
+selectorAffix.hengHookTop = "serifless"
 
 [prime.h.variants-buildup.stages.serifs.top-left-serifed]
 rank = 2
 disableIf = [{ tail = "NOT straight" }]
 descriptionAffix = "serif at top left"
 selectorAffix.h = "topLeftSerifed"
-selectorAffix."h/descBase" = "topLeftSerifed"
 selectorAffix."h/sansSerif" = "serifless"
+selectorAffix."h/descBase" = "topLeftSerifed"
 selectorAffix.hHookTop = "serifless"
-selectorAffix.hengHookTop = "serifless"
 selectorAffix.heng = "topLeftSerifed"
+selectorAffix.hengHookTop = "serifless"
 
 [prime.h.variants-buildup.stages.serifs.motion-serifed]
 rank = 3
 descriptionAffix = "serifs at top left and bottom right"
 selectorAffix.h = "motionSerifed"
-selectorAffix."h/descBase" = "topLeftSerifed"
 selectorAffix."h/sansSerif" = "serifless"
+selectorAffix."h/descBase" = "topLeftSerifed"
 selectorAffix.hHookTop = { if = [{ tail = "straight" }], then = "motionSerifed", else = "serifless" }
-selectorAffix.hengHookTop = "serifless"
 selectorAffix.heng = "topLeftSerifed"
+selectorAffix.hengHookTop = "serifless"
 
 [prime.h.variants-buildup.stages.serifs.serifed]
 rank = 4
 descriptionAffix = "serifs"
 selectorAffix.h = "serifed"
-selectorAffix."h/descBase" = "serifed"
 selectorAffix."h/sansSerif" = "serifless"
+selectorAffix."h/descBase" = "serifed"
 selectorAffix.hHookTop = "serifed"
-selectorAffix.hengHookTop = "serifed"
 selectorAffix.heng = "serifed"
+selectorAffix.hengHookTop = "serifed"
 
 
 


### PR DESCRIPTION
Also reduce number of unused glyphs surrounding `b`/`d`/`h`.

All affected letters (including some extra ones that I fixed while I was at it on the third row):
```
ƥ̇ ƭ̇ 𝼉̇ Ƈ̇ ƈ̇ Ƙ̇ ƙ̇ ʠ̇ ɧ̇
ɓ̇ ɗ̇ ᶑ̇   ʄ̇ Ɠ̇ ɠ̇ ʛ̇ ɦ̇
Ɋ̣ ɋ̣ ɖ̣ ᶑ̣ ƃ̇ ƌ̇ ȡ̇ ꜧ̇
```
Sans before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/5ee38bb7-2ef6-4d0b-a7e8-e928613ae568)
Sans after:
![image](https://github.com/be5invis/Iosevka/assets/37010132/ff644444-a45c-43f1-9019-ec1770e0feaf)
Slab before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/9b5a2f81-cf51-4436-a7c2-8e6f301582c8)
Slab after:
![image](https://github.com/be5invis/Iosevka/assets/37010132/5760a0fa-76bd-4028-923f-11b1361e7eb2)