### PR TITLE
Make Cyrillic Small Letter Reversed {Tse|Yu} (`U+A655`, `U+A661`) respond to CV/Italics.

### DIFF
--- a/changes/30.0.0.md
+++ b/changes/30.0.0.md
@@ -6,6 +6,9 @@
 * Refine shape of CYRILLIC CAPITAL LETTER SHHA (`U+04BA`).
 * Fix leaning mark anchors for letters with top hooks (`U+0187`, `U+0188`, `U+0193`, `U+0199`, `U+01A5`, `U+01AD`, `U+0253`, `U+0257`, `U+0260`, `U+0266`, `U+0267`, `U+0284`, `U+029B`, `U+0280`, `U+1D91`, `U+1DF09`).
 * Fix H bar position of CYRILLIC {CAPITAL|SMALL} LETTER NJE (`U+040A`, `U+045A`).
+* Fix earedness of Bulgarian Cyrillic Lower Pe (`U+043F`).
+* Add Italic form for CYRILLIC SMALL LETTER REVERSED TSE (`U+A661`).
+* Make CYRILLIC SMALL LETTER REVERSED YU (`U+A655`) follow tailed variants of Cyrillic Lower Yery (`cv82`).
 * Fix mapping of LEFT-FACING SNAKE HEAD WITH OPEN MOUTH (`U+1CC70`) ... DOWN-FACING SNAKE HEAD WITH CLOSED MOUTH (`U+1CC77`).
 * Add characters:
   - BOTTOM RIGHT CROP (`U+230C`) ... TOP LEFT CROP (`U+230F`).

--- a/packages/font-glyphs/src/letter/cyrillic/dzhe.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/dzhe.ptl
@@ -24,19 +24,3 @@ glyph-block Letter-Cyrillic-Dzhe : begin
 	create-glyph 'cyrl/dzhe.upright' : glyph-proc
 		include : MarkSet.p
 		include : CyrDzheShape XH
-
-	define ItalicVariants {
-		'toothedSerifless'
-		'toothedMotionSerifed'
-		'toothedBottomRightSerifed'
-		'toothedSerifed'
-		'tailedSerifless'
-		'tailedMotionSerifed'
-		'tailedSerifed'
-	}
-	foreach suffix [items-of ItalicVariants] : do
-		create-glyph "cyrl/dzhe.italic.\(suffix)" : glyph-proc
-			include [refer-glyph "u.\(suffix)"] AS_BASE ALSO_METRICS
-			include [refer-glyph 'descenderBarBelow']
-
-	select-variant 'cyrl/dzhe.italic'

--- a/packages/font-glyphs/src/letter/cyrillic/iotified-a.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/iotified-a.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Letter-Cyrillic-Iotified-A : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : SerifFrame
+	glyph-block-import Letter-Shared-Shapes : SerifFrame RightwardTailedBar
 	glyph-block-import Letter-Latin-Lower-AE-OE : SubDfAndShift
 
 	define SLAB-NONE		0
@@ -33,8 +33,11 @@ glyph-block Letter-Cyrillic-Iotified-A : begin
 					[Just SLAB-OUTWARD] : begin sf.lb.outer
 					__ : glyph-proc
 
-		export : define [RevShape] : with-params [df top hBarLeft [hBarY (top / 2)] [slabTop false] [slabBottom false] [swSerif df.mvs]] : glyph-proc
-			include : VBar.r df.rightSB 0 top df.mvs
+		export : define [RevShape] : with-params [df top hBarLeft [hBarY (top / 2)] [slabTop false] [slabBottom false] [swSerif df.mvs] [fTail false]] : glyph-proc
+			include : if fTail
+				RightwardTailedBar df.rightSB 0 top df.mvs
+				VBar.r df.rightSB 0 top df.mvs
+
 			if (hBarLeft < df.rightSB)
 				include : HBar.m hBarLeft df.rightSB hBarY df.mvs
 
@@ -44,7 +47,7 @@ glyph-block Letter-Cyrillic-Iotified-A : begin
 					[Just SLAB-FULL] : begin sf.rt.full
 					[Just SLAB-OUTWARD] : begin sf.rt.outer
 					__ : glyph-proc
-				include : tagged "serifRB" : match slabBottom
+				if (!fTail) : include : tagged "serifRB" : match slabBottom
 					[Just SLAB-FULL] : begin sf.rb.full
 					[Just SLAB-OUTWARD] : begin sf.rb.outer
 					__ : glyph-proc

--- a/packages/font-glyphs/src/letter/cyrillic/orthography.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/orthography.ptl
@@ -32,6 +32,7 @@ glyph-block Letter-Cyrillic-Orthography : begin
 	orthographic-italic 'cyrl/dche'           0x52D
 	orthographic-italic 'cyrl/teTall'         0x1C84
 	orthographic-italic 'cyrl/teThreeLeg'     0x1C85
+	orthographic-italic 'cyrl/tseRev'         0xA661
 	orthographic-italic 'cyrl/dzze'           0xA689
 	orthographic-italic 'cyrl/teMidHook'      0xA68B
 	orthographic-italic 'latn/yatSakha'       0xAB60

--- a/packages/font-glyphs/src/letter/cyrillic/tse.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/tse.ptl
@@ -34,7 +34,7 @@ glyph-block Letter-Cyrillic-Tse : begin
 		include : MarkSet.capital
 		include : CyrTseShape CAP true
 
-	create-glyph 'cyrl/tseRev' 0xA661 : glyph-proc
+	create-glyph 'cyrl/tseRev.upright' : glyph-proc
 		include : MarkSet.e
 		include : CyrTseShape XH true
 

--- a/packages/font-glyphs/src/letter/cyrillic/yeri.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/yeri.ptl
@@ -311,7 +311,7 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			include : ZhuangToneSixShape Lc XH
 
 	foreach { suffix { Uc Lc fTail } } [Object.entries YeryConfig] : do
-		create-glyph "cyrl/Yery.\(suffix)" : glyph-proc
+		if [not fTail] : create-glyph "cyrl/Yery.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.capital
 			include : CyrYeryShape Uc df CAP false fTail
@@ -319,7 +319,7 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.e
 			include : CyrYeryShape Lc df XH false fTail
-		create-glyph "cyrl/YeryBack.\(suffix)" : glyph-proc
+		if [not fTail] : create-glyph "cyrl/YeryBack.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.capital
 			include : CyrYeryShape Uc df CAP true fTail
@@ -342,8 +342,8 @@ glyph-block Letter-Cyrillic-Yeri : begin
 	select-variant 'cyrl/yeriBar' 0x48D (follow -- 'cyrl/yeri')
 	select-variant 'cyrl/YerNeutral' 0xA64E (follow -- 'cyrl/Yer')
 	select-variant 'cyrl/yerNeutral' 0xA64F (follow -- 'cyrl/yer')
-	select-variant 'cyrl/YeryBack' 0xA650 (follow -- 'cyrl/Yery')
-	select-variant 'cyrl/yeryBack' 0xA651 (follow -- 'cyrl/yery')
+	select-variant 'cyrl/YeryBack' 0xA650
+	select-variant 'cyrl/yeryBack' 0xA651
 
 	select-variant 'ZhuangToneSix' 0x184 (follow -- 'cyrl/Yer')
 	select-variant 'zhuangToneSix' 0x185 (follow -- 'cyrl/yer')

--- a/packages/font-glyphs/src/letter/cyrillic/yu.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/yu.ptl
@@ -25,7 +25,7 @@ glyph-block Letter-Cyrillic-Yu : begin
 			Iotified.ascender df xtop xm (top / 2)
 			Iotified.full df xtop xm (top / 2) (fCapital -- (slabType === SLAB-ALL))
 
-	define [CyrRevYuShape df slabType top xtop ada adb] : glyph-proc
+	define [CyrRevYuShape df slabType top xtop ada adb fTail] : glyph-proc
 		local xm : barMixL df.leftSB df.rightSB [HSwToV df.mvs] [StrokeWidthBlend 0.4 0.45]
 		local revXm : df.leftSB + df.rightSB - xm
 		include : OShape top 0 df.leftSB revXm df.mvs (ada * 0.7 * df.div) (adb * 0.7 * df.div)
@@ -39,6 +39,7 @@ glyph-block Letter-Cyrillic-Yu : begin
 			hBarY      -- (top / 2)
 			slabTop    -- slabTop
 			slabBottom -- slabBottom
+			fTail      -- fTail
 
 	create-glyph 'cyrl/Yu' 0x42E : glyph-proc
 		local df : include : DivFrame para.diversityM 3
@@ -55,12 +56,19 @@ glyph-block Letter-Cyrillic-Yu : begin
 		include : df.markSet.b
 		include : CyrYuShape df SLAB-BULGARIAN XH Ascender SmallArchDepthA SmallArchDepthB
 
-	create-glyph 'cyrl/YuRev' 0xA654 : glyph-proc
-		local df : include : DivFrame para.diversityM 3
-		include : df.markSet.capital
-		include : CyrRevYuShape df SLAB-ALL CAP CAP ArchDepthA ArchDepthB
+	define YuRevConfig : object
+		straight  false
+		tailed    true
 
-	create-glyph 'cyrl/yuRev' 0xA655 : glyph-proc
-		local df : include : DivFrame para.diversityM 3
-		include : df.markSet.e
-		include : CyrRevYuShape df SLAB-LOWER XH XH SmallArchDepthA SmallArchDepthB
+	foreach { suffix fTail } [Object.entries YuRevConfig] : do
+		if [not fTail] : create-glyph "cyrl/YuRev.\(suffix)" : glyph-proc
+			local df : include : DivFrame para.diversityM 3
+			include : df.markSet.capital
+			include : CyrRevYuShape df SLAB-ALL CAP CAP ArchDepthA ArchDepthB fTail
+		create-glyph "cyrl/yuRev.\(suffix)" : glyph-proc
+			local df : include : DivFrame para.diversityM 3
+			include : df.markSet.e
+			include : CyrRevYuShape df SLAB-LOWER XH XH SmallArchDepthA SmallArchDepthB fTail
+
+	select-variant 'cyrl/YuRev' 0xA654
+	select-variant 'cyrl/yuRev' 0xA655

--- a/packages/font-glyphs/src/letter/latin/lower-n.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-n.ptl
@@ -263,9 +263,9 @@ glyph-block Letter-Latin-Lower-N : begin
 	link-reduced-variant 'n/sansSerif' 'n' MathSansSerif
 	link-reduced-variant 'n/descBase' 'n'
 	select-variant 'cyrl/pe.italic' (shapeFrom -- 'n')
-	select-variant 'cyrl/peItalicDescBase' (shapeFrom -- 'n')
+	select-variant 'cyrl/pe.italic/descBase' (shapeFrom -- 'n')
 	select-variant 'n/lTailBase' (shapeFrom -- 'n')
-	alias 'cyrl/pe.BGR' null 'n'
+	alias 'cyrl/pe.BGR' null 'cyrl/pe.italic'
 
 	select-variant 'eng' 0x14B
 	link-reduced-variant 'eng/phoneticRight' 'eng'
@@ -284,7 +284,7 @@ glyph-block Letter-Latin-Lower-N : begin
 
 	derive-composites 'nDescender' 0xA791 'n/descBase' [CyrDescender.rSideJut RightSB 0]
 	derive-composites 'nPalatalHook' 0x1D87 'n/descBase' [PalatalHook.rSideJut RightSB 0]
-	derive-composites 'cyrl/peDescender.italic' null 'cyrl/peItalicDescBase' [CyrDescender.rSideJut RightSB 0]
+	derive-composites 'cyrl/peDescender.italic' null 'cyrl/pe.italic/descBase' [CyrDescender.rSideJut RightSB 0]
 
 	select-variant 'cyrl/peMidHook.italic' (follow -- 'cyrl/pe.italic')
 

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -216,22 +216,25 @@ glyph-block Letter-Latin-U : begin
 			include : Base df XH Stroke
 			include : dispiro
 				widths.rhs
-				flat SB Descender [heading Upward]
-				curl SB (Descender / 2) [heading Upward]
-				straight.up.end SB SmallArchDepthB [widths.heading 0 [AdviceStroke 4] Upward]
+				flat df.leftSB Descender [heading Upward]
+				curl df.leftSB (Descender / 2) [heading Upward]
+				straight.up.end df.leftSB SmallArchDepthB [widths.heading 0 [AdviceStroke 4] Upward]
 			include : Slabs df XH
-			include : LeaningAnchor.Below.VBar.l SB
+			include : LeaningAnchor.Below.VBar.l df.leftSB
 
 		create-glyph "cyrl/tse.italic.\(suffix)" : glyph-proc
 			include [refer-glyph "u.\(suffix)"] AS_BASE
 			eject-contour 'serifRB'
 			include : CyrDescender.rSideJut RightSB 0
 
-		create-glyph "cyrl/tetse.italic.\(suffix)" : glyph-proc
+		create-glyph "cyrl/tseRev.italic.\(suffix)" : glyph-proc
+			include [refer-glyph "u.\(suffix)"] AS_BASE
+			include : VBar.l SB 0 SmallArchDepthB [AdviceStroke 4]
+			include : CyrDescender.lSideJut SB 0
+
+		create-glyph "cyrl/dzhe.italic.\(suffix)" : glyph-proc
 			include [refer-glyph "u.\(suffix)"] AS_BASE ALSO_METRICS
-			include [refer-glyph "tildeAbove"]
-			eject-contour 'serifRB'
-			include : CyrDescender.rSideJut RightSB 0
+			include [refer-glyph 'descenderBarBelow']
 
 		create-glyph "turnh.\(suffix)" : glyph-proc
 			local df : DivFrame 1
@@ -312,8 +315,9 @@ glyph-block Letter-Latin-U : begin
 	alias 'cyrl/i.BGR' null 'cyrl/i.italic'
 
 	select-variant 'cyrl/tse.italic'
-	select-variant 'cyrl/tetse.italic' (follow -- 'cyrl/tse.italic')
 	alias 'cyrl/tse.BGR' null 'cyrl/tse.italic'
+	select-variant 'cyrl/tseRev.italic'
+	select-variant 'cyrl/dzhe.italic'
 
 	select-variant 'turnh' 0x265
 	select-variant 'turnhHookLeft' 0x2AE
@@ -330,13 +334,17 @@ glyph-block Letter-Latin-U : begin
 		include [refer-glyph src] AS_BASE ALSO_METRICS
 		include [refer-glyph 'graveAbove']
 
-	derive-composites 'cyrl/iShortTail.italic' null  'cyrl/i.italic/descBase'
+	derive-composites 'cyrl/iShortTail.italic' null 'cyrl/i.italic/descBase'
 		refer-glyph 'breveAbove'
 		CyrTailDescender.rSideJut RightSB 0
 
 	derive-glyphs 'cyrl/pe.SRB' null 'cyrl/i.italic' : lambda [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
 		include [refer-glyph 'macronAbove']
+
+	derive-glyphs 'cyrl/tetse.italic' null 'cyrl/tse.italic' : lambda [src gr] : glyph-proc
+		include [refer-glyph src] AS_BASE ALSO_METRICS
+		include [refer-glyph 'tildeAbove']
 
 	derive-composites 'uRTailBR' 0x1D99 'u/uRTailBase'
 		RetroflexHook.rSideJut RightSB 0 (yOverflow -- Stroke)

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -3058,7 +3058,7 @@ selectorAffix."eng/lTailBase" = ""
 selectorAffix."grek/eta" = ""
 selectorAffix."grek/eta/sansSerif" = ""
 selectorAffix."cyrl/pe.italic" = ""
-selectorAffix."cyrl/peItalicDescBase" = ""
+selectorAffix."cyrl/pe.italic/descBase" = ""
 selectorAffix."cyrl/yat.italic/base/corner" =  ""
 selectorAffix."cyrl/yat.italic/base/cursive" =  ""
 
@@ -3075,7 +3075,7 @@ selectorAffix."eng/lTailBase" = "earlessCorner"
 selectorAffix."grek/eta" = "earlessCorner"
 selectorAffix."grek/eta/sansSerif" = "earlessCorner"
 selectorAffix."cyrl/pe.italic" = ""
-selectorAffix."cyrl/peItalicDescBase" = ""
+selectorAffix."cyrl/pe.italic/descBase" = ""
 selectorAffix."cyrl/yat.italic/base/corner" = ""
 selectorAffix."cyrl/yat.italic/base/cursive" = ""
 
@@ -3092,7 +3092,7 @@ selectorAffix."eng/lTailBase" = "earlessRounded"
 selectorAffix."grek/eta" = "earlessRounded"
 selectorAffix."grek/eta/sansSerif" = "earlessRounded"
 selectorAffix."cyrl/pe.italic" = ""
-selectorAffix."cyrl/peItalicDescBase" = ""
+selectorAffix."cyrl/pe.italic/descBase" = ""
 selectorAffix."cyrl/yat.italic/base/corner" = ""
 selectorAffix."cyrl/yat.italic/base/cursive" = ""
 
@@ -3112,7 +3112,7 @@ selectorAffix."eng/lTailBase" = "straight"
 selectorAffix."grek/eta" = "straight"
 selectorAffix."grek/eta/sansSerif" = "straight"
 selectorAffix."cyrl/pe.italic" = "straight"
-selectorAffix."cyrl/peItalicDescBase" = "straight"
+selectorAffix."cyrl/pe.italic/descBase" = "straight"
 selectorAffix."cyrl/yat.italic/base/corner" = "straight"
 selectorAffix."cyrl/yat.italic/base/cursive" = "straight"
 
@@ -3129,7 +3129,7 @@ selectorAffix."eng/lTailBase" = "straight"
 selectorAffix."grek/eta" = "straight"
 selectorAffix."grek/eta/sansSerif" = "straight"
 selectorAffix."cyrl/pe.italic" = "tailed"
-selectorAffix."cyrl/peItalicDescBase" = "straight"
+selectorAffix."cyrl/pe.italic/descBase" = "straight"
 selectorAffix."cyrl/yat.italic/base/corner" = "straight"
 selectorAffix."cyrl/yat.italic/base/cursive" = "straight"
 
@@ -3147,7 +3147,7 @@ selectorAffix."eng/lTailBase" = "serifless"
 selectorAffix."grek/eta" = "serifless"
 selectorAffix."grek/eta/sansSerif" = "serifless"
 selectorAffix."cyrl/pe.italic" = "serifless"
-selectorAffix."cyrl/peItalicDescBase" = "serifless"
+selectorAffix."cyrl/pe.italic/descBase" = "serifless"
 selectorAffix."cyrl/yat.italic/base/corner" = "serifless"
 selectorAffix."cyrl/yat.italic/base/cursive" = "serifless"
 
@@ -3165,7 +3165,7 @@ selectorAffix."eng/lTailBase" = "topLeftSerifed"
 selectorAffix."grek/eta" = "topLeftSerifed"
 selectorAffix."grek/eta/sansSerif" = "serifless"
 selectorAffix."cyrl/pe.italic" = "topLeftSerifed"
-selectorAffix."cyrl/peItalicDescBase" = "topLeftSerifed"
+selectorAffix."cyrl/pe.italic/descBase" = "topLeftSerifed"
 selectorAffix."cyrl/yat.italic/base/corner" = "topLeftSerifed"
 selectorAffix."cyrl/yat.italic/base/cursive" = "topLeftSerifed"
 
@@ -3183,7 +3183,7 @@ selectorAffix."eng/lTailBase" = { if = [{ body = "eared" }], then = "topLeftSeri
 selectorAffix."grek/eta" = { if = [{ body = "eared" }], then = "topLeftSerifed", else = "serifless" }
 selectorAffix."grek/eta/sansSerif" = "serifless"
 selectorAffix."cyrl/pe.italic" = "motionSerifed"
-selectorAffix."cyrl/peItalicDescBase" = "topLeftSerifed"
+selectorAffix."cyrl/pe.italic/descBase" = "topLeftSerifed"
 selectorAffix."cyrl/yat.italic/base/corner" = "topLeftSerifed"
 selectorAffix."cyrl/yat.italic/base/cursive" = "topLeftSerifed"
 
@@ -3200,7 +3200,7 @@ selectorAffix."eng/lTailBase" = { if = [{ body = "eared" }], then = "topLeftSeri
 selectorAffix."grek/eta" = { if = [{ body = "eared" }], then = "topLeftSerifed", else = "serifless" }
 selectorAffix."grek/eta/sansSerif" = "serifless"
 selectorAffix."cyrl/pe.italic" = "serifed"
-selectorAffix."cyrl/peItalicDescBase" = "serifed"
+selectorAffix."cyrl/pe.italic/descBase" = "serifed"
 selectorAffix."cyrl/yat.italic/base/corner" = "serifedItalicYatCorner"
 selectorAffix."cyrl/yat.italic/base/cursive" = "serifedItalicYatCursive"
 
@@ -3742,6 +3742,7 @@ selectorAffix."cyrl/sha.italic" = "toothed"
 selectorAffix."cyrl/shcha.italic" = "toothed"
 selectorAffix."cyrl/dzhe.italic" = "toothed"
 selectorAffix."cyrl/tse.italic" = "toothed"
+selectorAffix."cyrl/tseRev.italic" = "toothed"
 selectorAffix."ue/u" = "toothed"
 selectorAffix."au/u" = "toothed"
 
@@ -3763,6 +3764,7 @@ selectorAffix."cyrl/sha.italic" = "tailed"
 selectorAffix."cyrl/shcha.italic" = "toothed"
 selectorAffix."cyrl/dzhe.italic" = "tailed"
 selectorAffix."cyrl/tse.italic" = "toothed"
+selectorAffix."cyrl/tseRev.italic" = "tailed"
 selectorAffix."ue/u" = "toothed"
 selectorAffix."au/u" = "tailed"
 
@@ -3784,6 +3786,7 @@ selectorAffix."cyrl/sha.italic" = "toothed"
 selectorAffix."cyrl/shcha.italic" = "toothed"
 selectorAffix."cyrl/dzhe.italic" = "toothed"
 selectorAffix."cyrl/tse.italic" = "toothed"
+selectorAffix."cyrl/tseRev.italic" = "toothed"
 selectorAffix."ue/u" = "toothed"
 selectorAffix."au/u" = "toothlessCorner"
 
@@ -3805,6 +3808,7 @@ selectorAffix."cyrl/sha.italic" = "toothed"
 selectorAffix."cyrl/shcha.italic" = "toothed"
 selectorAffix."cyrl/dzhe.italic" = "toothed"
 selectorAffix."cyrl/tse.italic" = "toothed"
+selectorAffix."cyrl/tseRev.italic" = "toothed"
 selectorAffix."ue/u" = "toothed"
 selectorAffix."au/u" = "toothlessRounded"
 
@@ -3827,6 +3831,7 @@ selectorAffix."cyrl/sha.italic" = "serifless"
 selectorAffix."cyrl/shcha.italic" = "serifless"
 selectorAffix."cyrl/dzhe.italic" = "serifless"
 selectorAffix."cyrl/tse.italic" = "serifless"
+selectorAffix."cyrl/tseRev.italic" = "serifless"
 selectorAffix."ue/u" = "serifless"
 selectorAffix."au/u" = "serifless"
 
@@ -3838,17 +3843,18 @@ selectorAffix.u = "bottomRightSerifed"
 selectorAffix."u/sansSerif" = "serifless"
 selectorAffix."u/uRTailBase" = "serifless"
 selectorAffix.uHookLeft = "bottomRightSerifed"
-selectorAffix.turnh = "bottomRightSerifed"
-selectorAffix.turnhHookLeft = "bottomRightSerifed"
+selectorAffix.turnh = "serifless"
+selectorAffix.turnhHookLeft = "serifless"
 selectorAffix.turnhHookLeftRTail = "serifless"
 selectorAffix.turnm = "bottomRightSerifed"
-selectorAffix.turnmLeg = "bottomRightSerifed"
+selectorAffix.turnmLeg = "serifless"
 selectorAffix."cyrl/i.italic" = "bottomRightSerifed"
 selectorAffix."cyrl/i.italic/descBase" = "serifless"
 selectorAffix."cyrl/sha.italic" = "bottomRightSerifed"
 selectorAffix."cyrl/shcha.italic" = "serifless"
 selectorAffix."cyrl/dzhe.italic" = "bottomRightSerifed"
 selectorAffix."cyrl/tse.italic" = "serifless"
+selectorAffix."cyrl/tseRev.italic" = "bottomRightSerifed"
 selectorAffix."ue/u" = "serifless"
 selectorAffix."au/u" = "bottomRightSerifed"
 
@@ -3870,6 +3876,7 @@ selectorAffix."cyrl/sha.italic" = "motionSerifed"
 selectorAffix."cyrl/shcha.italic" = "motionSerifed"
 selectorAffix."cyrl/dzhe.italic" = "motionSerifed"
 selectorAffix."cyrl/tse.italic" = "motionSerifed"
+selectorAffix."cyrl/tseRev.italic" = "motionSerifed"
 selectorAffix."ue/u" = "serifed"
 selectorAffix."au/u" = {if = [{body = "toothed"}], then = "bottomRightSerifed", else = "serifless"}
 
@@ -3891,6 +3898,7 @@ selectorAffix."cyrl/sha.italic" = "serifed"
 selectorAffix."cyrl/shcha.italic" = "serifed"
 selectorAffix."cyrl/dzhe.italic" = "serifed"
 selectorAffix."cyrl/tse.italic" = "serifed"
+selectorAffix."cyrl/tseRev.italic" = "serifed"
 selectorAffix."ue/u" = "serifed"
 selectorAffix."au/u" = "serifed"
 
@@ -6039,14 +6047,20 @@ selector."cyrl/lje"  = "cursive"
 [prime.cyrl-capital-yery.variants.corner]
 rank = 1
 selector."cyrl/Yery" = "corner"
+selector."cyrl/YeryBack" = "corner"
+selector."cyrl/YuRev" = "straight"
 
 [prime.cyrl-capital-yery.variants.round]
 rank = 2
 selector."cyrl/Yery" = "round"
+selector."cyrl/YeryBack" = "round"
+selector."cyrl/YuRev" = "straight"
 
 [prime.cyrl-capital-yery.variants.cursive]
 rank = 3
 selector."cyrl/Yery" = "cursive"
+selector."cyrl/YeryBack" = "cursive"
+selector."cyrl/YuRev" = "straight"
 
 
 
@@ -6059,31 +6073,43 @@ tagKind = "letter"
 rank = 1
 description = "Cyrillic Lower Yery (`ы`) with corner at bottom left"
 selector."cyrl/yery" = "corner"
+selector."cyrl/yeryBack" = "corner"
+selector."cyrl/yuRev" = "straight"
 
 [prime.cyrl-yery.variants.corner-tailed]
 rank = 2
 description = "Cyrillic Lower Yery (`ы`) with corner at bottom left and tail"
 selector."cyrl/yery" = "cornerTailed"
+selector."cyrl/yeryBack" = "cornerTailed"
+selector."cyrl/yuRev" = "tailed"
 
 [prime.cyrl-yery.variants.round]
 rank = 3
 description = "Cyrillic Lower Yery (`ы`) with rounded shape"
 selector."cyrl/yery" = "round"
+selector."cyrl/yeryBack" = "round"
+selector."cyrl/yuRev" = "straight"
 
 [prime.cyrl-yery.variants.round-tailed]
 rank = 4
 description = "Cyrillic Lower Yery (`ы`) with rounded shape and tail"
 selector."cyrl/yery" = "roundTailed"
+selector."cyrl/yeryBack" = "roundTailed"
+selector."cyrl/yuRev" = "tailed"
 
 [prime.cyrl-yery.variants.cursive]
 rank = 5
 description = "Cyrillic Lower Yery (`ы`) with cursive shape"
 selector."cyrl/yery" = "cursive"
+selector."cyrl/yeryBack" = "cursive"
+selector."cyrl/yuRev" = "straight"
 
 [prime.cyrl-yery.variants.cursive-tailed]
 rank = 6
 description = "Cyrillic Lower Yery (`ы`) with cursive shape and tail"
 selector."cyrl/yery" = "cursiveTailed"
+selector."cyrl/yeryBack" = "cursiveTailed"
+selector."cyrl/yuRev" = "tailed"
 
 
 


### PR DESCRIPTION
Also fix the eared variants of Bulgarian Cyrillic Pe while I'm at it.

Reversed tse loosely based on an issue raised over at Noto Fonts repo at https://github.com/notofonts/latin-greek-cyrillic/issues/45 .<br>The left stroke uses metrics from Greek Mu (`μ`/`µ`).
`иꙡџцшщ`
Sans Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/cd94576e-13a3-40ee-b3c0-516a80cfacaa)
Sans Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/abad3b1e-ba6e-4700-a65d-bb5070f145c6)
Slab Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/e99ce089-758d-42b4-9569-b09e8b140adb)
Slab Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/1d4bf5d5-a651-4500-b771-1d3aaedf98d8)

Cyrillic Reversed Yu having its iotated part on the right means it should fall under the behavior of tailed variants of Yery, which is also a ligature of some letter plus a dotless decimal i.
However, it should not apply to non-reversed iotated letters, according to https://github.com/notofonts/latin-greek-cyrillic/issues/50 .
`ыꙑꙕ`
Sans:
![image](https://github.com/be5invis/Iosevka/assets/37010132/7ccf4f6e-c64d-46e9-b1c7-e45c55c1b46b)
Slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/a16174f7-f496-408a-81e7-28e8b048b96f)
