### PR TITLE
Reduce `z` variants in phonetic digraphs, fix hook of capital Eng.

### DIFF
--- a/changes/30.0.1.md
+++ b/changes/30.0.1.md
@@ -1,4 +1,5 @@
 * Remove top-left serifs of `z`-parts of phonetic digraphs involving `d` (`U+02A3`..`U+02A5`, `U+AB66`).
+* Fix stroke width of hook part of LATIN CAPITAL LETTER ENG (`U+014A`) under heavy weight.
 * Add characters:
   - LATIN SMALL LETTER L WITH BELT AND PALATAL HOOK (`U+1DF13`) ... LATIN SMALL LETTER R WITH FISHHOOK AND PALATAL HOOK (`U+1DF16`).
   - LATIN SMALL LETTER EZH WITH PALATAL HOOK (`U+1DF18`).

--- a/changes/30.0.1.md
+++ b/changes/30.0.1.md
@@ -1,3 +1,4 @@
+* Remove top-left serifs of `z`-parts of phonetic digraphs involving `d` (`U+02A3`..`U+02A5`, `U+AB66`).
 * Add characters:
   - LATIN SMALL LETTER L WITH BELT AND PALATAL HOOK (`U+1DF13`) ... LATIN SMALL LETTER R WITH FISHHOOK AND PALATAL HOOK (`U+1DF16`).
   - LATIN SMALL LETTER EZH WITH PALATAL HOOK (`U+1DF18`).

--- a/packages/font-glyphs/src/auto-build/composite.ptl
+++ b/packages/font-glyphs/src/auto-build/composite.ptl
@@ -1343,39 +1343,39 @@ glyph-block Autobuild-Pnonetic-Ligatures : begin
 
 	define stdShrink : clamp 0.625 0.9 : StrokeWidthBlend 0.625 0.9
 	createPhoneticLigatures ToLetter 'phonetic' para.diversityM 2 stdShrink 1 : list
-		list 0x02A3 { 'd/phoneticLeft'  'z'                     } 'b'
-		list 0x02A4 { 'd/phoneticLeft'  'ezh'                   } 'bp'
-		list 0x02A5 { 'd/phoneticLeft'  'zCurlyTail'            } 'b'
-		list 0x02A6 { 't/phoneticLeft2' 's/phoneticRight'       } 'b'
-		list 0x02A7 { 't/teshLeft'      'esh'                   } 'bp'
-		list 0x02A8 { 't/phoneticLeft1' 'cCurlyTail'            } 'b'
-		list 0x02A9 { 'f/phoneticLeft'  'eng/phoneticRight'     } 'bp'
-		list 0x02AA { 'l/phoneticLeft'  's/phoneticRight'       } 'b'
-		list 0x02AB { 'l/phoneticLeft'  'z'                     } 'b'
-		list 0xAB66 { 'd/phoneticLeft'  'zRTailBR'              } 'bp'
-		list 0xAB67 { 't/phoneticLeft1' 'sRTail'                } 'bp'
-		list 0xFB00 { 'f'               'f'                     } null
-		list 0xFB01 { 'f/compLigLeft1'  'dotlessi/compLigRight' } null
-		list 0xFB02 { 'f/compLigLeft2'  'l/compLigRight'        } null
-		list 0xFB05 { 'longs/flatExt'   't/phoneticRight'       } null
-		list 0xFB06 { 's/compLigLeft'   't/phoneticRight'       } null
+		list 0x02A3 { 'd/phoneticLeft'  'z/phoneticRight'          } 'b'
+		list 0x02A4 { 'd/phoneticLeft'  'ezh/phoneticRight'        } 'bp'
+		list 0x02A5 { 'd/phoneticLeft'  'zCurlyTail/phoneticRight' } 'b'
+		list 0x02A6 { 't/phoneticLeft2' 's/phoneticRight'          } 'b'
+		list 0x02A7 { 't/teshLeft'      'esh'                      } 'bp'
+		list 0x02A8 { 't/phoneticLeft1' 'cCurlyTail'               } 'b'
+		list 0x02A9 { 'f/phoneticLeft'  'eng/phoneticRight'        } 'bp'
+		list 0x02AA { 'l/phoneticLeft'  's/phoneticRight'          } 'b'
+		list 0x02AB { 'l/phoneticLeft'  'z'                        } 'b'
+		list 0xAB66 { 'd/phoneticLeft'  'zRTail/phoneticRight'     } 'bp'
+		list 0xAB67 { 't/phoneticLeft1' 'sRTail'                   } 'bp'
+		list 0xFB00 { 'f'               'f'                        } null
+		list 0xFB01 { 'f/compLigLeft1'  'dotlessi/compLigRight'    } null
+		list 0xFB02 { 'f/compLigLeft2'  'l/compLigRight'           } null
+		list 0xFB05 { 'longs/flatExt'   't/phoneticRight'          } null
+		list 0xFB06 { 's/compLigLeft'   't/phoneticRight'          } null
 
 	createPhoneticLigatures ToLetter 'phonetic2' para.diversityM 3 stdShrink 1 : list
 		list 0xFB03 { 'f/compLigLeft1' 'f/compLigLeft1' 'dotlessi/compLigRight' } null
 		list 0xFB04 { 'f/compLigLeft3' 'f/compLigLeft2' 'l/compLigRight'        } null
 
 	createPhoneticLigatures ToSuperscript 'phoneticSuperscript' 1 2 stdShrink 1 : list
-		list 0x10787 { 'd/phoneticLeft'  'z'                     } 'b'
-		list 0x1078A { 'd/phoneticLeft'  'ezh'                   } 'bp'
-		list 0x10789 { 'd/phoneticLeft'  'zCurlyTail'            } 'bp'
-		list 0x107AC { 't/phoneticLeft2' 's/phoneticRight'       } 'b'
-		list 0x107AE { 't/teshLeft'      'esh'                   } 'bp'
-		list 0x107AB { 't/phoneticLeft1' 'cCurlyTail'            } 'b'
-		list 0x10790 { 'f/phoneticLeft'  'eng/phoneticRight'     } 'bp'
-		list 0x10799 { 'l/phoneticLeft'  's/phoneticRight'       } 'b'
-		list 0x1079A { 'l/phoneticLeft'  'z'                     } 'b'
-		list 0x10788 { 'd/phoneticLeft'  'zRTailBR'              } 'bp'
-		list 0x107AD { 't/phoneticLeft1' 'sRTail'                } 'p'
+		list 0x10787 { 'd/phoneticLeft'  'z/phoneticRight'          } 'b'
+		list 0x1078A { 'd/phoneticLeft'  'ezh/phoneticRight'        } 'bp'
+		list 0x10789 { 'd/phoneticLeft'  'zCurlyTail/phoneticRight' } 'bp'
+		list 0x107AC { 't/phoneticLeft2' 's/phoneticRight'          } 'b'
+		list 0x107AE { 't/teshLeft'      'esh'                      } 'bp'
+		list 0x107AB { 't/phoneticLeft1' 'cCurlyTail'               } 'b'
+		list 0x10790 { 'f/phoneticLeft'  'eng/phoneticRight'        } 'bp'
+		list 0x10799 { 'l/phoneticLeft'  's/phoneticRight'          } 'b'
+		list 0x1079A { 'l/phoneticLeft'  'z'                        } 'b'
+		list 0x10788 { 'd/phoneticLeft'  'zRTail/phoneticRight'     } 'bp'
+		list 0x107AD { 't/phoneticLeft1' 'sRTail'                   } 'p'
 
 	createPhoneticLigatures ToSubscript 'tenSubscript' 1 2 1 0.5 : list
 		list 0x23E8 { 'one.lnum' 'zero.lnum' } 'capital'

--- a/packages/font-glyphs/src/auto-build/transformed.ptl
+++ b/packages/font-glyphs/src/auto-build/transformed.ptl
@@ -281,7 +281,7 @@ glyph-block Autobuild-Transformed : begin
 			list 0x107A4 'closeomega'
 			list 0x107A5 'q'
 			list 0x107A6 'turnrLongLeg'
-			list 0x107A7 'rTurnLongLetRTail'
+			list 0x107A7 'rTurnLongLegRTail'
 			list 0x107A8 'rRTail'
 			list 0x107A9 'rFlap'
 			list 0x107AA 'smcpR'

--- a/packages/font-glyphs/src/auto-build/transformed.ptl
+++ b/packages/font-glyphs/src/auto-build/transformed.ptl
@@ -215,7 +215,7 @@ glyph-block Autobuild-Transformed : begin
 			list 0x1DB9 'vHookTop'
 			list 0x1DBA 'turnv'
 			list 0x1DBB 'z'
-			list 0x1DBC 'zRTailBR'
+			list 0x1DBC 'zRTail'
 			list 0x1DBD 'zCurlyTail'
 			list 0x1DBE 'ezh'
 			list 0x1DBF 'grek/theta'

--- a/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
@@ -185,6 +185,7 @@ glyph-block Letter-Latin-Ezh : begin
 	select-variant 'ezhCurlyTail' 0x293 (follow -- 'ezh')
 	select-variant 'ezhRetroflexHook' 0x1D9A (follow -- 'ezh')
 	select-variant 'ezhPalatalHook' 0x1DF18 (follow -- 'ezh')
+	select-variant 'ezh/phoneticRight' (shapeFrom -- 'ezh')
 
 	alias 'cyrl/abk/Dze' 0x4E0 'Ezh'
 	alias 'cyrl/abk/dze' 0x4E1 'ezh'

--- a/packages/font-glyphs/src/letter/latin/lower-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-m.ptl
@@ -9,9 +9,10 @@ glyph-block Letter-Latin-Lower-M : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Adjustment : LeaningAnchor
-	glyph-block-import Letter-Shared-Shapes : SerifFrame RightwardTailedBar DToothlessRise DMBlend
-	glyph-block-import Letter-Shared-Shapes : nShoulder nShoulderMask
-	glyph-block-import Letter-Shared-Shapes : CyrDescender PalatalHook MidHook CurlyTail UpwardHookShape
+	glyph-block-import Letter-Shared-Shapes : CurlyTail nShoulder nShoulderMask
+	glyph-block-import Letter-Shared-Shapes : RightwardTailedBar DToothlessRise DMBlend MidHook
+	glyph-block-import Letter-Shared-Shapes : CyrDescender PalatalHook EngHook UpwardHookShape
+	glyph-block-import Letter-Shared-Shapes : SerifFrame
 
 	define [SmallMSmooth df] : df.div * (0.5 * SmallArchDepth + 0.375 * Stroke)
 	define [SmallMShoulderSpiro] : with-params [left right top bottom width fine df coBottom] : glyph-proc
@@ -255,10 +256,10 @@ glyph-block Letter-Latin-Lower-M : begin
 
 		create-glyph "meng.\(suffix)" : glyph-proc
 			local df : include : dfM
-			include : df.markSet.e
-			include [refer-glyph "m.\(suffix)"]
+			include : df.markSet.p
+			include : mShapeBody df XH
 			eject-contour 'serifRB'
-			include : PalatalHook.rExt df.rightSB 0 (sw -- df.mvs)
+			include : EngHook df.rightSB 0 Descender (sw -- df.mvs)
 
 		create-glyph "mCrossedTail.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 4
@@ -334,6 +335,15 @@ glyph-block Letter-Latin-Lower-M : begin
 	select-variant 'meng' 0x271
 	select-variant 'mCrossedTail' 0xAB3A (follow -- 'meng')
 
+	define [turnMShapeBodyImpl df height body toothless tailed serifs] : glyph-proc
+		include : body df height 0 0 0
+		include : serifs df height 0 0 0 0 toothless
+		include : FlipAround df.middle (height / 2)
+		if tailed : begin
+			eject-contour 'barL'
+			eject-contour 'serifLT'
+			include : RightwardTailedBar df.rightSB 0 height (sw -- df.mvs)
+
 	define TurnMConfig : SuffixCfg.weave
 		object # body
 			toothed            { SmallMArches                        0 0 }
@@ -350,13 +360,7 @@ glyph-block Letter-Latin-Lower-M : begin
 
 	foreach { suffix { {Body toothless tailed} {Serifs} } } [pairs-of TurnMConfig] : do
 		define [turnMShapeBody df top] : glyph-proc
-			include : Body df top 0 0 0
-			include : Serifs df top 0 0 0 0 toothless
-			include : FlipAround df.middle (top / 2)
-			if tailed : begin
-				eject-contour 'barL'
-				eject-contour 'serifLT'
-				include : RightwardTailedBar df.rightSB 0 top (sw -- df.mvs)
+			include : turnMShapeBodyImpl df top Body toothless tailed Serifs
 
 		create-glyph "turnm.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 3

--- a/packages/font-glyphs/src/letter/latin/lower-r.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-r.ptl
@@ -285,7 +285,7 @@ glyph-block Letter-Latin-Lower-R : begin
 			define [object setTurnedMarks] : RDim df mode
 			include : setTurnedMarks doTS Ascender 0
 
-		create-glyph "rTurnLongLetRTail.\(suffix)" : glyph-proc
+		create-glyph "rTurnLongLegRTail.\(suffix)" : glyph-proc
 			include [refer-glyph "rLongLeg.\(suffix)"] AS_BASE ALSO_METRICS
 			eject-contour 'serifLT'
 			include : FlipAround df.middle (XH / 2)
@@ -319,7 +319,7 @@ glyph-block Letter-Latin-Lower-R : begin
 	select-variant 'smallLetterTurnedRWithTail' 0x2C79 (follow -- 'rRTail')
 
 	select-variant 'rTurnRTail' 0x27B
-	select-variant 'rTurnLongLetRTail' 0x1DF08 (follow -- 'rTurnRTail')
+	select-variant 'rTurnLongLegRTail' 0x1DF08 (follow -- 'rTurnRTail')
 	select-variant 'rPalatalHook' 0x1D89 (follow -- 'r')
 
 	define [BBRShape df md doTopSerif doBottomSerif] : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/upper-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-m.ptl
@@ -10,7 +10,7 @@ glyph-block Letter-Latin-Upper-M : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared : CreateTurnedLetter
-	glyph-block-import Letter-Shared-Shapes : SerifFrame CyrTailDescender PalatalHook
+	glyph-block-import Letter-Shared-Shapes : SerifFrame EngHook CyrTailDescender
 
 	define FORM-FLAT      0
 	define FORM-HANGING   1
@@ -135,10 +135,10 @@ glyph-block Letter-Latin-Upper-M : begin
 
 		create-glyph "Meng.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 3
-			include : df.markSet.capital
+			include : df.markSet.capDesc
 			local ret_M : include : MShape CAP df form slab slanted
 			eject-contour 'serifRB'
-			include : PalatalHook.rExt df.rightSB 0 (sw -- ret_M.swSideBot)
+			include : EngHook df.rightSB 0 Descender (sw -- ret_M.swSideBot)
 
 		create-glyph "smcpM.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 3

--- a/packages/font-glyphs/src/letter/latin/upper-n.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-n.ptl
@@ -26,6 +26,9 @@ glyph-block Letter-Latin-Upper-N : begin
 		local yEnd : match bodyType
 			[Just BODY-SYMMETRIC]    0
 			[Just BODY-ASYMMETRIC] : top * 0.375
+		local swEnd : match bodyType
+			[Just BODY-SYMMETRIC]    swDiag
+			[Just BODY-ASYMMETRIC]   stroke
 
 		include : union
 			match bodyType
@@ -38,8 +41,8 @@ glyph-block Letter-Latin-Upper-N : begin
 				[Just BODY-SYMMETRIC] : dispiro
 					flat right top [widths.heading 0 stroke Downward]
 					curl right (top * 0.6) [heading Downward]
-					straight.down.end right 0 [widths.heading 0 swDiag Downward]
-				[Just BODY-ASYMMETRIC] : VBar.r right 0 top stroke
+					straight.down.end right 0 [widths.heading 0 swEnd Downward]
+				[Just BODY-ASYMMETRIC] : VBar.r right 0 top swEnd
 			intersection [Rect top 0 left right]
 				ExtLineCenter 2 swDiag (left + swDiag) top (right - swDiag) yEnd
 
@@ -49,6 +52,8 @@ glyph-block Letter-Latin-Upper-N : begin
 			[Just SLAB-AUTO]   : NeedSlab SLAB : composite-proc sf.lt.outer sf.lb.full sf.rt.full
 			[Just SLAB-MOTION] : composite-proc sf.lt.outer
 			[Just SLAB-NONE]   : no-shape
+
+		return : object swEnd
 
 	define [NRevShape] : with-params [bodyType slabType top left right [crowd 2] [crDiag 4]] : glyph-proc
 		local swDiag : AdviceStroke crDiag
@@ -104,8 +109,8 @@ glyph-block Letter-Latin-Upper-N : begin
 
 		create-glyph "Eng.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
-			include : NShape bodyType slabType CAP SB RightSB (crDiag -- crD)
-			include : EngHook RightSB 0 Descender
+			local [object swEnd] : include : NShape bodyType slabType CAP SB RightSB (crDiag -- crD)
+			include : EngHook RightSB 0 Descender (sw -- swEnd)
 
 		create-glyph "NLTail.\(suffix)" : glyph-proc
 			include [refer-glyph "N.\(suffix)"] AS_BASE ALSO_METRICS

--- a/packages/font-glyphs/src/letter/latin/upper-n.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-n.ptl
@@ -110,7 +110,7 @@ glyph-block Letter-Latin-Upper-N : begin
 		create-glyph "Eng.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
 			local [object swEnd] : include : NShape bodyType slabType CAP SB RightSB (crDiag -- crD)
-			include : EngHook RightSB 0 Descender (sw -- swEnd)
+			include : EngHook RightSB 0 Descender (sw -- [Math.min Stroke (swEnd * 1.5)])
 
 		create-glyph "NLTail.\(suffix)" : glyph-proc
 			include [refer-glyph "N.\(suffix)"] AS_BASE ALSO_METRICS

--- a/packages/font-glyphs/src/letter/latin/z.ptl
+++ b/packages/font-glyphs/src/letter/latin/z.ptl
@@ -219,7 +219,7 @@ glyph-block Letter-Latin-Z : begin
 			if serifs : include : serifs CAP
 			if slash  : include : slash  CAP
 
-		create-glyph "ZDTail.\(suffix)" : glyph-proc
+		create-glyph "ZHookBottom.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
 			set-base-anchor 'overlay' Middle (CAP / 2)
 			include : capital MODE-ZDESC
@@ -265,7 +265,7 @@ glyph-block Letter-Latin-Z : begin
 			if serifs : include : serifs XH
 			if slash  : include : slash  XH
 
-		create-glyph "zDTail.\(suffix)" : glyph-proc
+		create-glyph "zHookBottom.\(suffix)" : glyph-proc
 			include : MarkSet.p
 			set-base-anchor 'overlay' Middle (XH / 2)
 			include : small MODE-ZDESC
@@ -328,8 +328,8 @@ glyph-block Letter-Latin-Z : begin
 	link-reduced-variant 'z/reduced' 'z'
 	select-variant 'z/rtailBase' (follow -- 'z')
 
-	select-variant 'ZDTail' 0x224 (follow -- 'ZDesc')
-	select-variant 'zDTail' 0x225 (follow -- 'zDesc')
+	select-variant 'ZHookBottom' 0x224 (follow -- 'ZDesc')
+	select-variant 'zHookBottom' 0x225 (follow -- 'zDesc')
 	select-variant 'ZSwash' 0x2C7F (follow -- 'ZDesc')
 	select-variant 'zSwash' 0x240 (follow -- 'zDesc')
 	select-variant 'zCurlyTail' 0x291 (follow -- 'zDesc')
@@ -338,13 +338,18 @@ glyph-block Letter-Latin-Z : begin
 	select-variant 'cyrl/Zemlya/reduced' (follow -- 'ZDesc/reduced') (shapeFrom -- 'cyrl/Zemlya')
 	select-variant 'cyrl/zemlya/reduced' (follow -- 'zDesc/reduced') (shapeFrom -- 'cyrl/zemlya')
 
+	select-variant 'z/phoneticRight'           (shapeFrom --'z')
+	select-variant 'z/rtailBase/phoneticRight' (shapeFrom --'z/rtailBase') (follow -- 'z/phoneticRight')
+	select-variant 'zCurlyTail/phoneticRight'  (shapeFrom --'zCurlyTail')  (follow -- 'zDesc/phoneticRight')
+
 	derive-composites 'ZDesc'        0x2C6B 'Z/rtailBase' [CyrDescender.r RightSB 0]
 	derive-composites 'zDesc'        0x2C6C 'z/rtailBase' [CyrDescender.r RightSB 0]
 
 	derive-composites 'ZPalatalHook' 0xA7C6 'Z/rtailBase' [PalatalHook.r RightSB 0]
 	derive-composites 'zPalatalHook' 0x1D8E 'z/rtailBase' [PalatalHook.r RightSB 0]
 
-	derive-composites 'zRTailBR'     0x290  'z/rtailBase' [RetroflexHook.r RightSB 0]
+	derive-composites 'zRTail'       0x290  'z/rtailBase' [RetroflexHook.r RightSB 0]
+	derive-composites 'zRTail/phoneticRight' null 'z/rtailBase/phoneticRight' [RetroflexHook.r RightSB 0]
 
 	alias 'grek/Zeta' 0x396 'Z/reduced'
 	alias-reduced-variant 'grek/Zeta/sansSerif' 'grek/Zeta' 'Z/reduced/sansSerif' MathSansSerif

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -4262,9 +4262,12 @@ descriptionAffix = "straight body shape"
 selectorAffix.z = "straight"
 selectorAffix."z/sansSerif" = "straight"
 selectorAffix."z/reduced" = "straight"
+selectorAffix."z/phoneticRight" = "straight"
 selectorAffix.zDesc = "straight"
 selectorAffix."zDesc/reduced" = "straight"
+selectorAffix."zDesc/phoneticRight" = "straight"
 selectorAffix.ezh = "straight"
+selectorAffix."ezh/phoneticRight" = "straight"
 
 [prime.z.variants-buildup.stages.body.curly]
 rank = 2
@@ -4272,9 +4275,12 @@ descriptionAffix = "curly body shape"
 selectorAffix.z = "curly"
 selectorAffix."z/sansSerif" = "curly"
 selectorAffix."z/reduced" = "curly"
+selectorAffix."z/phoneticRight" = "curly"
 selectorAffix.zDesc = "curly"
 selectorAffix."zDesc/reduced" = "curly"
+selectorAffix."zDesc/phoneticRight" = "curly"
 selectorAffix.ezh = "straight"
+selectorAffix."ezh/phoneticRight" = "straight"
 
 [prime.z.variants-buildup.stages.body.cursive]
 rank = 3
@@ -4283,9 +4289,12 @@ descriptionAffix = "cursive body shape"
 selectorAffix.z = "cursive"
 selectorAffix."z/sansSerif" = "cursive"
 selectorAffix."z/reduced" = "cursive"
+selectorAffix."z/phoneticRight" = "cursive"
 selectorAffix.zDesc = "cursive"
 selectorAffix."zDesc/reduced" = "cursive"
+selectorAffix."zDesc/phoneticRight" = "cursive"
 selectorAffix.ezh = "cursive"
+selectorAffix."ezh/phoneticRight" = "cursive"
 
 [prime.z.variants-buildup.stages.serifs."*"]
 next = "overlay"
@@ -4297,9 +4306,12 @@ descriptionJoiner = "without"
 selectorAffix.z = "serifless"
 selectorAffix."z/sansSerif" = "serifless"
 selectorAffix."z/reduced" = "serifless"
+selectorAffix."z/phoneticRight" = "serifless"
 selectorAffix.zDesc = "serifless"
 selectorAffix."zDesc/reduced" = "serifless"
+selectorAffix."zDesc/phoneticRight" = "serifless"
 selectorAffix.ezh = "serifless"
+selectorAffix."ezh/phoneticRight" = "serifless"
 
 [prime.z.variants-buildup.stages.serifs.top-serifed]
 rank = 2
@@ -4307,9 +4319,12 @@ descriptionAffix = "serifs at top"
 selectorAffix.z = "topSerifed"
 selectorAffix."z/sansSerif" = "serifless"
 selectorAffix."z/reduced" = "topSerifed"
+selectorAffix."z/phoneticRight" = "serifless"
 selectorAffix.zDesc = "topSerifed"
 selectorAffix."zDesc/reduced" = "topSerifed"
+selectorAffix."zDesc/phoneticRight" = "serifless"
 selectorAffix.ezh = "topSerifed"
+selectorAffix."ezh/phoneticRight" = "serifless"
 
 [prime.z.variants-buildup.stages.serifs.bottom-serifed]
 rank = 3
@@ -4317,9 +4332,12 @@ descriptionAffix = "serifs at bottom"
 selectorAffix.z = "bottomSerifed"
 selectorAffix."z/sansSerif" = "serifless"
 selectorAffix."z/reduced" = "bottomSerifed"
+selectorAffix."z/phoneticRight" = "bottomSerifed"
 selectorAffix.zDesc = "serifless"
 selectorAffix."zDesc/reduced" = "serifless"
+selectorAffix."zDesc/phoneticRight" = "serifless"
 selectorAffix.ezh = "serifless"
+selectorAffix."ezh/phoneticRight" = "serifless"
 
 [prime.z.variants-buildup.stages.serifs.serifed]
 rank = 4
@@ -4327,9 +4345,12 @@ descriptionAffix = "serifs"
 selectorAffix.z = "serifed"
 selectorAffix."z/sansSerif" = "serifless"
 selectorAffix."z/reduced" = "serifed"
+selectorAffix."z/phoneticRight" = "bottomSerifed"
 selectorAffix.zDesc = "topSerifed"
 selectorAffix."zDesc/reduced" = "topSerifed"
+selectorAffix."zDesc/phoneticRight" = "serifless"
 selectorAffix.ezh = "topSerifed"
+selectorAffix."ezh/phoneticRight" = "serifless"
 
 [prime.z.variants-buildup.stages.overlay.no-overlay]
 rank = 1
@@ -4337,9 +4358,12 @@ keyAffix = ""
 selectorAffix.z = ""
 selectorAffix."z/sansSerif" = ""
 selectorAffix."z/reduced" = ""
+selectorAffix."z/phoneticRight" = ""
 selectorAffix.zDesc = ""
 selectorAffix."zDesc/reduced" = ""
+selectorAffix."zDesc/phoneticRight" = ""
 selectorAffix.ezh = ""
+selectorAffix."ezh/phoneticRight" = ""
 
 [prime.z.variants-buildup.stages.overlay.with-crossbar]
 rank = 2
@@ -4347,9 +4371,12 @@ descriptionAffix = "a diagonal crossbar"
 selectorAffix.z = "withCrossBar"
 selectorAffix."z/sansSerif" = "withCrossBar"
 selectorAffix."z/reduced" = ""
+selectorAffix."z/phoneticRight" = "withCrossBar"
 selectorAffix.zDesc = "withCrossBar"
 selectorAffix."zDesc/reduced" = ""
+selectorAffix."zDesc/phoneticRight" = "withCrossBar"
 selectorAffix.ezh = ""
+selectorAffix."ezh/phoneticRight" = ""
 
 [prime.z.variants-buildup.stages.overlay.with-horizontal-crossbar]
 rank = 3
@@ -4357,9 +4384,12 @@ descriptionAffix = "a horizontal crossbar"
 selectorAffix.z = "withHorizontalCrossBar"
 selectorAffix."z/sansSerif" = "withHorizontalCrossBar"
 selectorAffix."z/reduced" = ""
+selectorAffix."z/phoneticRight" = "withHorizontalCrossBar"
 selectorAffix.zDesc = "withHorizontalCrossBar"
 selectorAffix."zDesc/reduced" = ""
+selectorAffix."zDesc/phoneticRight" = "withHorizontalCrossBar"
 selectorAffix.ezh = ""
+selectorAffix."ezh/phoneticRight" = ""
 
 
 


### PR DESCRIPTION
Basically remove the serif that touches the `d` part to make it look more like the left arm of `z` is physically attached to the `d`:
`ʦʣꭧꭦʧʤ`
Slab Before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/922cf149-85ec-4951-b2db-b52caf7f8713)
Slab After:
![image](https://github.com/be5invis/Iosevka/assets/37010132/104cbc90-7979-4ada-9eda-e48caf0a7266)
Compared to Doulos SIL:
![image](https://github.com/be5invis/Iosevka/assets/37010132/dbfaee88-ce91-4071-b1b6-723987bbe2a0)
Compared to Charis SIL:
![image](https://github.com/be5invis/Iosevka/assets/37010132/217df41d-5b8a-4c70-8beb-52c331492a62)
Italic is unchanged:
![image](https://github.com/be5invis/Iosevka/assets/37010132/0df638f8-6a68-42b8-921f-38adc2de9488)
Compared to Charis SIL:
![image](https://github.com/be5invis/Iosevka/assets/37010132/845c2375-d48c-4139-93bb-6a9c9c76454c)

Also fix stroke width of hook of capital Eng under heavy:
`ꜦꜧⱮɱŊŋ`
Thin Before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/33b72991-24bc-49e0-a6d1-0e0b1b43495f)
Regular Before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/15e2ac28-2a75-4e14-b83f-5736e9dec00e)
Heavy Before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/d1a24dbb-ad9a-4cbe-b5c0-ce560e4a44c2)
Thin After:
![image](https://github.com/be5invis/Iosevka/assets/37010132/3986d139-5189-484d-a03f-3693eb2ee8ef)
Regular After:
![image](https://github.com/be5invis/Iosevka/assets/37010132/7285ff78-a6f8-43d4-a883-2530c71e1204)
Heavy After:
![image](https://github.com/be5invis/Iosevka/assets/37010132/13e8defb-52a4-4142-a04a-1cd09538bdef)
