### PR TITLE
Fix Te bar terminal for Cyrillic TeTse/Tche under sans italic/oblique when `T` is serifed.

### DIFF
--- a/changes/30.1.2.md
+++ b/changes/30.1.2.md
@@ -1,3 +1,5 @@
+* Fix Te bar terminal for Cyrillic TeTse (`U+04B4`..`U+04B5`) and Tche (`U+A693`..`U+A694`) under sans italic/oblique when `T` (`cv19`) is serifed.
+* Make presence of non-Te serifs of Cyrillic TeTse automatic.
 * Add characters:
   - DOTTED OBELOS (`U+2E13`).
   - MODIFIER LETTER DOT VERTICAL BAR (`U+A717`) ... MODIFIER LETTER DOT HORIZONTAL BAR (`U+A719`).

--- a/packages/font-glyphs/src/letter/cyrillic/che.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/che.ptl
@@ -121,8 +121,8 @@ glyph-block Letter-Cyrillic-Che : begin
 
 		include : dispiro
 			widths.rhs sw
-			flat xTopBarLeft  top [if SLAB [heading Rightward] null]
-			curl xTopBarRight top [if SLAB [heading Rightward] null]
+			flat xTopBarLeft  top [if teSerifs [heading Rightward] null]
+			curl xTopBarRight top [if teSerifs [heading Rightward] null]
 
 		local sf : SerifFrame top 0 left right (swRef -- sw)
 		include : tagged 'SerifRT' : match slabType

--- a/packages/font-glyphs/src/letter/cyrillic/tse.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/tse.ptl
@@ -41,9 +41,8 @@ glyph-block Letter-Cyrillic-Tse : begin
 	define TeTseConfig : object
 		serifless     { false false }
 		motionSerifed { true  false }
-		serifed       { true  true  }
 
-	define [CyrTeTseShape top slabTop slabBot] : glyph-proc
+	define [CyrTeTseShape top teSerifs] : glyph-proc
 		local sw : AdviceStroke 2.75
 		local left : [mix SB RightSB 0.2] - [HSwToV : 0.25 * sw] + OX
 		local right : RightSB - OX
@@ -56,31 +55,30 @@ glyph-block Letter-Cyrillic-Tse : begin
 		include : VBar.r right 0 top sw
 		include : dispiro
 			widths.rhs sw
-			flat xTopBarLeft  top [if SLAB [heading Rightward] null]
-			curl xTopBarRight top [if SLAB [heading Rightward] null]
+			flat xTopBarLeft  top [if teSerifs [heading Rightward] null]
+			curl xTopBarRight top [if teSerifs [heading Rightward] null]
 
 		local sf : SerifFrame top 0 left right (swRef -- sw)
 		include : CyrDescender.rSideJut right 0 (sideJut -- sf.sideJut)
 
-		if slabTop : begin
+		if SLAB : begin
 			include sf.rt.outer
+			include sf.lb.outer
+			include sf.rb.outer
 
+		if teSerifs : begin
 			local swVJut : Math.min [AdviceStroke 4.5] (0.625 * (left - xTopBarLeft))
 			include : VSerif.dl  xTopBarLeft  top VJut swVJut
 			include : VSerif.dr  xTopBarRight top VJut swVJut
 
-		if slabBot : begin
-			include sf.lb.outer
-			include sf.rb.outer
-
 	foreach { suffix { doST doSB } } [Object.entries TeTseConfig] : do
 		create-glyph "cyrl/TeTse.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : CyrTeTseShape CAP doST doSB
+			include : CyrTeTseShape CAP doST
 
 		create-glyph "cyrl/tetse.upright.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			include : CyrTeTseShape XH doST doSB
+			include : CyrTeTseShape XH doST
 
-	select-variant 'cyrl/TeTse' 0x4B4 (follow -- 'T')
-	select-variant 'cyrl/tetse.upright' (follow -- 'T')
+	select-variant 'cyrl/TeTse' 0x4B4 (follow -- 'T/rtailBase')
+	select-variant 'cyrl/tetse.upright' (follow -- 'T/rtailBase')


### PR DESCRIPTION
All `T` variants:

`T𝖳ƮҴҵꚒꚓ`

Sans Upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/717422f5-16dc-4451-9d44-224db7115c24)
Sans Italic (Before):
![image](https://github.com/be5invis/Iosevka/assets/37010132/bd97d1a5-8560-4a7b-a0e6-78f90f69f796)
Sans Italic (After):
![image](https://github.com/be5invis/Iosevka/assets/37010132/7a789244-7d5d-4f7d-9796-d6cbf283bd61)

Also make the non-Te serifs of Cyrillic TeTse automatic.

Slab Upright (Before):
![image](https://github.com/be5invis/Iosevka/assets/37010132/07ba65f4-8f75-4850-b6e9-c4ffd7c99ad9)
Slab Upright (After):
![image](https://github.com/be5invis/Iosevka/assets/37010132/0ed036fb-393d-43fd-957f-ef8abd7fb9e8)
