### PR TITLE
Add five combining marks from Cyrillic Extended-B.

### DIFF
--- a/changes/30.1.2.md
+++ b/changes/30.1.2.md
@@ -2,4 +2,6 @@
 * Make presence of non-Te serifs of Cyrillic TeTse automatic.
 * Add characters:
   - DOTTED OBELOS (`U+2E13`).
+  - COMBINING CYRILLIC VZMET (`U+A66F`).
+  - COMBINING CYRILLIC KAVYKA (`U+A67C`) ... CYRILLIC PAYEROK (`U+A67F`).
   - MODIFIER LETTER DOT VERTICAL BAR (`U+A717`) ... MODIFIER LETTER DOT HORIZONTAL BAR (`U+A719`).

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -138,7 +138,7 @@ glyph-block Mark-Above : begin
 	foreach { suffix { DrawAt kdr } } [Object.entries DotVariants] : do
 		create-glyph "dieresisRingAbove.\(suffix)" : glyph-proc
 			set-width 0
-			include : StdAnchors.impl 'above' 0 1.5
+			include : StdAnchors.extraWide
 			include : RingShape markMiddle aboveMarkMid
 			include : DrawAt (markMiddle + markExtend * 1.7) aboveMarkMid (markDotsRadius * kdr)
 			include : DrawAt (markMiddle - markExtend * 1.7) aboveMarkMid (markDotsRadius * kdr)
@@ -263,7 +263,7 @@ glyph-block Mark-Above : begin
 		CaronLeftShape  top bottom xMiddle width swEnd swMid
 		CaronRightShape top bottom xMiddle width swEnd swMid
 
-	create-glyph 'caronAbove' 0x30c : glyph-proc
+	create-glyph 'caronAbove' 0x30C : glyph-proc
 		set-width 0
 		include : StdAnchors.medium
 		include : CaronShape
@@ -504,33 +504,45 @@ glyph-block Mark-Above : begin
 			flat (0 - Width) aboveMarkTop
 			curl 0           aboveMarkTop
 
+	define [BreveShape] : with-params [top bottom xMiddle width hs] : glyph-proc
+		local leftEnd (xMiddle - width * 0.5)
+		local rightEnd (xMiddle + width * 0.5)
+		include : dispiro
+			g4.down.start leftEnd top [widths.heading hs hs Downward]
+			arcvh
+			g4.right.mid xMiddle (bottom + hs) [heading Rightward]
+			archv
+			g4.up.end rightEnd top [heading Upward]
+
+	define [InvBreveShape] : with-params [top bottom xMiddle width hs] : glyph-proc
+		local leftEnd (xMiddle - width * 0.5)
+		local rightEnd (xMiddle + width * 0.5)
+		include : dispiro
+			g4.up.start leftEnd bottom [widths.heading hs hs Upward]
+			arcvh
+			g4.right.mid xMiddle (top - hs) [heading Rightward]
+			archv
+			g4.down.end rightEnd bottom [heading Downward]
+
 	create-glyph 'breveAbove' 0x306 : glyph-proc
 		set-width 0
 		include : StdAnchors.wide
-
-		local leftEnd (markMiddle - markExtend * 1.2)
-		local rightEnd (markMiddle + markExtend * 1.2)
-
-		include : dispiro
-			g4.down.start leftEnd aboveMarkTop [widths.heading markHalfStroke markHalfStroke Downward]
-			arcvh
-			g4.right.mid markMiddle (aboveMarkBot + markHalfStroke) [heading Rightward]
-			archv
-			g4.up.end rightEnd aboveMarkTop [heading Upward]
+		include : BreveShape
+			xMiddle -- markMiddle
+			width   -- 2.4 * markExtend
+			top     -- aboveMarkTop
+			bottom  -- aboveMarkBot
+			hs      -- markHalfStroke
 
 	create-glyph 'archAbove' 0x311 : glyph-proc
 		set-width 0
 		include : StdAnchors.wide
-
-		local leftEnd (markMiddle - markExtend * 1.2)
-		local rightEnd (markMiddle + markExtend * 1.2)
-
-		include : dispiro
-			g4.up.start leftEnd aboveMarkBot [widths.heading markHalfStroke markHalfStroke Upward]
-			arcvh
-			g4.right.mid markMiddle (aboveMarkTop - markHalfStroke) [heading Rightward]
-			archv
-			g4.down.end rightEnd aboveMarkBot [heading Downward]
+		include : InvBreveShape
+			xMiddle -- markMiddle
+			width   -- 2.4 * markExtend
+			top     -- aboveMarkTop
+			bottom  -- aboveMarkBot
+			hs      -- markHalfStroke
 
 	create-glyph 'hookAbove' 0x309 : glyph-proc
 		set-width 0
@@ -666,7 +678,6 @@ glyph-block Mark-Above : begin
 
 	select-variant 'revCommaAbove' 0x314 (follow -- 'diacriticDot')
 
-
 	derive-glyphs 'revCommaGrekUpperTonos' null 'revCommaAbove' : function [src gr] : glyph-proc
 		set-width 0
 		include : refer-glyph src
@@ -704,6 +715,17 @@ glyph-block Mark-Above : begin
 		include : VBar.m (SB - Width)      aboveMarkBot aboveMarkTop (markFine * 2)
 		include : VBar.m (RightSB - Width) aboveMarkBot aboveMarkTop (markFine * 2)
 		include : HBar.t (SB - Width) (RightSB - Width) aboveMarkTop (markFine * 2)
+
+	create-glyph 'crossAbove' 0x33D : glyph-proc
+		set-width 0
+		include : StdAnchors.mediumWide
+
+		include : dispiro
+			flat (markMiddle - markExtend) aboveMarkTop [widths.center : 2 * markFine]
+			curl (markMiddle + markExtend) aboveMarkBot
+		include : dispiro
+			flat (markMiddle - markExtend) aboveMarkBot [widths.center : 2 * markFine]
+			curl (markMiddle + markExtend) aboveMarkTop
 
 	create-glyph 'yerikAbove' 0x33E : glyph-proc
 		set-width 0
@@ -810,17 +832,6 @@ glyph-block Mark-Above : begin
 	select-variant 'dialytikaVariaAbove' (follow -- 'diacriticDot')
 	select-variant 'dialytikaOxiaAbove' (follow -- 'diacriticDot')
 
-	create-glyph 'crossAbove' 0x33D : glyph-proc
-		set-width 0
-		include : StdAnchors.mediumWide
-
-		include : dispiro
-			flat (markMiddle - markExtend) aboveMarkTop [widths.center : 2 * markFine]
-			curl (markMiddle + markExtend) aboveMarkBot
-		include : dispiro
-			flat (markMiddle - markExtend) aboveMarkBot [widths.center : 2 * markFine]
-			curl (markMiddle + markExtend) aboveMarkTop
-
 	create-glyph 'lessAbove' 0x1DFE : glyph-proc
 		set-width 0
 		include : StdAnchors.mediumWide
@@ -839,6 +850,43 @@ glyph-block Mark-Above : begin
 			curl (markMiddle - markExtend) [mix top bot 0.5] [widths.center.heading (markFine * exp) Leftward]
 
 	turned 'greaterAbove' 0x350 'lessAbove' markMiddle aboveMarkMid
+
+	create-glyph 'leftHalfCircleAbove' 0x351 : glyph-proc
+		set-width 0
+		include : StdAnchors.narrow
+		local [object radiusIn radiusOut] : RingDims
+		include : dispiro
+			g4.left.start markMiddle aboveMarkTop [widths.center.heading (radiusOut - radiusIn) Leftward]
+			archv
+			g4.down.mid   (markMiddle - (aboveMarkTop - aboveMarkBot) / 2) [mix aboveMarkTop aboveMarkBot 0.5] [heading Downward]
+			arcvh
+			g4.right.end  markMiddle aboveMarkBot [heading Rightward]
+		include : Translate ((aboveMarkTop - aboveMarkBot) / 4) 0
+
+	create-glyph 'rightHalfCircleAbove' 0x357 : glyph-proc
+		set-width 0
+		include : StdAnchors.narrow
+		local [object radiusIn radiusOut] : RingDims
+		include : dispiro
+			g4.right.start markMiddle aboveMarkTop [widths.center.heading (radiusOut - radiusIn) Rightward]
+			archv
+			g4.down.mid   (markMiddle + (aboveMarkTop - aboveMarkBot) / 2) [mix aboveMarkTop aboveMarkBot 0.5] [heading Downward]
+			arcvh
+			g4.left.end  markMiddle aboveMarkBot [heading Leftward]
+		include : Translate (-(aboveMarkTop - aboveMarkBot) / 4) 0
+
+	create-glyph 'zigzagAbove' 0x35B : glyph-proc
+		set-width 0
+		include : StdAnchors.mediumWide
+
+		local ext : 0.625 * markExtend + markFine
+		local coSlope  0.2
+		local fr : new Box aboveMarkTop aboveMarkBot (markMiddle - ext) (markMiddle + ext)
+		include : HBar.m fr.left fr.right fr.yMid (markFine * 2)
+		include : intersection [MaskBelow fr.top] [MaskAbove (fr.yMid - markFine)]
+			ExtLineLhs 4 (markFine * 2) (fr.left + coSlope * (fr.top - fr.yMid - markFine)) fr.top (fr.left - 2 * markFine * coSlope) (fr.yMid - markFine)
+		include : intersection [MaskAbove fr.bot] [MaskBelow (fr.yMid + markFine)]
+			ExtLineLhs 4 (markFine * 2) (fr.right - coSlope * (fr.yMid - fr.bot - markFine)) fr.bot (fr.right + 2 * markFine * coSlope) (fr.yMid + markFine)
 
 	create-glyph 'upArrowHeadAbove' : glyph-proc
 		set-width 0
@@ -976,20 +1024,38 @@ glyph-block Mark-Above : begin
 
 		include : VBar.m (markMiddle - markExtend) aboveMarkBot (aboveMarkMid + markFine) (markFine * 2)
 		include : VBar.m (markMiddle + markExtend) (aboveMarkMid - markFine) aboveMarkTop (markFine * 2)
-		include : HBar.m (markMiddle - markExtend) (markMiddle + markExtend)aboveMarkMid (markFine * 2)
+		include : HBar.m (markMiddle - markExtend) (markMiddle + markExtend) aboveMarkMid (markFine * 2)
 
-	create-glyph 'zigzagAbove' 0x35B : glyph-proc
+	create-glyph 'cyrlVzmetAbove' 0xA66F : glyph-proc
+		set-width 0
+		include : StdAnchors.wide
+
+		include : VBar.m (markMiddle - markExtend) aboveMarkBot (aboveMarkMid + markFine) (markFine * 2)
+		include : VBar.m (markMiddle + markExtend) aboveMarkBot (aboveMarkMid + markFine) (markFine * 2)
+		include : HBar.m (markMiddle - markExtend) (markMiddle + markExtend) aboveMarkMid (markFine * 2)
+
+	create-glyph 'cyrlKavykaAbove' 0xA67C : glyph-proc
+		set-width 0
+		include : StdAnchors.extraWide
+		include : BreveShape
+			xMiddle -- markMiddle
+			width   -- 3.0 * markExtend
+			top     -- aboveMarkTop
+			bottom  -- aboveMarkBot
+			hs      -- markHalfStroke
+
+	create-glyph 'cyrlPayerokAbove' 0xA67D : glyph-proc
 		set-width 0
 		include : StdAnchors.mediumWide
 
 		local ext : 0.625 * markExtend + markFine
 		local coSlope  0.2
 		local fr : new Box aboveMarkTop aboveMarkBot (markMiddle - ext) (markMiddle + ext)
-		include : HBar.m fr.left fr.right fr.yMid (markFine * 2)
+		include : HBar.m fr.left (fr.right - coSlope * (fr.top - fr.yMid)) fr.yMid (markFine * 2)
 		include : intersection [MaskBelow fr.top] [MaskAbove (fr.yMid - markFine)]
 			ExtLineLhs 4 (markFine * 2) (fr.left + coSlope * (fr.top - fr.yMid - markFine)) fr.top (fr.left - 2 * markFine * coSlope) (fr.yMid - markFine)
-		include : intersection [MaskAbove fr.bot] [MaskBelow (fr.yMid + markFine)]
-			ExtLineLhs 4 (markFine * 2) (fr.right - coSlope * (fr.yMid - fr.bot - markFine)) fr.bot (fr.right + 2 * markFine * coSlope) (fr.yMid + markFine)
+		include : intersection [MaskAbove fr.bot] [MaskBelow fr.top]
+			ExtLineLhs 4 (markFine * 2) (fr.right - coSlope * (fr.top - fr.bot - 2 * markFine)) fr.bot (fr.right + 2 * markFine * coSlope) fr.top
 
 	create-glyph 'ogonekAbove' 0x1DCE : glyph-proc
 		set-width 0
@@ -1015,30 +1081,6 @@ glyph-block Mark-Above : begin
 				arcvh [widths.rhs markStroke]
 				g4 (markMiddle + [mix extR (-extL) 0.625]) (XH + depth - O) [heading Leftward]
 				g4 (markMiddle - extL) (XH + depth - 0.5 * O) [heading Leftward]
-
-	create-glyph 'leftHalfCircleAbove' 0x351 : glyph-proc
-		set-width 0
-		include : StdAnchors.narrow
-		local [object radiusIn radiusOut] : RingDims
-		include : dispiro
-			g4.left.start markMiddle aboveMarkTop [widths.center.heading (radiusOut - radiusIn) Leftward]
-			archv
-			g4.down.mid   (markMiddle - (aboveMarkTop - aboveMarkBot) / 2) [mix aboveMarkTop aboveMarkBot 0.5] [heading Downward]
-			arcvh
-			g4.right.end  markMiddle aboveMarkBot [heading Rightward]
-		include : Translate ((aboveMarkTop - aboveMarkBot) / 4) 0
-
-	create-glyph 'rightHalfCircleAbove' 0x357 : glyph-proc
-		set-width 0
-		include : StdAnchors.narrow
-		local [object radiusIn radiusOut] : RingDims
-		include : dispiro
-			g4.right.start markMiddle aboveMarkTop [widths.center.heading (radiusOut - radiusIn) Rightward]
-			archv
-			g4.down.mid   (markMiddle + (aboveMarkTop - aboveMarkBot) / 2) [mix aboveMarkTop aboveMarkBot 0.5] [heading Downward]
-			arcvh
-			g4.left.end  markMiddle aboveMarkBot [heading Leftward]
-		include : Translate (-(aboveMarkTop - aboveMarkBot) / 4) 0
 
 	create-glyph 'dblBreveAbove' 0x1AC7 : glyph-proc
 		set-width 0

--- a/packages/font-glyphs/src/meta/unicode-knowledge.ptl
+++ b/packages/font-glyphs/src/meta/unicode-knowledge.ptl
@@ -102,6 +102,8 @@ export : define decompOverrides : object
 	0x1FFD { 'markBaseSpace' 'acuteAbove' }
 	0x1FFE { 'markBaseSpace' 'revCommaAbove' }
 	0x2E2F { 'markBaseSpace' 'yerikAbove' }
+	0xA67E { 'markBaseSpace' 'cyrlKavykaAbove' }
+	0xA67F { 'markBaseSpace' 'cyrlPayerokAbove' }
 	0xA788 { 'markBaseSpace' 'circumflexBelow' }
 	0xA78A { 'markBaseSpace' 'equalOver' }
 	0xAB6A { 'markBaseSpace' 'leftTackOver' }
@@ -223,6 +225,12 @@ export : define ccmpCombinations : list
 	list {0x003C 0x0338} 0x226E     # <
 	list {0x003D 0x0338} 0x2260     # =
 	list {0x003E 0x0338} 0x226F     # >
+	list {0x2190 0x0338} 0x219A     # ←
+	list {0x2192 0x0338} 0x219B     # →
+	list {0x2194 0x0338} 0x21AE     # ↔
+	list {0x21D0 0x0338} 0x21CD     # ⇐
+	list {0x21D2 0x0338} 0x21CF     # ⇒
+	list {0x21D4 0x0338} 0x21CE     # ⇔
 	list {0x2203 0x0338} 0x2204     # ∃
 	list {0x2208 0x0338} 0x2209     # ∈
 	list {0x220B 0x0338} 0x220C     # ∋


### PR DESCRIPTION
This completes the non-enclosing marks in Cyrillic Extended-B.
Note that Cyrillic Kavyka is supposed to be slightly wider than a normal breve; both appear in Cyrillic text but for mutually distinctive purposes (kavyka is an editorial mark whereas breve is a vowel length mark). However, due to the similarities, I decided to make the breve shape into its own callable function since I really hate repeating code.
```
а꙯а꙼а꙽◌꙯
◌꙼◌꙽꙾ꙿ
```
Thin:
![image](https://github.com/be5invis/Iosevka/assets/37010132/bef8b213-14ea-46b0-a4cb-9a27a0ccc585)
Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/03dfb74b-7e17-4af2-8724-25d860cbfefc)
Heavy:
![image](https://github.com/be5invis/Iosevka/assets/37010132/b8f158fe-8692-4bde-9ab9-fba8b765a697)
Combining Parentheses anchor test:
`а꙯᪻ а꙼᪻ а꙽᪻`
Thin:
![image](https://github.com/be5invis/Iosevka/assets/37010132/55e1b73b-6ebd-40e9-a3b7-14f9ee4b8e20)
Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/7114ccf7-1151-440e-8721-c81c6e0adab5)
Heavy:
![image](https://github.com/be5invis/Iosevka/assets/37010132/5daa8fcb-8eab-42cf-bdf6-59ca57b4bb2f)
