### PR TITLE
Add Combining Kavyka Above {Right|Left} (`U+1DF6`‥`U+1DF7`).

### DIFF
--- a/changes/30.1.2.md
+++ b/changes/30.1.2.md
@@ -1,6 +1,8 @@
 * Fix Te bar terminal for Cyrillic TeTse (`U+04B4`..`U+04B5`) and Tche (`U+A693`..`U+A694`) under sans italic/oblique when `T` (`cv19`) is serifed.
 * Make presence of non-Te serifs of Cyrillic TeTse automatic.
 * Add characters:
+  - COMBINING KAVYKA ABOVE RIGHT (`U+1DF6`).
+  - COMBINING KAVYKA ABOVE LEFT (`U+1DF7`).
   - DOTTED OBELOS (`U+2E13`).
   - COMBINING CYRILLIC VZMET (`U+A66F`).
   - COMBINING CYRILLIC KAVYKA (`U+A67C`) ... CYRILLIC PAYEROK (`U+A67F`).

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -504,6 +504,7 @@ glyph-block Mark-Above : begin
 			flat (0 - Width) aboveMarkTop
 			curl 0           aboveMarkTop
 
+	glyph-block-export BreveShape
 	define [BreveShape] : with-params [top bottom xMiddle width hs] : glyph-proc
 		local leftEnd (xMiddle - width * 0.5)
 		local rightEnd (xMiddle + width * 0.5)

--- a/packages/font-glyphs/src/marks/horn-and-angle.ptl
+++ b/packages/font-glyphs/src/marks/horn-and-angle.ptl
@@ -10,9 +10,9 @@ glyph-block Mark-Horn-And-Angle : begin
 	glyph-block-import Common-Derivatives
 
 	glyph-block-import Mark-Shared-Metrics : markExtend markStroke markStress markFine
-	glyph-block-import Mark-Shared-Metrics : markMiddle markDotsRadius
+	glyph-block-import Mark-Shared-Metrics : markHalfStroke markMiddle markDotsRadius
 	glyph-block-import Mark-Above : aboveMarkTop aboveMarkBot aboveMarkMid aboveMarkStack
-	glyph-block-import Mark-Above : commaAboveRadius
+	glyph-block-import Mark-Above : BreveShape commaAboveRadius
 	glyph-block-import Mark-Below : belowMarkBot belowMarkTop belowMarkMid
 
 	# horn and angle marks
@@ -79,7 +79,6 @@ glyph-block Mark-Horn-And-Angle : begin
 
 	select-variant 'horn' 0x31B (follow -- 'diacriticDot')
 
-
 	create-glyph 'longHorn.round' : glyph-proc
 		set-width 0
 		include : HornShape 0 XH (Width / 2) (ArchDepthB) 0.5
@@ -100,8 +99,30 @@ glyph-block Mark-Horn-And-Angle : begin
 		set-base-anchor 'aboveBraceL' (-0.75 * markExtend) aboveMarkMid
 		set-base-anchor 'aboveBraceR' 0 aboveMarkMid
 
+	create-glyph 'ltailBR' 0x321 : glyph-proc
+		set-width 0
+		set-mark-anchor 'bottomRight' 0 0 0 belowMarkBot
+		set-base-anchor 'belowBraceL' (-0.5 * HookX - 0.25 * markExtend - [HSwToV : 0.25 * Stroke]) (-0.5 * Hook - HalfStroke)
+		set-base-anchor 'belowBraceR' (-0.5 * HookX + 0.25 * markExtend - [HSwToV : 0.25 * Stroke]) (-0.5 * Hook - HalfStroke)
+		include : dispiro
+			widths.rhs
+			flat 0 (-O) [heading Downward]
+			curl 0 0 [heading Downward]
+			straight.left.end (-HookX - [HSwToV HalfStroke]) (-Hook - HalfStroke)
+
+	create-glyph 'rtailBR' 0x322 : glyph-proc
+		set-width 0
+		set-mark-anchor 'bottomRight' 0 0 0 belowMarkBot
+		set-base-anchor 'belowBraceL' (0.5 * HookX - 0.25 * markExtend - [HSwToV : 0.75 * Stroke]) (-0.5 * Hook - HalfStroke)
+		set-base-anchor 'belowBraceR' (0.5 * HookX + 0.25 * markExtend - [HSwToV : 0.5 * Stroke]) (-0.5 * Hook - HalfStroke)
+		include : dispiro
+			widths.rhs
+			flat 0 (-O) [heading Downward]
+			curl 0 0 [heading Downward]
+			straight.right.end (HookX - [HSwToV HalfStroke]) (-Hook + HalfStroke)
+
 	foreach { suffix { DrawAt kdr } } [Object.entries DotVariants] : do
-		create-glyph "dotTL.\(suffix)" 0x358 : glyph-proc
+		create-glyph "dotTL.\(suffix)" : glyph-proc
 			set-width 0
 			local [object radius attX attY startX startY] : HornDim 0 XH 0 0 0.5
 			local r : mix radius DotRadius 0.5
@@ -109,7 +130,7 @@ glyph-block Mark-Horn-And-Angle : begin
 			set-mark-anchor 'topLeft' 0 XH (-startX) startY
 			set-base-anchor 'aboveBraceL' (startX - r) startY
 			set-base-anchor 'aboveBraceR' (startX - r) startY
-		create-glyph "dotTR.\(suffix)" 0x358 : glyph-proc
+		create-glyph "dotTR.\(suffix)" : glyph-proc
 			set-width 0
 			local [object radius attX attY startX startY] : HornDim 0 XH 0 0 0.5
 			local r : mix radius DotRadius 0.5
@@ -117,7 +138,7 @@ glyph-block Mark-Horn-And-Angle : begin
 			set-mark-anchor 'topRight' 0 XH startX startY
 			set-base-anchor 'aboveBraceL' (startX - r) startY
 			set-base-anchor 'aboveBraceR' (startX - r) startY
-		create-glyph "dotBL.\(suffix)" 0x358 : glyph-proc
+		create-glyph "dotBL.\(suffix)" : glyph-proc
 			set-width 0
 			local [object radius attX attY startX startY] : HornDim 0 XH 0 0 0.5
 			local r : mix radius DotRadius 0.5
@@ -138,30 +159,29 @@ glyph-block Mark-Horn-And-Angle : begin
 		set-base-anchor 'aboveBraceL' (-SB + DotRadius) aboveMarkMid
 		set-base-anchor 'aboveBraceR' (-SB + DotRadius) aboveMarkMid
 
-	create-glyph 'rtailBR' 0x322 : glyph-proc
+	create-glyph 'cyrlKavykaTR' 0x1DF6 : glyph-proc
 		set-width 0
-		set-mark-anchor 'bottomRight' 0 0 0 belowMarkBot
-		set-base-anchor 'belowBraceL' (0.5 * HookX - 0.25 * markExtend - [HSwToV : 0.75 * Stroke]) (-0.5 * Hook - HalfStroke)
-		set-base-anchor 'belowBraceR' (0.5 * HookX + 0.25 * markExtend - [HSwToV : 0.5 * Stroke]) (-0.5 * Hook - HalfStroke)
+		include : BreveShape
+			xMiddle -- 0
+			width   -- 2 * (markExtend * 1.5 - [HSwToV markHalfStroke])
+			top     -- aboveMarkTop
+			bottom  -- aboveMarkBot
+			hs      -- markHalfStroke
+		set-mark-anchor 'topRight' 0 XH 0 aboveMarkTop
+		set-base-anchor 'aboveBraceL' (-0.75 * markExtend) aboveMarkMid
+		set-base-anchor 'aboveBraceR' ( 0.75 * markExtend) aboveMarkMid
 
-		include : dispiro
-			widths.rhs
-			flat 0 (-O) [heading Downward]
-			curl 0 0 [heading Downward]
-			straight.right.end (HookX - [HSwToV HalfStroke]) (-Hook + HalfStroke)
-
-	create-glyph 'ltailBR' 0x321 : glyph-proc
+	create-glyph 'cyrlKavykaTL' 0x1DF7 : glyph-proc
 		set-width 0
-
-		set-mark-anchor 'bottomRight' 0 0 0 belowMarkBot
-		set-base-anchor 'belowBraceL' (-0.5 * HookX - 0.25 * markExtend - [HSwToV : 0.25 * Stroke]) (-0.5 * Hook - HalfStroke)
-		set-base-anchor 'belowBraceR' (-0.5 * HookX + 0.25 * markExtend - [HSwToV : 0.25 * Stroke]) (-0.5 * Hook - HalfStroke)
-
-		include : dispiro
-			widths.rhs
-			flat 0 (-O) [heading Downward]
-			curl 0 0 [heading Downward]
-			straight.left.end (-HookX - [HSwToV HalfStroke]) (-Hook - HalfStroke)
+		include : BreveShape
+			xMiddle -- 0
+			width   -- 2 * (markExtend * 1.5 - [HSwToV markHalfStroke])
+			top     -- aboveMarkTop
+			bottom  -- aboveMarkBot
+			hs      -- markHalfStroke
+		set-mark-anchor 'topLeft' 0 XH 0 aboveMarkTop
+		set-base-anchor 'aboveBraceL' (-0.75 * markExtend) aboveMarkMid
+		set-base-anchor 'aboveBraceR' ( 0.75 * markExtend) aboveMarkMid
 
 	create-glyph 'rightHalfCircleTR' : glyph-proc
 		set-width 0


### PR DESCRIPTION
The widths of the above left/right versions of these marks are clamped to exactly `markExtend * 1.5` on either end by subtracting `markHalfstroke` twice. This is to limit the inevitable overflow with the neighboring character cells that these marks kind of have to have by design.

`а᷶ а᷷`

Thin:
![image](https://github.com/be5invis/Iosevka/assets/37010132/bdd212d5-d4d0-4d80-ba58-b191ad84aa33)
Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/2f9cae74-29a8-4147-ae6d-52fc84c3a417)
Heavy:
![image](https://github.com/be5invis/Iosevka/assets/37010132/4dbbc2a1-9e3c-4a70-bdc9-bf77ec41d428)

Combining parentheses anchor test:
`а᪻᷶ а᷷᪻`
Thin:
![image](https://github.com/be5invis/Iosevka/assets/37010132/6c7f4336-4927-4241-b21c-6f696d32e2bc)
Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/fa127a63-08f5-49fb-927d-36a5301858ea)
Heavy:
![image](https://github.com/be5invis/Iosevka/assets/37010132/fc062fe8-1582-4b0d-9399-b1f917298d0e)
