### PR TITLE
Fix mark placement of Sideways U with Diaeresis (`U+1D1E`) when a CV/SS is applied to it (#2353)

### DIFF
--- a/changes/30.1.2.md
+++ b/changes/30.1.2.md
@@ -7,3 +7,4 @@
   - COMBINING CYRILLIC VZMET (`U+A66F`).
   - COMBINING CYRILLIC KAVYKA (`U+A67C`) ... CYRILLIC PAYEROK (`U+A67F`).
   - MODIFIER LETTER DOT VERTICAL BAR (`U+A717`) ... MODIFIER LETTER DOT HORIZONTAL BAR (`U+A719`).
+* Fix mark placement of Sideways U with Diaeresis (`U+1D1E`) when a CV/SS is applied to it (#2353).

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -302,6 +302,7 @@ glyph-block Letter-Latin-U : begin
 			include : df.markSet.e
 			local ww : Width * para.diversityM
 			set-width ww
+			set-base-anchor 'cvDecompose' 0 0
 			include : PointingTo ww XH ww 0 : function [] : glyph-proc
 				include : Base  df (ww - SB - 0.75 * para.diversityM * AccentHeight) Stroke
 				include : Slabs df (ww - SB - 0.75 * para.diversityM * AccentHeight)
@@ -444,6 +445,7 @@ glyph-block Letter-Latin-U : begin
 	derive-glyphs "uDieresisSidewaysMark" null "dieresisAboveAlwaysUpright" : function [gns] : glyph-proc
 		local ww : Width * para.diversityM
 		set-width 0
+		set-mark-anchor 'cvDecompose' 0 0
 		include : PointingTo ww XH ww 0 : function [] : glyph-proc
 			include : refer-glyph gns
 			include : Translate (XH / 2 + Width / 2) (ww - SB - XH - AccentHeight)


### PR DESCRIPTION
Closes #2353.