### PR TITLE
Improve glyph shape of `U+2E46`, also use `Math.SQRT2` or `Math.SQRT1_2` constants whereever possible.

### DIFF
--- a/changes/30.1.3.md
+++ b/changes/30.1.3.md
@@ -1,0 +1,1 @@
+* Improve glyph shape of INVERTED LOW KAVYKA WITH KAVYKA ABOVE (`U+2E46`).

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -314,7 +314,7 @@ glyph-block Letter-Shared-Shapes : begin
 
 		export : define [toothless] : with-params [
 				[top XH] [left SB] [right RightSB] [rise SHook] [sw Stroke] [fine ShoulderFine]
-				[mBlend : Math.sqrt (1 / 2)] [ada SmallArchDepthA] [adb SmallArchDepthB]
+				[mBlend Math.SQRT1_2] [ada SmallArchDepthA] [adb SmallArchDepthB]
 			] : begin
 			return : dispiro
 				g4 left rise [widths.lhs sw]
@@ -343,7 +343,7 @@ glyph-block Letter-Shared-Shapes : begin
 
 		export : define [toothlessTop] : with-params [
 				[top XH] [left SB] [right RightSB] [rise SHook] [sw Stroke] [fine ShoulderFine]
-				[mBlend : Math.sqrt (1 / 2)] [ada SmallArchDepthA] [adb SmallArchDepthB]
+				[mBlend Math.SQRT1_2] [ada SmallArchDepthA] [adb SmallArchDepthB]
 			] : begin
 			return : dispiro
 				flat (left + (sw - fine) * HVContrast) (top - ada - TINY) [widths.lhs fine]
@@ -411,7 +411,7 @@ glyph-block Letter-Shared-Shapes : begin
 
 		export : define [toothless] : with-params [
 				[top XH] [left SB] [right RightSB] [rise SHook] [sw Stroke] [fine ShoulderFine]
-				[mBlend : Math.sqrt (1 / 2)] [ada SmallArchDepthA] [adb SmallArchDepthB]
+				[mBlend Math.SQRT1_2] [ada SmallArchDepthA] [adb SmallArchDepthB]
 			] : new-glyph : glyph-proc
 			include : OBarLeft.toothlessTop
 				top -- top

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -515,6 +515,7 @@ glyph-block Mark-Above : begin
 			archv
 			g4.up.end rightEnd top [heading Upward]
 
+	glyph-block-export InvBreveShape
 	define [InvBreveShape] : with-params [top bottom xMiddle width hs] : glyph-proc
 		local leftEnd (xMiddle - width * 0.5)
 		local rightEnd (xMiddle + width * 0.5)

--- a/packages/font-glyphs/src/marks/below.ptl
+++ b/packages/font-glyphs/src/marks/below.ptl
@@ -211,7 +211,6 @@ glyph-block Mark-Below : begin
 	TurnAboveMarkToBelow 'elipsisBelow'            0x20E8 'elipsisAbove'
 	TurnAboveMarkToBelow 'leftArrowBelow'          0x20EE 'rightArrowAbove'
 	TurnAboveMarkToBelow 'rightArrowBelow'         0x20EF 'leftArrowAbove'
-	TurnAboveMarkToBelow 'cyrlInvKavykaBelow'      null   'cyrlKavykaAbove'
 	TurnAboveMarkToBelow 'upArrowHeadBelow'        null   'downArrowHeadAbove'
 	TurnAboveMarkToBelow 'downArrowHeadBelow'      null   'upArrowHeadAbove'
 	TurnAboveMarkToBelow 'descenderBarBelow'       null   'ascenderBarAbove'

--- a/packages/font-glyphs/src/meta/unicode-knowledge.ptl
+++ b/packages/font-glyphs/src/meta/unicode-knowledge.ptl
@@ -103,7 +103,6 @@ export : define decompOverrides : object
 	0x1FFE { 'markBaseSpace' 'revCommaAbove' }
 	0x2E2F { 'markBaseSpace' 'yerikAbove' }
 	0x2E45 { 'markBaseSpace' 'cyrlInvKavykaOver' }
-	0x2E46 { 'markBaseSpace' 'cyrlInvKavykaBelow' 'cyrlKavykaAbove' }
 	0x2E47 { 'markBaseSpace' 'cyrlKavykaOver' }
 	0x2E48 { 'markBaseSpace' 'cyrlKavykaWithDotOver' }
 	0xA67E { 'markBaseSpace' 'cyrlKavykaAbove' }

--- a/packages/font-glyphs/src/symbol/arrow.ptl
+++ b/packages/font-glyphs/src/symbol/arrow.ptl
@@ -211,8 +211,8 @@ glyph-block Symbol-Arrow : for-width-kinds WideWidth1
 		local fine : Math.min [AdviceStroke 5] (size * 0.75 / 3)
 		local mag : Math.hypot (y2 - y1) (x2 - x1)
 		local p : (mag - fine) / mag
-		local p2 : (mag - fine * [Math.sqrt 2]) / mag
-		local innerHeaderLengthShrink : fine * (1 + [Math.sqrt 2])
+		local p2 : (mag - fine * Math.SQRT2) / mag
+		local innerHeaderLengthShrink : fine * (1 + Math.SQRT2)
 
 		local x1a : mix x1 x2 (1 - p)
 		local y1a : mix y1 y2 (1 - p)
@@ -595,14 +595,14 @@ glyph-block Symbol-Arrow : for-width-kinds WideWidth1
 	do "Half Circle Arrow"
 		local arcSW : Math.min arrowSw [AdviceStroke 5 MosaicWidthScalar]
 		local headSize : mix arcSW arrowHeadSize 0.5
-		local headLength : (headSize + fine) * [Math.sqrt 0.5]
+		local headLength : (headSize + fine) * Math.SQRT1_2
 		local l : arrowSB  + 0.5 * headSize
 		local r : arrowRSB - 0.5 * headSize
 		local t : arrowTop - 0.5 * headSize
 		local b : arrowBot + 0.5 * headSize
 		local ada : ArchDepthAOf (SmallArchDepth * (r - l) / (RightSB - SB)) (r - l)
 		local adb : ArchDepthBOf (SmallArchDepth * (r - l) / (RightSB - SB)) (r - l)
-		local gapWidth : Math.max ((t - b) * 0.05) (fine * [Math.sqrt 0.5])
+		local gapWidth : Math.max ((t - b) * 0.05) (fine * Math.SQRT1_2)
 
 		define [HalfCircleArrow headFunc fCcw fGapped] : glyph-proc
 			local arrowX : if fCcw (l + [HSwToV : 0.5 * arcSW]) (r - [HSwToV : 0.5 * arcSW])
@@ -626,7 +626,7 @@ glyph-block Symbol-Arrow : for-width-kinds WideWidth1
 
 		define [ShareAlikeArrow] : glyph-proc
 			local arrowX : l + [HSwToV : 0.5 * Stroke]
-			local headLength : headSize * [Math.sqrt 0.5]
+			local headLength : headSize * Math.SQRT1_2
 			local gapSize : Math.max (2 * headLength) (CAP - 0 - ada - adb)
 			local gapTop : CAP / 2 + 0.5 * gapSize
 			local gapBot : CAP / 2 - 0.5 * gapSize

--- a/packages/font-glyphs/src/symbol/geometric/ballot-box.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/ballot-box.ptl
@@ -40,7 +40,7 @@ glyph-block Symbol-Geometric-Ballot-Box : for-width-kinds WideWidth1
 	define lightSwMark : UnicodeWeightGrade 3 Geom.Scalar
 	define boldSwMark  : UnicodeWeightGrade 7 Geom.Scalar
 	define bbSize : Geom.Size - bbGap - swMark * 0.75
-	define circXSize : (Geom.Size - bbGap) * [Math.sqrt 0.5] - swMark * 0.75
+	define circXSize : (Geom.Size - bbGap) * Math.SQRT1_2 - swMark * 0.75
 
 	create-glyph [MangleName 'checkedBallotBox'] [MangleUnicode 0x2611] : glyph-proc
 		local k1 0.4

--- a/packages/font-glyphs/src/symbol/geometric/masked.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/masked.ptl
@@ -333,7 +333,7 @@ glyph-block Symbol-Geometric-Masked : for-width-kinds WideWidth1
 		create-glyph [MangleName 'uni2389'] [MangleUnicode 0x2389] : glyph-proc
 			define shiftUp : ApparentTranslate 0
 				Math.max
-					0.5 * [Math.sqrt 2] * Size.MediumSmall.sw
+					Math.SQRT1_2 * Size.MediumSmall.sw
 					Geom.Size * (1 - Size.MediumSmall.size)
 
 			set-width Geom.Width

--- a/packages/font-glyphs/src/symbol/geometric/plain.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/plain.ptl
@@ -377,7 +377,7 @@ glyph-block Symbol-Geometric-Plain : for-width-kinds WideWidth1
 		StdBlackShape DiamondFill 'blackCenteredDiamond' 0x2BC1 Size.Oblique
 
 		StdWhiteShape DiamondFill 'whiteDiamond' 0x25C7 Size.Oblique
-		StdWhiteShape DiamondFill 'whiteDiamondOperatorImpl' null [Object.assign {.} Size.Oblique {.sw ([Math.sqrt 2] * [AdviceStroke 4])}]
+		StdWhiteShape DiamondFill 'whiteDiamondOperatorImpl' null [Object.assign {.} Size.Oblique {.sw (Math.SQRT2 * [AdviceStroke 4])}]
 
 		StdBlackShape DiamondFill 'blackMediumDiamond' 0x2B25 Size.MediumOblique
 		StdBlackShape DiamondFill 'blackSmallDiamond' 0x2B29 Size.SmallOblique
@@ -447,7 +447,7 @@ glyph-block Symbol-Geometric-Plain : for-width-kinds WideWidth1
 				g4     [mix cx [mix cx (cx - size) 0.5] p] [mix cy [mix (cy + size) cy 0.5] p]
 				close
 
-		StdWhiteShape DiamondLazongeShape 'whiteConcaveSidedDiamond'  0x27E1 [Object.assign {.} Size.Oblique {.sw ([Math.sqrt 2] * [UnicodeWeightGrade 6 Geom.Scalar])}]
+		StdWhiteShape DiamondLazongeShape 'whiteConcaveSidedDiamond'  0x27E1 [Object.assign {.} Size.Oblique {.sw (Math.SQRT2 * [UnicodeWeightGrade 6 Geom.Scalar])}]
 		StdBlackShape DiamondLazongeShape 'lightFourPointedBlackCusp' 0x2BCC Size.Oblique
 		StdWhiteShape DiamondLazongeShape 'whiteFourPointedBlackCusp' 0x2BCE Size.ObliqueSA
 

--- a/packages/font-glyphs/src/symbol/geometric/shared.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/shared.ptl
@@ -53,7 +53,7 @@ glyph-block Symbol-Geometric-Shared : begin
 		VerySmallOblique   { .size DesignParameters.geometric_very_small_x    .sw [Math.min GeometryStroke : AdviceStroke 7.25 Geom.Scalar] }
 		TinyOblique        { .size DesignParameters.geometric_tiny_x          .sw [Math.min GeometryStroke : AdviceStroke 8.25 Geom.Scalar] }
 
-		ObliqueSA          {                                                  .sw ([Math.sqrt 2] * [Math.min GeometryStroke : AdviceStroke 4.75 Geom.Scalar]) }
+		ObliqueSA          {                                                  .sw (Math.SQRT2 * [Math.min GeometryStroke : AdviceStroke 4.75 Geom.Scalar]) }
 
 		TinyInner   { .innerSize (1 / 4) }
 		SmallInner  { .innerSize (1 / 3) }

--- a/packages/font-glyphs/src/symbol/letter.ptl
+++ b/packages/font-glyphs/src/symbol/letter.ptl
@@ -24,7 +24,7 @@ glyph-block Symbol-Currency : begin
 			include : dispiro
 				widths.center sw
 				flat (Middle + radius * 0.87 * [Math.cos angle]) (SymbolMid + radius * 0.87 * [Math.sin angle])
-				curl (Middle + radius * [Math.sqrt 2] * [Math.cos angle]) (SymbolMid + radius * [Math.sqrt 2] * [Math.sin angle])
+				curl (Middle + radius * Math.SQRT2 * [Math.cos angle]) (SymbolMid + radius * Math.SQRT2 * [Math.sin angle])
 
 	do "Sterling"
 		define xBarLeft : [mix SB RightSB 0.2] - Stroke * 0.1

--- a/packages/font-glyphs/src/symbol/letter.ptl
+++ b/packages/font-glyphs/src/symbol/letter.ptl
@@ -345,6 +345,9 @@ glyph-block Symbol-Cyrl-Thousands : begin
 
 glyph-block Symbol-Letter-Phonetic : begin
 	glyph-block-import CommonShapes
+	glyph-block-import Mark-Above : BreveShape InvBreveShape
+	glyph-block-import Mark-Shared-Metrics : markExtend markHalfStroke
+
 	create-glyph 'modifierArchBreve' 0xAB5B : glyph-proc
 		include : MarkSet.e
 		local archHeight : XH * 0.45
@@ -360,3 +363,20 @@ glyph-block Symbol-Letter-Phonetic : begin
 			g4.down.start (SB + OX) XH [heading Downward]
 			arch.lhs (XH - archHeight)
 			g4.up.end (RightSB - OX) XH [heading Upward]
+
+	create-glyph 'cyrlInvLowKavykaWithKavyka' 0x2E46 : glyph-proc
+		include : MarkSet.e
+
+		include : BreveShape
+			xMiddle -- Middle
+			width   -- markExtend * 3.0
+			top     -- XH
+			bottom  -- XH - AccentHeight
+			hs      -- markHalfStroke
+
+		include : InvBreveShape
+			xMiddle -- Middle
+			width   -- markExtend * 3.0
+			top     -- AccentHeight
+			bottom  -- 0
+			hs      -- markHalfStroke

--- a/packages/font-glyphs/src/symbol/math/relation.ptl
+++ b/packages/font-glyphs/src/symbol/math/relation.ptl
@@ -399,7 +399,7 @@ glyph-block Symbol-Math-Relation-Inequality : begin
 
 	define [LessShapeHalf sign top bot l r s p] : begin
 		define exp : LessGreaterExpansion top bot l r
-		define expAmend : Math.min [Math.sqrt 2] exp
+		define expAmend : Math.min Math.SQRT2 exp
 		define endAdj : 0.5 * s * (exp - expAmend)
 		define pp : fallback p 1
 
@@ -410,7 +410,7 @@ glyph-block Symbol-Math-Relation-Inequality : begin
 
 	define [GreaterShapeHalf sign top bot l r s p] : begin
 		define exp : LessGreaterExpansion top bot l r
-		define expAmend : Math.min [Math.sqrt 2] exp
+		define expAmend : Math.min Math.SQRT2 exp
 		define endAdj : 0.5 * s * (exp - expAmend)
 		define pp : fallback p 1
 

--- a/packages/font-glyphs/src/symbol/pictograph/kome.ptl
+++ b/packages/font-glyphs/src/symbol/pictograph/kome.ptl
@@ -25,9 +25,9 @@ glyph-block Symbol-Pictograph-Kome : begin
 					curl (MosaicWidth / 2 - shapeSize) (SymbolMid + shapeSize)
 
 				local r0 : Math.min
-					(RightSB - SB + (sw / [Math.sqrt 2]) - sw * 3) / 4
+					(RightSB - SB + (sw * Math.SQRT1_2) - sw * 3) / 4
 					DotRadius * kdr
-				local r  : shapeSize - r0 + (sw / 2 / [Math.sqrt 2])
+				local r  : shapeSize - r0 + (sw / 2 * Math.SQRT1_2)
 
 				include : DrawAt (MosaicWidth / 2 + r) SymbolMid (r0 - ov)
 				include : DrawAt (MosaicWidth / 2 - r) SymbolMid (r0 - ov)


### PR DESCRIPTION
`Hx꙾⹅⹆⹇⹈`
Before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/f5a9df25-5fae-41a2-be6c-54d450095afc)
After:
![image](https://github.com/be5invis/Iosevka/assets/37010132/7ef0b26b-9651-499c-abd9-e79ffd4b3f2d)
