### PR TITLE
Fix IPPH/APPH localization for {super|sub}script Greek Lower Beta and Chi.

### DIFF
--- a/changes/30.1.3.md
+++ b/changes/30.1.3.md
@@ -1,1 +1,2 @@
 * Improve glyph shape of INVERTED LOW KAVYKA WITH KAVYKA ABOVE (`U+2E46`).
+* Fix IPPH/APPH localization for superscript/subscript Greek Lower Beta and Chi (`U+1D5D`, `U+1D61`, `U+1D66`, `U+1D6A`).

--- a/packages/font-glyphs/src/letter/greek.ptl
+++ b/packages/font-glyphs/src/letter/greek.ptl
@@ -30,3 +30,5 @@ export : define [apply] : begin
 	run-glyph-module "./greek/sampi.mjs"
 	run-glyph-module "./greek/qoppa.mjs"
 
+	run-glyph-module "./greek/orthography.mjs"
+

--- a/packages/font-glyphs/src/letter/greek/orthography.ptl
+++ b/packages/font-glyphs/src/letter/greek/orthography.ptl
@@ -1,0 +1,13 @@
+$$include '../../meta/macros.ptl'
+
+import [LocalizedForm] from "@iosevka/glyph/relation"
+
+glyph-module
+
+glyph-block Letter-Greek-Orthography : begin
+	glyph-block-import Common-Derivatives
+
+	# Link localization forms
+
+	link-gr LocalizedForm.IPPH 'grek/beta' 'latn/beta'
+	link-gr LocalizedForm.IPPH 'grek/chi'  'latn/chi'

--- a/packages/font-otl/src/gsub-locl.ptl
+++ b/packages/font-otl/src/gsub-locl.ptl
@@ -88,10 +88,6 @@ export : define [buildLOCL gsub para glyphStore] : begin
 	define loclIPPH : gsub.createFeature 'locl'
 	grekIPPH.addFeature loclIPPH
 	grekAPPH.addFeature loclIPPH
-	loclIPPH.addLookup : gsub.createLookup
-		.type 'gsub_single'
-		.substitutions : object
-			'grek/beta' : glyphStore.ensureExists 'latn/beta'
-			'grek/chi'  : glyphStore.ensureExists 'latn/chi'
+	loclIPPH.addLookup : createGsubLookupFromGr gsub glyphStore LocalizedForm.IPPH
 
 	gsub.endBlockAtFront rec

--- a/packages/glyph/src/relation.mjs
+++ b/packages/glyph/src/relation.mjs
@@ -30,6 +30,7 @@ export const LocalizedForm = {
 		Italic: LinkedGlyphProp("SerbianLocItalic"),
 	},
 	BGR: LinkedGlyphProp("BulgarianLoc"),
+	IPPH: LinkedGlyphProp("IPALoc"),
 };
 
 export const Texture = {
@@ -183,6 +184,7 @@ export const AnyLocalizedForm = {
 		if (LocalizedForm.SRB.Upright.get(glyph)) grs.push(LocalizedForm.SRB.Upright);
 		if (LocalizedForm.SRB.Italic.get(glyph)) grs.push(LocalizedForm.SRB.Italic);
 		if (LocalizedForm.BGR.get(glyph)) grs.push(LocalizedForm.BGR);
+		if (LocalizedForm.IPPH.get(glyph)) grs.push(LocalizedForm.IPPH);
 		if (grs.length) return grs;
 		return null;
 	},


### PR DESCRIPTION
`βᵝᵦχᵡᵪ`
Before:
![image](https://github.com/be5invis/Iosevka/assets/37010132/c1ab3f46-278d-4b6c-b44e-e97e12d20da2)
After:
![image](https://github.com/be5invis/Iosevka/assets/37010132/987f0dfe-7052-41da-8822-e385beb0070e)
