### PR TITLE
Add some miscellaneous symbols and arrows.

### DIFF
--- a/changes/30.1.3.md
+++ b/changes/30.1.3.md
@@ -2,3 +2,11 @@
 * Fix IPPH/APPH localization for superscript/subscript Greek Lower Beta and Chi (`U+1D5D`, `U+1D61`, `U+1D66`, `U+1D6A`).
 * Fix metrics of Cyrillie EnGhe and Abkhasian Che under Aile/Etoile (#2366).
 * Fix CV/SS application of localized form of superscript/subscript letters (#2368).
+* Improve glyph visual for `U+279D`, `U+27A2`, `U+27A3`, and `U+2B4D`.
+* Add characters:
+  - STAR OF DAVID (`U+2720`).
+  - HEAVY TRIANGLE-HEADED RIGHTWARDS ARROW (`U+279E`).
+  - LEFTWARDS HARPOON WITH BARB UP ABOVE LEFTWARDS HARPOON WITH BARB DOWN (`U+2962`) ... DOWNWARDS HARPOON WITH BARB LEFT BESIDE DOWNWARDS HARPOON WITH BARB RIGHT (`U+2965`).
+  - UPWARDS HARPOON WITH BARB LEFT BESIDE DOWNWARDS HARPOON WITH BARB RIGHT (`U+296E`).
+  - DOWNWARDS HARPOON WITH BARB LEFT BESIDE UPWARDS HARPOON WITH BARB RIGHT (`U+296F`).
+  - HELLSCHREIBER PAUSE SYMBOL (`U+2BFF`).

--- a/packages/font-glyphs/src/symbol/arrow.ptl
+++ b/packages/font-glyphs/src/symbol/arrow.ptl
@@ -541,7 +541,6 @@ glyph-block Symbol-Arrow : for-width-kinds WideWidth1
 		MkArrow ThinArrowShape [MangleName 'thinArrowRight'] null arrowSB SymbolMid arrowRSB SymbolMid
 		MkArrow ThinArrowShape [MangleName 'thinArrowDown']  null arrowMidX arrowTop arrowMidX arrowBot
 
-		MkArrow TrigArrowShape [MangleName 'uni279D']             [MangleUnicode 0x279D] arrowSB SymbolMid arrowRSB SymbolMid
 		MkArrow TrigArrowShape [MangleName 'trigArrowLeft']       [MangleUnicode 0x2B60] arrowRSB SymbolMid arrowSB SymbolMid
 		MkArrow TrigArrowShape [MangleName 'trigArrowUp']         [MangleUnicode 0x2B61] arrowMidX arrowBot arrowMidX arrowTop
 		MkArrow TrigArrowShape [MangleName 'trigArrowRight']      [MangleUnicode 0x2B62] arrowSB SymbolMid arrowRSB SymbolMid
@@ -942,6 +941,9 @@ glyph-block Symbol-Arrow : for-width-kinds WideWidth1
 		TrigGroupSquat 'trigArrowSquared'         0x1F838 (2 * Geom.Size * Size.VerySmall.size) kSmall
 		TrigGroupSquat 'trigArrowCompressed'      0x1F83C (2 * Geom.Size * Size.Small.size) kMedium kSmall
 		TrigGroupSquat 'trigArrowCompressedHeavy' 0x1F840 (2 * Geom.Size * Size.MediumSmall.size) kMedium kSmall
+
+		MkArrow [WeightedTrigArrowShape [UnicodeWeightGrade 3 MosaicWidthScalar] 1] [MangleName "uni279D"] [MangleUnicode 0x279D] arrowSB SymbolMid arrowRSB SymbolMid
+		MkArrow [WeightedTrigArrowShape [UnicodeWeightGrade 7 MosaicWidthScalar] 1] [MangleName "uni279E"] [MangleUnicode 0x279E] arrowSB SymbolMid arrowRSB SymbolMid
 		MkArrow [WeightedTrigArrowShape (2 * Geom.Size * Size.Medium.size) kMedium kSmall] [MangleName "trigArrowSquatBlackRight"] [MangleUnicode 0x27A7] (arrowMidX - squatRange) SymbolMid (arrowMidX + squatRange) SymbolMid
 
 	do "Round-stroke arrows"
@@ -1299,6 +1301,12 @@ glyph-block Symbol-Arrow : for-width-kinds WideWidth1
 		VCombine [MangleName 'uni21CB'] [MangleUnicode 0x21CB] [MangleName 'arrowLeftHR'] [MangleName 'arrowRightHR'] (arrowHeadSize)
 		VCombine [MangleName 'uni21CC'] [MangleUnicode 0x21CC] [MangleName 'arrowRightHL'] [MangleName 'arrowLeftHL'] (arrowHeadSize)
 		VCombine [MangleName 'uni21B9'] [MangleUnicode 0x21B9] [MangleName 'arrowBarLeft'] [MangleName 'arrowBarRight'] (arrowHeadSize * 1.75)
+		VCombine [MangleName 'uni2962'] [MangleUnicode 0x2962] [MangleName 'arrowLeftHR'] [MangleName 'arrowLeftHL'] (arrowHeadSize)
+		HCombine [MangleName 'uni2963'] [MangleUnicode 0x2963] [MangleName 'arrowUpHL'] [MangleName 'arrowUpHR'] (arrowHeadSize)
+		VCombine [MangleName 'uni2964'] [MangleUnicode 0x2964] [MangleName 'arrowRightHL'] [MangleName 'arrowRightHR'] (arrowHeadSize)
+		HCombine [MangleName 'uni2965'] [MangleUnicode 0x2965] [MangleName 'arrowDownHR'] [MangleName 'arrowDownHL'] (arrowHeadSize)
+		HCombine [MangleName 'uni296E'] [MangleUnicode 0x296E] [MangleName 'arrowUpHL'] [MangleName 'arrowDownHL'] (arrowHeadSize)
+		HCombine [MangleName 'uni296F'] [MangleUnicode 0x296F] [MangleName 'arrowDownHR'] [MangleName 'arrowUpHR'] (arrowHeadSize)
 
 		VCombine [MangleName 'uni2B80'] [MangleUnicode 0x2B80] [MangleName 'trigArrowLeft'] [MangleName 'trigArrowRight'] (arrowHeadSize * 1.75)
 		HCombine [MangleName 'uni2B81'] [MangleUnicode 0x2B81] [MangleName 'trigArrowUp'] [MangleName 'trigArrowDown'] hcDist
@@ -1367,7 +1375,7 @@ glyph-block Symbol-Arrow : for-width-kinds WideWidth1
 		create-glyph [MangleName 'zigZagTrigArrow'] [MangleUnicode 0x2B4D] : glyph-proc
 			set-width MosaicWidth
 			include : union
-				TriangleArrowHead x3ArrowHeadMock y3 x4 y4 arrowHeadSize
+				TriangleArrowHead x3ArrowHeadMock y3 x4 y4 (arrowHeadSize * 0.75)
 				ZigZagArrowBar
 
 	do "Lightning"

--- a/packages/font-glyphs/src/symbol/geometric/plain.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/plain.ptl
@@ -575,6 +575,13 @@ glyph-block Symbol-Geometric-Plain : for-width-kinds WideWidth1
 		StdBlackShape [RegularPolygonFill 5  2  1.1  0] 'blackSmallStar' 0x2B51 Size.Small
 		StdWhiteShape [RegularPolygonFill 5  2  1.1  0] 'whiteSmallStar' 0x2B52 [Object.assign [PentagramSw 3] Size.Small]
 
+		create-glyph [MangleName 'Hexagram'] [MangleUnicode 0x2721] : glyph-proc
+			set-width Geom.Width
+			local offset : Geom.Size / 3
+			include : union
+				with-transform [Translate 0   offset ] : refer-glyph : MangleName 'whiteTriangleUp'
+				with-transform [Translate 0 (-offset)] : refer-glyph : MangleName 'whiteTriangleDown'
+
 	do "Other Stars"
 		define [CurlyEdgeStar sides shrink overflow phase] : lambda [cx cy size] : begin
 			local corners {}
@@ -601,7 +608,7 @@ glyph-block Symbol-Geometric-Plain : for-width-kinds WideWidth1
 			corner (cx - 0.5 * size)  cy
 
 		StdBlackShape RightArrowHeadShape 'blackArrowHeadRight' 0x27A4 Size.Oblique
-		StdWhiteShape RightArrowHeadShape 'whiteArrowHeadRight' null   Size.Oblique
+		StdWhiteShape RightArrowHeadShape 'whiteArrowHeadRight' null {.sw ([Math.min GeometryStroke : AdviceStroke 4.75 : Math.sqrt Geom.Scalar] * [Math.sqrt 5])}
 
 	do "Other Polygon"
 		create-glyph [MangleName 'straightness'] [MangleUnicode 0x23E4] : glyph-proc

--- a/packages/font-glyphs/src/symbol/mosaic/teletext.ptl
+++ b/packages/font-glyphs/src/symbol/mosaic/teletext.ptl
@@ -389,3 +389,6 @@ glyph-block Symbol-Mosaic-Teletext : begin
 			set-width MosaicWidth
 			include : MosaicPattern (Geom.MidY + Geom.Size * 1.4) (Geom.MidY - Geom.Size * 1.4) Geom.Left Geom.Right 5 7 {1 3 5 7 9 11 13 15 17 19 21 23 25 27 29 31 33}
 
+		create-glyph [MangleName 'hellschreiberPause'] [MangleUnicode 0x2BFF] : glyph-proc
+			set-width MosaicWidth
+			include : MosaicPattern (Geom.MidY + Geom.Size * 2) (Geom.MidY - Geom.Size * 2) Geom.Left Geom.Right 5 10 {0 1 2 3 4 5 6 7 8 9 12 17 22 23 24 27 28 29 32 37 40 41 42 43 44 45 46 47 48 49}

--- a/packages/font-glyphs/src/symbol/mosaic/teletext.ptl
+++ b/packages/font-glyphs/src/symbol/mosaic/teletext.ptl
@@ -391,4 +391,4 @@ glyph-block Symbol-Mosaic-Teletext : begin
 
 		create-glyph [MangleName 'hellschreiberPause'] [MangleUnicode 0x2BFF] : glyph-proc
 			set-width MosaicWidth
-			include : MosaicPattern (Geom.MidY + Geom.Size * 2) (Geom.MidY - Geom.Size * 2) Geom.Left Geom.Right 5 10 {0 1 2 3 4 5 6 7 8 9 12 17 22 23 24 27 28 29 32 37 40 41 42 43 44 45 46 47 48 49}
+			include : MosaicPattern [Math.min (Geom.MidY + Geom.Size * 2) top] [Math.max (Geom.MidY - Geom.Size * 2) bottom] Geom.Left Geom.Right 5 10 {0 1 2 3 4 5 6 7 8 9 12 17 22 23 24 27 28 29 32 37 40 41 42 43 44 45 46 47 48 49}


### PR DESCRIPTION
Also improve glyph visual for `U+279D`, `U+27A2`, `U+27A3`, and `U+2B4D`.
```
✡➝➞
➢➣➤
⇋⇌⥮⥯
⥢⥣⥤⥥
⭍⯿
```
<details>
<summary>NWID=0</summary>

Thin:
![image](https://github.com/be5invis/Iosevka/assets/37010132/e9e27444-a941-4056-bb34-cc1059ae54d7)

Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/21e571d2-199b-4b86-a444-35d3bec16a1c)

Heavy:
![image](https://github.com/be5invis/Iosevka/assets/37010132/763f38e9-c015-4185-b9ff-d296106e5f4e)

</details>

<details>
<summary>NWID=1</summary>

Thin:
![image](https://github.com/be5invis/Iosevka/assets/37010132/a54991ef-ff10-44c8-a0f3-46674fcd9f22)

Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/f93e45c2-2ba5-4c7f-bbba-5cc3c29d323f)

Heavy:
![image](https://github.com/be5invis/Iosevka/assets/37010132/e4cc6822-f787-4cb2-bb0c-11034c93baf3)

</details>
