### PR TITLE
Utilize diamond terminal caps for ligation junctions

### DIFF
--- a/packages/font-glyphs/src/symbol/ligation.ptl
+++ b/packages/font-glyphs/src/symbol/ligation.ptl
@@ -12,7 +12,7 @@ glyph-block Symbol-Ligation : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Symbol-Math-Relation-Common : LessSlope EqualHalfSpace EqualHoleWidth
 	glyph-block-import Symbol-Math-Relation-Equal : EqualShape EqualHole IdentShape IdentHole
-	glyph-block-import Symbol-Math-Arith : PlusShape
+	glyph-block-import Symbol-Math-Arith : PlusShape JunctDiamond
 
 	local arrowheadsKern : (2 / 3) * [clamp 0 (Width * 0.4) (Width - OperatorStroke * 3)]
 
@@ -41,8 +41,8 @@ glyph-block Symbol-Ligation : begin
 
 	do "Arrow Bar"
 		define [ArrowBarConfig extend kern join doubleBar] : begin
-			define cleft O
-			define cright (Width - O)
+			define cleft   0
+			define cright  Width
 			define arrowr : if doubleBar
 				Width + SB + [HSwToV OperatorStroke]
 				Width + extend
@@ -51,32 +51,30 @@ glyph-block Symbol-Ligation : begin
 				0 - extend
 			define zleft : cleft - Width + RightSB
 			define zright : cright + SB
+
 			define lk : object
-				x    (SB - Width)
-				y    (-join - Width)
-				f    SB
-				p    (arrowl + Width)
-				l    arrowl
-				l1 : arrowl - kern
-				c    cleft
-				m    (0 - RodBarHOffset)
-				j    (-join)
-				j1   (-join - kern)
-				z    zleft
-				lx : mix arrowl 0 0.5
+				f   { SB                      false } # Free end
+				x   { (SB - Width)            false } # !='s bar shape, extension to left
+				y   { (-join - Width)         false } # -!-'s second bar, more to left
+				l   { arrowl                  false } # <-
+				l1  { (arrowl - kern)         false } # <<-
+				lx  { [mix arrowl 0 0.5]      false } # Bar right after <!--'s exclam
+				m   { (0 - RodBarHOffset)     false } # |-
+				j   { (-join)                 false } # >-
+				j1  { (-join - kern)          false } # >>-
+				c   { cleft                   true  } # Connected rod
+				z   { zleft                   true  } # Connected rod
 
 			define rk : object
-				x    (RightSB + Width)
-				y    (2 * Width + join)
-				f    RightSB
-				p    (arrowr - Width)
-				r    arrowr
-				r1 : arrowr + kern
-				c    cright
-				m    (Width + RodBarHOffset)
-				j    (Width + join)
-				j1   (Width + join + kern)
-				z    zright
+				f   { RightSB                 false } # Free end
+				p   { (arrowr - Width)        false } # bar in :> when ">" is turned into an arrow
+				r   { arrowr                  false } # ->
+				r1  { (arrowr + kern)         false } # ->>
+				m   { (Width + RodBarHOffset) false } # -|
+				j   { (Width + join)          false } # -<
+				j1  { (Width + join + kern)   false } # -<<
+				c   { cright                  true  } # Connected rods
+				z   { zright                  true  } # Connected rods
 
 			define result {}
 			foreach [l : items-of : Object.keys lk] : foreach [r : items-of : Object.keys rk]
@@ -84,6 +82,7 @@ glyph-block Symbol-Ligation : begin
 			return result
 
 		define [HyphenShape l r] : HBar.m l r SymbolMid OperatorStroke
+		define [HyphenShape.joinCap x] : JunctDiamond x SymbolMid OperatorStroke
 
 		define Shapes : object
 			'plus'   { PlusShape   HyphenNotch { arrowExtend arrowheadsKern arrowJ    0 } }
@@ -96,12 +95,15 @@ glyph-block Symbol-Ligation : begin
 			'withNotch'    { true  }
 
 		foreach { prefix { Shape Notch { extend kern join fDB } } } [Object.entries Shapes] : do
-			foreach { lS rS left right } [items-of : ArrowBarConfig extend kern join fDB] : do
+			foreach { lS rS { left capLeft } { right capRight } } [items-of : ArrowBarConfig extend kern join fDB] : do
 				foreach { suffix { fNotch } } [Object.entries NotchConfig] : do
 					create-glyph "\(prefix).lig.\(lS)\(rS).\(suffix)" : glyph-proc
 						include : SetJoiningKind lS rS
 						include : difference
-							Shape left right
+							union
+								Shape left right
+								if capLeft  [Shape.joinCap left]  [no-shape]
+								if capRight [Shape.joinCap right] [no-shape]
 							if (fNotch && left < (SB - Width))       [Notch (-Width)]    [no-shape]
 							if (fNotch && left < SB)                 [Notch 0]           [no-shape]
 							if (fNotch && right > RightSB)           [Notch Width]       [no-shape]
@@ -255,9 +257,22 @@ glyph-block Symbol-Ligation : begin
 		glyph-block-import Symbol-Punctuation-Dashes : UnderScoreConfig
 
 		foreach { suffix { yBar } } [Object.entries UnderScoreConfig] : do
-			create-glyph "underscore.lig.zf.\(suffix)" : glyph-proc
+			# ___ shapes
+			create-glyph "underscore.lig.fc.\(suffix)" : glyph-proc
 				Joining.set currentGlyph Joining.Classes.Left
-				include : HBar.b (O - SB) RightSB yBar
+				include : HBar.b SB Width yBar
+				include : JunctDiamond Width (yBar + HalfStroke) Stroke
+			create-glyph "underscore.lig.cf.\(suffix)" : glyph-proc
+				Joining.set currentGlyph Joining.Classes.Left
+				include : HBar.b 0 RightSB yBar
+				include : JunctDiamond 0 (yBar + HalfStroke) Stroke
+			create-glyph "underscore.lig.cc.\(suffix)" : glyph-proc
+				Joining.set currentGlyph Joining.Classes.Left
+				include : HBar.b 0 Width yBar
+				include : JunctDiamond 0     (yBar + HalfStroke) Stroke
+				include : JunctDiamond Width (yBar + HalfStroke) Stroke
+
+			# _|_ shapes
 			create-glyph "underscore.lig.fm.\(suffix)" : glyph-proc
 				Joining.set currentGlyph Joining.Classes.Right
 				include : HBar.b SB (Width + RodBarHOffset) yBar
@@ -267,7 +282,9 @@ glyph-block Symbol-Ligation : begin
 			create-glyph "bar.lig.bottomMid.\(suffix)"
 				VBar.m Middle yBar ParenTop
 
-		select-variant "underscore.lig.zf" (follow -- 'underscore')
+		select-variant "underscore.lig.fc" (follow -- 'underscore')
+		select-variant "underscore.lig.cc" (follow -- 'underscore')
+		select-variant "underscore.lig.cf" (follow -- 'underscore')
 		select-variant "underscore.lig.fm" (follow -- 'underscore')
 		select-variant "underscore.lig.mf" (follow -- 'underscore')
 		select-variant "bar.lig.bottomMid" (follow -- 'underscore')
@@ -431,12 +448,16 @@ glyph-block Symbol-Ligation : begin
 			create-glyph "plus.lig.fc.s.\(suffix)" : glyph-proc
 				Joining.set currentGlyph Joining.Classes.Right
 				include : difference
-					PlusShape SB (Width - O) SB
+					union
+						PlusShape SB Width SB
+						PlusShape.joinCap Width
 					if fNotch [HyphenNotch Width] [no-shape]
 			create-glyph "plus.lig.cf.s.\(suffix)" : glyph-proc
 				Joining.set currentGlyph Joining.Classes.Left
 				include : difference
-					PlusShape O RightSB (-SB)
+					union
+						PlusShape 0 RightSB (-SB)
+						PlusShape.joinCap 0
 					if fNotch [HyphenNotch 0] [no-shape]
 
 		select-variant 'plus.lig.fc.s' (follow -- 'lig-plus')

--- a/packages/font-glyphs/src/symbol/math/arith.ptl
+++ b/packages/font-glyphs/src/symbol/math/arith.ptl
@@ -17,6 +17,15 @@ glyph-block Symbol-Math-Arith : begin
 			HBar.m left right SymbolMid [fallback sw OperatorStroke]
 			VBar.m (Middle + [fallback s 0]) PlusTop PlusBot [fallback sw OperatorStroke]
 
+		glyph-block-export JunctDiamond
+		local [JunctDiamond x y sw] : spiro-outline
+			corner (x - [HSwToV (0.5 * sw)]) y
+			corner x (y + (0.5 * sw))
+			corner (x + [HSwToV (0.5 * sw)]) y
+			corner x (y - (0.5 * sw))
+
+		define [PlusShape.joinCap x] : JunctDiamond x SymbolMid OperatorStroke
+
 		create-glyph 'plus' '+' : PlusShape SB RightSB
 		create-glyph 'minus' 0x2212 : HBar.m SB RightSB SymbolMid OperatorStroke
 
@@ -241,14 +250,14 @@ glyph-block Symbol-Math-Arith : begin
 				refer-glyph 'minus'
 				DrawAt Middle PlusTop (dr - overshoot)
 
-			create-glyph "dotslash.\(suffix)" : composite-proc 
+			create-glyph "dotslash.\(suffix)" : composite-proc
 				dispiro
 					widths.center OperatorStroke
 					flat [mix Middle SB      Math.SQRT1_2] [mix SymbolMid PlusBot Math.SQRT1_2]
 					curl [mix Middle RightSB Math.SQRT1_2] [mix SymbolMid PlusTop Math.SQRT1_2]
 				DrawAt [mix Middle SB Math.SQRT1_2] [mix SymbolMid PlusTop Math.SQRT1_2] (dr - overshoot)
 
-			create-glyph "dotvbar.\(suffix)" : composite-proc 
+			create-glyph "dotvbar.\(suffix)" : composite-proc
 				VBar.m [mix Middle RightSB 0.5] PlusTop PlusBot OperatorStroke
 				DrawAt [mix Middle SB      0.5] SymbolMid (dr - overshoot)
 

--- a/packages/font-glyphs/src/symbol/math/relation.ptl
+++ b/packages/font-glyphs/src/symbol/math/relation.ptl
@@ -44,12 +44,16 @@ glyph-block Symbol-Math-Relation-Equal : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Symbol-Math-Relation-Common : EqualHalfSpace IdentHalfSpace dH EqualHoleWidth
-	glyph-block-export EqualShape EqualHole IdentShape IdentHole
+	glyph-block-import Symbol-Math-Arith : JunctDiamond
 
 	glyph-block-export : EqualShape
 	define [EqualShape left right] : union
 		HBar.m left right (SymbolMid + EqualHalfSpace) OperatorStroke
 		HBar.m left right (SymbolMid - EqualHalfSpace) OperatorStroke
+
+	define [EqualShape.joinCap x] : union
+		JunctDiamond x (SymbolMid + EqualHalfSpace) OperatorStroke
+		JunctDiamond x (SymbolMid - EqualHalfSpace) OperatorStroke
 
 	glyph-block-export : EqualHole
 	define [EqualHole x]
@@ -60,6 +64,11 @@ glyph-block Symbol-Math-Relation-Equal : begin
 		HBar.m left right (SymbolMid + IdentHalfSpace) OperatorStroke
 		HBar.m left right SymbolMid OperatorStroke
 		HBar.m left right (SymbolMid - IdentHalfSpace) OperatorStroke
+
+	define [IdentShape.joinCap x] : union
+		JunctDiamond x (SymbolMid + IdentHalfSpace) OperatorStroke
+		JunctDiamond x SymbolMid OperatorStroke
+		JunctDiamond x (SymbolMid - IdentHalfSpace) OperatorStroke
 
 	glyph-block-export : IdentHole
 	define [IdentHole x]

--- a/packages/font-otl/src/gsub-ligation.ptl
+++ b/packages/font-otl/src/gsub-ligation.ptl
@@ -1049,20 +1049,25 @@ define [buildLigationsImpl gsub para $LigGroup$] : begin
 	LigGroup "Underscore chains" : if [hasLG 'underscore-underscore-underscore'] : begin
 		CreateLigationLookup : list
 			chain-rule # Extension
-				[[lsx 'zf'] underscore] ~> look-around
-				underscore ~> [lsx 'zf']
+				[[lsx 'cf'] underscore] ~> look-around
+				underscore ~> [lsx 'cf']
 			chain-rule # Start 4
-				underscore ~> advance
-				underscore ~> [lsx 'zf']
-				underscore ~> [lsx 'zf']
-				underscore ~> [lsx 'zf']
+				underscore ~> [lsx 'fc']
+				underscore ~> [lsx 'cc']
+				underscore ~> [lsx 'cc']
+				underscore ~> [lsx 'cf']
 			chain-rule # Start 3
-				underscore ~> advance
-				underscore ~> [lsx 'zf']
-				underscore ~> [lsx 'zf']
+				underscore ~> [lsx 'fc']
+				underscore ~> [lsx 'cc']
+				underscore ~> [lsx 'cf']
 			chain-rule # Start 2
-				underscore ~> advance
-				underscore ~> [if [hasLG 'underscore-underscore'] [lsx 'zf'] advance]
+				underscore ~> [if [hasLG 'underscore-underscore'] [lsx 'fc'] advance]
+				underscore ~> [if [hasLG 'underscore-underscore'] [lsx 'cf'] advance]
+
+		CreateLigationLookup : list
+			chain-rule # Uniformalize
+				[[lsx 'cf'] underscore] ~> [[lsx 'cc'] underscore]
+				[[lsx 'cf'] underscore] ~> look-around
 
 	LigGroup "Number sign chains" : if [hasLG 'hash-hash-hash'] : begin
 		CreateLigationLookup : list


### PR DESCRIPTION
This change made the junction part of joining ligations to use a diamond shape instead of flat ends, which will reduce some of the unwanted pixel patterns of these joining ligations.