### PR TITLE
Some CV application adjustments and fixes.

### DIFF
--- a/changes/30.1.3.md
+++ b/changes/30.1.3.md
@@ -1,4 +1,5 @@
 * Improve glyph shape of INVERTED LOW KAVYKA WITH KAVYKA ABOVE (`U+2E46`).
+* Fix `cv96` application to LOW KAVYKA WITH DOT (`U+2E48`).
 * Fix metrics of Cyrillie EnGhe and Abkhasian Che under Aile/Etoile (#2366).
 * Make CYRILLIC CAPITAL LETTER SOFT DE (`U+A662`) ... CYRILLIC SMALL LETTER SOFT EM (`A667`) follow variants of Greek Capital Gamma (`cv56`).
 * Fix CV/SS application of localized form of superscript/subscript letters (#2368).

--- a/changes/30.1.3.md
+++ b/changes/30.1.3.md
@@ -1,7 +1,8 @@
 * Improve glyph shape of INVERTED LOW KAVYKA WITH KAVYKA ABOVE (`U+2E46`).
-* Fix IPPH/APPH localization for superscript/subscript Greek Lower Beta and Chi (`U+1D5D`, `U+1D61`, `U+1D66`, `U+1D6A`).
 * Fix metrics of Cyrillie EnGhe and Abkhasian Che under Aile/Etoile (#2366).
+* Make CYRILLIC CAPITAL LETTER SOFT DE (`U+A662`) ... CYRILLIC SMALL LETTER SOFT EM (`A667`) follow variants of Greek Capital Gamma (`cv56`).
 * Fix CV/SS application of localized form of superscript/subscript letters (#2368).
+* Fix IPPH/APPH localization for superscript/subscript Greek Lower Beta and Chi (`U+1D5D`, `U+1D61`, `U+1D66`, `U+1D6A`).
 * Improve glyph visual for `U+279D`, `U+27A2`, `U+27A3`, and `U+2B4D`.
 * Add characters:
   - STAR OF DAVID (`U+2720`).

--- a/changes/30.1.3.md
+++ b/changes/30.1.3.md
@@ -1,5 +1,6 @@
 * Improve glyph shape of INVERTED LOW KAVYKA WITH KAVYKA ABOVE (`U+2E46`).
 * Fix `cv96` application to LOW KAVYKA WITH DOT (`U+2E48`).
+* Make MODIFIER LETTER DOT VERTICAL BAR (`U+A717`) ... MODIFIER LETTER DOT HORIZONTAL BAR (`U+A719`) follow variants of Diacritical Dot (`cv96`).
 * Fix metrics of Cyrillie EnGhe and Abkhasian Che under Aile/Etoile (#2366).
 * Make CYRILLIC CAPITAL LETTER SOFT DE (`U+A662`) ... CYRILLIC SMALL LETTER SOFT EM (`A667`) follow variants of Greek Capital Gamma (`cv56`).
 * Fix CV/SS application of localized form of superscript/subscript letters (#2368).

--- a/packages/font-glyphs/src/auto-build/transformed.ptl
+++ b/packages/font-glyphs/src/auto-build/transformed.ptl
@@ -238,7 +238,7 @@ glyph-block Autobuild-Transformed : begin
 			list 0xA705 'supstBarNoRise'
 			list 0xA717 'dotvbar'
 			list 0xA718 'dotslash'
-			list 0xA719 'dotminus'
+			list 0xA719 'dothbar'
 			list 0xA71A 'turnedRevNegate'
 			list 0xA71B 'arrowUp.NWID'
 			list 0xA71C 'arrowDown.NWID'

--- a/packages/font-glyphs/src/letter/cyrillic/de.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/de.ptl
@@ -56,7 +56,7 @@ glyph-block Letter-Cyrillic-De : begin
 
 		return : object desc xTopLeft xTopRight
 
-	define [CyrSoftDeShape top left right _sw] : glyph-proc
+	define [CyrSoftDeShape top left right _sw vSlab] : glyph-proc
 		local descenderOverflow : if SLAB SideJut ((right - left) * 0.075)
 		local sw : fallback _sw Stroke
 		local xm : if SLAB
@@ -65,11 +65,12 @@ glyph-block Letter-Cyrillic-De : begin
 		local xTopRight : mix left xm : StrokeWidthBlend 0.95 0.96
 
 		include : CyrDeShape top left xm _sw
-		if SLAB
-		: then : begin
-				include : HBar.t (xTopRight + descenderOverflow) right top sw
-				include : VSerif.dr right top VJut (sw * VJutStroke / Stroke)
-		: else : include : HBar.t xTopRight right top sw
+
+		include : if SLAB
+			then : HBar.t (xTopRight + descenderOverflow) right top sw
+			else : HBar.t xTopRight right top sw
+
+		if vSlab : include : VSerif.dr right top VJut (sw * VJutStroke / Stroke)
 
 	create-glyph 'cyrl/De' 0x414 : glyph-proc
 		include : MarkSet.capital
@@ -85,18 +86,33 @@ glyph-block Letter-Cyrillic-De : begin
 		include : MarkSet.p
 		include : CyrDeShape XH SB RightSB Stroke Descender
 
-	create-glyph 'cyrl/DeSoft' 0xA662 : glyph-proc
+	create-glyph 'cyrl/DeSoft.serifless' : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.capital
 		include : ExtendBelowBaseAnchors BottomExtension
-		include : CyrSoftDeShape CAP df.leftSB df.rightSB df.mvs
+		include : CyrSoftDeShape CAP df.leftSB df.rightSB df.mvs false
 
-	create-glyph 'cyrl/deSoft' 0xA663 : glyph-proc
+	create-glyph 'cyrl/DeSoft.topRightSerifed' : glyph-proc
+		local df : include : DivFrame para.diversityM 3
+		include : df.markSet.capital
+		include : ExtendBelowBaseAnchors BottomExtension
+		include : CyrSoftDeShape CAP df.leftSB df.rightSB df.mvs true
+
+	select-variant 'cyrl/DeSoft' 0xA662 (follow -- 'cyrl/EnGhe/GhePart')
+
+	create-glyph 'cyrl/deSoft.serifless' : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.e
 		include : ExtendBelowBaseAnchors BottomExtension
-		include : CyrSoftDeShape XH df.leftSB df.rightSB df.mvs
+		include : CyrSoftDeShape XH df.leftSB df.rightSB df.mvs false
 
+	create-glyph 'cyrl/deSoft.topRightSerifed' : glyph-proc
+		local df : include : DivFrame para.diversityM 3
+		include : df.markSet.e
+		include : ExtendBelowBaseAnchors BottomExtension
+		include : CyrSoftDeShape XH df.leftSB df.rightSB df.mvs true
+
+	select-variant 'cyrl/deSoft' 0xA663 (follow -- 'cyrl/enghe/ghePart')
 
 	foreach { suffix { st sb }} [Object.entries EpsilonConfig] : do
 		define [DzzeDescendershape de] : begin

--- a/packages/font-glyphs/src/letter/cyrillic/el.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/el.ptl
@@ -2,12 +2,14 @@ $$include '../../meta/macros.ptl'
 
 import [mix linreg clamp fallback] from "@iosevka/util"
 import [Point] from "@iosevka/geometry/point"
+import [DependentSelector] from "@iosevka/glyph/relation"
 
 glyph-module
 
 glyph-block Letter-Cyrillic-El : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
+	glyph-block-import Letter-Shared : CreateSelectorVariants DefineSelectorGlyph
 	glyph-block-import Letter-Shared-Shapes : SerifFrame LegShape RightwardTailedBar
 	glyph-block-import Letter-Shared-Shapes : CyrDescender CyrTailDescender PalatalHook MidHook UpwardHookShape
 
@@ -53,7 +55,7 @@ glyph-block Letter-Cyrillic-El : begin
 				[Just SLAB-LOWER]  : HSerif.rb right 0 SideJut sw
 				__                 : glyph-proc
 
-	define [CyrSoftElShape left right top bodyType slabType _sw] : glyph-proc
+	define [CyrSoftElShape left right top bodyType slabType _sw vSlab] : glyph-proc
 		local sw : fallback _sw Stroke
 		local xm : if SLAB
 			[mix left right 0.625] + [HSwToV : 0.25 * sw]
@@ -61,7 +63,7 @@ glyph-block Letter-Cyrillic-El : begin
 
 		include : CyrElShape left xm top bodyType slabType _sw
 		include : HBar.t xm right top sw
-		if SLAB : include : VSerif.dr right top VJut (sw * VJutStroke / Stroke)
+		if vSlab : include : VSerif.dr right top VJut (sw * VJutStroke / Stroke)
 
 	create-glyph 'cyrl/El' 0x41B : glyph-proc
 		include : MarkSet.capital
@@ -71,28 +73,66 @@ glyph-block Letter-Cyrillic-El : begin
 		include : MarkSet.e
 		include : CyrElShape SB RightSB XH BODY-STRAIGHT : if SLAB SLAB-ALL SLAB-NONE
 
-	create-glyph 'cyrl/el.straight' : glyph-proc
-		include : MarkSet.e
-		include : CyrElShape SB RightSB XH BODY-STRAIGHT : if SLAB [if para.isItalic SLAB-LOWER SLAB-ALL] SLAB-NONE
+	create-glyph 'cyrl/ElMidHook' 0x520 : glyph-proc
+		local df : include : DivFrame para.diversityM 3
+		include : df.markSet.capDesc
 
-	create-glyph 'cyrl/el.tailed' : glyph-proc
-		include : MarkSet.e
-		include : CyrElShape SB RightSB XH BODY-TAILED : if SLAB [if para.isItalic SLAB-TAILED-I SLAB-TAILED-U] SLAB-NONE
+		local xm : df.middle + [HSwToV : 0.5 * df.mvs]
+		include : CyrElShape df.leftSB xm CAP BODY-STRAIGHT [if SLAB SLAB-ALL SLAB-NONE] df.mvs
+		include : MidHook.m df CAP
 
-	create-glyph 'cyrl/ElSoft' 0xA664 : glyph-proc
+	create-glyph 'cyrl/ElSoft.serifless' : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.capital
-		include : CyrSoftElShape df.leftSB df.rightSB CAP BODY-STRAIGHT [if SLAB SLAB-ALL SLAB-NONE] df.mvs
+		include : CyrSoftElShape df.leftSB df.rightSB CAP BODY-STRAIGHT [if SLAB SLAB-ALL SLAB-NONE] df.mvs false
 
-	create-glyph 'cyrl/elSoft.straight' : glyph-proc
+	create-glyph 'cyrl/ElSoft.topRightSerifed' : glyph-proc
 		local df : include : DivFrame para.diversityM 3
-		include : df.markSet.e
-		include : CyrSoftElShape df.leftSB df.rightSB XH BODY-STRAIGHT [if SLAB [if para.isItalic SLAB-LOWER SLAB-ALL] SLAB-NONE] df.mvs
+		include : df.markSet.capital
+		include : CyrSoftElShape df.leftSB df.rightSB CAP BODY-STRAIGHT [if SLAB SLAB-ALL SLAB-NONE] df.mvs true
 
-	create-glyph 'cyrl/elSoft.tailed' : glyph-proc
-		local df : include : DivFrame para.diversityM 3
-		include : df.markSet.e
-		include : CyrSoftElShape df.leftSB df.rightSB XH BODY-TAILED [if SLAB [if para.isItalic SLAB-TAILED-I SLAB-TAILED-U] SLAB-NONE] df.mvs
+	select-variant 'cyrl/ElSoft' 0xA664 (follow -- 'cyrl/EnGhe/GhePart')
+
+	define ElConfig : object
+		straight  { BODY-STRAIGHT SLAB-ALL      SLAB-LOWER    }
+		tailed    { BODY-TAILED   SLAB-TAILED-U SLAB-TAILED-I }
+
+	define CyrlSoftElGheConfig : object
+		serifless       false
+		topRightSerifed true
+
+	foreach { suffix { body slabUpright slabItalic } } [pairs-of ElConfig] : do
+		create-glyph "cyrl/el.\(suffix)" : glyph-proc
+			include : MarkSet.e
+			include : CyrElShape SB RightSB XH body : if SLAB [if para.isItalic slabItalic slabUpright] SLAB-NONE
+
+		create-glyph "cyrl/elMidHook.\(suffix)" : glyph-proc
+			local df : include : DivFrame para.diversityM 3
+			include : df.markSet.p
+
+			local xm : df.middle + [HSwToV : 0.5 * df.mvs]
+			include : CyrElShape df.leftSB xm XH body [if SLAB [if para.isItalic slabItalic slabUpright] SLAB-NONE] df.mvs
+			include : MidHook.m df XH
+
+		define cyrlSoftElDf : DivFrame para.diversityM 3
+
+		DefineSelectorGlyph "cyrl/elSoft" suffix cyrlSoftElDf 'e'
+
+		foreach { suffixGhe cyrlSoftElVSlab } [Object.entries CyrlSoftElGheConfig] : do
+			create-glyph "cyrl/elSoft.\(suffix).\(suffixGhe)" : glyph-proc
+				set-width 0
+				set-mark-anchor 'cvDecompose' 0 0
+				include : CyrSoftElShape cyrlSoftElDf.leftSB cyrlSoftElDf.rightSB XH body [if SLAB [if para.isItalic slabItalic slabUpright] SLAB-NONE] cyrlSoftElDf.mvs cyrlSoftElVSlab
+
+		select-variant "cyrl/elSoft.\(suffix)" (follow -- 'cyrl/enghe/ghePart')
+
+	select-variant 'cyrl/el' 0x43B
+	select-variant 'cyrl/elMidHook' 0x521 (follow -- 'cyrl/el')
+
+	CreateSelectorVariants 'cyrl/elSoft' 0xA665 [Object.keys ElConfig] (follow -- 'cyrl/el')
+
+	alias 'cyrl/El.BGR' null 'grek/Lambda'
+	alias 'cyrl/el.BGR' null 'turnv'
 
 	derive-composites 'cyrl/ElDescender' 0x52E 'cyrl/El' [CyrDescender.rSideJut RightSB 0]
 	derive-composites 'cyrl/elDescender' 0x52F 'cyrl/el.straight' [CyrDescender.rSideJut RightSB 0]
@@ -102,30 +142,6 @@ glyph-block Letter-Cyrillic-El : begin
 
 	derive-composites 'cyrl/ElHook' 0x512 'cyrl/El' [PalatalHook.rSideJut RightSB 0]
 	derive-composites 'cyrl/elHook' 0x513 'cyrl/el.straight' [PalatalHook.rSideJut RightSB 0]
-
-	create-glyph 'cyrl/ElMidHook' 0x520 : glyph-proc
-		local df : include : DivFrame para.diversityM 3
-		include : df.markSet.capDesc
-
-		local xm : df.middle + [HSwToV : 0.5 * df.mvs]
-		include : CyrElShape df.leftSB xm CAP BODY-STRAIGHT [if SLAB SLAB-ALL SLAB-NONE] df.mvs
-		include : MidHook.m df CAP
-
-	create-glyph 'cyrl/elMidHook.straight' : glyph-proc
-		local df : include : DivFrame para.diversityM 3
-		include : df.markSet.p
-
-		local xm : df.middle + [HSwToV : 0.5 * df.mvs]
-		include : CyrElShape df.leftSB xm XH BODY-STRAIGHT [if SLAB [if para.isItalic SLAB-LOWER SLAB-ALL] SLAB-NONE] df.mvs
-		include : MidHook.m df XH
-
-	create-glyph 'cyrl/elMidHook.tailed' : glyph-proc
-		local df : include : DivFrame para.diversityM 3
-		include : df.markSet.p
-
-		local xm : df.middle + [HSwToV : 0.5 * df.mvs]
-		include : CyrElShape df.leftSB xm XH BODY-TAILED [if SLAB [if para.isItalic SLAB-TAILED-I SLAB-TAILED-U] SLAB-NONE] df.mvs
-		include : MidHook.m df XH
 
 	create-glyph 'cyrl/LjeKomi' 0x508 : glyph-proc
 		local df : include : DivFrame para.diversityM 3
@@ -160,9 +176,3 @@ glyph-block Letter-Cyrillic-El : begin
 			sw -- df.mvs
 		local sf2 : [SerifFrame.fromDf df (XH / 2) 0].slice 1 2
 		if SLAB : include sf2.rt.full
-
-	select-variant 'cyrl/el' 0x43B
-	select-variant 'cyrl/elSoft' 0xA665 (follow -- 'cyrl/el')
-	select-variant 'cyrl/elMidHook' 0x521 (follow -- 'cyrl/el')
-	alias 'cyrl/El.BGR' null 'grek/Lambda'
-	alias 'cyrl/el.BGR' null 'turnv'

--- a/packages/font-glyphs/src/letter/latin/upper-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-m.ptl
@@ -1,7 +1,7 @@
 $$include '../../meta/macros.ptl'
 
 import [mix fallback SuffixCfg] from "@iosevka/util"
-import [MathSansSerif] from "@iosevka/glyph/relation"
+import [MathSansSerif DependentSelector] from "@iosevka/glyph/relation"
 
 glyph-module
 
@@ -10,6 +10,7 @@ glyph-block Letter-Latin-Upper-M : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared : CreateTurnedLetter
+	glyph-block-import Letter-Shared : CreateSelectorVariants DefineSelectorGlyph
 	glyph-block-import Letter-Shared-Shapes : SerifFrame EngHook CyrTailDescender
 
 	define FORM-FLAT      0
@@ -91,7 +92,7 @@ glyph-block Letter-Latin-Upper-M : begin
 
 		return : object [swSideBot]
 
-	define [CyrSoftEmShape] : with-params [top df form slabType slanted] : glyph-proc
+	define [CyrSoftEmShape] : with-params [top df form slabType slanted vSlab] : glyph-proc
 		local subDf : df.slice 4 3
 		local sidesSlope : if slanted 0.04 0
 		local xRightTop : subDf.rightSB - top * sidesSlope
@@ -106,9 +107,7 @@ glyph-block Letter-Latin-Upper-M : begin
 		include : MShape top subDf form slabType slanted (kMidHang -- df.div)
 
 		include : HBar.t xRightTop df.rightSB top swSideBot
-		if SLAB : include : VSerif.dr df.rightSB top VJut (swSideBot * VJutStroke / Stroke)
-
-
+		if vSlab : include : VSerif.dr df.rightSB top VJut (swSideBot * VJutStroke / Stroke)
 
 	define MConfig : SuffixCfg.combine
 		SuffixCfg.weave
@@ -126,6 +125,10 @@ glyph-block Letter-Latin-Upper-M : begin
 		object # Greek San variants
 			grekCapitalSan { false FORM-SAN       SLAB-AUTO }
 			grekSmallSan   { false FORM-SAN-SMALL SLAB-NONE }
+
+	define CyrlSoftEmGheConfig : object
+		serifless       false
+		topRightSerifed true
 
 	foreach { suffix { slanted form slab } } [Object.entries MConfig] : do
 		create-glyph "M.\(suffix)" : glyph-proc
@@ -151,15 +154,24 @@ glyph-block Letter-Latin-Upper-M : begin
 			include : LeaningAnchor.Below.VBar.l df.leftSB
 			include : MShape XH df form slab slanted
 
-		create-glyph "cyrl/EmSoft.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.diversityM 3
-			include : df.markSet.capital
-			include : CyrSoftEmShape CAP df form slab slanted
+		define cyrlSoftEmDf : DivFrame para.diversityM 4
 
-		create-glyph "cyrl/emSoft.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.diversityM 3
-			include : df.markSet.e
-			include : CyrSoftEmShape XH df form slab slanted
+		DefineSelectorGlyph "cyrl/EmSoft" suffix cyrlSoftEmDf 'capital'
+		DefineSelectorGlyph "cyrl/emSoft" suffix cyrlSoftEmDf 'e'
+
+		foreach { suffixGhe cyrlSoftEmVSlab } [Object.entries CyrlSoftEmGheConfig] : do
+			create-glyph "cyrl/EmSoft.\(suffix).\(suffixGhe)" : glyph-proc
+				set-width 0
+				set-mark-anchor 'cvDecompose' 0 0
+				include : CyrSoftEmShape CAP cyrlSoftEmDf form slab slanted cyrlSoftEmVSlab
+
+			create-glyph "cyrl/emSoft.\(suffix).\(suffixGhe)" : glyph-proc
+				set-width 0
+				set-mark-anchor 'cvDecompose' 0 0
+				include : CyrSoftEmShape XH cyrlSoftEmDf form slab slanted cyrlSoftEmVSlab
+
+		select-variant "cyrl/EmSoft.\(suffix)" (follow -- 'cyrl/EnGhe/GhePart')
+		select-variant "cyrl/emSoft.\(suffix)" (follow -- 'cyrl/enghe/ghePart')
 
 	select-variant 'M' 'M'
 	link-reduced-variant 'M/sansSerif' 'M' MathSansSerif
@@ -169,8 +181,9 @@ glyph-block Letter-Latin-Upper-M : begin
 	alias 'grek/Mu' 0x39C 'M'
 	alias-reduced-variant 'grek/Mu/sansSerif' 'grek/Mu' 'M/sansSerif' MathSansSerif
 	alias 'cyrl/Em' 0x41C 'M'
-	select-variant 'cyrl/EmSoft' 0xA666 (follow -- 'M')
-	select-variant 'cyrl/emSoft' 0xA667 (follow -- 'cyrl/em')
+
+	CreateSelectorVariants 'cyrl/EmSoft' 0xA666 [Object.keys MConfig] (follow -- 'M')
+	CreateSelectorVariants 'cyrl/emSoft' 0xA667 [Object.keys MConfig] (follow -- 'cyrl/em')
 
 	derive-composites 'cyrl/EmTail' 0x4CD 'cyrl/Em' : do
 		local df : DivFrame para.diversityM 3

--- a/packages/font-glyphs/src/marks/overlay.ptl
+++ b/packages/font-glyphs/src/marks/overlay.ptl
@@ -416,12 +416,15 @@ glyph-block Mark-Overlay : begin
 			include : with-transform [ApparentTranslate (-markMiddle) (-aboveMarkMid)]
 				refer-glyph 'cyrlKavykaAbove'
 
-		create-glyph 'cyrlKavykaWithDotOver' : glyph-proc
-			set-width 0
-			set-mark-anchor 'overlay' 0 0 0 0
+		foreach { suffix { DrawAt kdr } } [Object.entries DotVariants] : do
+			create-glyph "cyrlKavykaWithDotOver.\(suffix)" : glyph-proc
+				set-width 0
+				set-mark-anchor 'overlay' 0 0 0 0
 
-			include : with-transform [ApparentTranslate (-markMiddle) (-aboveMarkMid)]
-				refer-glyph 'cyrlKavykaWithDotAbove'
+				include : with-transform [ApparentTranslate (-markMiddle) (-aboveMarkMid)]
+					refer-glyph "cyrlKavykaWithDotAbove.\(suffix)"
+
+		select-variant 'cyrlKavykaWithDotOver' (follow -- 'diacriticDot')
 
 	do "Inner dots"
 		glyph-block-export InnerDot

--- a/packages/font-glyphs/src/symbol/math/arith.ptl
+++ b/packages/font-glyphs/src/symbol/math/arith.ptl
@@ -336,8 +336,9 @@ glyph-block Symbol-Math-Arith : begin
 		select-variant 'dotminus' 0x2238 (follow -- 'punctuationDot')
 		turned 'minusdot' 0x2A2A 'dotminus' Middle SymbolMid
 
-		select-variant 'dotslash' null (follow -- 'punctuationDot')
-		select-variant 'dotvbar' null (follow -- 'punctuationDot')
+		select-variant 'dotvbar' (follow -- 'diacriticDot')
+		select-variant 'dotslash' (follow -- 'diacriticDot')
+		select-variant 'dothbar' (shapeFrom -- 'dotminus') (follow -- 'diacriticDot')
 
 		select-variant 'dottimes' 0x2A30 (follow -- 'punctuationDot')
 


### PR DESCRIPTION
* Make CYRILLIC CAPITAL LETTER SOFT DE (`U+A662`) ... CYRILLIC SMALL LETTER SOFT EM (`A667`) follow variants of Greek Capital Gamma (`cv56`).

I'll only show gamma variants due to the sheer amount of images of all the De/El/Em/En variants I'd have to setup, screenshot, and post otherwise (4×4×2×3=96 images in that case), but I assure you I tested them all under each of sans/slab/aile/etoile just like in the images below.

`Γ𝝘ϜϝГгҐґꙢꙣꙤꙥꙦꙧҤҥ`
All Gamma variants:
Sans Upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/4029a665-ff92-4071-addf-a3fc19dec426)
Sans Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/ff6e8914-3865-4fb5-829a-31a1bb4490d0)
Slab Upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/ceca36e2-2261-404d-9cc5-06247916a864)
Slab Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/f4378f80-8140-4d44-b72d-b03699d0cf8a)
Aile Upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/28fae4f0-5833-4758-bcaa-5babb04bc828)
Aile Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/98716185-e23e-477f-b05a-d113ad17c97c)
Etoile Upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/cd49a5ac-e724-47f6-b8ff-3b1dae6f7a13)
Etoile Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/c8b7fd76-f2d1-4ec8-9a0a-ebc66411891f)

Also fix `cv96` application to `⹈` and make it apply to `ꜗ`/`ꜘ`/`ꜙ` as well:
![image](https://github.com/be5invis/Iosevka/assets/37010132/3014c8d8-e100-463a-97e9-4a568355d6a3)
![image](https://github.com/be5invis/Iosevka/assets/37010132/16430aa9-3b25-41bb-9d09-b2d8416a2ed7)

