### PR TITLE
Some adjustments to variants of `cyrl/el.BGR` and `cyrl/ghe.SRB`.

### DIFF
--- a/changes/30.1.3.md
+++ b/changes/30.1.3.md
@@ -4,6 +4,7 @@
 * Fix metrics of Cyrillie EnGhe and Abkhasian Che under Aile/Etoile (#2366).
 * Make CYRILLIC CAPITAL LETTER SOFT DE (`U+A662`) ... CYRILLIC SMALL LETTER SOFT EM (`A667`) follow variants of Greek Capital Gamma (`cv56`).
 * Make Bulgarian Cyrillic Lower El follow variants of Greek Capital Lambda (`cv60`).
+* Allow Italic Serbian Cyrillic Lower Ghe to use Hooky Bottom and Z-Shaped variants of `i` (`cv34`).
 * Fix CV/SS application of localized form of superscript/subscript letters (#2368).
 * Fix IPPH/APPH localization for superscript/subscript Greek Lower Beta and Chi (`U+1D5D`, `U+1D61`, `U+1D66`, `U+1D6A`).
 * Improve glyph visual for `U+279D`, `U+27A2`, `U+27A3`, and `U+2B4D`.

--- a/changes/30.1.3.md
+++ b/changes/30.1.3.md
@@ -3,6 +3,7 @@
 * Make MODIFIER LETTER DOT VERTICAL BAR (`U+A717`) ... MODIFIER LETTER DOT HORIZONTAL BAR (`U+A719`) follow variants of Diacritical Dot (`cv96`).
 * Fix metrics of Cyrillie EnGhe and Abkhasian Che under Aile/Etoile (#2366).
 * Make CYRILLIC CAPITAL LETTER SOFT DE (`U+A662`) ... CYRILLIC SMALL LETTER SOFT EM (`A667`) follow variants of Greek Capital Gamma (`cv56`).
+* Make Bulgarian Cyrillic Lower El follow variants of Greek Capital Lambda (`cv60`).
 * Fix CV/SS application of localized form of superscript/subscript letters (#2368).
 * Fix IPPH/APPH localization for superscript/subscript Greek Lower Beta and Chi (`U+1D5D`, `U+1D61`, `U+1D66`, `U+1D6A`).
 * Improve glyph visual for `U+279D`, `U+27A2`, `U+27A3`, and `U+2B4D`.

--- a/packages/font-glyphs/src/letter/cyrillic/el.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/el.ptl
@@ -97,7 +97,7 @@ glyph-block Letter-Cyrillic-El : begin
 		straight  { BODY-STRAIGHT SLAB-ALL      SLAB-LOWER    }
 		tailed    { BODY-TAILED   SLAB-TAILED-U SLAB-TAILED-I }
 
-	define CyrlSoftElGheConfig : object
+	define CyrSoftElGheConfig : object
 		serifless       false
 		topRightSerifed true
 
@@ -114,15 +114,15 @@ glyph-block Letter-Cyrillic-El : begin
 			include : CyrElShape df.leftSB xm XH body [if SLAB [if para.isItalic slabItalic slabUpright] SLAB-NONE] df.mvs
 			include : MidHook.m df XH
 
-		define cyrlSoftElDf : DivFrame para.diversityM 3
+		define cyrSoftElDf : DivFrame para.diversityM 3
 
-		DefineSelectorGlyph "cyrl/elSoft" suffix cyrlSoftElDf 'e'
+		DefineSelectorGlyph "cyrl/elSoft" suffix cyrSoftElDf 'e'
 
-		foreach { suffixGhe cyrlSoftElVSlab } [Object.entries CyrlSoftElGheConfig] : do
+		foreach { suffixGhe cyrSoftElVSlab } [Object.entries CyrSoftElGheConfig] : do
 			create-glyph "cyrl/elSoft.\(suffix).\(suffixGhe)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
-				include : CyrSoftElShape cyrlSoftElDf.leftSB cyrlSoftElDf.rightSB XH body [if SLAB [if para.isItalic slabItalic slabUpright] SLAB-NONE] cyrlSoftElDf.mvs cyrlSoftElVSlab
+				include : CyrSoftElShape cyrSoftElDf.leftSB cyrSoftElDf.rightSB XH body [if SLAB [if para.isItalic slabItalic slabUpright] SLAB-NONE] cyrSoftElDf.mvs cyrSoftElVSlab
 
 		select-variant "cyrl/elSoft.\(suffix)" (follow -- 'cyrl/enghe/ghePart')
 
@@ -130,9 +130,6 @@ glyph-block Letter-Cyrillic-El : begin
 	select-variant 'cyrl/elMidHook' 0x521 (follow -- 'cyrl/el')
 
 	CreateSelectorVariants 'cyrl/elSoft' 0xA665 [Object.keys ElConfig] (follow -- 'cyrl/el')
-
-	alias 'cyrl/El.BGR' null 'grek/Lambda'
-	alias 'cyrl/el.BGR' null 'turnv'
 
 	derive-composites 'cyrl/ElDescender' 0x52E 'cyrl/El' [CyrDescender.rSideJut RightSB 0]
 	derive-composites 'cyrl/elDescender' 0x52F 'cyrl/el.straight' [CyrDescender.rSideJut RightSB 0]

--- a/packages/font-glyphs/src/letter/latin/lower-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-g.ptl
@@ -154,9 +154,9 @@ glyph-block Letter-Latin-Lower-G : begin
 			singleStorey            SingleStorey.RoundHook
 			singleStoreyFlatHook    SingleStorey.FlatHook
 		object # ear/serif
+			""                    { SingleStorey.AutoSerifedBody    0                      }
 			serifless             { SingleStorey.SeriflessBody      0                      }
 			serifed               { SingleStorey.SerifedBody        0                      }
-			autoSerifed           { SingleStorey.AutoSerifedBody    0                      }
 			earlessCorner         { SingleStorey.EarlessCornerBody  DToothlessRise         }
 			earlessCornerHTB      { SingleStorey.EarlessCornerBody  0                      }
 			earlessRounded        { SingleStorey.EarlessRoundedBody (XH - SmallArchDepthA) }

--- a/packages/font-glyphs/src/letter/latin/lower-il.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-il.ptl
@@ -297,7 +297,6 @@ glyph-block Letter-Latin-Lower-I : begin
 		select-variant 'dotlessi' 0x131
 		link-reduced-variant 'dotlessi/sansSerif' 'dotlessi' MathSansSerif
 		select-variant 'dotlessi/compLigRight' (shapeFrom -- 'dotlessi')
-		select-variant 'dotlessi/tailed' (shapeFrom -- 'dotlessi')
 		select-variant 'dotlessiRetroflexHook' (follow -- 'dotlessi')
 		CreateOgonekComposition 'iOgonek.dotless' null 'dotlessi'
 
@@ -320,11 +319,13 @@ glyph-block Letter-Latin-Lower-I : begin
 		select-variant 'latn/Iota' 0x196 (follow -- 'latn/iota')
 		alias 'cyrl/Iota' 0xA646 'latn/Iota'
 
+		select-variant 'cyrl/ghe.SRB/base' (shapeFrom -- 'dotlessi') (follow -- 'cyrl/ghe.SRB')
+		CreateAccentedComposition      'cyrl/ghe.SRB' null 'cyrl/ghe.SRB/base'   'macronAbove'
+		CreateMultiAccentedComposition 'cyrl/gje.SRB' null 'cyrl/ghe.SRB/base' { 'macronAbove' 'acuteAbove' }
+
 		CreateTurnedLetter 'turni' 0x1D09 'i' HalfAdvance (XH / 2)
 		CreateTurnedLetter 'grek/turniota' 0x2129 'latn/iota' HalfAdvance (XH / 2)
 
-		CreateAccentedComposition      'cyrl/ghe.SRB' null 'dotlessi/tailed'   'macronAbove'
-		CreateMultiAccentedComposition 'cyrl/gje.SRB' null 'dotlessi/tailed' { 'macronAbove' 'acuteAbove' }
 		CreateAccentedComposition 'dotlessiBarOver' null 'dotlessi' 'barOver'
 		CreateAccentedComposition 'iBarOver' 0x268 'dotlessiBarOver' 'tittleAbove'
 		CreateAccentedComposition 'iOgonek' 0x12F 'iOgonek.dotless' 'tittleAbove'

--- a/packages/font-glyphs/src/letter/latin/upper-a.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-a.ptl
@@ -15,10 +15,11 @@ glyph-block Letter-Latin-Upper-A : begin
 	glyph-block-import Letter-Shared-Shapes : SerifFrame
 	glyph-block-import Letter-Latin-V : VShapeOutline VShape VCornerHalfWidth
 
-	define SLAB-NONE    0
-	define SLAB-TOP     1
-	define SLAB-LEFT    2
-	define SLAB-RIGHT   4
+	define SLAB-NONE     0
+	define SLAB-TOP      1
+	define SLAB-LEFT     2
+	define SLAB-RIGHT    4
+	define SLAB-CYRL-BGR 8
 
 	glyph-block-export AMaskShape
 	define [AMaskShape] : with-params [df fBarStraight top sw] : new-glyph : glyph-proc
@@ -44,8 +45,10 @@ glyph-block Letter-Latin-Upper-A : begin
 
 	define [ASerifs df top sw slabKind] : glyph-proc : begin
 		local sf : SerifFrame.fromDf df top 0
-		if [maskBits slabKind SLAB-LEFT] : include sf.lb.full
-		if [maskBits slabKind SLAB-RIGHT] : include sf.rb.full
+		if [maskBits slabKind SLAB-LEFT] : include
+			if ([maskBits slabKind SLAB-CYRL-BGR] && para.isItalic) sf.lb.outer sf.lb.full
+		if [maskBits slabKind SLAB-RIGHT] : include
+			if ([maskBits slabKind SLAB-CYRL-BGR] && para.isItalic) sf.rb.outer sf.rb.full
 		if [maskBits slabKind SLAB-TOP] : include : intersection [MaskLeft df.middle]
 			if [maskBits slabKind : bitOr SLAB-LEFT SLAB-RIGHT]
 			: then : HSerif.lt df.middle top (MidJutSide + [HSwToV : 0.25 * sw]) sf.swSerif
@@ -149,6 +152,15 @@ glyph-block Letter-Latin-Upper-A : begin
 				sw           -- Stroke
 				slabKind     -- slabKind
 
+		create-glyph "cyrl/el.BGR.\(suffix)" : glyph-proc
+			include : MarkSet.e
+			include : LambdaShape
+				df           -- [DivFrame 1]
+				fBarStraight -- fStraightBar
+				top          -- XH
+				sw           -- Stroke
+				slabKind     -- [bitOr slabKind SLAB-CYRL-BGR]
+
 	select-variant 'A' 'A'
 	link-reduced-variant 'A/sansSerif' 'A' MathSansSerif
 	select-variant 'smcpA' 0x1D00 (follow -- 'A')
@@ -161,6 +173,9 @@ glyph-block Letter-Latin-Upper-A : begin
 	select-variant 'grek/Lambda' 0x39B
 	link-reduced-variant 'grek/Lambda/sansSerif' 'grek/Lambda' MathSansSerif
 	select-variant 'grek/smcpLambda' 0x1D27 (follow -- 'grek/Lambda')
+
+	alias 'cyrl/El.BGR' null 'grek/Lambda'
+	select-variant 'cyrl/el.BGR' (follow -- 'grek/Lambda')
 
 	# Delta
 	glyph-block-export DeltaShape

--- a/packages/font-glyphs/src/letter/latin/upper-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-m.ptl
@@ -126,7 +126,7 @@ glyph-block Letter-Latin-Upper-M : begin
 			grekCapitalSan { false FORM-SAN       SLAB-AUTO }
 			grekSmallSan   { false FORM-SAN-SMALL SLAB-NONE }
 
-	define CyrlSoftEmGheConfig : object
+	define CyrSoftEmGheConfig : object
 		serifless       false
 		topRightSerifed true
 
@@ -154,21 +154,21 @@ glyph-block Letter-Latin-Upper-M : begin
 			include : LeaningAnchor.Below.VBar.l df.leftSB
 			include : MShape XH df form slab slanted
 
-		define cyrlSoftEmDf : DivFrame para.diversityM 4
+		define cyrSoftEmDf : DivFrame [mix 1 para.diversityM 2] 4
 
-		DefineSelectorGlyph "cyrl/EmSoft" suffix cyrlSoftEmDf 'capital'
-		DefineSelectorGlyph "cyrl/emSoft" suffix cyrlSoftEmDf 'e'
+		DefineSelectorGlyph "cyrl/EmSoft" suffix cyrSoftEmDf 'capital'
+		DefineSelectorGlyph "cyrl/emSoft" suffix cyrSoftEmDf 'e'
 
-		foreach { suffixGhe cyrlSoftEmVSlab } [Object.entries CyrlSoftEmGheConfig] : do
+		foreach { suffixGhe cyrSoftEmVSlab } [Object.entries CyrSoftEmGheConfig] : do
 			create-glyph "cyrl/EmSoft.\(suffix).\(suffixGhe)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
-				include : CyrSoftEmShape CAP cyrlSoftEmDf form slab slanted cyrlSoftEmVSlab
+				include : CyrSoftEmShape CAP cyrSoftEmDf form slab slanted cyrSoftEmVSlab
 
 			create-glyph "cyrl/emSoft.\(suffix).\(suffixGhe)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
-				include : CyrSoftEmShape XH cyrlSoftEmDf form slab slanted cyrlSoftEmVSlab
+				include : CyrSoftEmShape XH cyrSoftEmDf form slab slanted cyrSoftEmVSlab
 
 		select-variant "cyrl/EmSoft.\(suffix)" (follow -- 'cyrl/EnGhe/GhePart')
 		select-variant "cyrl/emSoft.\(suffix)" (follow -- 'cyrl/enghe/ghePart')

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2165,7 +2165,7 @@ selectorAffix."g/sansSerif" = "doubleStorey"
 selectorAffix."g/hookTopBase" = "singleStoreySerifless"
 selectorAffix."gScript" = "singleStoreyScriptCut"
 selectorAffix."gScriptCrossedTail" = "singleStoreyScriptCut"
-selectorAffix."g/single" = "singleStoreyAutoSerifed"
+selectorAffix."g/single" = "singleStorey"
 
 [prime.g.variants-buildup.stages.openness.open]
 rank = 1
@@ -2175,7 +2175,7 @@ selectorAffix."g/sansSerif" = "openDoubleStorey"
 selectorAffix."g/hookTopBase" = "singleStoreySerifless"
 selectorAffix."gScript" = "singleStoreyScriptCut"
 selectorAffix."gScriptCrossedTail" = "singleStoreyScriptCut"
-selectorAffix."g/single" = "singleStoreyAutoSerifed"
+selectorAffix."g/single" = "singleStorey"
 
 [prime.g.variants-buildup.stages.storey.single-storey]
 next = "hook"
@@ -2338,7 +2338,7 @@ description = "`i` like a straight line"
 selector.dotlessi = "serifless"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "hooky"
-selector."dotlessi/tailed" = "flatTailed"
+selector."cyrl/ghe.SRB" = "flatTailed"
 
 [prime.i.variants.hooky]
 rank = 2
@@ -2347,7 +2347,7 @@ description = "Hooky `i`"
 selector.dotlessi = "hooky"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "hooky"
-selector."dotlessi/tailed" = "serifedFlatTailed"
+selector."cyrl/ghe.SRB" = "serifedFlatTailed"
 
 [prime.i.variants.hooky-bottom]
 rank = 3
@@ -2356,7 +2356,7 @@ description = "`i` with a sharp-turning horizontal tail"
 selector.dotlessi = "hookyBottom"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "zshaped"
-selector."dotlessi/tailed" = "flatTailed"
+selector."cyrl/ghe.SRB" = "hookyBottom"
 
 [prime.i.variants.zshaped]
 rank = 4
@@ -2365,7 +2365,7 @@ description = "Z-shaped `i`"
 selector.dotlessi = "zshaped"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "zshaped"
-selector."dotlessi/tailed" = "serifedFlatTailed"
+selector."cyrl/ghe.SRB" = "zshaped"
 
 [prime.i.variants.serifed]
 rank = 5
@@ -2374,7 +2374,7 @@ description = "Serifed `i`"
 selector.dotlessi = "serifed"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "serifed"
-selector."dotlessi/tailed" = "serifedFlatTailed"
+selector."cyrl/ghe.SRB" = "zshaped"
 
 [prime.i.variants.serifed-asymmetric]
 rank = 6
@@ -2383,7 +2383,7 @@ description = "`i` with shorter top serif and full bottom serif"
 selector.dotlessi = "serifedAsymmetric"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "serifed"
-selector."dotlessi/tailed" = "serifedFlatTailed"
+selector."cyrl/ghe.SRB" = "zshaped"
 
 [prime.i.variants.tailed]
 rank = 7
@@ -2392,7 +2392,7 @@ description = "`i` with curly tail"
 selector.dotlessi = "tailed"
 selector."dotlessi/sansSerif" = "tailed"
 selector."dotlessi/compLigRight" = "tailedSerifed"
-selector."dotlessi/tailed" = "tailed"
+selector."cyrl/ghe.SRB" = "tailed"
 
 [prime.i.variants.tailed-serifed]
 rank = 8
@@ -2401,7 +2401,7 @@ description = "`i` with top serif and curly tail"
 selector.dotlessi = "tailedSerifed"
 selector."dotlessi/sansSerif" = "tailed"
 selector."dotlessi/compLigRight" = "tailedSerifed"
-selector."dotlessi/tailed" = "tailedSerifed"
+selector."cyrl/ghe.SRB" = "tailedSerifed"
 
 [prime.i.variants.flat-tailed]
 rank = 9
@@ -2410,7 +2410,7 @@ description = "`i` with curly-then-flat tail"
 selector.dotlessi = "flatTailed"
 selector."dotlessi/sansSerif" = "flatTailed"
 selector."dotlessi/compLigRight" = "serifedFlatTailed"
-selector."dotlessi/tailed" = "flatTailed"
+selector."cyrl/ghe.SRB" = "flatTailed"
 
 [prime.i.variants.serifed-flat-tailed]
 rank = 10
@@ -2419,7 +2419,7 @@ description = "`i` with top serif and curly-then-flat tail"
 selector.dotlessi = "serifedFlatTailed"
 selector."dotlessi/sansSerif" = "flatTailed"
 selector."dotlessi/compLigRight" = "serifedFlatTailed"
-selector."dotlessi/tailed" = "serifedFlatTailed"
+selector."cyrl/ghe.SRB" = "serifedFlatTailed"
 
 [prime.i.variants.diagonal-tailed]
 rank = 11
@@ -2428,7 +2428,7 @@ description = "`i` with diagonal tail"
 selector.dotlessi = "diagonalTailed"
 selector."dotlessi/sansSerif" = "diagonalTailed"
 selector."dotlessi/compLigRight" = "serifedDiagonalTailed"
-selector."dotlessi/tailed" = "diagonalTailed"
+selector."cyrl/ghe.SRB" = "diagonalTailed"
 
 [prime.i.variants.serifed-diagonal-tailed]
 rank = 12
@@ -2437,7 +2437,7 @@ description = "`i` with top serif and diagonal tail"
 selector.dotlessi = "serifedDiagonalTailed"
 selector."dotlessi/sansSerif" = "diagonalTailed"
 selector."dotlessi/compLigRight" = "serifedDiagonalTailed"
-selector."dotlessi/tailed" = "serifedDiagonalTailed"
+selector."cyrl/ghe.SRB" = "serifedDiagonalTailed"
 
 [prime.i.variants.semi-tailed]
 rank = 13
@@ -2446,7 +2446,7 @@ description = "`i` with slightly curly tail"
 selector.dotlessi = "semiTailed"
 selector."dotlessi/sansSerif" = "semiTailed"
 selector."dotlessi/compLigRight" = "serifedSemiTailed"
-selector."dotlessi/tailed" = "semiTailed"
+selector."cyrl/ghe.SRB" = "semiTailed"
 
 [prime.i.variants.serifed-semi-tailed]
 rank = 14
@@ -2455,7 +2455,7 @@ description = "`i` with top serif and slightly curly tail"
 selector.dotlessi = "serifedSemiTailed"
 selector."dotlessi/sansSerif" = "semiTailed"
 selector."dotlessi/compLigRight" = "serifedSemiTailed"
-selector."dotlessi/tailed" = "serifedSemiTailed"
+selector."cyrl/ghe.SRB" = "serifedSemiTailed"
 
 
 


### PR DESCRIPTION
* Allow Italic Serbian Cyrillic Lower Ghe to use Hooky Bottom and Z-Shaped variants of `i` (`cv34`).
  - Using `i`.`serifed` under italics causes it to use `i`.`z-shaped` as a form of motion serifs.
  - It still responds to tailed variants as normal.

All `i` variants under SRB:
`i𝗂гѓi𝗂гѓ`
![image](https://github.com/be5invis/Iosevka/assets/37010132/5d864980-addf-49d5-9711-d82e0953ad6d)

Compared to DejaVu serif:
![image](https://github.com/be5invis/Iosevka/assets/37010132/f0627459-4c15-47b1-8ec1-20f29ecd0b49)
![image](https://github.com/be5invis/Iosevka/assets/37010132/404a8743-11a6-482e-9966-621a297c6c71)


* Make Bulgarian Cyrillic Lower El follow variants of Greek Capital Lambda (`cv60`).
  - Its lower serifs respond to italics to match `cyrl/em`.

All Lambda variants under BGR:
`Λ𝝠ЛлΛ𝝠Лл`
![image](https://github.com/be5invis/Iosevka/assets/37010132/84a50659-d09f-4e9c-a20c-b492fb7ebc74)

Some more sample text under `ss18` under SRB/BGR:
```
δб𞀱 в𞀲 гӷ𞀳 ΔДɡgд𞀴 жӝӂҗ𞀶
иӥйҋ𞀸 кқ𞀹 ΛЛлЉљ𞀺 НнЊњᵸ пԥ𞀽 тҭ𞁀 Фф𞁂
ч𞁅 ицшщ𞀸𞁄𞁆◌ⷳ ьъыꙑꚝꚜ𞁇𞁬 ю𞁉
```
![image](https://github.com/be5invis/Iosevka/assets/37010132/20c04935-2100-4df9-b08b-383019624cf7)

Also make Soft Em slightly wider under Quasi-Proportional:
`ДꙢдꙣЛꙤлꙥМꙦмꙧНҤнҥ`
![image](https://github.com/be5invis/Iosevka/assets/37010132/1676b90c-3fef-48d9-bde6-935af6d4db5e)
![image](https://github.com/be5invis/Iosevka/assets/37010132/d1f50385-fa78-48fe-bb47-40c30bc7ebbc)
Monospace is unaffected:
![image](https://github.com/be5invis/Iosevka/assets/37010132/7a01dc76-3a4b-49f3-aa97-aa364cdb4660)
![image](https://github.com/be5invis/Iosevka/assets/37010132/18110943-0a6d-4130-8953-c1e55ea454d7)
