### PR TITLE
Add bottom-serifed variants to Cyrillic E.

### DIFF
--- a/packages/font-glyphs/src/letter/cyrillic/e.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/e.ptl
@@ -66,7 +66,7 @@ glyph-block Letter-Cyrillic-E : begin
 
 	select-variant 'cyrl/E' 0x42D
 	select-variant 'cyrl/e' 0x44D
-	select-variant 'cyrl/Ye' 0x404 (follow -- 'cyrl/E')
-	select-variant 'cyrl/ye' 0x454 (follow -- 'cyrl/e')
-	select-variant "cyrl/EIotified" 0x464 (follow -- 'cyrl/E')
-	select-variant "cyrl/eIotified" 0x465 (follow -- 'cyrl/e')
+	select-variant 'cyrl/Ye' 0x404
+	select-variant 'cyrl/ye' 0x454
+	select-variant "cyrl/EIotified" 0x464 (follow -- 'cyrl/Ye')
+	select-variant "cyrl/eIotified" 0x465 (follow -- 'cyrl/ye')

--- a/packages/font-glyphs/src/letter/latin/c.ptl
+++ b/packages/font-glyphs/src/letter/latin/c.ptl
@@ -134,6 +134,7 @@ glyph-block Letter-Latin-C : begin
 	define CConfig : object
 		serifless               { SLAB-NONE      SLAB-NONE      }
 		bottomSerifed           { SLAB-NONE      SLAB-CLASSICAL }
+		bottomInwardSerifed     { SLAB-NONE      SLAB-INWARD    }
 		unilateralSerifed       { SLAB-CLASSICAL SLAB-NONE      }
 		bilateralSerifed        { SLAB-CLASSICAL SLAB-CLASSICAL }
 		unilateralInwardSerifed { SLAB-INWARD    SLAB-NONE      }
@@ -163,6 +164,12 @@ glyph-block Letter-Latin-C : begin
 			include : ExtendAboveBaseAnchors (CAP + Ascender - XH)
 			include : LeaningAnchor.Above.VBar.r RightSB
 
+		create-glyph "currency/euroSign.\(suffix)" : glyph-proc
+			include [refer-glyph "C.\(suffix)"] AS_BASE ALSO_METRICS
+			include : union
+				LetterBarOverlay.l SB (CAP * 0.4)
+				LetterBarOverlay.l SB (CAP * 0.6)
+
 		create-glyph "c.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			local lf : CLetterForm [DivFrame 1] sty styBot XH 0
@@ -188,7 +195,7 @@ glyph-block Letter-Latin-C : begin
 				adb -- SmallArchDepthB
 			include : lf.full
 
-		create-glyph "revSmallC.\(suffix)" : glyph-proc
+		create-glyph "revc.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			local lf : CLetterForm [DivFrame 1] sty styBot XH 0
 				ada -- SmallArchDepthA
@@ -240,7 +247,9 @@ glyph-block Letter-Latin-C : begin
 			difference base
 				Rect (top / 2) Descender (Middle + [HSwToV Stroke]) (Width * 4)
 				Rect (XH / 2) [mix Stroke Hook 0.5] Middle (Width * 4)
-			if styTop [HSerif.mb (Middle + [HSwToV HalfStroke]) Descender MidJutSide] [no-shape]
+			if (styTop && [not para.isItalic])
+				HSerif.mb (Middle + [HSwToV HalfStroke]) Descender MidJutSide
+				no-shape
 
 		if [not styBot] : create-glyph "cyrl/Koppa.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
@@ -286,10 +295,12 @@ glyph-block Letter-Latin-C : begin
 	select-variant 'CHookTop' 0x187
 	select-variant 'smcpC' 0x1D04 (follow -- 'C')
 
+	select-variant 'currency/euroSign' 0x20AC
+
 	select-variant 'c' 'c'
 	link-reduced-variant 'c/sansSerif' 'c' MathSansSerif
-	link-reduced-variant 'c/turnDescBase' 'c'
-	select-variant 'revSmallC' 0x2184 (follow -- 'c')
+	link-reduced-variant 'c/turnDescBase' 'c' (follow -- 'cHookTop')
+	select-variant 'revc' 0x2184 (follow -- 'c')
 	select-variant 'c/centKernelStd' (follow -- 'c')
 	select-variant 'c/centKernelCap' (follow -- 'c')
 	alias 'cyrl/es' 0x441 'c'
@@ -310,6 +321,42 @@ glyph-block Letter-Latin-C : begin
 	select-variant 'c/descBase'
 	select-variant 'romanSixLateForm' 0x2185 (follow -- 'C/descBase')
 
+	CreateTurnedLetter 'turnC' 0x186 'C' HalfAdvance (CAP / 2)
+	CreateTurnedLetter 'turnc' 0x254 'c' HalfAdvance (XH / 2)
+	CreateTurnedLetter 'turnSmcpC' 0x1D10 'smcpC' HalfAdvance (XH / 2)
+	alias 'grek/revLunateSigma' 0x3FD 'revC'
+	alias 'grek/revLunateSmallSigma' 0x37B 'revc.serifless'
+
+	CreateTurnedLetter 'turnc/descBase' null 'c/turnDescBase' HalfAdvance (XH / 2)
+	derive-composites 'turncRetroflexHook' 0x1D97 'turnc/descBase'
+		RetroflexHook.l SB 0 (yAttach -- DToothlessRise)
+
+	derive-composites 'CPalatalHook' 0xA7C4 'C/descBase'
+		PalatalHook.r RightSB 0 (yAttach -- DToothlessRise)
+
+	derive-composites 'cPalatalHook' 0xA794 'c/descBase'
+		PalatalHook.r RightSB 0 (yAttach -- DToothlessRise)
+
+	derive-composites 'cRetroflexHook' 0x1DF1D 'c/descBase'
+		RetroflexHook.r RightSB 0 (yAttach -- DToothlessRise)
+
+	derive-composites 'grek/dotLunateSigma' 0x3FE 'grek/lunateSigma' 'innerDot'
+	derive-composites 'grek/dotRevLunateSigma' 0x3FF 'grek/revLunateSigma' 'innerDot'
+	derive-composites 'grek/dotLunateSmallSigma' 0x37C 'grek/lunateSmallSigma' 'innerDotSmall'
+	derive-composites 'grek/dotRevLunateSmallSigma' 0x37D 'grek/revLunateSmallSigma' 'innerDotSmall'
+	derive-composites 'CRevDot' 0xA73E 'revC' 'innerDotSmall'
+	derive-composites 'cRevDot' 0xA73F 'revc' 'innerDotSmall'
+
+	create-glyph 'CBarOverlay' : LetterBarOverlay.l.in SB 0 CAP
+	create-glyph 'cBarOverlay' : LetterBarOverlay.l.in SB 0 XH
+	derive-composites 'CBar' 0xA792 'C' 'CBarOverlay'
+	derive-composites 'cBar' 0xA793 'c' 'cBarOverlay'
+
+	derive-composites 'CCedilla' 0xC7 'C' 'cedillaExtShapeBelowOArc'
+	derive-composites 'cCedilla' 0xE7 'c' 'cedillaExtShapeBelowOArc'
+	derive-composites 'cyrl/The' 0x4AA 'cyrl/Es' 'cedillaExtShapeBelowOArc'
+	derive-composites 'cyrl/the' 0x4AB 'cyrl/es' 'cedillaExtShapeBelowOArc'
+
 	create-glyph 'mathbb/C' 0x2102 : glyph-proc
 		include : MarkSet.capital
 		include : CShapeT dispiro 0 [DivFrame 1] SLAB-NONE SLAB-NONE CAP 0 ArchDepthA ArchDepthB Hook BBS
@@ -323,11 +370,6 @@ glyph-block Letter-Latin-C : begin
 		include : intersection
 			CShapeT spiro-outline 0.1 [DivFrame 1] SLAB-NONE SLAB-NONE XH 0 SmallArchDepthA SmallArchDepthB Hook BBS
 			VBar.l (SB + BBD + OX) 0 CAP BBS
-
-	create-glyph 'currency/euroSign/overlay' : union
-		LetterBarOverlay.l SB (CAP * 0.4)
-		LetterBarOverlay.l SB (CAP * 0.6)
-	derive-composites 'currency/euroSign' 0x20AC 'C' 'currency/euroSign/overlay'
 
 	define CentBarConfig : object
 		open           { (Descender / 2) (XH - Descender / 2) 0 "std" }
@@ -379,39 +421,3 @@ glyph-block Letter-Latin-C : begin
 	CreateDependentComposite 'cent/centSign' 0xA2 "cent/bar" : object
 		'std' 'c/centKernelStd'
 		'cap' 'c/centKernelCap'
-
-	CreateTurnedLetter 'turnC' 0x186 'C' HalfAdvance (CAP / 2)
-	CreateTurnedLetter 'turnc' 0x254 'c' HalfAdvance (XH / 2)
-	CreateTurnedLetter 'turnSmcpC' 0x1D10 'smcpC' HalfAdvance (XH / 2)
-	alias 'grek/revLunateSigma' 0x3FD 'revC'
-	alias 'grek/revLunateSmallSigma' 0x37B 'revSmallC.serifless'
-
-	CreateTurnedLetter 'turnc/turnDescBase' null 'c/turnDescBase' HalfAdvance (XH / 2)
-	derive-composites 'turncRetroflexHook' 0x1D97 'turnc/turnDescBase'
-		RetroflexHook.l SB 0 (yAttach -- DToothlessRise)
-
-	derive-composites 'CPalatalHook' 0xA7C4 'C/descBase'
-		PalatalHook.r RightSB 0 (yAttach -- DToothlessRise)
-
-	derive-composites 'cPalatalHook' 0xA794 'c/descBase'
-		PalatalHook.r RightSB 0 (yAttach -- DToothlessRise)
-
-	derive-composites 'cRetroflexHook' 0x1DF1D 'c/descBase'
-		RetroflexHook.r RightSB 0 (yAttach -- DToothlessRise)
-
-	derive-composites 'grek/dotLunateSigma' 0x3FE 'grek/lunateSigma' 'innerDot'
-	derive-composites 'grek/dotRevLunateSigma' 0x3FF 'grek/revLunateSigma' 'innerDot'
-	derive-composites 'grek/dotLunateSmallSigma' 0x37C 'grek/lunateSmallSigma' 'innerDotSmall'
-	derive-composites 'grek/dotRevLunateSmallSigma' 0x37D 'grek/revLunateSmallSigma' 'innerDotSmall'
-	derive-composites 'CRevDot' 0xA73E 'revC'      'innerDotSmall'
-	derive-composites 'cRevDot' 0xA73F 'revSmallC' 'innerDotSmall'
-
-	create-glyph 'CBarOverlay' : LetterBarOverlay.l.in SB 0 CAP
-	create-glyph 'cBarOverlay' : LetterBarOverlay.l.in SB 0 XH
-	derive-composites 'CBar' 0xA792 'C' 'CBarOverlay'
-	derive-composites 'cBar' 0xA793 'c' 'cBarOverlay'
-
-	derive-composites 'CCedilla' 0xC7 'C' 'cedillaExtShapeBelowOArc'
-	derive-composites 'cCedilla' 0xE7 'c' 'cedillaExtShapeBelowOArc'
-	derive-composites 'cyrl/The' 0x4AA 'cyrl/Es' 'cedillaExtShapeBelowOArc'
-	derive-composites 'cyrl/the' 0x4AB 'cyrl/es' 'cedillaExtShapeBelowOArc'

--- a/packages/font-glyphs/src/letter/latin/upper-f.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-f.ptl
@@ -84,7 +84,7 @@ glyph-block Letter-Latin-Upper-F : begin
 	link-reduced-variant 'F/sansSerif' 'F' MathSansSerif
 	select-variant 'smcpF' 0xA730 (follow -- 'F')
 	select-variant 'FBar' 0xA798 (follow -- 'F')
-	select-variant 'currency/frenchFrancSign' 0x20A3 (follow -- 'F')
+	select-variant 'currency/frenchFrancSign' 0x20A3
 
 	glyph-block-import Letter-Blackboard : BBS BBD
 	create-glyph 'mathbb/F' 0x1D53D : glyph-proc

--- a/packages/font-glyphs/src/symbol/letter.ptl
+++ b/packages/font-glyphs/src/symbol/letter.ptl
@@ -26,7 +26,11 @@ glyph-block Symbol-Currency : begin
 				flat (Middle + radius * 0.87 * [Math.cos angle]) (SymbolMid + radius * 0.87 * [Math.sin angle])
 				curl (Middle + radius * Math.SQRT2 * [Math.cos angle]) (SymbolMid + radius * Math.SQRT2 * [Math.sin angle])
 
-	do "Sterling"
+	define SterlingConfig : object
+		serifless     { 0 }
+		motionSerifed { 1 }
+
+	foreach { suffix { serifGrade } } [Object.entries SterlingConfig] : do
 		define xBarLeft : [mix SB RightSB 0.2] - Stroke * 0.1
 		define [BaseShape] : glyph-proc
 			local xBarLeft : [mix SB RightSB 0.2] - Stroke * 0.1
@@ -39,17 +43,21 @@ glyph-block Symbol-Currency : begin
 					curl xBarLeft [mix Stroke CAP 0.3]
 					g4   SB Stroke
 				HBar.b SB RightSB 0
+			if serifGrade : include : VSerif.ur RightSB 0 VJut
 
-		create-glyph 'currency/sterlingSign' 0xA3 : glyph-proc
+		create-glyph "currency/sterlingSign.\(suffix)" : glyph-proc
 			set-width Width
 			include : BaseShape
 			include : LetterBarOverlay.l xBarLeft (CAP * 0.5)
 
-		create-glyph 'currency/liraSymbolSign' 0x20A4 : glyph-proc
+		create-glyph "currency/liraSymbolSign.\(suffix)" : glyph-proc
 			set-width Width
 			include : BaseShape
 			include : LetterBarOverlay.l xBarLeft (CAP * 0.37)
 			include : LetterBarOverlay.l xBarLeft (CAP * 0.60 - OverlayStroke * 0.25)
+
+	select-variant 'currency/sterlingSign'   0xA3
+	select-variant 'currency/liraSymbolSign' 0x20A4 (follow -- 'currency/sterlingSign')
 
 glyph-block Symbol-Currency-Letter-Derived : begin
 	glyph-block-import CommonShapes

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -180,7 +180,7 @@ selector."C/descBase" = "bilateralSerifed"
 selector."C/sansSerif" = "serifless"
 selector.CHookTop = "bilateralSerifed"
 selector.CTopSerifOnly = "unilateralSerifed"
-selector.CBottomSerifOnly = "bilateralSerifed"
+selector.CBottomSerifOnly = "bottomSerifed"
 
 [prime.capital-c.variants.unilateral-inward-serifed]
 rank = 4
@@ -200,7 +200,7 @@ selector."C/descBase" = "bilateralInwardSerifed"
 selector."C/sansSerif" = "serifless"
 selector.CHookTop = "bilateralInwardSerifed"
 selector.CTopSerifOnly = "unilateralInwardSerifed"
-selector.CBottomSerifOnly = "bilateralInwardSerifed"
+selector.CBottomSerifOnly = "bottomInwardSerifed"
 
 
 
@@ -289,18 +289,21 @@ rank = 1
 description = "F without serifs"
 selector.F = "serifless"
 selector."F/sansSerif" = "serifless"
+selector."currency/frenchFrancSign" = "serifless"
 
 [prime.capital-f.variants.top-left-serifed]
 rank = 2
 description = "F with serif only at top left"
 selector.F = "topLeftSerifed"
 selector."F/sansSerif" = "serifless"
+selector."currency/frenchFrancSign" = "topLeftSerifed"
 
 [prime.capital-f.variants.serifed]
 rank = 3
 description = "F with serifs"
 selector.F = "serifed"
 selector."F/sansSerif" = "serifless"
+selector."currency/frenchFrancSign" = "serifed"
 
 
 
@@ -644,18 +647,21 @@ rank = 1
 description = "Serifless `L`"
 selector.L = "serifless"
 selector."L/sansSerif" = "serifless"
+selector."currency/sterlingSign" = "serifless"
 
 [prime.capital-l.variants.motion-serifed]
 rank = 2
 description = "Standard `L` with motion serif at bottom right"
 selector.L = "motionSerifed"
 selector."L/sansSerif" = "serifless"
+selector."currency/sterlingSign" = "motionSerifed"
 
 [prime.capital-l.variants.serifed]
 rank = 3
 description = "`L` with serifs"
 selector.L = "serifed"
 selector."L/sansSerif" = "serifless"
+selector."currency/sterlingSign" = "motionSerifed"
 
 
 
@@ -1792,7 +1798,6 @@ description = "Serifless `c`"
 selector.c = "serifless"
 selector."c/sansSerif" = "serifless"
 selector."c/descBase" = "serifless"
-selector."c/turnDescBase" = "unilateralSerifed"
 selector.cCurlyTail = "serifless"
 selector.cHookTop = "unilateralSerifed"
 selector.cTopSerifOnly = "serifless"
@@ -1804,7 +1809,6 @@ description = "`c` with serif at top"
 selector.c = "unilateralSerifed"
 selector."c/sansSerif" = "serifless"
 selector."c/descBase" = "bilateralSerifed"
-selector."c/turnDescBase" = "unilateralSerifed"
 selector.cCurlyTail = "unilateralSerifed"
 selector.cHookTop = "unilateralSerifed"
 selector.cTopSerifOnly = "unilateralSerifed"
@@ -1816,11 +1820,10 @@ description = "`c` with serifs at both top and bottom"
 selector.c = "bilateralSerifed"
 selector."c/sansSerif" = "serifless"
 selector."c/descBase" = "bilateralSerifed"
-selector."c/turnDescBase" = "bilateralSerifed"
 selector.cCurlyTail = "unilateralSerifed"
 selector.cHookTop = "bilateralSerifed"
 selector.cTopSerifOnly = "unilateralSerifed"
-selector.cBottomSerifOnly = "bilateralSerifed"
+selector.cBottomSerifOnly = "bottomSerifed"
 
 [prime.c.variants.unilateral-inward-serifed]
 rank = 4
@@ -1828,7 +1831,6 @@ description = "`c` with inward serif at top"
 selector.c = "unilateralInwardSerifed"
 selector."c/sansSerif" = "serifless"
 selector."c/descBase" = "hybridSerifed1"
-selector."c/turnDescBase" = "unilateralInwardSerifed"
 selector.cCurlyTail = "unilateralInwardSerifed"
 selector.cHookTop = "unilateralInwardSerifed"
 selector.cTopSerifOnly = "unilateralInwardSerifed"
@@ -1840,11 +1842,10 @@ description = "`c` with inward serif at both top and bottom"
 selector.c = "bilateralInwardSerifed"
 selector."c/sansSerif" = "serifless"
 selector."c/descBase" = "bilateralInwardSerifed"
-selector."c/turnDescBase" = "bilateralInwardSerifed"
 selector.cCurlyTail = "unilateralInwardSerifed"
 selector.cHookTop = "bilateralInwardSerifed"
 selector.cTopSerifOnly = "unilateralInwardSerifed"
-selector.cBottomSerifOnly = "bilateralInwardSerifed"
+selector.cBottomSerifOnly = "bottomInwardSerifed"
 
 
 
@@ -6212,30 +6213,56 @@ rank = 1
 description = "Serifless Cyrillic Capital E (`Э`)"
 selector."cyrl/E" = "serifless"
 selector."cyrl/ETopSerifOnly" = "serifless"
+selector."cyrl/Ye" = "serifless"
+selector."currency/euroSign" = "serifless"
 
 [prime.cyrl-capital-e.variants.unilateral-serifed]
 rank = 2
 description = "Cyrillic Capital E (`Э`) with serif at top"
 selector."cyrl/E" = "unilateralSerifed"
 selector."cyrl/ETopSerifOnly" = "unilateralSerifed"
+selector."cyrl/Ye" = "unilateralSerifed"
+selector."currency/euroSign" = "unilateralSerifed"
+
+[prime.cyrl-capital-e.variants.unilateral-bottom-serifed]
+rank = 3
+description = "Cyrillic Capital E (`Э`) with serif at bottom"
+selector."cyrl/E" = "bottomSerifed"
+selector."cyrl/ETopSerifOnly" = "serifless"
+selector."cyrl/Ye" = "unilateralSerifed"
+selector."currency/euroSign" = "unilateralSerifed"
 
 [prime.cyrl-capital-e.variants.bilateral-serifed]
-rank = 3
+rank = 4
 description = "Cyrillic Capital E (`Э`) with serifs at both top and bottom"
 selector."cyrl/E" = "bilateralSerifed"
 selector."cyrl/ETopSerifOnly" = "unilateralSerifed"
+selector."cyrl/Ye" = "bilateralSerifed"
+selector."currency/euroSign" = "bilateralSerifed"
 
 [prime.cyrl-capital-e.variants.unilateral-inward-serifed]
-rank = 4
+rank = 5
 description = "Cyrillic Capital E (`Э`) with inward serif at top"
 selector."cyrl/E" = "unilateralInwardSerifed"
 selector."cyrl/ETopSerifOnly" = "unilateralInwardSerifed"
+selector."cyrl/Ye" = "unilateralInwardSerifed"
+selector."currency/euroSign" = "unilateralInwardSerifed"
+
+[prime.cyrl-capital-e.variants.unilateral-bottom-inward-serifed]
+rank = 6
+description = "Cyrillic Capital E (`Э`) with inward serif at bottom"
+selector."cyrl/E" = "bottomInwardSerifed"
+selector."cyrl/ETopSerifOnly" = "serifless"
+selector."cyrl/Ye" = "unilateralInwardSerifed"
+selector."currency/euroSign" = "unilateralInwardSerifed"
 
 [prime.cyrl-capital-e.variants.bilateral-inward-serifed]
-rank = 5
+rank = 7
 description = "Cyrillic Capital E (`Э`) with inward serif at both top and bottom"
 selector."cyrl/E" = "bilateralInwardSerifed"
 selector."cyrl/ETopSerifOnly" = "unilateralInwardSerifed"
+selector."cyrl/Ye" = "bilateralInwardSerifed"
+selector."currency/euroSign" = "bilateralInwardSerifed"
 
 
 
@@ -6250,30 +6277,49 @@ rank = 1
 description = "Serifless Cyrillic Lower E (`э`)"
 selector."cyrl/e" = "serifless"
 selector."cyrl/eTopSerifOnly" = "serifless"
+selector."cyrl/ye" = "serifless"
 
 [prime.cyrl-e.variants.unilateral-serifed]
 rank = 2
 description = "Cyrillic Lower E (`э`) with serif at top"
 selector."cyrl/e" = "unilateralSerifed"
 selector."cyrl/eTopSerifOnly" = "unilateralSerifed"
+selector."cyrl/ye" = "unilateralSerifed"
+
+[prime.cyrl-e.variants.unilateral-bottom-serifed]
+rank = 3
+description = "Cyrillic Lower E (`э`) with serif at bottom"
+selector."cyrl/e" = "bottomSerifed"
+selector."cyrl/eTopSerifOnly" = "serifless"
+selector."cyrl/ye" = "unilateralSerifed"
 
 [prime.cyrl-e.variants.bilateral-serifed]
-rank = 3
+rank = 4
 description = "Cyrillic Lower E (`э`) with serifs at both top and bottom"
 selector."cyrl/e" = "bilateralSerifed"
 selector."cyrl/eTopSerifOnly" = "unilateralSerifed"
+selector."cyrl/ye" = "bilateralSerifed"
 
 [prime.cyrl-e.variants.unilateral-inward-serifed]
-rank = 4
+rank = 5
 description = "Cyrillic Lower E (`э`) with inward serif at top"
 selector."cyrl/e" = "unilateralInwardSerifed"
 selector."cyrl/eTopSerifOnly" = "unilateralInwardSerifed"
+selector."cyrl/ye" = "unilateralInwardSerifed"
+
+[prime.cyrl-e.variants.unilateral-bottom-inward-serifed]
+rank = 6
+description = "Cyrillic Lower E (`э`) with inward serif at bottom"
+selector."cyrl/e" = "bottomInwardSerifed"
+selector."cyrl/eTopSerifOnly" = "serifless"
+selector."cyrl/ye" = "unilateralInwardSerifed"
 
 [prime.cyrl-e.variants.bilateral-inward-serifed]
-rank = 5
+rank = 7
 description = "Cyrillic Lower E (`э`) with inward serif at both top and bottom"
 selector."cyrl/e" = "bilateralInwardSerifed"
 selector."cyrl/eTopSerifOnly" = "unilateralInwardSerifed"
+selector."cyrl/ye" = "bilateralInwardSerifed"
 
 
 


### PR DESCRIPTION
Basically, I've seen fonts around that use a bottom serif for Cyrillic E in particular, emulating a turned Ukrainian Ye, where Ukrainian Ye itself continues to use unturned serifs like ASCII `C` or Cyrillic Es.
Additionally, Euro Sign now follows Cyrillic Ye variants because it is originally derived from a capital Lunate Epsilon, which while currently not in Unicode, it would of course behave like the Greek/Latin analogue to Cyrillic Ye if it were, as each share a common origin.

All Cyrillic E variants:
`ЄѤ€ЭӘ`
![image](https://github.com/be5invis/Iosevka/assets/37010132/ba59bce5-58d4-4cdd-be4c-aa4f693f027e)
`єѥэә`
![image](https://github.com/be5invis/Iosevka/assets/37010132/01383ca1-27a6-4dec-a6d6-5c0289527707)

Also make Pound Sterling sign respond to bottom-right serifed variants of `L` as it is derived from a cursive L:
`L£₤`
![image](https://github.com/be5invis/Iosevka/assets/37010132/b828866c-0587-4e00-946a-b4b9d0e4e3d0)
![image](https://github.com/be5invis/Iosevka/assets/37010132/dca39fba-4b14-4107-a60f-48dc0c7e6356)
![image](https://github.com/be5invis/Iosevka/assets/37010132/0d6617da-183a-46f3-927d-04b73dc4ff3f)

You may also notice in the diffs that I carved out an independent variant selection for the French Franc sign only to make it follow the exact same variants as before. This is for future proofing for if we ever get around to making the capped serifed variants for `F`/`E` as they wouldn't apply to the French Franc sign. I did the same for the Euro Sign too, as opposed to making it directly follow Cyrillic Ye.
