### PR TITLE
Draft: Add bottom-serifed variants to Cyrillic Ze.

### DIFF
--- a/changes/30.3.0.md
+++ b/changes/30.3.0.md
@@ -1,1 +1,2 @@
 * Add separate variant selectors For Cyrillic Capital/Lower E (`VXAA`, `VXAB`).
+* Add `unilateral-bottom-serifed` and `unilateral-bottom-inward-serifed` variants for Cyrillic Capital/Lower Ze (`cv69`, `cv70`).

--- a/packages/font-glyphs/src/letter/cyrillic/de.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/de.ptl
@@ -179,6 +179,6 @@ glyph-block Letter-Cyrillic-De : begin
 			local ze : CyrZe 1 sb XH Descender xZeLeft xZeRight 0.65 Hook df.mvs
 			include : union [ze.Shape] [ze.AutoEndSerifL]
 
-	select-variant 'cyrl/Dzze' 0xA688 (follow -- 'cyrl/ze/topAttached')
-	select-variant 'cyrl/dzze.upright' (follow -- 'cyrl/ze/topAttached')
-	select-variant 'cyrl/dzze.italic' (follow -- 'cyrl/ze/topAttached')
+	select-variant 'cyrl/Dzze' 0xA688 (follow -- 'cyrl/ZeBottomSerifOnly')
+	select-variant 'cyrl/dzze.upright' (follow -- 'cyrl/zeBottomSerifOnly')
+	select-variant 'cyrl/dzze.italic' (follow -- 'cyrl/zeBottomSerifOnly')

--- a/packages/font-glyphs/src/letter/cyrillic/dzzhe-zhwe.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/dzzhe-zhwe.ptl
@@ -7,7 +7,7 @@ glyph-module
 glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Greek-Lower-Epsilon : CyrZe
+	glyph-block-import Letter-Greek-Lower-Epsilon : CyrZe EpsilonConfig
 
 	glyph-block-export SubDfDimBy4
 	define [SubDfDimBy4 pShift keeps df _o] : begin
@@ -51,17 +51,6 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 			include : CyrDzzheDeItalicShape df
 
 	do "ze subglyph"
-		define SLAB-NONE       0
-		define SLAB-CLASSICAL  1
-		define SLAB-INWARD     2
-
-		define ZeConfig : object
-			serifless               { SLAB-NONE      SLAB-NONE      }
-			unilateralSerifed       { SLAB-CLASSICAL SLAB-NONE      }
-			bilateralSerifed        { SLAB-CLASSICAL SLAB-CLASSICAL }
-			unilateralInwardSerifed { SLAB-INWARD    SLAB-NONE      }
-			bilateralInwardSerifed  { SLAB-INWARD    SLAB-INWARD    }
-
 		define [CyrZhweZeShape slabTop slabBot df top hook] : glyph-proc
 			local [object subDf sw] : SubDfDimBy4 0 2 df OX
 			local ze : CyrZe slabTop slabBot top 0 subDf.leftSB subDf.rightSB 0.65 hook sw (xo -- 0.33 * OX)
@@ -69,7 +58,7 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 			include : ze.AutoStartSerifL
 			include : ze.AutoEndSerifL
 
-		foreach { suffix { slabTop slabBot } } [Object.entries ZeConfig] : do
+		foreach { suffix { slabTop slabBot } } [Object.entries EpsilonConfig] : do
 			create-glyph "cyrl/Zhwe/left.\(suffix)" : glyph-proc
 				define df : include : DivFrame para.diversityM 3.5
 				include : df.markSet.capital

--- a/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
@@ -208,13 +208,13 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 	glyph-block-export EpsilonConfig
 	define EpsilonConfig : object
 		serifless               { SLAB-NONE      SLAB-NONE      }
+		bottomSerifed           { SLAB-NONE      SLAB-CLASSICAL }
+		bottomInwardSerifed     { SLAB-NONE      SLAB-INWARD    }
 		unilateralSerifed       { SLAB-CLASSICAL SLAB-NONE      }
 		bilateralSerifed        { SLAB-CLASSICAL SLAB-CLASSICAL }
 		unilateralInwardSerifed { SLAB-INWARD    SLAB-NONE      }
 		bilateralInwardSerifed  { SLAB-INWARD    SLAB-INWARD    }
-
-		seriflessDesc               { SLAB-NONE      SLAB-CLASSICAL }
-		unilateralInwardSerifedDesc { SLAB-INWARD    SLAB-CLASSICAL }
+		hybridSerifed1          { SLAB-INWARD    SLAB-CLASSICAL }
 
 	foreach { suffix { slabTop slabBot } } [Object.entries EpsilonConfig] : do
 		create-glyph "latn/Epsilon.\(suffix)" : glyph-proc
@@ -471,22 +471,22 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 
 	select-variant 'cyrl/Ze' 0x417
 	select-variant 'cyrl/ze' 0x437
-	select-variant 'cyrl/KsiBase' (follow -- 'cyrl/Ksi')
-	select-variant 'cyrl/ksiBase' (follow -- 'cyrl/ksi')
-	select-variant 'cyrl/ze.BGR' (follow -- 'cyrl/ze')
+	select-variant 'cyrl/KsiBase' (follow -- 'cyrl/ZeTopSerifOnly')
+	select-variant 'cyrl/ksiBase' (follow -- 'cyrl/zeTopSerifOnly')
+	select-variant 'cyrl/ze.BGR'  (follow -- 'cyrl/ze')
 	alias 'latn/EpsilonRev' 0xA7AB 'cyrl/Ze'
 	alias 'latn/epsilonRev' 0x25C  'cyrl/ze'
 
-	select-variant 'cyrl/ZjeKomi' 0x504 (follow -- 'cyrl/Ksi')
-	select-variant 'cyrl/zjeKomi' 0x505 (follow -- 'cyrl/ksi')
-	select-variant 'cyrl/DzjeKomi' 0x506 (follow -- 'cyrl/Ksi')
-	select-variant 'cyrl/dzjeKomi' 0x507 (follow -- 'cyrl/ksi')
+	select-variant 'cyrl/ZjeKomi'  0x504 (follow -- 'cyrl/ZeTopSerifOnly')
+	select-variant 'cyrl/zjeKomi'  0x505 (follow -- 'cyrl/zeTopSerifOnly')
+	select-variant 'cyrl/DzjeKomi' 0x506 (follow -- 'cyrl/ZeTopSerifOnly')
+	select-variant 'cyrl/dzjeKomi' 0x507 (follow -- 'cyrl/zeTopSerifOnly')
 
 	derive-composites 'cyrl/Dhe' 0x498 'cyrl/Ze' 'cedillaExtShapeBelowOArc'
 	derive-composites 'cyrl/dhe' 0x499 'cyrl/ze' 'cedillaExtShapeBelowSOArc'
 
 	select-variant 'latn/epsilon/descBase' (shapeFrom -- 'latn/epsilon')
-	select-variant 'latn/epsilonRev/descBase' (shapeFrom -- 'cyrl/ze') (follow -- 'latn/epsilon/descBase')
+	select-variant 'latn/epsilonRev/descBase' (shapeFrom -- 'cyrl/ze') (follow -- 'cyrl/ze/descBase')
 
 	derive-composites 'latn/epsilonRetroflexHook' 0x1D93 'latn/epsilon/descBase'
 		RetroflexHook.r RightSB 0 (refSw -- [AdviceStroke2 2 3 XH])

--- a/packages/font-glyphs/src/letter/latin-ext/yogh.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/yogh.ptl
@@ -64,5 +64,5 @@ glyph-block Letter-Latin-Yogh : begin
 			include : MarkSet.capital
 			include : YoghShape slabTop XH Descender
 
-	select-variant 'Yogh' 0x21C
-	select-variant 'yogh' 0x21D
+	select-variant 'Yogh' 0x21C (follow -- 'cyrl/ZeTopSerifOnly')
+	select-variant 'yogh' 0x21D (follow -- 'cyrl/zeTopSerifOnly')

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -5353,40 +5353,58 @@ rank = 1
 description = "Serifless Cyrillic Capital Ze (`З`)"
 selector."latn/Epsilon" = "serifless"
 selector."cyrl/Ze" = "serifless"
-selector."cyrl/Ksi" = "serifless"
-selector."Yogh" = "serifless"
+selector."cyrl/ZeTopSerifOnly" = "serifless"
+selector."cyrl/ZeBottomSerifOnly" = "serifless"
 
 [prime.cyrl-capital-ze.variants.unilateral-serifed]
 rank = 2
 description = "Cyrillic Capital Ze (`З`) with serif at top"
 selector."latn/Epsilon" = "unilateralSerifed"
 selector."cyrl/Ze" = "unilateralSerifed"
-selector."cyrl/Ksi" = "unilateralSerifed"
-selector."Yogh" = "unilateralSerifed"
+selector."cyrl/ZeTopSerifOnly" = "unilateralSerifed"
+selector."cyrl/ZeBottomSerifOnly" = "serifless"
+
+[prime.cyrl-capital-ze.variants.unilateral-bottom-serifed]
+rank = 3
+nonBreakingVariantAdditionPriority = 100
+description = "Cyrillic Capital Ze (`З`) with serif at bottom"
+selector."latn/Epsilon" = "unilateralSerifed"
+selector."cyrl/Ze" = "bottomSerifed"
+selector."cyrl/ZeTopSerifOnly" = "serifless"
+selector."cyrl/ZeBottomSerifOnly" = "bottomSerifed"
 
 [prime.cyrl-capital-ze.variants.bilateral-serifed]
-rank = 3
+rank = 4
 description = "Cyrillic Capital Ze (`З`) with serif at both top and bottom"
 selector."latn/Epsilon" = "bilateralSerifed"
 selector."cyrl/Ze" = "bilateralSerifed"
-selector."cyrl/Ksi" = "unilateralSerifed"
-selector."Yogh" = "unilateralSerifed"
+selector."cyrl/ZeTopSerifOnly" = "unilateralSerifed"
+selector."cyrl/ZeBottomSerifOnly" = "bottomSerifed"
 
 [prime.cyrl-capital-ze.variants.unilateral-inward-serifed]
-rank = 4
+rank = 5
 description = "Cyrillic Capital Ze (`З`) with inward serif at top"
 selector."latn/Epsilon" = "unilateralInwardSerifed"
 selector."cyrl/Ze" = "unilateralInwardSerifed"
-selector."cyrl/Ksi" = "unilateralInwardSerifed"
-selector."Yogh" = "unilateralInwardSerifed"
+selector."cyrl/ZeTopSerifOnly" = "unilateralInwardSerifed"
+selector."cyrl/ZeBottomSerifOnly" = "serifless"
+
+[prime.cyrl-capital-ze.variants.unilateral-bottom-inward-serifed]
+rank = 6
+nonBreakingVariantAdditionPriority = 200
+description = "Cyrillic Capital Ze (`З`) with inward serif at bottom"
+selector."latn/Epsilon" = "unilateralInwardSerifed"
+selector."cyrl/Ze" = "bottomInwardSerifed"
+selector."cyrl/ZeTopSerifOnly" = "serifless"
+selector."cyrl/ZeBottomSerifOnly" = "bottomInwardSerifed"
 
 [prime.cyrl-capital-ze.variants.bilateral-inward-serifed]
-rank = 5
+rank = 7
 description = "Cyrillic Capital Ze (`З`) with inward serif at both top and bottom"
 selector."latn/Epsilon" = "bilateralInwardSerifed"
 selector."cyrl/Ze" = "bilateralInwardSerifed"
-selector."cyrl/Ksi" = "unilateralInwardSerifed"
-selector."Yogh" = "unilateralInwardSerifed"
+selector."cyrl/ZeTopSerifOnly" = "unilateralInwardSerifed"
+selector."cyrl/ZeBottomSerifOnly" = "bottomInwardSerifed"
 
 
 
@@ -5399,11 +5417,11 @@ tagKind = "letter"
 rank = 1
 description = "Serifless Cyrillic Lower Ze (`з`)"
 selector."latn/epsilon" = "serifless"
-selector."latn/epsilon/descBase" = "seriflessDesc"
+selector."latn/epsilon/descBase" = "bottomSerifed"
 selector."cyrl/ze" = "serifless"
-selector."cyrl/ze/topAttached" = "serifless"
-selector."cyrl/ksi" = "serifless"
-selector."yogh" = "serifless"
+selector."cyrl/ze/descBase" = "bottomSerifed"
+selector."cyrl/zeTopSerifOnly" = "serifless"
+selector."cyrl/zeBottomSerifOnly" = "serifless"
 
 [prime.cyrl-ze.variants.unilateral-serifed]
 rank = 2
@@ -5411,39 +5429,61 @@ description = "Cyrillic Lower Ze (`з`) with serif at top"
 selector."latn/epsilon" = "unilateralSerifed"
 selector."latn/epsilon/descBase" = "bilateralSerifed"
 selector."cyrl/ze" = "unilateralSerifed"
-selector."cyrl/ze/topAttached" = "serifless"
-selector."cyrl/ksi" = "unilateralSerifed"
-selector."yogh" = "unilateralSerifed"
+selector."cyrl/ze/descBase" = "bilateralSerifed"
+selector."cyrl/zeTopSerifOnly" = "unilateralSerifed"
+selector."cyrl/zeBottomSerifOnly" = "serifless"
+
+[prime.cyrl-ze.variants.unilateral-bottom-serifed]
+rank = 3
+nonBreakingVariantAdditionPriority = 100
+description = "Cyrillic Lower Ze (`з`) with serif at bottom"
+selector."latn/epsilon" = "unilateralSerifed"
+selector."latn/epsilon/descBase" = "bilateralSerifed"
+selector."cyrl/ze" = "bottomSerifed"
+selector."cyrl/ze/descBase" = "bottomSerifed"
+selector."cyrl/zeTopSerifOnly" = "serifless"
+selector."cyrl/zeBottomSerifOnly" = "bottomSerifed"
 
 [prime.cyrl-ze.variants.bilateral-serifed]
-rank = 3
+rank = 4
 description = "Cyrillic Lower Ze (`з`) with serif at both top and bottom"
 selector."latn/epsilon" = "bilateralSerifed"
 selector."latn/epsilon/descBase" = "bilateralSerifed"
 selector."cyrl/ze" = "bilateralSerifed"
-selector."cyrl/ze/topAttached" = "bilateralSerifed"
-selector."cyrl/ksi" = "unilateralSerifed"
-selector."yogh" = "unilateralSerifed"
+selector."cyrl/ze/descBase" = "bilateralSerifed"
+selector."cyrl/zeTopSerifOnly" = "unilateralSerifed"
+selector."cyrl/zeBottomSerifOnly" = "bottomSerifed"
 
 [prime.cyrl-ze.variants.unilateral-inward-serifed]
-rank = 4
+rank = 5
 description = "Cyrillic Lower Ze (`з`) with inward serif at top"
 selector."latn/epsilon" = "unilateralInwardSerifed"
-selector."latn/epsilon/descBase" = "unilateralInwardSerifedDesc"
+selector."latn/epsilon/descBase" = "hybridSerifed1"
 selector."cyrl/ze" = "unilateralInwardSerifed"
-selector."cyrl/ze/topAttached" = "serifless"
-selector."cyrl/ksi" = "unilateralInwardSerifed"
-selector."yogh" = "unilateralInwardSerifed"
+selector."cyrl/ze/descBase" = "hybridSerifed1"
+selector."cyrl/zeTopSerifOnly" = "unilateralInwardSerifed"
+selector."cyrl/zeBottomSerifOnly" = "serifless"
+
+[prime.cyrl-ze.variants.unilateral-bottom-inward-serifed]
+rank = 6
+nonBreakingVariantAdditionPriority = 200
+description = "Cyrillic Lower Ze (`з`) with inward serif at bottom"
+selector."latn/epsilon" = "unilateralInwardSerifed"
+selector."latn/epsilon/descBase" = "hybridSerifed1"
+selector."cyrl/ze" = "bottomInwardSerifed"
+selector."cyrl/ze/descBase" = "bottomSerifed"
+selector."cyrl/zeTopSerifOnly" = "serifless"
+selector."cyrl/zeBottomSerifOnly" = "bottomInwardSerifed"
 
 [prime.cyrl-ze.variants.bilateral-inward-serifed]
-rank = 5
+rank = 7
 description = "Cyrillic Lower Ze (`з`) with inward serif at both top and bottom"
 selector."latn/epsilon" = "bilateralInwardSerifed"
-selector."latn/epsilon/descBase" = "unilateralInwardSerifedDesc"
+selector."latn/epsilon/descBase" = "hybridSerifed1"
 selector."cyrl/ze" = "bilateralInwardSerifed"
-selector."cyrl/ze/topAttached" = "bilateralInwardSerifed"
-selector."cyrl/ksi" = "unilateralInwardSerifed"
-selector."yogh" = "unilateralInwardSerifed"
+selector."cyrl/ze/descBase" = "hybridSerifed1"
+selector."cyrl/zeTopSerifOnly" = "unilateralInwardSerifed"
+selector."cyrl/zeBottomSerifOnly" = "bottomInwardSerifed"
 
 
 


### PR DESCRIPTION
(Marking as draft because I cannot figure out how to get the `nonBreakingVariantAdditionPriority` argument to shift the new variants to the end of the stack instead of just permanently assigning them an index at the end.)

Basically, I took a closer look at some of the fonts I talked about in #2380 and saw that they tended to also put bottom serifs on Cyrillic Ze as well.
Mind you, these variants are mostly used under italics.

DejaVu Serif Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/d68ddf29-c538-4011-9f2b-6aad089bd021)
Palatino Linotype Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/aecd3c99-3eb9-442c-9f85-0c96e7f27bef)

All Cyrillic Ze variants:
`ƐЗꚄꚈѮȜ`
![image](https://github.com/be5invis/Iosevka/assets/37010132/3051e295-baab-463b-86eb-0dd45b366f82)
`ɛᶓзᶔꚅꚉѯȝ`
![image](https://github.com/be5invis/Iosevka/assets/37010132/378b25a3-00bd-4311-bfea-e469202b0acb)