### PR TITLE
Add `serifed-capped` variants for `E` and `F` (#2026).

### DIFF
--- a/changes/30.3.0.md
+++ b/changes/30.3.0.md
@@ -1,4 +1,5 @@
 * Add separate variant selectors For Cyrillic Capital/Lower E (`VXAA`, `VXAB`).
+* Add `serifed-capped` variants for `capital-e` and `capital-f` (`cv05`, `cv06`) (#2026).
 * Add `unilateral-bottom-serifed` and `unilateral-bottom-inward-serifed` variants for Cyrillic Capital/Lower Ze (`cv69`, `cv70`).
 * Add characters:
   - SYMBOL FOR SAMARITAN SOURCE (`U+214F`).

--- a/packages/font-glyphs/src/letter/latin-ext/upper-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/upper-ae-oe.ptl
@@ -17,6 +17,7 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 
 	define SLAB-E-NONE    0
 	define SLAB-E-ALL     2
+	define SLAB-E-CAPPED  3
 
 	define [AESW df top] : Math.min df.mvs : AdviceStroke2 3 3 top df.div
 
@@ -97,16 +98,24 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 		define eleft : df.middle - [HSwToV : 0.25 * sw]
 		define swVJut : Math.min sw ((df.rightSB - eleft - [HSwToV sw]) * (4 / 5))
 
+		local xMidRight : df.rightSB - sw / 4
+		local yBar : top * eBarPos
+		local { jutTop jutBot } : EFVJutLength top eBarPos sw
+
 		# E half
 		include : VBar.l eleft 0 top sw
 		include : HBar.t (eleft - O) df.rightSB top
-		include : HBar.m (eleft - O) (df.rightSB - sw / 4) (top * eBarPos)
+		include : HBar.m (eleft - O) xMidRight yBar
 		include : HBar.b (eleft - O) df.rightSB 0
+
 		match slabKind
-			[Just SLAB-E-ALL] : begin
-				local { jutTop jutBot } : EFVJutLength top eBarPos sw
+			([Just SLAB-E-ALL] || [Just SLAB-E-CAPPED]) : begin
 				include : VSerif.dr df.rightSB top jutTop swVJut
 				include : VSerif.ur df.rightSB 0 jutBot swVJut
+		match slabKind
+			[Just SLAB-E-CAPPED] : begin
+				local fine : swVJut * [AdviceStroke 3.5] / Stroke
+				include : VBar.r xMidRight (yBar - 0.5 * jutBot) (yBar + 0.5 * jutBot) fine
 
 	do "P/Ya Half"
 		glyph-block-import Letter-Latin-Upper-P : PShape PBarPosY
@@ -140,8 +149,9 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 		curlyTriSerifed       { false  SLAB-A-TRI  }
 
 	define EConfig : object
-		serifless     { SLAB-E-NONE }
-		serifed       { SLAB-E-ALL  }
+		serifless     { SLAB-E-NONE   }
+		serifed       { SLAB-E-ALL    }
+		serifedCapped { SLAB-E-CAPPED }
 
 	foreach { suffix { fStraightBar slabKind } } [Object.entries AConfig] : do
 		create-glyph "AE/AHalf.\(suffix)" : glyph-proc
@@ -184,6 +194,10 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 		define eleft : df.middle - sw * [if SLAB (1 / 3) (1 / 4)] * HVContrast
 		define swVJut : Math.min sw ((df.rightSB - eleft - [HSwToV sw]) * (4 / 5))
 
+		local xMidRight : df.rightSB - sw / 4
+		local yBar : top * eBarPos
+		local { jutTop jutBot } : EFVJutLength top eBarPos sw
+
 		# O half
 		include : dispiro
 			widths.lhs sw 0
@@ -197,15 +211,17 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 		# E half
 		include : VBar.l eleft 0 top sw
 		include : HBar.t (eleft - O) df.rightSB top sw
-		include : HBar.m (eleft - O) (df.rightSB - sw / 4) (top * 0.54) sw
+		include : HBar.m (eleft - O) xMidRight yBar sw
 		include : HBar.b (eleft - O) df.rightSB 0 sw
 
 		match slabKind
-			[Just SLAB-E-ALL] : begin
-				local { jutTop jutBot } : EFVJutLength top eBarPos sw
+			([Just SLAB-E-ALL] || [Just SLAB-E-CAPPED]) : begin
 				include : VSerif.dr df.rightSB top jutTop swVJut
 				include : VSerif.ur df.rightSB 0 jutBot swVJut
-
+		match slabKind
+			[Just SLAB-E-CAPPED] : begin
+				local fine : swVJut * [AdviceStroke 3.5] / Stroke
+				include : VBar.r xMidRight (yBar - 0.5 * jutBot) (yBar + 0.5 * jutBot) fine
 
 	foreach { suffix { slabKind } } [Object.entries EConfig] : do
 		create-glyph "OE.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/upper-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-e.ptl
@@ -15,40 +15,56 @@ glyph-block Letter-Latin-Upper-E : begin
 	define kSB 1
 	define xEBarLeft     : SB * kSB - O
 	define xRevEBarRight : Width - SB * kSB + O
-	define [EShape] : with-params [top pyBar serifLT serifLB serifV [stroke : AdviceStroke2 2 3 top]] : glyph-proc
+
+	define [EShape] : with-params [top pyBar serifLT serifLB serifV serifM [stroke : AdviceStroke2 2 3 top]] : glyph-proc
+		local xMidRight : RightSB - [xMidBarShrink serifV]
+		local yBar : yMidBar top pyBar
+		local { jutTop jutBot } : EFVJutLength top pyBar stroke
+
 		include : VBar.l (xEBarLeft) 0 top stroke
 		include : HBar.t (xEBarLeft - O) RightSB top stroke
-		include : HBar.m (xEBarLeft - O) (RightSB - [xMidBarShrink serifV]) [yMidBar top pyBar] stroke
+		include : HBar.m (xEBarLeft - O) xMidRight yBar stroke
 		include : HBar.b (xEBarLeft - O) RightSB 0 stroke
+
 		if serifLT : include : HSerif.lt xEBarLeft top SideJut
 		if serifLB : include : HSerif.lb xEBarLeft 0 SideJut
 		if serifV : begin
-			local { jutTop jutBot } : EFVJutLength top pyBar stroke
 			include : VSerif.dr RightSB top jutTop
 			include : VSerif.ur RightSB 0 jutBot
+		if serifM : begin
+			local fine : stroke * [AdviceStroke 3.5] / Stroke
+			include : VBar.r xMidRight (yBar - 0.5 * jutBot) (yBar + 0.5 * jutBot) fine
 
 	glyph-block-export RevEShape
-	define [RevEShape] : with-params [top pyBar serifRT serifRB serifV [stroke : AdviceStroke2 2 3 top]] : glyph-proc
+	define [RevEShape] : with-params [top pyBar serifRT serifRB serifV serifM [stroke : AdviceStroke2 2 3 top]] : glyph-proc
+		local xMidLeft : SB + [xMidBarShrink serifV]
+		local yBar : yMidBar top pyBar
+		local { jutTop jutBot } : EFVJutLength top pyBar stroke
+
 		include : VBar.r (xRevEBarRight) 0 top stroke
 		include : HBar.t SB (xRevEBarRight + O) top stroke
-		include : HBar.m (SB + [xMidBarShrink serifV]) (xRevEBarRight + O) [yMidBar top pyBar] stroke
+		include : HBar.m xMidLeft (xRevEBarRight + O) yBar stroke
 		include : HBar.b SB (xRevEBarRight + O) 0 stroke
+
 		if serifRT : include : HSerif.rt xRevEBarRight top SideJut
 		if serifRB : include : HSerif.rb xRevEBarRight 0 SideJut
 		if serifV : begin
-			local { jutTop jutBot } : EFVJutLength top pyBar stroke
 			include : VSerif.dl SB top jutTop
 			include : VSerif.ul SB 0 jutBot
+		if serifM : begin
+			local fine : stroke * [AdviceStroke 3.5] / Stroke
+			include : VBar.l xMidLeft (yBar - 0.5 * jutBot) (yBar + 0.5 * jutBot) fine
 
 	define EConfig : object
-		serifless      { false false false }
-		topLeftSerifed { true false false  }
-		serifed        { true true true    }
+		serifless      { false false false false }
+		topLeftSerifed { true  false false false }
+		serifed        { true  true  true  false }
+		serifedCapped  { true  true  true  true  }
 
-	foreach { suffix { lt lb v } } [Object.entries EConfig] : do
+	foreach { suffix { lt lb v m } } [Object.entries EConfig] : do
 		create-glyph "E.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : EShape CAP (serifLT -- lt) (serifLB -- lb) (serifV -- v)
+			include : EShape CAP (serifLT -- lt) (serifLB -- lb) (serifV -- v) (serifM -- m)
 			set-base-anchor 'trailing' RightSB 0
 
 		create-glyph "grek/Epsilon.\(suffix)" : glyph-proc
@@ -57,13 +73,12 @@ glyph-block Letter-Latin-Upper-E : begin
 
 		create-glyph "smcpE.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			include : EShape XH (serifLT -- lt) (serifLB -- lb) (serifV -- v)
+			include : EShape XH (serifLT -- lt) (serifLB -- lb) (serifV -- v) (serifM -- m)
 			set-base-anchor 'trailing' (RightSB - markHalfStroke) 0
 
 		create-glyph "revE.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : RevEShape CAP (serifRT -- lt) (serifRB -- lb) (serifV -- v)
-
+			include : RevEShape CAP (serifRT -- lt) (serifRB -- lb) (serifV -- v) (serifM -- m)
 
 	select-variant 'E' 'E'
 	link-reduced-variant 'E/sansSerif' 'E' MathSansSerif

--- a/packages/font-glyphs/src/letter/latin/upper-f.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-f.ptl
@@ -28,31 +28,37 @@ glyph-block Letter-Latin-Upper-F : begin
 	define xFBarLeft : SB * 1.5
 	define xFBarRight : Width - SB * 1.5
 
-	define [FShape] : with-params [top pyBar serifLT serifLB serifV [stroke : AdviceStroke2 2 3 top]] : glyph-proc
+	define [FShape] : with-params [top pyBar serifLT serifLB serifV serifM [stroke : AdviceStroke2 2 3 top]] : glyph-proc
+		local xMidRight : RightSB - [xMidBarShrink serifV]
+		local yBar : yMidBar top pyBar
+		local { jutTop jutBot } : EFVJutLength top pyBar stroke
+
 		include : VBar.l (xFBarLeft) 0 top stroke
 		include : HBar.t (xFBarLeft - O) RightSB top stroke
-		include : tagged 'crossBar'
-			HBar.m (xFBarLeft - O) (RightSB - [xMidBarShrink serifV]) [yMidBar top pyBar] stroke
+		include : tagged 'crossBar' : HBar.m (xFBarLeft - O) xMidRight yBar stroke
+
 		if serifLT : include : HSerif.lt xFBarLeft top SideJut
 		if serifLB : begin
 			include : tagged 'serifBottom' : HSerif.lb xFBarLeft 0 SideJut
 			include : tagged 'serifBottom' : HSerif.rb (xFBarLeft + [HSwToV HalfStroke]) 0 MidJutSide
-		if serifV : begin
-			local { jutTop jutBot } : EFVJutLength top pyBar stroke
-			include : VSerif.dr RightSB top jutTop
+		if serifV : include : VSerif.dr RightSB top jutTop
+		if serifM : begin
+			local fine : stroke * [AdviceStroke 3.5] / Stroke
+			include : VBar.r xMidRight (yBar - 0.5 * jutBot) (yBar + 0.5 * jutBot) fine
 
 	define FConfig : object
-		serifless      { false false false }
-		topLeftSerifed { true false false  }
-		serifed        { true true true    }
+		serifless      { false false false false }
+		topLeftSerifed { true  false false false }
+		serifed        { true  true  true  false }
+		serifedCapped  { true  true  true  true  }
 
-	foreach { suffix { lt lb v } } [Object.entries FConfig] : do
+	foreach { suffix { lt lb v m } } [Object.entries FConfig] : do
 		create-glyph "F.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : LeaningAnchor.Below.VBar.l xFBarLeft [AdviceStroke2 2 3 CAP]
-			include : FShape CAP (serifLT -- lt) (serifLB -- lb) (serifV -- v)
+			include : FShape CAP (serifLT -- lt) (serifLB -- lb) (serifV -- v) (serifM -- m)
 
-		create-glyph "currency/frenchFrancSign.\(suffix)" : glyph-proc
+		if [not m] : create-glyph "currency/frenchFrancSign.\(suffix)" : glyph-proc
 			include [refer-glyph "F.\(suffix)"] AS_BASE ALSO_METRICS
 
 			eject-contour 'crossBar'
@@ -78,7 +84,7 @@ glyph-block Letter-Latin-Upper-F : begin
 		create-glyph "smcpF.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : LeaningAnchor.Below.VBar.l xFBarLeft [AdviceStroke2 2 3 XH]
-			include : FShape XH (serifLT -- lt) (serifLB -- lb) (serifV -- v)
+			include : FShape XH (serifLT -- lt) (serifLB -- lb) (serifV -- v) (serifM -- m)
 
 	select-variant 'F' 'F'
 	link-reduced-variant 'F/sansSerif' 'F' MathSansSerif

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -278,6 +278,13 @@ selector.E = "serifed"
 selector."E/sansSerif" = "serifless"
 selector."AE/EHalf" = "serifed"
 
+[prime.capital-e.variants.serifed-capped]
+rank = 4
+description = "E with serifs and capped middle bar"
+selector.E = "serifedCapped"
+selector."E/sansSerif" = "serifless"
+selector."AE/EHalf" = "serifedCapped"
+
 
 
 [prime.capital-f]
@@ -302,6 +309,13 @@ selector."currency/frenchFrancSign" = "topLeftSerifed"
 rank = 3
 description = "F with serifs"
 selector.F = "serifed"
+selector."F/sansSerif" = "serifless"
+selector."currency/frenchFrancSign" = "serifed"
+
+[prime.capital-f.variants.serifed-capped]
+rank = 4
+description = "F with serifs and capped middle bar"
+selector.F = "serifedCapped"
 selector."F/sansSerif" = "serifless"
 selector."currency/frenchFrancSign" = "serifed"
 
@@ -9194,6 +9208,7 @@ q = "earless-corner-straight-serifless"
 r = "earless-corner-serifless"
 u = "toothless-corner-serifless"
 y = "straight-turn-serifless"
+long-s = "bent-hook-serifless"
 eszet = "longs-s-lig-serifless"
 lower-alpha = "barred-earless-corner-tailed"
 capital-gamma = "bottom-serifed"
@@ -9258,6 +9273,7 @@ r = "earless-corner-serifed"
 u = "toothless-corner-serifed"
 y = "straight-turn-serifed"
 z = "straight-serifed"
+long-s = "bent-hook-bottom-serifed"
 eszet = "longs-s-lig-bottom-serifed"
 capital-gamma = "serifed"
 lower-mu = "toothless-corner-serifed"
@@ -9281,6 +9297,7 @@ r = "earless-corner-serifless"
 u = "tailed-motion-serifed"
 x = "straight-motion-serifed"
 y = "straight-turn-motion-serifed"
+long-s = "bent-hook-tailed"
 eszet = "longs-s-lig-tailed-serifless"
 lower-mu = "tailed-motion-serifed"
 cyrl-ka = "symmetric-touching-top-left-serifed"


### PR DESCRIPTION
Closes #2026 .
Metrics taken from Capital Greek Xi and adapted for values available to `E`/`F`.
The additional middle serif is only applicable to variants which are otherwise fully-serifed; A hypothetical `serifless-capped` variant would make no sense.
New variants are placed at the ends of the stacks.


All `E` variants:
`E𝖤ƎÆŒԘᴇᴁɶ`

Thin:
![image](https://github.com/be5invis/Iosevka/assets/37010132/fb409802-985c-4518-ac2f-2de3604f2925)
Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/2e82b9c4-4241-4334-abff-d38ef61213be)
Heavy:
![image](https://github.com/be5invis/Iosevka/assets/37010132/aa348f9f-680a-4e2c-98ce-b8f02dcb2d1c)

All `F` variants:
`F𝖥₣ꜰ`
Thin:
![image](https://github.com/be5invis/Iosevka/assets/37010132/1c02e072-d2c8-46c5-99e2-ff29a95d908c)
Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/d892baec-cc28-433f-9c24-08e192a1c47f)
Heavy:
![image](https://github.com/be5invis/Iosevka/assets/37010132/de98d0da-f0e8-48e5-9a60-b55762d9cba0)

