### PR TITLE
Make `ss04` use square dots for braille.

### DIFF
--- a/params/variants.toml
+++ b/params/variants.toml
@@ -7207,7 +7207,7 @@ selector.punctuationDot = "square"
 
 
 [prime.braille-dot]
-sampler = "⠭⠽"
+sampler = "⠭⠽ "
 hotChars = "⠭⠽"
 nonBreakingTagForNewVariantSelector = "VXAE" # REMOVE IN NEXT MAJOR VERSION CHANGE
 samplerExplain = "Dot shape in braille"
@@ -7215,12 +7215,12 @@ tagKind = "dot"
 
 [prime.braille-dot.variants.round]
 rank = 1
-description = "Braille use round dots"
+description = "Braille uses round dots"
 selector.brailleDot = "round"
 
 [prime.braille-dot.variants.square]
 rank = 2
-description = "Braille use square dots"
+description = "Braille uses square dots"
 selector.brailleDot = "square"
 
 
@@ -8629,6 +8629,7 @@ l = "serifed-flat-tailed"
 t = "flat-hook"
 u = "toothed-serifless"
 y = "straight-turn-serifless"
+capital-eszet = "rounded-serifless"
 long-s = "flat-hook-middle-serifed"
 eszet = "longs-s-lig-serifless"
 lower-eth = "straight-bar"
@@ -8655,6 +8656,7 @@ nine = "closed-contour"
 tittle = "square"
 punctuation-dot = "square"
 diacritic-dot = "square"
+braille-dot = "square"
 asterisk = "hex-low"
 underscore = "low"
 brace = "straight"
@@ -8688,6 +8690,7 @@ w = "straight-serifed"
 x = "straight-serifed"
 y = "straight-turn-serifed"
 z = "straight-serifed"
+capital-eszet = "rounded-serifed"
 long-s = "flat-hook-double-serifed"
 eszet = "longs-s-lig-bottom-serifed"
 lower-mu = "tailed-serifed"


### PR DESCRIPTION
Based on the relationship between Menlo and DejaVu fonts.
Also fix grammar in braille dot variant descriptions ("braille" is a mass noun).