### PR TITLE
Fix leaning mark anchors for five characters, optimize glyph shape for Yr (`U+01A6`).

### DIFF
--- a/changes/30.3.1.md
+++ b/changes/30.3.1.md
@@ -1,2 +1,4 @@
 * Add Capital Eszet (`VXAC`) variants with top-left corner.
 * Add square-dotted variant for brailles (#2388).
+* Fix leaning mark anchors for `U+0195`, `U+019E`, `U+01A6`, and `U+0220`.
+* Optimize glyph shape for `U+01A6`.

--- a/packages/font-glyphs/src/letter/latin-ext/hwair.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/hwair.ptl
@@ -8,6 +8,7 @@ glyph-module
 glyph-block Letter-Latin-Hwair : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
+	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared-Shapes : nShoulderKnots
 	glyph-block-import Letter-Shared-Shapes : SerifFrame
 
@@ -20,6 +21,7 @@ glyph-block Letter-Latin-Hwair : begin
 		create-glyph "hwair.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.b
+			include : LeaningAnchor.Above.VBar.l df.leftSB
 			include : VBar.l df.leftSB 0 Ascender df.mvs
 			include : dispiro
 				nShoulderKnots (df.leftSB + [HSwToV df.mvs]) (df.middle + [HSwToV : 0.5 * df.mvs]) (df.mvs * 0.4) nothing (XH * 0.51) (SmallArchDepthA * 0.6 * df.div) (SmallArchDepthB * 0.6 * df.div) df.mvs

--- a/packages/font-glyphs/src/letter/latin/lower-n.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-n.ptl
@@ -168,6 +168,7 @@ glyph-block Letter-Latin-Lower-N : begin
 
 		create-glyph "latn/Eta.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
+			include : LeaningAnchor.Below.VBar.r RightSB
 			include : Body CAP SB RightSB [if tailed (CAP - SmallArchDepthB + O) Descender] Stroke
 			if tailed : include : EndingTail RightSB Descender (CAP - SmallArchDepthB) Stroke
 			if sLT : include : sLT [DivFrame 1] CAP
@@ -176,6 +177,7 @@ glyph-block Letter-Latin-Lower-N : begin
 
 		create-glyph "latn/eta.\(suffix)" : glyph-proc
 			include : MarkSet.p
+			include : LeaningAnchor.Below.VBar.r RightSB
 			include : Body XH SB RightSB [if tailed (XH - SmallArchDepthB + O) Descender] Stroke
 			if tailed : include : EndingTail RightSB Descender (XH - SmallArchDepthB) Stroke
 			if sLT : include : sLT [DivFrame 1] XH

--- a/packages/font-glyphs/src/letter/latin/upper-r.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-r.ptl
@@ -8,6 +8,7 @@ glyph-module
 glyph-block Letter-Latin-Upper-R : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
+	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared : CreateTurnedLetter
 	glyph-block-import Letter-Shared-Shapes : RightwardTailedBar RetroflexHook
 	glyph-block-import Letter-Blackboard : BBS BBD
@@ -222,10 +223,10 @@ glyph-block Letter-Latin-Upper-R : begin
 
 		create-glyph "Yr.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
-			local top : CAP * 0.85
-			local bp 0.45
-			local legTop : RLegTop top Stroke bp
-			local right (RightSB - O - [if SLAB (Jut / 8) 0])
+			local top : CAP * 0.825 + [if fSlabBot (-0.2125) 0.25  ] * Stroke
+			local bp : (CAP * 0.25  + [if fSlabBot   0.8375  0.7125] * Stroke) / top
+			include : LeaningAnchor.Above.VBar.l SB
+			include : LeaningAnchor.Below.VBar.r RightSB
 
 			include : VBar.l SB (top - 1) CAP
 			include : RShape legShape top (legSlab -- doLegSlab) (bp -- bp) (open -- fOpen) (legBottom -- Descender)
@@ -237,6 +238,7 @@ glyph-block Letter-Latin-Upper-R : begin
 		create-glyph "smcpRLongRightLeg.\(suffix)" : glyph-proc
 			include : MarkSet.p
 			include : StrikeAnchor
+			include : LeaningAnchor.Below.VBar.r RightSB
 			include : RShape legShape XH (slab -- slabs) (legSlab -- doLegSlab) (bp -- bpXH) (open -- fOpen) (legBottom -- Descender)
 
 		if (!slabs && !fOpen) : create-glyph "currency/indianRupeeSign.\(suffix)" : glyph-proc


### PR DESCRIPTION
Demonstration of leaning mark anchors:
`ƕ̇`
![image](https://github.com/be5invis/Iosevka/assets/37010132/75198852-638b-47ec-8466-f17f89259ec6)
`Ʀ̣̇ ꭆ̣̇`
![image](https://github.com/be5invis/Iosevka/assets/37010132/439811e3-0bdb-435e-bb78-900ea6542f78)
`Ƞ̣ ƞ̣ η̣`
![image](https://github.com/be5invis/Iosevka/assets/37010132/d337f2ad-2d0f-44e4-8878-3b501a2500f3)
Demonstration of Yr glyph shape optimization:
`ƦÞ`
sans:
![image](https://github.com/be5invis/Iosevka/assets/37010132/7c0dba65-eaf9-487a-bab0-7ed5914f4690)
![image](https://github.com/be5invis/Iosevka/assets/37010132/faf3aecb-3bf2-49fc-bd01-cfc224ca2494)
![image](https://github.com/be5invis/Iosevka/assets/37010132/c5828ba6-defb-4e2f-90a1-34ce3cd310f9)
slab:
![image](https://github.com/be5invis/Iosevka/assets/37010132/7c5ce2d0-1cd3-474b-b28d-badee2023539)
![image](https://github.com/be5invis/Iosevka/assets/37010132/7fc0532c-7277-4fe2-82be-b469f560cae6)
![image](https://github.com/be5invis/Iosevka/assets/37010132/0d472fb3-e783-43a1-afee-fb15b874b694)
Mind you, the numbers used to unify Yr with Thorn only look ridiculously hyperparticular because it's actually combining Thorn's bowl top and bowl bottom functions together, as well as compensating for the existing stroke adjustment that the P shape function already uses.
If we end up adding separate symmetric/asymmetric variants to Thorn some day, Yr should still assume asymmetric. (However, that would be a breaking change and I don't want to cause another version bump right now).