### PR TITLE
Make six characters slightly wider under Quasi-Proportional.

### DIFF
--- a/changes/30.3.1.md
+++ b/changes/30.3.1.md
@@ -6,4 +6,4 @@
 * Make `ss20` use `seven`.`curly-serifless` by default.
 * Adjust balancing of r with corner hooks (#2394).
 * Fix side bearings of Latin-1 Macron (`U+00AF`) under Quasi-Proportional.
-* Make LATIN SMALL LIGATURE {FFI|FFL} (`U+FB03`..`U+FB04`) slightly wider under Quasi-Proportional.
+* Make `U+050F`, `U+A68B`, `U+FB03`, and `U+FB04` slightly wider under Quasi-Proportional.

--- a/changes/30.3.1.md
+++ b/changes/30.3.1.md
@@ -1,7 +1,7 @@
 * Add Capital Eszet (`VXAC`) variants with top-left corner.
 * Add square-dotted variant for brailles (#2388).
 * Fix leaning mark anchors for `U+0195`, `U+019E`, `U+01A6`, and `U+0220`.
-* Optimize glyph shape for `U+01A6`.
+* Optimize glyph shape for `U+01A6`, `U+A68A`, and `U+A68B`.
 * Make Aile and Etoile use {`six`|`nine`}.`closed-contour` by default.
 * Make `ss20` use `seven`.`curly-serifless` by default.
 * Adjust balancing of r with corner hooks (#2394).

--- a/changes/30.3.1.md
+++ b/changes/30.3.1.md
@@ -6,3 +6,4 @@
 * Make `ss20` use `seven`.`curly-serifless` by default.
 * Adjust balancing of r with corner hooks (#2394).
 * Fix side bearings of Latin-1 Macron (`U+00AF`) under Quasi-Proportional.
+* Make LATIN SMALL LIGATURE {FFI|FFL} (`U+FB03`..`U+FB04`) slightly wider under Quasi-Proportional.

--- a/changes/30.3.1.md
+++ b/changes/30.3.1.md
@@ -5,3 +5,4 @@
 * Make Aile and Etoile use {`six`|`nine`}.`closed-contour` by default.
 * Make `ss20` use `seven`.`curly-serifless` by default.
 * Adjust balancing of r with corner hooks (#2394).
+* Fix side bearings of Latin-1 Macron (`U+00AF`) under Quasi-Proportional.

--- a/packages/font-glyphs/src/auto-build/composite.ptl
+++ b/packages/font-glyphs/src/auto-build/composite.ptl
@@ -1429,7 +1429,7 @@ glyph-block Autobuild-Pnonetic-Ligatures : begin
 		list 0xFB05  { 'longs/flatExt'   't/phoneticRight'              } null
 		list 0xFB06  { 's/compLigLeft'   't/phoneticRight'              } null
 
-	createPhoneticLigatures ToLetter 'phonetic2' para.diversityM 3 stdShrink 1 : list
+	createPhoneticLigatures ToLetter 'phonetic2' [mix 1 para.diversityM 1.5] 3 stdShrink 1 : list
 		list 0xFB03  { 'f/compLigLeft1' 'f/compLigLeft1' 'dotlessi/compLigRight' } null
 		list 0xFB04  { 'f/compLigLeft3' 'f/compLigLeft2' 'l/compLigRight'        } null
 

--- a/packages/font-glyphs/src/letter/cyrillic/te-midhook.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/te-midhook.ptl
@@ -9,47 +9,47 @@ glyph-block Letter-Cyrillic-Te-MidHook : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Shapes : MidHook
 
-	define [Shape top pArc slabTop slabBot] : glyph-proc
-		local sw : AdviceStroke 2.75
-		local left : [mix SB RightSB 0.20] + OX
-		local right : RightSB - OX
+	define [Shape df top pArc slabTop slabBot] : glyph-proc
+		local left : [mix df.leftSB df.rightSB 0.3] + OX
 
-		local xTopBarLeft : SB - SideJut
-		local xTopBarRightSym : 2 * left + [HSwToV sw] - xTopBarLeft
-		local xTopBarRight : Math.max xTopBarRightSym : mix left RightSB 0.475
+		local xTopBarLeft : df.leftSB - SideJut
+		local xTopBarRightSym : 2 * left + [HSwToV df.mvs] - xTopBarLeft
+		local xTopBarRight : Math.max xTopBarRightSym : mix left df.rightSB 0.475
 
-		include : VBar.l left 0 top sw
-		include : HBar.t xTopBarLeft xTopBarRight top sw
+		include : VBar.l left 0 top df.mvs
+		include : HBar.t xTopBarLeft xTopBarRight top df.mvs
 		include : MidHook.general
-			left   -- (left + [HSwToV sw])
-			right  -- RightSB
-			top    -- top * HBarPos + sw / 4
+			left   -- (left + [HSwToV df.mvs])
+			right  -- df.rightSB
+			top    -- top * HBarPos + df.mvs / 4
 			ada    -- ArchDepthA * pArc
 			adb    -- ArchDepthB * pArc
-			sw     -- sw
+			sw     -- df.mvs
 
 		if slabTop : begin
-			local swVJut : Math.min [AdviceStroke 4.5] (0.625 * (left - xTopBarLeft))
-			include : VSerif.dl  xTopBarLeft top VJut swVJut
-			include : VSerif.dr xTopBarRight top VJut swVJut
+			include : VSerif.dl  xTopBarLeft top VJut
+			include : VSerif.dr xTopBarRight top VJut
 
 		if slabBot : begin
-			include : HSerif.mb (left + [HSwToV : 0.5 * sw]) 0 Jut
+			include : HSerif.mb (left + [HSwToV : 0.5 * df.mvs]) 0 Jut
 
 	define Config : object
-		serifless     { false false }
-		motionSerifed { true  false }
-		serifed       { true  true  }
+		serifless     { 1                           false false }
+		motionSerifed { [mix 1 para.diversityM 0.5] true  false }
+		serifed       { [mix 1 para.diversityM 0.5] true  true  }
 
-	foreach { suffix { doST doSB } } [Object.entries Config] : do
+	foreach { suffix { div doST doSB } } [Object.entries Config] : do
+		local df : DivFrame div 3
 
 		create-glyph "cyrl/TeMidHook.\(suffix)" : glyph-proc
-			include : MarkSet.capDesc
-			include : Shape CAP 1 doST doSB
+			set-width df.width
+			include : df.markSet.capDesc
+			include : Shape df CAP 1 doST doSB
 
 		create-glyph "cyrl/teMidHook.upright.\(suffix)" : glyph-proc
-			include : MarkSet.p
-			include : Shape XH [Math.pow HBarPos 0.3] doST doSB
+			set-width df.width
+			include : df.markSet.p
+			include : Shape df XH [Math.pow HBarPos 0.3] doST doSB
 
 	select-variant 'cyrl/TeMidHook' 0xA68A (follow -- 'T')
 	select-variant 'cyrl/teMidHook.upright' (follow -- 'T')

--- a/packages/font-glyphs/src/letter/latin/lower-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-m.ptl
@@ -279,7 +279,7 @@ glyph-block Letter-Latin-Lower-M : begin
 		if (Body === SmallMArches && !shortLeg) : begin
 			if (!tailed) : begin
 				create-glyph "cyrl/tjeKomi.italic.\(suffix)" : glyph-proc
-					local df : include : DivFrame para.diversityM 4
+					local df : include : DivFrame [mix 1 para.diversityM 2] 4
 					include : df.markSet.e
 					local subDf : df.slice 4 3 0
 					include : Body subDf XH 0 0 (XH / 2)
@@ -296,7 +296,7 @@ glyph-block Letter-Latin-Lower-M : begin
 					if SLAB : include sf2.rt.full
 
 			create-glyph "cyrl/teMidHook.italic.\(suffix)" : glyph-proc
-				local df : include : DivFrame para.diversityM 4
+				local df : include : DivFrame [mix 1 para.diversityM 2] 4
 				include : df.markSet.e
 				local subDf : df.slice 4 3 0
 				include : mShapeBody subDf XH

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -488,6 +488,12 @@ glyph-block Mark-Above : begin
 			flat (SB - Width)      aboveMarkMid [widths.center : 2 * markHalfStroke]
 			curl (RightSB - Width) aboveMarkMid
 
+	create-glyph 'latin1macron' 0xAF : glyph-proc
+		local df : include : DivFrame 1
+		include : dispiro
+			flat df.leftSB  aboveMarkMid [widths.center : 2 * markHalfStroke]
+			curl df.rightSB aboveMarkMid
+
 	create-glyph 'dblOverlineAbove' 0x33F : glyph-proc
 		set-width 0
 		include : StdAnchors.impl 'above' 0 2

--- a/packages/font-glyphs/src/meta/unicode-knowledge.ptl
+++ b/packages/font-glyphs/src/meta/unicode-knowledge.ptl
@@ -52,7 +52,6 @@ export : define decompOverrides : object
 
 	# Spacing marks
 	0xA8   { 'markBaseSpace' 'dieresisAbove' }
-	0xAF   { 'markBaseSpace' 'sbRsbOverlineAbove' }
 	0xB8   { 'markBaseSpace' 'cedillaBelow' }
 	0x2C2  { 'markBaseSpace' 'lessAbove' }
 	0x2C3  { 'markBaseSpace' 'greaterAbove' }
@@ -391,6 +390,9 @@ export : define ccmpCombinations : list
 
 	# Ring overlays
 	list {0x006C 0x20D8} 0xAB39     # l
+	list {0x2190 0x20D8} 0x2B30     # ←
+	list {0x2192 0x20D8} 0x21F4     # →
+	list {0x2194 0x20D8} 0x2948     # ↔
 
 	# Reverse solidus overlays
 	list {0x2223 0x20E5} 0x2AEE     # ∣


### PR DESCRIPTION
`ﬁﬃﬂﬄԎԏꚊꚋ¯`
Aile Upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/fb61c7a3-b925-435a-a1c9-5dc954464db2)
Aile Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/60c71a47-b45a-46ad-ad09-ae96ae05c89b)
Etoile Upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/79054624-5570-4981-972b-a8695cedbd42)
Etoile Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/412ddbe9-8184-4aa3-bd8f-4ab6936f6aa7)
