### PR TITLE
Add Modifier Letter Stress And {High|Low} Tone (`U+A720`‥`U+A721`).

### DIFF
--- a/changes/30.3.2.md
+++ b/changes/30.3.2.md
@@ -1,0 +1,5 @@
+* Fix side bearings of `U+02CC` under Quasi-Proportional.
+* Improve glyph shape for `U+02ED`.
+* Add characters:
+  - MODIFIER LETTER STRESS AND HIGH TONE (`U+A720`).
+  - MODIFIER LETTER STRESS AND LOW TONE (`U+A721`).

--- a/packages/font-glyphs/src/meta/unicode-knowledge.ptl
+++ b/packages/font-glyphs/src/meta/unicode-knowledge.ptl
@@ -79,7 +79,6 @@ export : define decompOverrides : object
 	0x2DD  { 'markBaseSpace' 'doubleAcuteAbove' }
 	0x2DF  { 'markBaseSpace' 'crossAbove' }
 	0x2EC  { 'markBaseSpace' 'caronBelow' }
-	0x2ED  { 'markBaseSpace' 'dblOverlineAbove' }
 	0x2EF  { 'markBaseSpace' 'downArrowHeadBelow' }
 	0x2F0  { 'markBaseSpace' 'upArrowHeadBelow' }
 	0x2F1  { 'markBaseSpace' 'lessBelow' }

--- a/packages/font-glyphs/src/symbol/punctuation/dashes.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/dashes.ptl
@@ -11,8 +11,9 @@ glyph-block Symbol-Punctuation-Dashes : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Symbol-Math-Relation-Common : EqualHalfSpace
 
+	define openBoxGap : Math.max (Stroke * 1.25) (XH / 4)
+
 	do 'underscore'
-		define openBoxGap : Math.max (Stroke * 1.25) (XH / 4)
 		define [OpenBoxSide y] : union
 			VBar.l SB      y (y + openBoxGap) OperatorStroke
 			VBar.r RightSB y (y + openBoxGap) OperatorStroke
@@ -57,6 +58,9 @@ glyph-block Symbol-Punctuation-Dashes : begin
 
 	create-glyph 'figureDash' 0x2012 : HBar.m SB RightSB SymbolMid
 	create-glyph 'overline' 0x203E : HBar.t SB RightSB CAP
+	create-glyph 'mdfUnaspirated' 0x2ED : composite-proc
+		HBar.t SB RightSB CAP
+		HBar.t SB RightSB (CAP - openBoxGap)
 
 	create-glyph 'enDash' 0x2013 : glyph-proc
 		set-width Width
@@ -74,11 +78,11 @@ glyph-block Symbol-Punctuation-Dashes : begin
 			set-width emDashWidth
 			include : dispiro
 				widths.center
-				flat (SB + [HSwToV HalfStroke]) (SymbolMid + [Math.max ((RightSB - SB) * 0.55) (XH * 0.5)]) [heading Downward]
-				curl (SB + [HSwToV HalfStroke]) (SymbolMid + SmallArchDepthB)
+				flat (SB + [HSwToV HalfStroke] + OX) (SymbolMid + [Math.max ((RightSB - SB) * 0.55) (XH * 0.5)]) [heading Downward]
+				curl (SB + [HSwToV HalfStroke] + OX) (SymbolMid + SmallArchDepthB)
 				arcvh
 				flat Middle SymbolMid
-				curl (emDashWidth - SB) SymbolMid [heading Rightward]
+				curl (emDashWidth - SB - OX) SymbolMid [heading Rightward]
 
 	derive-multi-part-glyphs 'hyphenDieresis' 0x2E1A { 'figureDash' 'dieresisAbove'}
 		function [src sel] : composite-proc

--- a/packages/font-glyphs/src/symbol/punctuation/other-phonetic.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/other-phonetic.ptl
@@ -14,6 +14,10 @@ glyph-block Symbol-Other-Phonetic : begin
 	local toneMarkLeft : mix SB RightSB 0.1
 	local toneMarkRight : Width - toneMarkLeft
 
+	define [dblToneMarkLeft df] : mix df.leftSB df.rightSB 0.1
+	define [dblToneMarkRight df] : mix df.leftSB df.rightSB 0.9
+	define [dblToneMarkMiddle df] : mix [dblToneMarkLeft df] [dblToneMarkRight df] 0.5
+
 	create-glyph 'triangleColon' 0x2D0 : glyph-proc
 		include : MarkSet.e
 		include : union
@@ -35,7 +39,7 @@ glyph-block Symbol-Other-Phonetic : begin
 
 	define [yOfTone tone]        : mix (OperatorStroke / 2) (CAP - OperatorStroke / 2) (tone / 4)
 	define [yOfToneNeutral tone] : mix DotRadius (CAP - DotRadius) (tone / 4)
-	define [yOfToneDepart a b p]     : mix (CAP * a + OperatorStroke / 2) (CAP * b - OperatorStroke / 2) p
+	define [yOfToneDepart a b p] : mix (CAP * a + OperatorStroke / 2) (CAP * b - OperatorStroke / 2) p
 
 	foreach tone [range 4 downtill 0] : begin
 		create-glyph ('tone' + tone) (0x2E5 + 4 - tone) : glyph-proc
@@ -122,7 +126,7 @@ glyph-block Symbol-Other-Phonetic : begin
 		list 'departingToneYin'  0x2EA  0    0.5  0
 		list 'departingToneYang' 0x2EB  0    0.5  0.5
 		list 'beginHighTone'     0x2F9  0.6  1    1.0
-		list 'beginLowTone'      0x2FB  0    0.4   0
+		list 'beginLowTone'      0x2FB  0    0.4  0
 	foreach { name code a b pos } [items-of DepartingToneConfig] : begin
 		create-glyph name code : glyph-proc
 			include : VBar.l toneMarkLeft (CAP * a) (CAP * b) OperatorStroke
@@ -135,3 +139,14 @@ glyph-block Symbol-Other-Phonetic : begin
 		create-glyph name code : glyph-proc
 			include : VBar.r toneMarkRight (CAP * a) (CAP * b) OperatorStroke
 			include : HBar.m toneMarkLeft (toneMarkRight - TINY) [yOfToneDepart a b pos] OperatorStroke
+
+	local DblToneConfig : list
+		list 'stressAndHighTone'     0xA720  0.6  1    1.0
+		list 'stressAndLowTone'      0xA721  0    0.4  0
+	foreach { name code a b pos } [items-of DblToneConfig] : begin
+		create-glyph name code : glyph-proc
+			local df : include : DivFrame 1 3.75
+			local fine : OperatorStroke * df.mvs / Stroke
+			include : VBar.l [dblToneMarkLeft df] (CAP * a) (CAP * b) fine
+			include : VBar.m [dblToneMarkMiddle df] (CAP * a) (CAP * b) fine
+			include : HBar.m ([dblToneMarkLeft df] + TINY) [dblToneMarkRight df] [yOfToneDepart a b pos] OperatorStroke

--- a/packages/font-glyphs/src/symbol/punctuation/quotes-and-primes.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/quotes-and-primes.ptl
@@ -160,7 +160,7 @@ glyph-block Symbol-Punctuation-Quotes-And-Primes : begin
 	alias 'grek/numberSign' 0x374 'prime'
 	alias 'mdfDoublePrime' 0x2BA 'doubleprime'
 
-	derive-composites 'grek/lowNumberSign' 0x375 'prime'
+	derive-composites 'grek/lowNumberSign' 0x375 'grek/numberSign'
 		ApparentTranslate 0 ([mix [mix [mix PeriodSize commaLow 0.5] yCurlyQuotes 0.5] quoteBottom (-1)] - quoteTop)
 
 	create-glyph 'doubleSuspensionMark' 0x2E44 : composite-proc
@@ -217,7 +217,7 @@ glyph-block Symbol-Punctuation-Quotes-And-Primes : begin
 		'raisedComma'         'closeSingleQuote'
 
 	alias 'mdfStress' 0x2C8 'asciiSingleQuote/body/straight'
-	turned 'mdfSecondaryStress' 0x2CC 'asciiSingleQuote/body/straight' Middle (XH / 2)
+	turned 'mdfSecondaryStress' 0x2CC 'asciiSingleQuote/body/straight' [DivFrame para.diversityF].middle (XH / 2)
 
 	create-glyph 'asciiDoubleQuote' 0x22 : glyph-proc
 		local dfSingle : DivFrame para.diversityF


### PR DESCRIPTION
Also improve glyph visual for `mdfUnaspirated`, unifying it with both overline and double underline.
Also fix side bearings for `mdfSecondaryStress` under Quasi-Proportional.
```
ˈˌ‾˭_‗
˹˻꜠꜡
```
Thin:
![image](https://github.com/be5invis/Iosevka/assets/37010132/70f5bcdf-c008-4819-bc8e-ac8e1ddefa3e)
Regular:
![image](https://github.com/be5invis/Iosevka/assets/37010132/72c48150-9fe4-4963-a407-188de5797ec2)
Heavy:
![image](https://github.com/be5invis/Iosevka/assets/37010132/f8d3db65-99d1-46ee-8b87-f04b89256824)
