### PR TITLE
Make `revs`-derived letters follow `cyrl/{Ze|ze}`.

### DIFF
--- a/changes/30.3.3.md
+++ b/changes/30.3.3.md
@@ -1,0 +1,1 @@
+* Make Reversed S (`U+01A7`..`U+01A8`, `U+A644`..`U+A645`) and Italic Cyrillic Lower Ghe (`U+0433`, `U+0453`, `U+0493`, `U+04F7`, `U+04FB`) follow variants of Cyrillic Ze (`cv69`..`cv70`).

--- a/packages/font-glyphs/src/letter/latin/s.ptl
+++ b/packages/font-glyphs/src/letter/latin/s.ptl
@@ -337,8 +337,8 @@ glyph-block Letter-Latin-S : begin
 	select-variant 's' 's'
 	link-reduced-variant 's/sansSerif' 's' MathSansSerif
 	select-variant 'smcpS' 0xA731 (follow -- 'S')
-	select-variant 'revS' 0x1A7 (follow -- 'S')
-	select-variant 'revs' 0x1A8 (follow -- 's')
+	select-variant 'revS' 0x1A7
+	select-variant 'revs' 0x1A8
 	alias 'cyrl/Dze' 0x405 'S'
 	alias 'cyrl/dze' 0x455 's'
 	alias 'cyrl/ghe.italic' null 'revs'
@@ -359,7 +359,7 @@ glyph-block Letter-Latin-S : begin
 	select-variant 'S/descBase' (shapeFrom -- 'S') (follow -- 'SRTail')
 	select-variant 's/ascBase' (shapeFrom -- 's')
 	select-variant 's/descBase' (shapeFrom -- 's') (follow -- 'sRTail')
-	select-variant 'revs/descBase' (shapeFrom -- 'revs') (follow -- 'sRTail')
+	select-variant 'revs/descBase' (shapeFrom -- 'revs')
 
 	select-variant 's/phoneticRight'
 
@@ -367,6 +367,7 @@ glyph-block Letter-Latin-S : begin
 		RetroflexHook.l SB 0 (yAttach -- DToothlessRise) (refSw -- [AdviceStroke2 2 3 CAP])
 	derive-composites 'sRTail' 0x282 's/descBase'
 		RetroflexHook.l SB 0 (yAttach -- DToothlessRise) (refSw -- [AdviceStroke2 2 3 XH])
+
 	derive-composites 'cyrl/gheDescender.italic' null 'revs/descBase'
 		CyrDescender.r DfLower.rightSB 0 (yAttach -- DToothlessRise) (refSw -- [AdviceStroke2 2 3 XH])
 	derive-composites 'cyrl/gheDHook.italic' null 'revs/descBase'

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -5448,6 +5448,7 @@ selector."latn/Epsilon" = "serifless"
 selector."cyrl/Ze" = "serifless"
 selector."cyrl/ZeTopSerifOnly" = "serifless"
 selector."cyrl/ZeBottomSerifOnly" = "serifless"
+selector.revS = "serifless"
 
 [prime.cyrl-capital-ze.variants.unilateral-serifed]
 rank = 2
@@ -5456,6 +5457,7 @@ selector."latn/Epsilon" = "unilateralSerifed"
 selector."cyrl/Ze" = "unilateralSerifed"
 selector."cyrl/ZeTopSerifOnly" = "unilateralSerifed"
 selector."cyrl/ZeBottomSerifOnly" = "serifless"
+selector.revS = "unilateralSerifed"
 
 [prime.cyrl-capital-ze.variants.unilateral-bottom-serifed]
 rank = 3
@@ -5465,6 +5467,7 @@ selector."latn/Epsilon" = "unilateralSerifed"
 selector."cyrl/Ze" = "bottomSerifed"
 selector."cyrl/ZeTopSerifOnly" = "serifless"
 selector."cyrl/ZeBottomSerifOnly" = "bottomSerifed"
+selector.revS = "serifless"
 
 [prime.cyrl-capital-ze.variants.bilateral-serifed]
 rank = 4
@@ -5473,6 +5476,7 @@ selector."latn/Epsilon" = "bilateralSerifed"
 selector."cyrl/Ze" = "bilateralSerifed"
 selector."cyrl/ZeTopSerifOnly" = "unilateralSerifed"
 selector."cyrl/ZeBottomSerifOnly" = "bottomSerifed"
+selector.revS = "bilateralSerifed"
 
 [prime.cyrl-capital-ze.variants.unilateral-inward-serifed]
 rank = 5
@@ -5481,6 +5485,7 @@ selector."latn/Epsilon" = "unilateralInwardSerifed"
 selector."cyrl/Ze" = "unilateralInwardSerifed"
 selector."cyrl/ZeTopSerifOnly" = "unilateralInwardSerifed"
 selector."cyrl/ZeBottomSerifOnly" = "serifless"
+selector.revS = "unilateralInwardSerifed"
 
 [prime.cyrl-capital-ze.variants.unilateral-bottom-inward-serifed]
 rank = 6
@@ -5490,6 +5495,7 @@ selector."latn/Epsilon" = "unilateralInwardSerifed"
 selector."cyrl/Ze" = "bottomInwardSerifed"
 selector."cyrl/ZeTopSerifOnly" = "serifless"
 selector."cyrl/ZeBottomSerifOnly" = "bottomInwardSerifed"
+selector.revS = "serifless"
 
 [prime.cyrl-capital-ze.variants.bilateral-inward-serifed]
 rank = 7
@@ -5498,6 +5504,7 @@ selector."latn/Epsilon" = "bilateralInwardSerifed"
 selector."cyrl/Ze" = "bilateralInwardSerifed"
 selector."cyrl/ZeTopSerifOnly" = "unilateralInwardSerifed"
 selector."cyrl/ZeBottomSerifOnly" = "bottomInwardSerifed"
+selector.revS = "bilateralInwardSerifed"
 
 
 
@@ -5515,6 +5522,8 @@ selector."cyrl/ze" = "serifless"
 selector."cyrl/ze/descBase" = "bottomSerifed"
 selector."cyrl/zeTopSerifOnly" = "serifless"
 selector."cyrl/zeBottomSerifOnly" = "serifless"
+selector.revs = "serifless"
+selector."revs/descBase" = "bottomSerifed"
 
 [prime.cyrl-ze.variants.unilateral-serifed]
 rank = 2
@@ -5525,6 +5534,8 @@ selector."cyrl/ze" = "unilateralSerifed"
 selector."cyrl/ze/descBase" = "bilateralSerifed"
 selector."cyrl/zeTopSerifOnly" = "unilateralSerifed"
 selector."cyrl/zeBottomSerifOnly" = "serifless"
+selector.revs = "unilateralSerifed"
+selector."revs/descBase" = "bilateralSerifed"
 
 [prime.cyrl-ze.variants.unilateral-bottom-serifed]
 rank = 3
@@ -5536,6 +5547,8 @@ selector."cyrl/ze" = "bottomSerifed"
 selector."cyrl/ze/descBase" = "bottomSerifed"
 selector."cyrl/zeTopSerifOnly" = "serifless"
 selector."cyrl/zeBottomSerifOnly" = "bottomSerifed"
+selector.revs = "serifless"
+selector."revs/descBase" = "bottomSerifed"
 
 [prime.cyrl-ze.variants.bilateral-serifed]
 rank = 4
@@ -5546,6 +5559,8 @@ selector."cyrl/ze" = "bilateralSerifed"
 selector."cyrl/ze/descBase" = "bilateralSerifed"
 selector."cyrl/zeTopSerifOnly" = "unilateralSerifed"
 selector."cyrl/zeBottomSerifOnly" = "bottomSerifed"
+selector.revs = "bilateralSerifed"
+selector."revs/descBase" = "bilateralSerifed"
 
 [prime.cyrl-ze.variants.unilateral-inward-serifed]
 rank = 5
@@ -5556,6 +5571,8 @@ selector."cyrl/ze" = "unilateralInwardSerifed"
 selector."cyrl/ze/descBase" = "hybridSerifed1"
 selector."cyrl/zeTopSerifOnly" = "unilateralInwardSerifed"
 selector."cyrl/zeBottomSerifOnly" = "serifless"
+selector.revs = "unilateralInwardSerifed"
+selector."revs/descBase" = "hybridSerifed1"
 
 [prime.cyrl-ze.variants.unilateral-bottom-inward-serifed]
 rank = 6
@@ -5567,6 +5584,8 @@ selector."cyrl/ze" = "bottomInwardSerifed"
 selector."cyrl/ze/descBase" = "bottomSerifed"
 selector."cyrl/zeTopSerifOnly" = "serifless"
 selector."cyrl/zeBottomSerifOnly" = "bottomInwardSerifed"
+selector.revs = "serifless"
+selector."revs/descBase" = "bottomSerifed"
 
 [prime.cyrl-ze.variants.bilateral-inward-serifed]
 rank = 7
@@ -5577,6 +5596,8 @@ selector."cyrl/ze" = "bilateralInwardSerifed"
 selector."cyrl/ze/descBase" = "hybridSerifed1"
 selector."cyrl/zeTopSerifOnly" = "unilateralInwardSerifed"
 selector."cyrl/zeBottomSerifOnly" = "bottomInwardSerifed"
+selector.revs = "bilateralInwardSerifed"
+selector."revs/descBase" = "hybridSerifed1"
 
 
 
@@ -8747,6 +8768,7 @@ l = "serifed-semi-tailed"
 r = "corner-hooked-serifed"
 u = "toothed-serifless"
 y = "straight-turn-serifless"
+capital-eszet = "rounded-serifless"
 long-s = "bent-hook-serifless"
 eszet = "longs-s-lig-serifless"
 lower-iota = "serifed-semi-tailed"
@@ -8804,6 +8826,7 @@ w = "straight-serifed"
 x = "straight-serifed"
 y = "straight-turn-serifed"
 z = "straight-serifed"
+capital-eszet = "rounded-serifed"
 long-s = "bent-hook-bottom-serifed"
 eszet = "longs-s-lig-bottom-serifed"
 lower-mu = "toothed-serifed"


### PR DESCRIPTION
Basically, because the top serif of rev-S is in the same "orbit" as the top serif of Cyrillic Ze, and because Cyrillic Ze's CV feature is sophisticated enough to know when it's appropriate to populate Latin Epsilon's bottom serif, which itself is in the same "orbit" as rev-S's bottom serif, this means that it may actually be more consistent to make rev-S's serifs follow Cyrillic Ze instead of unreversed S for rotational symmetry/balancing purposes.

On that note, unreversed/ASCII `S`/`s` is unchanged.

```
ꙄꙅГгӶӷӺӻ
ЗꙄСзꙅс
```

Slab upright:
![image](https://github.com/be5invis/Iosevka/assets/37010132/7fb4d90d-7006-45a5-a82d-f51a70a58556)
Slab Italic:
![image](https://github.com/be5invis/Iosevka/assets/37010132/0d7e6912-bc01-4dfe-941d-42d5ef17b9fb)
`ЅѕГгӶӷӺӻ`
Compared to Vollkorn under Bulgarian:
![image](https://github.com/be5invis/Iosevka/assets/37010132/4e3634cb-eb18-43fe-8e8b-61878b2b440a)
Compared to Source Serif 4 under Bulgarian:
![image](https://github.com/be5invis/Iosevka/assets/37010132/1413e748-434f-470b-b0ae-cd3bfa9d7a18)

All Cyrillic Capital Ze variants:
`ƐЗꚄꚈѮȜꙄ`
![image](https://github.com/be5invis/Iosevka/assets/37010132/07da41ad-a62b-438e-aead-01f3997a05b0)
All Cyrillic Lower Ze variants:
`ɛᶓзᶔꚅꚉѯȝꙅгғӷӻ`
![image](https://github.com/be5invis/Iosevka/assets/37010132/dc665ad3-c4e1-42df-a652-8d25e3cedec5)
