### PR TITLE
Return `param/private-parameters.toml` to git ignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ packages/font-otl/src/**/*.mjs
 # Private config files
 private.toml
 private-build-plans.toml
+params/private-parameters.toml
 
 # pages-source ignores
 .next


### PR DESCRIPTION
As demonstrated in the example given in #2186 , having the ability to override the default parameters toml is currently one of the only ways to compile a custom font with different `diversityM` etc. values. The line was removed a few months ago in 2a19d92 but the feature still exists otherwise.

Perhaps it would be more constructive to mention it in the documentation than to silently remove it.