### PR TITLE
Some composite character additions and tweaks.

### DIFF
--- a/changes/30.3.3.md
+++ b/changes/30.3.3.md
@@ -1,4 +1,4 @@
-Make TELEPHONE SIGN (`U+2121`) and FACSIMILE SIGN (`U+213B`) use small-capital forms instead of superscript.
+* Make TELEPHONE SIGN (`U+2121`) and FACSIMILE SIGN (`U+213B`) use small-capital forms instead of superscript.
 * Add Characters:
   - FRACTION NUMERATOR ONE (`U+215F`) (#1539).
   - BIG SOLIDUS (`U+29F8`) (#2414).

--- a/changes/30.3.3.md
+++ b/changes/30.3.3.md
@@ -1,3 +1,6 @@
+Make TELEPHONE SIGN (`U+2121`) and FACSIMILE SIGN (`U+213B`) use small-capital forms instead of superscript.
 * Add Characters:
+  - FRACTION NUMERATOR ONE (`U+215F`) (#1539).
   - BIG SOLIDUS (`U+29F8`) (#2414).
   - BIG REVERSE SOLIDUS (`U+29F9`) (#2414).
+  - REGIONAL INDICATOR SYMBOL LETTER A (`U+1F1E6`) ... REGIONAL INDICATOR SYMBOL LETTER Z (`U+1F1FF`).

--- a/packages/font-glyphs/src/auto-build/composite.ptl
+++ b/packages/font-glyphs/src/auto-build/composite.ptl
@@ -372,10 +372,10 @@ glyph-block AutoBuild-Enclosure : begin
 		define [object width sw top bot left right] : CircleDimens digits ww
 		set-width width
 		include : union
-			HBar.t    left right top sw
-			HBar.b left right bot sw
-			VBar.l   left bot top   sw
-			VBar.r  right bot top  sw
+			HBar.t left  right top sw
+			HBar.b left  right bot sw
+			VBar.l left  bot   top sw
+			VBar.r right bot   top sw
 		include : AddEnclosureMark digits : CircleDimens digits ww
 
 	define [createTwoRowBoxedGlyphs digits demands]
@@ -384,10 +384,10 @@ glyph-block AutoBuild-Enclosure : begin
 		define [object width sw top bot left right] : CircleDimens digits ww
 		set-width width
 		include : union
-			HBar.t    left right top sw
-			HBar.b left right bot sw
-			VBar.l   left bot top   sw
-			VBar.r  right bot top  sw
+			HBar.t left  right top sw
+			HBar.b left  right bot sw
+			VBar.l left  bot   top sw
+			VBar.r right bot   top sw
 		include : AddEnclosureMarkTwoLine digits : CircleDimens digits ww
 
 	define [createDashedBoxedGlyphs digits demands]
@@ -397,13 +397,13 @@ glyph-block AutoBuild-Enclosure : begin
 		set-width width
 		include : difference
 			union
-				HBar.t    left right top sw
-				HBar.b left right bot sw
-				VBar.l   left bot top   sw
-				VBar.r  right bot top  sw
+				HBar.t left  right top sw
+				HBar.b left  right bot sw
+				VBar.l left  bot   top sw
+				VBar.r right bot   top sw
 			union
 				VBar.m [mix left right 0.25] bot top sw
-				VBar.m [mix left right 0.5] bot top sw
+				VBar.m [mix left right 0.50] bot top sw
 				VBar.m [mix left right 0.75] bot top sw
 				HBar.m left right [mix bot top 0.25] sw
 				HBar.m left right [mix bot top 0.50] sw
@@ -506,7 +506,7 @@ glyph-block AutoBuild-Enclosure : begin
 
 	define [BraceCrowd digits width] : 2.75 + [AdjustDigitCount digits width]
 	define [BraceScale digits width] : 0.65 / [Math.pow [AdjustDigitCount digits width] 0.5]
-	define [bracedDottdeDimens digits width] : begin
+	define [bracedDottedDimens digits width] : begin
 		define dscale : linreg Width 0.55 UPM 0.65 width
 		define pscale : linreg Width 0.6 UPM 0.75 width
 		define sw0 : [EnclosureStrokeScale dscale digits width] * [AdviceStroke [BraceCrowd digits width]] / [BraceScale digits width]
@@ -530,7 +530,7 @@ glyph-block AutoBuild-Enclosure : begin
 		define [CreateGlyphImpl jobDecomposable job] : begin
 			local {gn unicode parts w bal baly} job
 			if [not : query-glyph gn] : create-glyph gn [if (w == ww) unicode null] : glyph-proc
-				define dimens : bracedDottdeDimens digits ww
+				define dimens : bracedDottedDimens digits ww
 				define [object width] dimens
 				set-width width
 
@@ -544,7 +544,7 @@ glyph-block AutoBuild-Enclosure : begin
 
 	define [createBracedGlyphs digits demands] : BracedT 'braced' digits demands BraceShape
 	define [BraceShape digits ww] : glyph-proc
-		define [object width pscale sw l r] : bracedDottdeDimens digits ww
+		define [object width pscale sw l r] : bracedDottedDimens digits ww
 		local s : TanSlope * SymbolMid / 2
 		local p : 0.1 * [Math.sqrt : Math.min 1 (width / (digits * Width))]
 		set-width width
@@ -563,11 +563,11 @@ glyph-block AutoBuild-Enclosure : begin
 		include : Ungizmo
 		include : Translate 0 (SymbolMid - SymbolMid * pscale)
 		include : Regizmo
-		include : AddEnclosureMark digits : bracedDottdeDimens digits ww
+		include : AddEnclosureMark digits : bracedDottedDimens digits ww
 
 	define [createHexBracedGlyphs digits demands] : BracedT 'hex-braced' digits demands HexBracedShape
 	define [HexBracedShape digits ww] : glyph-proc
-		define [object width pscale sw l r] : bracedDottdeDimens digits ww
+		define [object width pscale sw l r] : bracedDottedDimens digits ww
 		local s : TanSlope * SymbolMid / 2
 		local p : (1 / 6) * [Math.sqrt : Math.min 1 (width / (digits * Width))]
 		set-width width
@@ -605,7 +605,7 @@ glyph-block AutoBuild-Enclosure : begin
 		include : Ungizmo
 		include : Translate 0 (SymbolMid - SymbolMid * pscale)
 		include : Regizmo
-		include : AddEnclosureMark digits : bracedDottdeDimens digits ww
+		include : AddEnclosureMark digits : bracedDottedDimens digits ww
 
 	define [DottedCrowd digits width] : 2 + [AdjustDigitCount digits width]
 	define [DottedScale digits width] : 1 / [Math.pow [AdjustDigitCount digits width] 0.5]
@@ -634,7 +634,7 @@ glyph-block AutoBuild-Enclosure : begin
 
 			define [createDottedGlyphImpl job jobDecomposable] : begin
 				local {gn unicode partsWithDot w} job
-				define [object width dscale pscale sw l r] : bracedDottdeDimens 1 ww
+				define [object width dscale pscale sw l r] : bracedDottedDimens 1 ww
 
 				local totalWidth 0
 				local offsets    { }
@@ -739,14 +739,14 @@ glyph-block AutoBuild-Enclosure : begin
 		foreach [j : range 11 till 20] : compositions.push : list (0x24EB + j - 11) [digitGlyphNames j] WideWidth1
 		createDecomposableInsetCircledGlyphs 2 compositions
 
-	do "boxed"
+	do "Single-digit boxed"
 		local compositions {}
 		compositions.push { null {'markBaseSpace'} WideWidth1 }
 		foreach [j : range 0 26] : compositions.push {(0x1F130 + j) {[glyphStore.queryNameByUnicode (['A'.charCodeAt 0] + j)]} WideWidth1}
 		compositions.push : list 0x1F1A5 {'d'} WideWidth1
 		createBoxedGlyphs 1 compositions
 
-	do "double-digit boxed"
+	do "Double-digit boxed"
 		createBoxedGlyphs 2 : list
 			list null    {'markBaseSpace'} WideWidth1
 			list 0x1F14A {'H' 'V'} WideWidth1
@@ -763,9 +763,9 @@ glyph-block AutoBuild-Enclosure : begin
 			list 0x1F19D {'two.lnum' 'K'} WideWidth1
 			list 0x1F19E {'four.lnum' 'K'} WideWidth1
 			list 0x1F19F {'eight.lnum' 'K'} WideWidth1
-			list 0x1F1A6 {'H' 'C' } WideWidth1
+			list 0x1F1A6 {'H' 'C'} WideWidth1
 
-	do "triple-digit boxed"
+	do "Triple-digit boxed"
 		createBoxedGlyphs 3 : list
 			list null    {'markBaseSpace'} WideWidth1
 			list 0x1F14E {'P' 'P' 'V'} WideWidth1
@@ -780,7 +780,7 @@ glyph-block AutoBuild-Enclosure : begin
 			list 0x1F1AB {'U' 'H' 'D'} WideWidth1
 			list 0x1F1AC {'V' 'O' 'D'} WideWidth1
 
-	do "quad-digit boxed"
+	do "Quadruple-digit boxed"
 		createBoxedGlyphs 4 : list
 			list null    {'markBaseSpace'} WideWidth1
 			list 0x1F192 {'C' 'O' 'O' 'L'} WideWidth1
@@ -788,31 +788,36 @@ glyph-block AutoBuild-Enclosure : begin
 			list 0x1F1A2 {'two.lnum' 'two.lnum' 'period' 'two.lnum'} WideWidth1
 			list 0x1F1A4 {'one.lnum' 'two.lnum' 'zero.lnum' 'P'} WideWidth1
 
-	do "triple-digit two-row boxed"
+	do "Triple-digit two-row boxed"
 		createTwoRowBoxedGlyphs 3 : list
 			list null    { 'markBaseSpace' 'markBaseSpace' } WideWidth1
-			list 0x1F19C { 'two.lnum' 'N' 'D' 'S' 'C' 'R' }  WideWidth1
-			list 0x1F1A8 { 'H' 'I' 'hyphen' 'R' 'E' 'S' }  WideWidth1
+			list 0x1F19C { 'two.lnum' 'N' 'D' 'S' 'C' 'R' } WideWidth1
+			list 0x1F1A8 { 'H' 'I' 'hyphen' 'R' 'E' 'S' } WideWidth1
 
-	do "quad-digit two-row boxed"
+	do "Quadruple-digit two-row boxed"
 		createTwoRowBoxedGlyphs 4 : list
 			list null    { 'markBaseSpace' 'markBaseSpace' } WideWidth1
-			list 0x1F1A9 { 'L' 'O' 'S' 'S' 'L' 'E' 'S' 'S' }  WideWidth1
+			list 0x1F1A9 { 'L' 'O' 'S' 'S' 'L' 'E' 'S' 'S' } WideWidth1
 
-	do "triple-digit dashed-boxed"
+	do "Single-digit dashed-boxed"
+		local compositions {}
+		foreach [j : range 0 26] : compositions.push {(0x1F1E6 + j) {[glyphStore.queryNameByUnicode (['A'.charCodeAt 0] + j)]} WideWidth1}
+		createDashedBoxedGlyphs 1 compositions
+
+	do "Triple-digit dashed-boxed"
 		createDashedBoxedGlyphs 3 : list
 			list 0xFFFC {'O' 'B' 'J/noDescend'} WideWidth1
 
-	do "inset boxed"
+	do "Single-digit inset boxed"
 		local compositions {}
 		foreach [j : range 0 26] : compositions.push {(0x1F170 + j) {[glyphStore.queryNameByUnicode (['A'.charCodeAt 0] + j)]} WideWidth1}
 		createInsetBoxedGlyphs 1 compositions
 
-	do "inset diamond"
+	do "Single-digit inset diamond"
 		createInsetDiamondGlyphs 1 : list
 			list 0xFFFD { "question" } WideWidth2
 
-	do "double-digit inset boxed"
+	do "Double-digit inset boxed"
 		createDecomposableInsetBoxedGlyphs 2 : list
 			list 0x1F18B {'I' 'C'} WideWidth1
 			list 0x1F18C {'P' 'A'} WideWidth1
@@ -820,11 +825,11 @@ glyph-block AutoBuild-Enclosure : begin
 			list 0x1F18E {'A' 'B'} WideWidth1
 			list 0x1F18F {'W' 'C'} WideWidth1
 
-	do "negative square"
+	do "Single-digit negative square"
 		createCrossInsetBoxedGlyphs 1 : list
 			list 0x1F18A { "P" } WideWidth1
 
-	do "inset mosaic"
+	do "Single-digit inset mosaic"
 		local compositions {}
 		compositions.push { 0x1FBB1 { [[glyphStore.queryNameByUnicode (0x2714)].replace [regex '.WWID$'] ".NWID"] } WideWidth4 }
 		compositions.push { 0x1FBB4 { [[glyphStore.queryNameByUnicode (0x21B2)].replace [regex '.WWID$'] ".NWID"] } WideWidth4 }
@@ -1009,6 +1014,7 @@ glyph-block Autobuild-Fractions : begin
 		list 0x215C { 'three.lnum' 'eight.lnum' }
 		list 0x215D { 'five.lnum' 'eight.lnum' }
 		list 0x215E { 'seven.lnum' 'eight.lnum' }
+		list 0x215F { 'one.lnum' 'markBaseSpace' }
 		list 0x2189 { 'zero.lnum' 'three.lnum' }
 		list 0x214D { 'A' 'S' }
 
@@ -1139,9 +1145,6 @@ glyph-block AutoBuild-Accented-Equal : begin
 		list 0x1F16A {"M" "C"}
 		list 0x1F16B {"M" "D"}
 		list 0x1F16C {"M" "R"}
-	createAccentedOp 'markDemoBaseSpace' 6.5 0.35 0 (aboveMarkBot - (CAP * 0.35 - XH * 0.35)) : list
-		list 0x2121  {"T" "E" "L"}
-		list 0x213B  {"F" "A" "X"}
 
 glyph-block Autobuild-Ligatures : begin
 	glyph-block-import CommonShapes
@@ -1432,6 +1435,10 @@ glyph-block Autobuild-Pnonetic-Ligatures : begin
 	createPhoneticLigatures ToLetter 'phonetic2' [mix 1 para.diversityM 1.5] 3 stdShrink 1 : list
 		list 0xFB03  { 'f/compLigLeft1' 'f/compLigLeft1' 'dotlessi/compLigRight' } null
 		list 0xFB04  { 'f/compLigLeft3' 'f/compLigLeft2' 'l/compLigRight'        } null
+
+	createPhoneticLigatures ToLetter 'phonetic3' [mix 1 para.diversityM (2 * XH / CAP)] 3 1 0.5 : list
+		list 0x2121  { 'smcpT' 'smcpE' 'smcpL' } 'e'
+		list 0x213B  { 'smcpF' 'smcpA' 'smcpX' } 'e'
 
 	createPhoneticLigatures ToSuperscript 'phoneticSuperscript' 1 2 stdShrink 1 : list
 		list 0x10787 { 'd/phoneticLeft'  'z/phoneticRight'          } 'b'

--- a/packages/font-glyphs/src/letter/latin/x.ptl
+++ b/packages/font-glyphs/src/letter/latin/x.ptl
@@ -243,7 +243,7 @@ glyph-block Letter-Latin-X : begin
 	select-variant 'latn/chi' 0xAB53 (follow -- 'x')
 	select-variant 'latn/Chi' 0xA7B3 (follow -- 'X')
 
-	# select-variant 'smcpX' 0xEF11 (shapeFrom -- 'x') (follow -- 'X')
+	select-variant 'smcpX' (shapeFrom -- 'x') (follow -- 'X')
 
 	define [AddDescender Ctor] : function [src sel] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS


### PR DESCRIPTION
* Make TELEPHONE SIGN (`U+2121`) and FACSIMILE SIGN (`U+213B`) use small-capital forms instead of superscript.
  - This is closer to their representative glyphs in the Unicode charts. They are not decompositionally defined as superscript, although many fonts make them so anyway to match `™` and `℠`.

`Hx™℡℠℻`

Sans Monospace:
![image](https://github.com/user-attachments/assets/754ca473-a97e-4c67-9a79-b57a3740ac4c)

Aile:
![image](https://github.com/user-attachments/assets/299faae0-a844-4f1e-8076-cc48140c9f8d)

Compared to Fairfax HD:
![image](https://github.com/user-attachments/assets/16a6d39a-2ee8-43d1-9d5b-3de138ea277a)

* Add Characters:
  - FRACTION NUMERATOR ONE (`U+215F`) (#1539).
    - After buying Pragmata Pro for 200€ and cross-referencing its behavior with all other fonts I have installed, I realized that this character has no real special functionality regardless of whether `frac` is enabled or not.
    - Closes #1539 .
  - REGIONAL INDICATOR SYMBOL LETTER A (`U+1F1E6`) ... REGIONAL INDICATOR SYMBOL LETTER Z (`U+1F1FF`).
    - Completes Enclosed Alphanumeric Supplement block.

Fraction Numerator One:
`½⅓¼⅕⅙⅐⅛⅑⅒⅟`

![image](https://github.com/user-attachments/assets/b351fe7f-92bb-4b22-87c4-5a0d6c95bbbc)

Pragmata Pro:
![image](https://github.com/user-attachments/assets/58b7db69-c047-4422-acb5-b7f7b629cbd7)
```
      🇦‌🇧‌🇨‌🇩‌🇪‌🇫‌🇬‌🇭‌🇮‌🇯
🇰‌🇱‌🇲‌🇳‌🇴‌🇵‌🇶‌🇷‌🇸‌🇹‌🇺‌🇻‌🇼‌🇽‌🇾‌🇿
```
Regional Indicator Symbols A-Z:
![image](https://github.com/user-attachments/assets/fe2d8c04-ffbc-4258-832c-1b9d1c68a872)

Compared with Fairfax HD:
![image](https://github.com/user-attachments/assets/0330308c-df9b-4c5c-a74b-b166939929d1)

