### PR TITLE
Simplify glyph shape of Joker cards.

### DIFF
--- a/packages/font-glyphs/src/auto-build/composite.ptl
+++ b/packages/font-glyphs/src/auto-build/composite.ptl
@@ -935,19 +935,16 @@ glyph-block AutoBuild-Enclosure : begin
 			list 0x1F0BC {'C' 'whiteHeartSuit'} WideWidth4
 			list 0x1F0BD {'Q' 'whiteHeartSuit'} WideWidth4
 			list 0x1F0BE {'K' 'whiteHeartSuit'} WideWidth4
-			list 0x1F0BF {'J/noDescend' 'vShadeStar.NWID'} WideWidth4
 			list 0x1F0C1 {'A' 'whiteDiamondSuit'} WideWidth4
 			list 0x1F0CB {'J/noDescend' 'whiteDiamondSuit'} WideWidth4
 			list 0x1F0CC {'C' 'whiteDiamondSuit'} WideWidth4
 			list 0x1F0CD {'Q' 'whiteDiamondSuit'} WideWidth4
 			list 0x1F0CE {'K' 'whiteDiamondSuit'} WideWidth4
-			list 0x1F0CF {'J/noDescend' 'blackStar.NWID'} WideWidth4
 			list 0x1F0D1 {'A' 'clubSuit'} WideWidth4
 			list 0x1F0DB {'J/noDescend' 'clubSuit'} WideWidth4
 			list 0x1F0DC {'C' 'clubSuit'} WideWidth4
 			list 0x1F0DD {'Q' 'clubSuit'} WideWidth4
 			list 0x1F0DE {'K' 'clubSuit'} WideWidth4
-			list 0x1F0DF {'J/noDescend' 'whiteStar.NWID'} WideWidth4
 		foreach [j : range 2 till 9] : compositions.push : list (0x1F0A0 + j) [[digitGlyphNames j].concat {'spadeSuit'}] WideWidth4
 		foreach [j : range 2 till 9] : compositions.push : list (0x1F0B0 + j) [[digitGlyphNames j].concat {'whiteHeartSuit'}] WideWidth4
 		foreach [j : range 2 till 9] : compositions.push : list (0x1F0C0 + j) [[digitGlyphNames j].concat {'whiteDiamondSuit'}] WideWidth4
@@ -965,6 +962,9 @@ glyph-block AutoBuild-Enclosure : begin
 	do "Single-digit trump cards"
 		createTrumpCardGlyphs 1 : list
 			list null    {'markBaseSpace'} WideWidth1
+			list 0x1F0BF {'vShadeStar.NWID'} WideWidth4
+			list 0x1F0CF {'blackStar.NWID'} WideWidth4
+			list 0x1F0DF {'whiteStar.NWID'} WideWidth4
 			list 0x1F0E0 {'zero.lnum/forceUnslashed'} WideWidth4
 			list 0x1F0E1 {'I'} WideWidth4
 			list 0x1F0E5 {'V'} WideWidth4


### PR DESCRIPTION
Basically, since the stroke widths of normal playing cards and trump cards are now unified (thank you btw), it's now straightforward to use the single-row design for Joker cards that I originally had in the initial commit of my draft PR. This is what DejaVu Sans does, and also the Unicode charts do not provide an index digit for them in the example glyphs (just the joker face symbol). Additionally, it avoids confusion with Jack cards from a distance or indeed at smaller optical sizes.

```
🂠🂡🂢🂣🂤🂥🂦🂧🂨🂩🂪🂫🂬🂭🂮
 🂱🂲🂳🂴🂵🂶🂷🂸🂹🂺🂻🂼🂽🂾🂿
 🃁🃂🃃🃄🃅🃆🃇🃈🃉🃊🃋🃌🃍🃎🃏
 🃑🃒🃓🃔🃕🃖🃗🃘🃙🃚🃛🃜🃝🃞🃟
🃠🃡🃢🃣🃤🃥🃦🃧🃨🃩🃪🃫🃬🃭🃮🃯
🃰🃱🃲🃳🃴🃵
```
![image](https://github.com/user-attachments/assets/8dfd8739-4059-4764-8b8c-c891bbbace19)

compared to DejaVu Sans (it does not have the trump cards or the third joker as they're all newer additions in Unicode):
![image](https://github.com/user-attachments/assets/d1e6c3c1-08ce-4861-8dd6-9cae798f534b)
