### PR TITLE
Fix build breaks caused by contiaional select-variant follows

### DIFF
--- a/packages/font-glyphs/src/common/derivatives.ptl
+++ b/packages/font-glyphs/src/common/derivatives.ptl
@@ -8,24 +8,24 @@ extern Map
 glyph-module
 
 glyph-block Common-Derivatives : begin
-	define [ApplyCv g shapeFrom follow para] : begin
-		foreach { kPrime prime } para.variants.primes : foreach pv [prime.variants.values] : begin
-			local suffix : pv.resolveFor para follow
-			if suffix : begin
-				local dstName : shapeFrom + '.' + suffix
-				local dstGlyph : query-glyph dstName
-				if dstGlyph : g.dependsOn dstGlyph
+	define [ApplyCv g shapeFrom primaryFollow allFollows para] : begin
+		foreach follow [items-of allFollows] : foreach { kPrime prime } para.variants.primes
+			foreach pv [prime.variants.values] : begin
+				local suffix : pv.resolveFor para follow
+				if suffix : begin
+					local dstName : shapeFrom + '.' + suffix
+					local dstGlyph : query-glyph dstName
+					if dstGlyph : g.dependsOn dstGlyph
 
-				if (para.enableCvSs && pv.tag && pv.rank) : begin
-					pv.set g dstName
-					if pv.nonDeriving : pv.setPreventDeriving g
+					if (follow === primaryFollow && para.enableCvSs && pv.tag && pv.rank) : begin
+						pv.set g dstName
+						if pv.nonDeriving : pv.setPreventDeriving g
 
 	glyph-block-export select-variant
-	define [select-variant] : with-params [name unicode [shapeFrom name] [follow name] [reduction null]] : begin
+	define [select-variant] : with-params [name unicode [shapeFrom name] [follow name]] : begin
 		if [not : glyph-is-needed name] : return nothing
 
-		local variant para.variantSelector.(follow)
-		if reduction : set variant : reduction.(variant) || variant
+		local variant para.variantSelector.([resolveMainFollow follow])
 		if [not variant] : begin
 			throw : new Error "Variant for \(name) (selector: \(shapeFrom)) is not assigned."
 
@@ -38,11 +38,28 @@ glyph-block Common-Derivatives : begin
 			currentGlyph.dependsOn fromGlyph
 			currentGlyph.cloneRankFromGlyph fromGlyph
 
-			ApplyCv currentGlyph shapeFrom follow para
+			ApplyCv currentGlyph shapeFrom [resolveMainFollow follow] [resolveAllFollow follow] para
 
 			foreach gr [items-of SvInheritableRelations] : begin
 				local v : gr.get fromGlyph
 				if v : gr.set currentGlyph v
+
+	define [resolveMainFollow follow] : begin
+		if ([typeof follow] === 'string') : return follow
+		return : follow.resolveMain
+	define [resolveAllFollow follow] : begin
+		if ([typeof follow] === 'string') : return { follow }
+		return : follow.resolveAll
+
+	glyph-block-export conditional-follow
+	define [conditional-follow c f1 f2] : new CConditionalFollow c f1 f2
+	class CConditionalFollow
+		public [new c f1 f2] : begin
+			set this.c c
+			set this.f1 f1
+			set this.f2 f2
+		public [resolveMain] : return : if this.c this.f1 this.f2
+		public [resolveAll] : return { this.f1 this.f2 }
 
 	glyph-block-export orthographic-italic
 	define [orthographic-italic name unicode] : if para.isItalic

--- a/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
@@ -402,7 +402,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 	select-variant "ae/e" (follow -- 'e')
 	select-variant "aeInvE/right" (follow -- 'e')
 	select-variant "ue/u"
-	select-variant "au/u" (follow -- [if [MEnoughSpaceForFullSerifs : dfM] 'au/u/full' 'au/u/reduced'])
+	select-variant "au/u" (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'au/u/full' 'au/u/reduced'])
 	select-variant "oeOpenO/left" (follow -- 'c')
 	select-variant "cyrl/ae/a" (shapeFrom -- 'ae/a')
 	select-variant "cyrl/yae/left"

--- a/packages/font-glyphs/src/letter/latin-ext/upper-aa-ao.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/upper-aa-ao.ptl
@@ -117,7 +117,7 @@ glyph-block Letter-Latin-Upper-AA-AO : begin
 				include : with-transform [ApparentTranslate shift 0]
 					union [Base subDf CAP df.mvs] [Slabs subDf CAP]
 
-		select-variant "AU/Right" (follow -- [if [MEnoughSpaceForFullSerifs : dfM] 'AU/U/full' 'AU/U/reduced'])
+		select-variant "AU/Right" (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'AU/U/full' 'AU/U/reduced'])
 
 	do "AU"
 		select-variant 'AA/AU/Left' (follow -- 'A')

--- a/packages/font-glyphs/src/letter/latin/lower-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-m.ptl
@@ -401,22 +401,22 @@ glyph-block Letter-Latin-Lower-M : begin
 				eject-contour 'serifLT'
 				include : CyrDescender.rSideJut df.rightSB 0 (refSw -- df.mvs)
 
-	select-variant 'turnm' 0x26F (follow -- [if [MEnoughSpaceForFullSerifs : dfM] 'turnm/full' 'turnm/reduced'])
+	select-variant 'turnm' 0x26F (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'turnm/full' 'turnm/reduced'])
 	select-variant 'turnm/reduced' (shapeFrom -- 'turnm')
 
-	select-variant 'capitalTurnm' 0x19C (follow -- [if [MEnoughSpaceForFullSerifs : dfM] 'turnm/full' 'turnm/reduced'])
+	select-variant 'capitalTurnm' 0x19C (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'turnm/full' 'turnm/reduced'])
 
-	select-variant 'turnmLeg' 0x270 (follow -- [if [MEnoughSpaceForFullSerifs : dfM] 'turnmLeg/full' 'turnmLeg/reduced'])
+	select-variant 'turnmLeg' 0x270 (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'turnmLeg/full' 'turnmLeg/reduced'])
 	select-variant 'turnmLeg/reduced' (shapeFrom -- 'turnmLeg')
 
-	select-variant 'turnmSideways' 0x1D1F (follow -- [if [MEnoughSpaceForFullSerifs : dfM] 'turnm/full' 'turnm/reduced'])
+	select-variant 'turnmSideways' 0x1D1F (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'turnm/full' 'turnm/reduced'])
 
-	select-variant 'cyrl/sha.italic' (shapeFrom -- 'turnm') (follow -- [if [MEnoughSpaceForFullSerifs : dfM] 'cyrl/sha.italic/full' 'cyrl/sha.italic/reduced'])
+	select-variant 'cyrl/sha.italic' (shapeFrom -- 'turnm') (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'cyrl/sha.italic/full' 'cyrl/sha.italic/reduced'])
 	alias 'cyrl/sha.BGR' null 'cyrl/sha.italic'
 	select-variant 'cyrl/sha/reduced.italic' (shapeFrom -- 'turnm') (follow -- 'cyrl/sha.italic/reduced')
 	alias 'cyrl/sha/reduced.BGR' null 'cyrl/sha/reduced.italic'
 
-	select-variant 'cyrl/shcha.italic' (follow -- [if [MEnoughSpaceForFullSerifs : dfM] 'cyrl/shcha.italic/full' 'cyrl/shcha.italic/reduced'])
+	select-variant 'cyrl/shcha.italic' (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'cyrl/shcha.italic/full' 'cyrl/shcha.italic/reduced'])
 	alias 'cyrl/shcha.BGR' null 'cyrl/shcha.italic'
 	select-variant 'cyrl/shcha/reduced.italic' (shapeFrom -- 'cyrl/shcha.italic') (follow -- 'cyrl/shcha.italic/reduced')
 	alias 'cyrl/shcha/reduced.BGR' null 'cyrl/shcha/reduced.italic'

--- a/packages/font-glyphs/src/meta/aesthetics.ptl
+++ b/packages/font-glyphs/src/meta/aesthetics.ptl
@@ -192,17 +192,16 @@ export : define [calculateMetrics para] : begin
 		ParenTop ParenBot OperTop OperBot TackTop TackBot PlusTop PlusBot PictTop PictBot BgOpTop
 		BgOpBot Italify Upright Scale Translate ApparentTranslate Rotate GlobalTransform TanSlope
 		HVContrast Upward Downward Rightward Leftward O OX OXHook Hook AHook SHook RHook JHook
-		HookX TailX TailY ArchDepth SmallArchDepth Stroke DotSize
-		PeriodSize HBarPos OverlayPos LongJut Jut VJut VJutStroke AccentStackOffset AccentWidth
-		AccentClearance AccentHeight CThin CThinB SLAB IBalance IBalance2
-		JBalance JBalance2 TBalance TBalance2 RBalance RBalance2 FBalance OneBalance WideWidth0
-		WideWidth1 WideWidth2 WideWidth3 WideWidth4 EssUpper EssLower EssQuestion HalfStroke
-		RightSB Middle DotRadius PeriodRadius SideJut ArchDepthA ArchDepthB SmallArchDepthA
-		SmallArchDepthB CorrectionOMidX CorrectionOMidS compositeBaseAnchors
-		AdviceStroke AdviceStroke2 OverlayStroke OperatorStroke GeometryStroke ShoulderFine
-		_SuperXY AdviceGlottalStopArchDepth StrokeWidthBlend
-		ArchDepthAOf ArchDepthBOf SmoothAdjust MidJutSide MidJutCenter YSmoothMidR YSmoothMidL
-		HSwToV NarrowUnicodeT WideUnicodeT VERY-FAR TINY]
+		HookX TailX TailY ArchDepth SmallArchDepth Stroke DotSize PeriodSize HBarPos OverlayPos
+		LongJut Jut VJut VJutStroke AccentStackOffset AccentWidth AccentClearance AccentHeight
+		CThin CThinB SLAB IBalance IBalance2 JBalance JBalance2 TBalance TBalance2 RBalance
+		RBalance2 FBalance OneBalance WideWidth0 WideWidth1 WideWidth2 WideWidth3 WideWidth4
+		EssUpper EssLower EssQuestion HalfStroke RightSB Middle DotRadius PeriodRadius SideJut
+		ArchDepthA ArchDepthB SmallArchDepthA SmallArchDepthB CorrectionOMidX CorrectionOMidS
+		compositeBaseAnchors AdviceStroke AdviceStroke2 OverlayStroke OperatorStroke GeometryStroke
+		ShoulderFine _SuperXY AdviceGlottalStopArchDepth StrokeWidthBlend ArchDepthAOf ArchDepthBOf
+		SmoothAdjust MidJutSide MidJutCenter YSmoothMidR YSmoothMidL HSwToV NarrowUnicodeT
+		WideUnicodeT VERY-FAR TINY]
 
 export : define [setFontMetrics para metrics fm] : begin
 	define [object CAP Descender XH Width SymbolMid] metrics

--- a/packages/font-glyphs/src/meta/macros.ptl
+++ b/packages/font-glyphs/src/meta/macros.ptl
@@ -185,9 +185,9 @@ define-macro run-glyph-module : syntax-rules
 define-macro glyph-block-import : syntax-rules
 	`[glyph-block-import @_blockName] : begin
 		define allExports : object
-			Common-Derivatives `[select-variant orthographic-italic orthographic-slanted
-			refer-glyph query-glyph alias turned HDual HCombine VDual VCombine derive-glyphs
-			derive-composites link-reduced-variant alias-reduced-variant HalfAdvance
+			Common-Derivatives `[select-variant conditional-follow orthographic-italic
+			orthographic-slanted refer-glyph query-glyph alias turned HDual HCombine VDual VCombine
+			derive-glyphs derive-composites link-reduced-variant alias-reduced-variant HalfAdvance
 			derive-multi-part-glyphs DeriveMeshT link-gr]
 
 			CommonShapes `[no-shape tagged Rect SquareAt Ring RingAt DotAt RingStroke


### PR DESCRIPTION
We could not simply use `[if]` in select-variant's `(follow -- ·)` as it will influence the glyph dependency graph. Thus we create a helper class to properly add all the dependencies for conditional follows.

Fixes #2434 .