### PR TITLE
Optimize glyph for Vertical Line with Middle Dot (`U+2327`).

### DIFF
--- a/changes/31.1.0.md
+++ b/changes/31.1.0.md
@@ -1,4 +1,5 @@
 * Add separate variant selectors for Cyrillic Capital En/Er (`VXAA`, `VXAB`).
+* Optimize glyph for VERTICAL LINE WITH MIDDLE DOT (`U+2327`).
 * Add characters:
   - BLACK-LETTER CAPITAL H (`U+210C`) (#714).
   - BLACK-LETTER CAPITAL I (`U+2111`) (#714).

--- a/packages/font-glyphs/src/symbol/math/other.ptl
+++ b/packages/font-glyphs/src/symbol/math/other.ptl
@@ -27,6 +27,10 @@ glyph-block Symbol-Math-Other : begin
 			flat SB [mix SymbolMid TackBot 0.5]
 			curl RightSB [mix SymbolMid TackTop 0.5]
 
+	WithDotVariants 'barWithDot' 0x237F : function [DrawAt kr ov] : glyph-proc
+		include : refer-glyph 'stile'
+		include : DrawAt Middle SymbolMid (PeriodRadius * kr - ov)
+
 	create-glyph 'barStroke' 0x27CA : glyph-proc
 		include : refer-glyph 'stile'
 		include : HBar.m [mix SB RightSB 0.1] [mix SB RightSB 0.9] SymbolMid OverlayStroke

--- a/packages/font-glyphs/src/symbol/punctuation/bar.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/bar.ptl
@@ -82,18 +82,6 @@ glyph-block Symbol-Punctuation-Bar : begin
 		include : ForceUpright
 		include : TripleBarShape Middle ParenTop ParenBot
 
-	WithDotVariants 'barWithDot.upright' null : function [DrawAt kr ov] : glyph-proc
-		include : refer-glyph 'bar.upright'
-		include : DrawAt Middle SymbolMid (PeriodRadius * kr - ov)
-
-	WithDotVariants 'barWithDot.slanted.naturalSlope' null : function [DrawAt kr ov] : glyph-proc
-		include : refer-glyph 'bar.slanted.naturalSlope'
-		include : DrawAt Middle SymbolMid (PeriodRadius * kr - ov)
-
-	WithDotVariants 'barWithDot.slanted.forceUpright' null : function [DrawAt kr ov] : glyph-proc
-		include : refer-glyph 'bar.slanted.forceUpright'
-		include : DrawAt Middle SymbolMid (PeriodRadius * kr - ov)
-
 	select-variant 'bar.slanted'
 	orthographic-slanted 'bar' '|'
 
@@ -105,9 +93,6 @@ glyph-block Symbol-Punctuation-Bar : begin
 
 	select-variant 'tripleBar.slanted' (follow -- 'bar.slanted')
 	orthographic-slanted 'tripleBar' 0x2980
-
-	select-variant 'barWithDot.slanted' (follow -- 'bar.slanted')
-	orthographic-slanted 'barWithDot' 0x237F
 
 	create-glyph 'dentalclick'          0x1C0 :       BarShape Middle ParenTop ParenBot
 	create-glyph 'alveolarlateralclick' 0x1C1 : DoubleBarShape Middle ParenTop ParenBot


### PR DESCRIPTION
This has been subtly bothering me for a while now.

The glyph in the Unicode charts shows that this character should be shorter than ASCII bar, closer to a Stile (or "Divides" as it's called in Unicode).

As such, it also doesn't really need to respond to `force-upright` variants of `bar`; However, its behavior under this feature was inconsistent anyway.

```
|‖⦀¦
ǀǁǂ
∣∥⫴⫼
⍿
```

Default upright:
![image](https://github.com/user-attachments/assets/730be4d3-a700-4765-a0e9-d33c8e017f67)
Default Italic:
![image](https://github.com/user-attachments/assets/275b8dfa-8690-4f9e-b76a-10fec49f622d)
ss04 upright:
![image](https://github.com/user-attachments/assets/a831008f-0d93-4f33-86a0-b11db30b50f4)
ss04 italic:
![image](https://github.com/user-attachments/assets/ef31b877-34da-4e4d-a241-ddeaf3db15db)
