### PR TITLE
Optimize glyphs for four characters.

### DIFF
--- a/changes/31.2.0.md
+++ b/changes/31.2.0.md
@@ -1,1 +1,4 @@
 * Add variant selectors for Greek lower Phi/Psi (`VXAG`, `VXAH`).
+* Optimize cross position for Cyrillic Lower Straight U (`U+04AF`, `U+04B1`).
+* Optimize glyph shape for `lower-gamma`.`straight` and `lower-gamma`.`curly`.
+* Optimize glyph shape for `U+1DF15`.

--- a/packages/font-glyphs/src/letter/greek/lower-gamma.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-gamma.ptl
@@ -9,15 +9,8 @@ glyph-block Letter-Greek-Lower-Gamma : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarLeft
 
-	create-glyph 'grek/gamma.straight' : glyph-proc
-		include : MarkSet.p
-		include : refer-glyph "v.straightSerifless"
-		include : VBar.m Middle Descender HalfStroke
-
-	create-glyph 'grek/gamma.curly' : glyph-proc
-		include : MarkSet.p
-		include : refer-glyph "v.curlySerifless"
-		include : VBar.m Middle Descender HalfStroke
+	alias 'grek/gamma.straight' null 'cyrl/ue.straightSerifless'
+	alias 'grek/gamma.curly'    null 'cyrl/ue.curlySerifless'
 
 	create-glyph 'grek/gamma.casual' : glyph-proc
 		include : MarkSet.p

--- a/packages/font-glyphs/src/letter/latin/lower-r.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-r.ptl
@@ -274,7 +274,7 @@ glyph-block Letter-Latin-Lower-R : begin
 			include : setTurnedMarks doTS XH 0
 			include : PalatalHook.r
 				xLink -- (df.rightSB - xBar + df.leftSB)
-				x -- (df.rightSB + SideJut)
+				x -- (df.rightSB - xBar + df.leftSB + [HSwToV Stroke] + SideJut)
 				y -- 0
 
 		create-glyph "turnrLongLeg.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/upper-y.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-y.ptl
@@ -32,8 +32,7 @@ glyph-block Letter-Latin-Upper-Y : begin
 			[Just SLAB-MOTION] : include sf.lt.outer
 			[Just SLAB-BASE] : include : HSerif.mb Middle bot MidJutSide
 
-	define [YShape bodyType slabType top bot] : glyph-proc
-		local cross : YCrossPos top bot
+	define [YShape] : with-params [bodyType slabType top bot [cross : YCrossPos top bot]] : glyph-proc
 		local maskLT : slabType == SLAB-ALL || slabType == SLAB-MOTION
 		local maskRT : slabType == SLAB-ALL
 
@@ -51,35 +50,29 @@ glyph-block Letter-Latin-Upper-Y : begin
 		include : HOverlayBar SB RightSB ([mix bot [YCrossPos CAP 0] 0.5] - OverlayStroke * ks)
 		include : HOverlayBar SB RightSB [mix bot [YCrossPos CAP 0] 1.0]
 
-	define [YHookLeftHookedStroke top bot] : begin
-		local cross : YCrossPos top bot
-		return : dispiro
-			widths.lhs
-			straight.right.start (SB - TailX / 3) (top - Stroke - O)
-			g4 (SB + TailX / 3) (top - TailY) [widths.lhs : AdviceStroke 2.75]
-			quadControls 0.55 0.7 32 unimportant
-			g4 (Middle - [HSwToV : 0.5 * Stroke]) cross [widths.lhs : AdviceStroke 3.5]
+	define [YHookLeftHookedStroke top bot cross] : dispiro
+		widths.lhs
+		straight.right.start (SB - TailX / 3) (top - Stroke - O)
+		g4 (SB + TailX / 3) (top - TailY) [widths.lhs : AdviceStroke 2.75]
+		quadControls 0.55 0.7 32 unimportant
+		g4 (Middle - [HSwToV : 0.5 * Stroke]) cross [widths.lhs : AdviceStroke 3.5]
 
-	define [YHookRightHookedStroke top bot] : begin
-		local cross : YCrossPos top bot
-		return : dispiro
-			widths.rhs
-			straight.left.start (RightSB + TailX / 3) (top - Stroke - O)
-			g4 (RightSB - TailX / 3) (top - TailY) [widths.rhs : AdviceStroke 2.75]
-			quadControls 0.55 0.7 32 unimportant
-			g4 (Middle + [HSwToV : 0.5 * Stroke]) cross [widths.rhs : AdviceStroke 3.5]
+	define [YHookRightHookedStroke top bot cross] : dispiro
+		widths.rhs
+		straight.left.start (RightSB + TailX / 3) (top - Stroke - O)
+		g4 (RightSB - TailX / 3) (top - TailY) [widths.rhs : AdviceStroke 2.75]
+		quadControls 0.55 0.7 32 unimportant
+		g4 (Middle + [HSwToV : 0.5 * Stroke]) cross [widths.rhs : AdviceStroke 3.5]
 
-	define [YHookTopShape bodyType slabType top bot] : glyph-proc
-		include : YShape bodyType slabType top bot
+	define [YHookTopShape] : with-params [bodyType slabType top bot [cross : YCrossPos top bot]] : glyph-proc
+		include : YShape bodyType slabType top bot cross
 		eject-contour 'strokeRT'
-		include : YHookRightHookedStroke top bot
+		include : YHookRightHookedStroke top bot cross
 
-	define [UpsilonHookedSymbolShape top bot] : glyph-proc
-		local cross : YCrossPos top bot
-
+	define [UpsilonHookedSymbolShape] : with-params [top bot [cross : YCrossPos top bot]] : glyph-proc
 		include : VBar.m Middle bot (cross + HalfStroke)
-		include : YHookLeftHookedStroke top bot
-		include : YHookRightHookedStroke top bot
+		include : YHookLeftHookedStroke top bot cross
+		include : YHookRightHookedStroke top bot cross
 
 	define YConfig : object
 		straightSerifless     { BODY-STRAIGHT SLAB-NONE   }
@@ -116,7 +109,7 @@ glyph-block Letter-Latin-Upper-Y : begin
 		if (slabType !== SLAB-BASE) : begin
 			create-glyph "cyrl/ue.\(suffix)" : glyph-proc
 				include : MarkSet.p
-				include : YShape bodyType slabType XH Descender
+				include : YShape bodyType slabType XH Descender (cross -- 0)
 				include : YSlabs slabType XH Descender
 
 		if ((slabType === SLAB-NONE || slabType === SLAB-BASE) && bodyType === BODY-STRAIGHT) : begin


### PR DESCRIPTION
Greek Gamma straight/curly optimization:
`γᵞᵧ`
Before (notice the seam):
![image](https://github.com/user-attachments/assets/c8d83434-7a6a-4fb5-ae26-1783589ee6d2)
After:
![image](https://github.com/user-attachments/assets/f4cdf5e4-d0d8-47c9-805c-32e3578fbc53)
Cyrillic Lower Straight U Optimization:
`уўүұ`
Before (cross position appears raised):
![image](https://github.com/user-attachments/assets/3ccbcfd5-831f-4a2f-a367-22fa6a6060b6)
After (fixing this also facilitated fixing straight/curly gamma as a side benefit):
![image](https://github.com/user-attachments/assets/07f69173-2a9a-4dea-8657-5f59c53f4b82)
Turned r palatal hook optimization:
`ᶁ𝼕`
Thin before:
![image](https://github.com/user-attachments/assets/663354a8-c931-41c3-98cf-93d8f9975e2c)
Thin after:
![image](https://github.com/user-attachments/assets/5b3debfd-8c94-4c1b-b600-c85a2f3f9a0e)
Regular before:
![image](https://github.com/user-attachments/assets/108f3f49-d347-42e1-9e57-715dcf405b3f)
Regular after:
![image](https://github.com/user-attachments/assets/06f3c99c-2ad0-40c6-905e-5f91f9105923)
Heavy before:
![image](https://github.com/user-attachments/assets/ff93f7d8-988e-49fe-80d3-4d5962c9f5ee)
Heavy After:
![image](https://github.com/user-attachments/assets/d065586c-3c6a-4257-9272-614b688b25a8)
