### PR TITLE
Minor variant documentation corrections.

### DIFF
--- a/params/variants.toml
+++ b/params/variants.toml
@@ -5726,49 +5726,49 @@ selectorAffix."cyrl/Yus" = ""
 
 [prime.lower-lambda]
 sampler = "λ"
-samplerExplain = "Greek small Lambda"
+samplerExplain = "Greek lower Lambda"
 tagKind = "letter"
 
 [prime.lower-lambda.variants.straight]
 rank = 1
-description = "More-straight Greek small Lambda (`λ`)"
+description = "More-straight Greek lower Lambda (`λ`)"
 selector."grek/lambda" = "straightSerifless"
 
 [prime.lower-lambda.variants.straight-turn]
 rank = 2
-description = "Greek small Lambda (`λ`) with straight upper and a tail turns leftward"
+description = "Greek lower Lambda (`λ`) with straight upper and a tail turns leftward"
 selector."grek/lambda" = "straightTurnSerifless"
 
 [prime.lower-lambda.variants.tailed-turn]
 rank = 3
-description = "More curly Greek small Lambda (`λ`), with a tail turns leftward at top and a tail turns right at bottom-right"
+description = "More curly Greek lower Lambda (`λ`), with a tail turns leftward at top and a tail turns right at bottom-right"
 selector."grek/lambda" = "tailedTurnSerifless"
 
 [prime.lower-lambda.variants.curly]
 rank = 4
-description = "More curly Greek small Lambda (`λ`), like Iosevka 2.x"
+description = "More curly Greek lower Lambda (`λ`), like Iosevka 2.x"
 selector."grek/lambda" = "curlySerifless"
 
 [prime.lower-lambda.variants.curly-turn]
 rank = 5
-description = "More curly Greek small Lambda (`λ`), like Iosevka 2.x, with a tail turns leftward"
+description = "More curly Greek lower Lambda (`λ`), like Iosevka 2.x, with a tail turns leftward"
 selector."grek/lambda" = "curlyTurnSerifless"
 
 [prime.lower-lambda.variants.curly-tailed-turn]
 rank = 6
-description = "More curly Greek small Lambda (`λ`), with a tail turns leftward at top, a tail turns right at bottom-right, and curly bottom-left leg"
+description = "More curly Greek lower Lambda (`λ`), with a tail turns leftward at top, a tail turns right at bottom-right, and curly bottom-left leg"
 selector."grek/lambda" = "curlyTailedTurnSerifless"
 
 
 
 [prime.lower-mu]
 sampler = "μ"
-samplerExplain = "Greek small Mu"
+samplerExplain = "Greek lower Mu"
 tagKind = "letter"
 
 [prime.lower-mu.variants-buildup]
 entry = "body"
-descriptionLeader = "Greek small Mu (`μ`)"
+descriptionLeader = "Greek lower Mu (`μ`)"
 
 [prime.lower-mu.variants-buildup.stages.body."*"]
 next = "serifs"
@@ -5988,7 +5988,7 @@ selector."grek/phi" = "cursive"
 
 [prime.lower-phi.variants.neo-hellenic]
 rank = 3
-description = "Greek lower Phi (`ν`) with neo-hellenic shape"
+description = "Greek lower Phi (`φ`) with neo-hellenic shape"
 selector."grek/phi" = "neohellenic"
 
 
@@ -6121,7 +6121,7 @@ selectorAffix."cyrl/psi" = "serifed"
 
 [prime.cyrl-a]
 sampler = "а"
-samplerExplain = "Cyrillic A"
+samplerExplain = "Cyrillic Lower A"
 tagKind = "letter"
 
 [prime.cyrl-a.variants-buildup]
@@ -6231,7 +6231,7 @@ selectorAffix."cyrl/ae/a" = "serifless"
 
 [prime.cyrl-ve]
 sampler = "в"
-samplerExplain = "Cyrillic Ve"
+samplerExplain = "Cyrillic Lower Ve"
 tagKind = "letter"
 
 [prime.cyrl-ve.variants-buildup]
@@ -6328,7 +6328,7 @@ selector."cyrl/Zhe" = "cursive"
 
 [prime.cyrl-zhe]
 sampler = "ж"
-samplerExplain = "Cyrillic Zhe"
+samplerExplain = "Cyrillic Lower Zhe"
 tagKind = "letter"
 
 [prime.cyrl-zhe.variants.straight]
@@ -6596,7 +6596,7 @@ selectorAffix."cyrl/KaBashkir" = "serifed"
 
 [prime.cyrl-ka]
 sampler = "к"
-samplerExplain = "Cyrillic Ka"
+samplerExplain = "Cyrillic Lower Ka"
 tagKind = "letter"
 
 [prime.cyrl-ka.variants-buildup]
@@ -7632,12 +7632,12 @@ tagKind = "dot"
 
 [prime.tittle.variants.round]
 rank = 1
-description = "Dots in i/j are round"
+description = "Dots in `i`/`j` are round"
 selector.tittle = "round"
 
 [prime.tittle.variants.square]
 rank = 2
-description = "Dots in i/j are square"
+description = "Dots in `i`/`j` are square"
 selector.tittle = "square"
 
 


### PR DESCRIPTION
I mainly wanted to correct a typo with the description of `lower-phi`.`neo-hellenic` that erroneously shows a Greek nu (`ν`) leftover from me copy/pasting some code, but I decided to also unify the descriptions of lowercase Greek variants while I'm at it (changing the word "small" to "lower" universally, for consistency).

The functionality and variant behavior is completely unchanged otherwise.