### PR TITLE
Add `diagonal-tailed-cursive` variants for Cyrillic Lower Ef, for `ss15`.

### DIFF
--- a/changes/31.2.1.md
+++ b/changes/31.2.1.md
@@ -1,0 +1,1 @@
+* Add `diagonal-tailed-cursive` variants for Cyrillic Lower Ef (`cv93`).

--- a/packages/font-glyphs/src/letter/greek/phi.ptl
+++ b/packages/font-glyphs/src/letter/greek/phi.ptl
@@ -9,7 +9,7 @@ glyph-block Letter-Greek-Phi : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors ExtendBelowBaseAnchors
-	glyph-block-import Letter-Shared-Shapes : FlatHookDepth OBarLeft OBarRight
+	glyph-block-import Letter-Shared-Shapes : FlatHookDepth DiagTail OBarLeft OBarRight
 	glyph-block-import Letter-Latin-Lower-AE-OE : SubDfAndShift
 
 	define [VarPhiRing fFlatTB df y1 y2] : glyph-proc
@@ -86,6 +86,23 @@ glyph-block Letter-Greek-Phi : begin
 			flat xBarRight [Math.min y1 (bot + hd.y)]
 			curl xBarRight (y1 - O)
 
+	define [DiagonalTailCursiveBar df bot y1 y2 top] : glyph-proc
+		local hd : FlatHookDepth df
+
+		local xCrossRight : mix df.width  df.rightSB  [mix 1 df.div 2]
+		local xBarLeft    : df.middle - [HSwToV HalfStroke]
+
+		include : dispiro
+			flat xCrossRight top [widths.lhs]
+			curl [Math.min (xBarLeft + hd.x) (xCrossRight - TINY)] top
+			archv
+			flat xBarLeft [Math.max y2 (top - hd.y)]
+			curl xBarLeft (y2 + O)
+
+		include : dispiro
+			flat df.middle (y1 - O) [widths.center.heading Stroke Downward]
+			DiagTail.L df.middle bot [DiagTail.StdDepth df Stroke] Stroke
+
 	define [MtSerif df y] : tagged 'serifMT' : HSerif.lt df.middle y Jut
 	define [MbSerif df y] : tagged 'serifMB' : HSerif.mb df.middle y Jut
 
@@ -149,7 +166,7 @@ glyph-block Letter-Greek-Phi : begin
 		include : VarPhiRing 0 df 0 XH
 		include : VBar.m df.middle Descender (0.2 * df.mvs)
 
-	select-variant 'grek/phi'    0x3C6
+	select-variant 'grek/phi' 0x3C6
 	alias 'grek/varphi' 0x3D5 'grek/phi.straight'
 
 	create-glyph 'latn/phi' 0x278 : glyph-proc
@@ -162,13 +179,14 @@ glyph-block Letter-Greek-Phi : begin
 
 	define CyrlLowerEfConfig : SuffixCfg.weave
 		object # bowl
-			""                  VarPhiRing
-			splitBowl           CyrlEfSplitRing
+			""                      VarPhiRing
+			splitBowl               CyrlEfSplitRing
 		object # bar
-			serifless          { StraightBar nothing nothing }
-			topSerifed         { StraightBar MtSerif nothing }
-			serifed            { StraightBar MtSerif MbSerif }
-			cursive            { CursiveBar  nothing nothing }
+			serifless             { StraightBar nothing nothing }
+			topSerifed            { StraightBar MtSerif nothing }
+			serifed               { StraightBar MtSerif MbSerif }
+			cursive               { CursiveBar  nothing nothing }
+			diagonalTailedCursive { DiagonalTailCursiveBar nothing nothing }
 
 	foreach { suffix { Bowl { Bar sMT sMB } } } [Object.entries CyrlLowerEfConfig] : do
 		create-glyph "cyrl/ef.\(suffix)" : glyph-proc

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -7180,6 +7180,14 @@ descriptionAffix = "cursive bar"
 selectorAffix."cyrl/ef" = "cursive"
 selectorAffix."cyrl/ef.BGR" = "cursive"
 
+[prime.cyrl-ef.variants-buildup.stages.bar.diagonal-tailed-cursive]
+rank = 3
+nonBreakingVariantAdditionPriority = 100
+next = "END"
+descriptionAffix = "cursive bar, and diagonal tail"
+selectorAffix."cyrl/ef" = "diagonalTailedCursive"
+selectorAffix."cyrl/ef.BGR" = "diagonalTailedCursive"
+
 [prime.cyrl-ef.variants-buildup.stages.serifs.serifless]
 rank = 1
 descriptionAffix = "serifs"
@@ -10351,7 +10359,7 @@ lower-tau = "diagonal-tailed"
 cyrl-a = "single-storey-tailed"
 cyrl-zhe = "cursive"
 cyrl-u = "cursive-serifless"
-cyrl-ef = "split-cursive"
+cyrl-ef = "split-diagonal-tailed-cursive"
 cyrl-yeri = "cursive"
 cyrl-yery = "cursive"
 ampersand = "closed"
@@ -10388,7 +10396,7 @@ x = "cursive"
 y = "cursive-motion-serifed"
 cyrl-ka = "symmetric-connected-top-left-and-bottom-right-serifed"
 cyrl-u = "cursive-motion-serifed"
-cyrl-ef = "split-cursive"
+cyrl-ef = "split-diagonal-tailed-cursive"
 micro-sign = "toothed-motion-serifed"
 
 


### PR DESCRIPTION
After this, the only character left with descending tailed variants yet none with a diagonal tail will be lower eszet
(although IBM Plex Mono doesn't use a tailed variant for it full-stop; It only uses one for Cyrillic Lower Ef).
```
ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ
abc.def.ghi.jkl.mno.pqrs.tuv.wxyz
!iIlL17|¦ ¢coO08BDQ $5SZ2zs ∂96µm
float il1[]={1-2/3.4,5+6=7/8%90};
1234567890 ,._-+= >< «¯-¬_» ~–÷+×
{*}[]()<>`+-=$/#_%^@\&|~?'" !,.;:
G6Qg9q¶ Þẞðþſß ΓΔΛαβγδιλμνξπτυφχψ
ЖЗКНРУЭЯавжзклмнруфчьыэя <= != ==
```
ss15 upright:
![image](https://github.com/user-attachments/assets/3e14555c-d3bc-46cf-97d0-f7128c0f25ab)
ss15 italic:
![image](https://github.com/user-attachments/assets/0d8e78d2-6f6e-4643-8441-27299b324802)
All Cyrillic Ef variants:
`ф𞁂𞁠`
![image](https://github.com/user-attachments/assets/d3d3ad97-07db-46b3-ae38-8c87ffd99654)
