### PR TITLE
Add `rounded-vertical-sides` variants for Capital/Lower W, for `ss10`.

### DIFF
--- a/changes/31.3.0.md
+++ b/changes/31.3.0.md
@@ -1,2 +1,3 @@
 * Add `diagonal-tailed-cursive` variants for Cyrillic Lower Ef (`cv93`).
+* Add `rounded-vertical-sides` variants for Capital/Lower W (`cv32`, `cv57`).
 * Prevent clipping of texture-extended glyphs in Kitty.

--- a/packages/font-glyphs/src/letter/latin/lower-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-m.ptl
@@ -182,6 +182,7 @@ glyph-block Letter-Latin-Lower-M : begin
 		include : tagged 'barL' : VBar.l df.leftSB lbot (top - DToothlessRise) df.mvs
 		# include : tagged 'barM' : VBar.m mid mbot (top - DToothlessRise) df.mvs
 
+	glyph-block-export EarlessRoundedDoubleArchSmallMShape
 	define [EarlessRoundedDoubleArchSmallMShape df top lbot mbot rbot _mid] : glyph-proc
 		local mid : fallback _mid df.middle
 		include : union

--- a/packages/font-glyphs/src/letter/latin/w.ptl
+++ b/packages/font-glyphs/src/letter/latin/w.ptl
@@ -10,6 +10,7 @@ glyph-block Letter-Latin-W : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared : CreateTurnedLetter
 	glyph-block-import Letter-Shared-Shapes : DiagTail SerifFrame VerticalHook
+	glyph-block-import Letter-Latin-Lower-M : EarlessRoundedDoubleArchSmallMShape
 	glyph-block-import Letter-Latin-Upper-M : MShape
 
 	define FORM-CURLY      0
@@ -269,6 +270,31 @@ glyph-block Letter-Latin-W : begin
 
 		include : VerticalHook.r df.rightSB (top - TailY - HalfStroke - O) TailX (-TailY)
 
+	define [WRounded df top bodyType slabType] : glyph-proc
+		include : new-glyph : glyph-proc
+			include : EarlessRoundedDoubleArchSmallMShape df top 0 (top * 0.4) 0
+			include : FlipAround (df.width / 2) (top / 2)
+
+		local sf : SerifFrame top 0 df.leftSB df.rightSB
+		include : match slabType
+			[Just SERIFS-AUTO]   : NeedSlab SLAB : composite-proc sf.lt.full sf.rt.full
+			[Just SERIFS-ALL]    : composite-proc sf.lt.full sf.rt.full
+			[Just SERIFS-MOTION] : begin sf.lt.outer
+			___                  : glyph-proc
+
+	define [WHookTopRounded df top bodyType slabType] : glyph-proc
+		include : new-glyph : glyph-proc
+			include : EarlessRoundedDoubleArchSmallMShape df top (TailY + HalfStroke + O) (top * 0.4) 0
+			include : FlipAround (df.width / 2) (top / 2)
+
+		local sf : SerifFrame top 0 df.leftSB df.rightSB
+		include : match slabType
+			[Just SERIFS-AUTO]   : NeedSlab SLAB sf.lt.full
+			[Just SERIFS-ALL]    : begin sf.lt.full
+			[Just SERIFS-MOTION] : begin sf.lt.outer
+			___                  : glyph-proc
+
+		include : VerticalHook.r df.rightSB (top - TailY - HalfStroke - O) TailX (-TailY) (sw -- df.mvs)
 
 	define [WCursiveImplImpl fHookTop df top bodyType slabType] : glyph-proc
 		define fine : AdviceStroke 3.25 df.div
@@ -327,9 +353,10 @@ glyph-block Letter-Latin-W : begin
 			straightDoubleV                    { WShapeImpl   WHooktopShape   FORM-DOUBLE-V   }
 			straightFlatTop                    { WShapeImpl   WHooktopShape   FORM-FLAT-TOP   }
 			straightVerticalSides              { WVertSides   WVSHookTopShape FORM-STRAIGHT   }
+			roundedVerticalSides               { WRounded     WHookTopRounded FORM-CURLY      } 
 			curly                              { WShapeImpl   WHooktopShape   FORM-CURLY      }
 			cursive                            { WCursiveImpl WHookTopCursive FORM-CURLY      }
-			cyrlCapialOmega					   { WShapeImpl   WHooktopShape   FORM-CYRL-OMEGA }
+			cyrlCapialOmega                    { WShapeImpl   WHooktopShape   FORM-CYRL-OMEGA }
 			cyrlSmallOmega                     { WShapeImpl   WHooktopShape   FORM-CYRL-OMEGA }
 
 		# Serifs

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1818,10 +1818,18 @@ selectorAffix.WHookTop = "straightAsymmetric"
 
 [prime.capital-w.variants-buildup.stages.body.straight-vertical-sides]
 rank = 6
-descriptionAffix = "body shape with vertical sides"
+descriptionAffix = "straight body shape with vertical sides"
 selectorAffix.W = "straightVerticalSides"
 selectorAffix."W/sansSerif" = "straightVerticalSides"
 selectorAffix.WHookTop = "straightVerticalSides"
+
+[prime.capital-w.variants-buildup.stages.body.rounded-vertical-sides]
+rank = 7
+nonBreakingVariantAdditionPriority = 100
+descriptionAffix = "rounded body shape with vertical sides"
+selectorAffix.W = "roundedVerticalSides"
+selectorAffix."W/sansSerif" = "roundedVerticalSides"
+selectorAffix.WHookTop = "roundedVerticalSides"
 
 [prime.capital-w.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -4620,13 +4628,22 @@ selectorAffix.wHookTop = "curly"
 [prime.w.variants-buildup.stages.body.straight-vertical-sides]
 rank = 3
 groupRank = 1
-descriptionAffix = "body shape with vertical sides"
+descriptionAffix = "straight body shape with vertical sides"
 selectorAffix.w = "straightVerticalSides"
 selectorAffix."w/sansSerif" = "straightVerticalSides"
 selectorAffix.wHookTop = "straightVerticalSides"
 
-[prime.w.variants-buildup.stages.body.straight-flat-top]
+[prime.w.variants-buildup.stages.body.rounded-vertical-sides]
 rank = 4
+groupRank = 1
+nonBreakingVariantAdditionPriority = 100
+descriptionAffix = "rounded body shape with vertical sides"
+selectorAffix.w = "roundedVerticalSides"
+selectorAffix."w/sansSerif" = "roundedVerticalSides"
+selectorAffix.wHookTop = "roundedVerticalSides"
+
+[prime.w.variants-buildup.stages.body.straight-flat-top]
+rank = 5
 groupRank = 2
 descriptionAffix = "straight body shape that the middle is forced to be aligned the top"
 selectorAffix.w = "straightFlatTop"
@@ -4634,7 +4651,7 @@ selectorAffix."w/sansSerif" = "straightFlatTop"
 selectorAffix.wHookTop = "straightFlatTop"
 
 [prime.w.variants-buildup.stages.body.straight-double-v]
-rank = 5
+rank = 6
 groupRank = 2
 descriptionAffix = "body shape like double V"
 selectorAffix.w = "straightDoubleV"
@@ -4642,7 +4659,7 @@ selectorAffix."w/sansSerif" = "straightDoubleV"
 selectorAffix.wHookTop = "straightDoubleV"
 
 [prime.w.variants-buildup.stages.body.straight-asymmetric]
-rank = 6
+rank = 7
 groupRank = 2
 descriptionAffix = "asymmetric shape"
 selectorAffix.w = "straightAsymmetric"
@@ -4650,7 +4667,7 @@ selectorAffix."w/sansSerif" = "straightAsymmetric"
 selectorAffix.wHookTop = "straightAsymmetric"
 
 [prime.w.variants-buildup.stages.body.cursive]
-rank = 7
+rank = 8
 groupRank = 3
 descriptionAffix = "cursive shape"
 selectorAffix.w = "cursive"
@@ -9808,6 +9825,7 @@ j = "flat-hook-serifed"
 k = "symmetric-connected-serifless"
 l = "hooky"
 t = "flat-hook"
+w = "rounded-vertical-sides-serifless"
 y = "cursive-flat-hook-serifless"
 long-s = "flat-hook-middle-serifed"
 eszet = "sulzbacher-serifless"
@@ -9850,6 +9868,7 @@ g = "single-storey-flat-hook-serifed"
 i = "serifed"
 k = "symmetric-connected-serifed"
 l = "serifed"
+w = "rounded-vertical-sides-serifed"
 x = "straight-serifed"
 y = "cursive-flat-hook-serifed"
 z = "straight-serifed"
@@ -9867,6 +9886,7 @@ g = "single-storey-flat-hook-serifless"
 i = "serifed-flat-tailed"
 k = "symmetric-connected-top-left-and-bottom-right-serifed"
 l = "serifed-flat-tailed"
+w = "rounded-vertical-sides-motion-serifed"
 x = "straight-bilateral-motion-serifed"
 y = "cursive-flat-hook-motion-serifed"
 cyrl-ka = "symmetric-connected-top-left-and-bottom-right-serifed"


### PR DESCRIPTION
This could also be added to #2146 because flat-top variants for this shape also exist.
However, as far as the current stylistic sets go, Envy Code R only uses this style.

After this I'm probably done adding variants for the time being. Anything else I can think of is either frivolous or outside of my current abilities.

```
ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ
abc.def.ghi.jkl.mno.pqrs.tuv.wxyz
!iIlL17|¦ ¢coO08BDQ $5SZ2zs ∂96µm
float il1[]={1-2/3.4,5+6=7/8%90};
1234567890 ,._-+= >< «¯-¬_» ~–÷+×
{*}[]()<>`+-=$/#_%^@\&|~?'" !,.;:
G6Qg9q¶ Þẞðþſß ΓΔΛαβγδιλμνξπτυφχψ
ЖЗКНРУЭЯавжзклмнруфчьыэя <= != ==
```

ss10 sans upright:
![image](https://github.com/user-attachments/assets/7ec82b35-e7ff-48e6-9819-44bf5439210e)
ss10 sans italic:
![image](https://github.com/user-attachments/assets/edd2cb9a-60e6-4fba-af73-d212cfe2f54f)
ss10 slab upright:
![image](https://github.com/user-attachments/assets/16598214-bf34-4287-8528-827437bce5db)
ss10 slab italic:
![image](https://github.com/user-attachments/assets/51863248-07e3-4a3b-8ae8-991c1006dc4b)
all `W` variants:
`W𝖶Ⱳ`
![image](https://github.com/user-attachments/assets/7ac291c8-05e1-4632-a9c9-6c549a1c45fb)
all `w` variants:
`w𝗐ⱳ`
![image](https://github.com/user-attachments/assets/e7d4e681-ae18-4bf9-8ca3-f83749df41a4)
