### PR TITLE
Make descending variants of `Q`/`J` use `MarkSet.capDesc` instead of `MarkSet.bp`.

### DIFF
--- a/packages/font-glyphs/src/letter/greek/phi.ptl
+++ b/packages/font-glyphs/src/letter/greek/phi.ptl
@@ -12,36 +12,36 @@ glyph-block Letter-Greek-Phi : begin
 	glyph-block-import Letter-Shared-Shapes : FlatHookDepth DiagTail OBarLeft OBarRight
 	glyph-block-import Letter-Latin-Lower-AE-OE : SubDfAndShift
 
-	define [VarPhiRing fFlatTB df y1 y2] : glyph-proc
+	define [VarPhiRing fFlatTB df y2 y3] : glyph-proc
 		local gap : Math.max df.mvs : 0.25 * (df.rightSB - df.leftSB)
-		include : VBar.m df.middle y1 y2 df.mvs
+		include : VBar.m df.middle y2 y3 df.mvs
 		include : if fFlatTB
-			OShapeFlatTB y2 y1 df.leftSB df.rightSB df.mvs (ArchDepthA * df.div) (ArchDepthB * df.div) gap
-			OShape y2 y1 df.leftSB df.rightSB df.mvs (ArchDepthA * df.div) (ArchDepthB * df.div)
+			OShapeFlatTB y3 y2 df.leftSB df.rightSB df.mvs (ArchDepthA * df.div) (ArchDepthB * df.div) gap
+			OShape y3 y2 df.leftSB df.rightSB df.mvs (ArchDepthA * df.div) (ArchDepthB * df.div)
 
-	define [CyrlEfSplitRing fFlatTB df y1 y2] : glyph-proc
+	define [CyrlEfSplitRing fFlatTB df y2 y3] : glyph-proc
 		local { subDf } : SubDfAndShift 0 df OX
 		local ada : subDf.archDepthA SmallArchDepth df.mvs
 		local adb : subDf.archDepthB SmallArchDepth df.mvs
 
-		include : VBar.m df.middle y1 y2 df.mvs
-		include : with-transform [ApparentTranslate 0 y1] : union
+		include : VBar.m df.middle y2 y3 df.mvs
+		include : with-transform [ApparentTranslate 0 y2] : union
 			OBarRight.shape
-				top       -- (y2 - y1)
+				top       -- (y3 - y2)
 				left      -- df.leftSB
 				right     -- df.middle + [HSwToV : 0.5 * df.mvs]
 				sw        -- df.mvs
 				ada       -- ada
 				adb       -- adb
 			OBarLeft.shape
-				top       -- (y2 - y1)
+				top       -- (y3 - y2)
 				left      -- df.middle - [HSwToV : 0.5 * df.mvs]
 				right     -- df.rightSB
 				sw        -- df.mvs
 				ada       -- ada
 				adb       -- adb
 
-	define [GrekLowerPhiCursiveRing fFlatTB df y1 y2] : glyph-proc
+	define [GrekLowerPhiCursiveRing fFlatTB df y2 y3] : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.e
 
@@ -49,21 +49,21 @@ glyph-block Letter-Greek-Phi : begin
 		local r : df.width - l
 		include : dispiro
 			widths.lhs df.mvs
-			g4 [mix df.leftSB df.rightSB 0.1] y2
-			g4 l [mix y1 y2 0.55]
-			arch.lhs y1 (sw -- df.mvs)
-			g4 r [mix y1 y2 0.55]
+			g4 [mix df.leftSB df.rightSB 0.1] y3
+			g4 l [mix y2 y3 0.55]
+			arch.lhs y2 (sw -- df.mvs)
+			g4 r [mix y2 y3 0.55]
 			arcvh 8
-			g4.left.mid [mix r (df.middle - [HSwToV : 0.5 * df.mvs]) 0.525] y2 [heading Leftward]
+			g4.left.mid [mix r (df.middle - [HSwToV : 0.5 * df.mvs]) 0.525] y3 [heading Leftward]
 			archv
-			flat (df.middle - [HSwToV : 0.5 * df.mvs]) [mix y1 y2 0.66]
-			curl (df.middle - [HSwToV : 0.5 * df.mvs]) (y1 + 0.2 * df.mvs) [heading Downward]
+			flat (df.middle - [HSwToV : 0.5 * df.mvs]) [mix y2 y3 0.66]
+			curl (df.middle - [HSwToV : 0.5 * df.mvs]) (y2 + 0.2 * df.mvs) [heading Downward]
 
-	define [StraightBar df bot y1 y2 top] : glyph-proc
-		include : VBar.m df.middle bot (y1 + HalfStroke)
-		include : VBar.m df.middle (y2 - HalfStroke) top
+	define [StraightBar df y1 y2 y3 y4] : glyph-proc
+		include : VBar.m df.middle y1 (y2 + HalfStroke)
+		include : VBar.m df.middle (y3 - HalfStroke) y4
 
-	define [CursiveBar df bot y1 y2 top] : glyph-proc
+	define [CursiveBar df y1 y2 y3 y4] : glyph-proc
 		local hd : FlatHookDepth df
 
 		local xCrossLeft  : mix 0         df.leftSB   [mix 1 df.div 2]
@@ -73,44 +73,44 @@ glyph-block Letter-Greek-Phi : begin
 		local xBarRight   : df.middle + [HSwToV HalfStroke]
 
 		include : dispiro
-			flat xCrossRight top [widths.lhs]
-			curl [Math.min (xBarLeft + hd.x) (xCrossRight - TINY)] top
+			flat xCrossRight y4 [widths.lhs]
+			curl [Math.min (xBarLeft + hd.x) (xCrossRight - TINY)] y4
 			archv
-			flat xBarLeft [Math.max y2 (top - hd.y)]
-			curl xBarLeft (y2 + O)
+			flat xBarLeft [Math.max y3 (y4 - hd.y)]
+			curl xBarLeft (y3 + O)
 
 		include : dispiro
-			flat xCrossLeft bot [widths.lhs]
-			curl [Math.max (xBarRight - hd.x) (xCrossLeft + TINY)] bot
+			flat xCrossLeft y1 [widths.lhs]
+			curl [Math.max (xBarRight - hd.x) (xCrossLeft + TINY)] y1
 			archv
-			flat xBarRight [Math.min y1 (bot + hd.y)]
-			curl xBarRight (y1 - O)
+			flat xBarRight [Math.min y2 (y1 + hd.y)]
+			curl xBarRight (y2 - O)
 
-	define [DiagonalTailCursiveBar df bot y1 y2 top] : glyph-proc
+	define [DiagonalTailCursiveBar df y1 y2 y3 y4] : glyph-proc
 		local hd : FlatHookDepth df
 
 		local xCrossRight : mix df.width  df.rightSB  [mix 1 df.div 2]
 		local xBarLeft    : df.middle - [HSwToV HalfStroke]
 
 		include : dispiro
-			flat xCrossRight top [widths.lhs]
-			curl [Math.min (xBarLeft + hd.x) (xCrossRight - TINY)] top
+			flat xCrossRight y4 [widths.lhs]
+			curl [Math.min (xBarLeft + hd.x) (xCrossRight - TINY)] y4
 			archv
-			flat xBarLeft [Math.max y2 (top - hd.y)]
-			curl xBarLeft (y2 + O)
+			flat xBarLeft [Math.max y3 (y4 - hd.y)]
+			curl xBarLeft (y3 + O)
 
 		include : dispiro
-			flat df.middle (y1 - O) [widths.center.heading Stroke Downward]
-			DiagTail.L df.middle bot [DiagTail.StdDepth df Stroke] Stroke
+			flat df.middle (y2 - O) [widths.center.heading Stroke Downward]
+			DiagTail.L df.middle y1 [DiagTail.StdDepth df Stroke] Stroke
 
 	define [MtSerif df y] : tagged 'serifMT' : HSerif.lt df.middle y Jut
 	define [MbSerif df y] : tagged 'serifMB' : HSerif.mb df.middle y Jut
 
 	define [GrekCapitalPhiImpl fFlatTB df] : glyph-proc
-		local y1 : mix [if SLAB Stroke 0] [if SLAB (CAP - Stroke) CAP] 0.125
-		local y2 : mix [if SLAB Stroke 0] [if SLAB (CAP - Stroke) CAP] 0.875
-		include : VarPhiRing fFlatTB df y1 y2
-		include : StraightBar df 0 y1 y2 CAP
+		local y2 : mix [if SLAB Stroke 0] [if SLAB (CAP - Stroke) CAP] 0.125
+		local y3 : mix [if SLAB Stroke 0] [if SLAB (CAP - Stroke) CAP] 0.875
+		include : VarPhiRing fFlatTB df y2 y3
+		include : StraightBar df 0 y2 y3 CAP
 
 		if SLAB : begin
 			include : tagged 'serifMT' : HSerif.mt df.middle CAP MidJutSide

--- a/packages/font-glyphs/src/letter/greek/psi.ptl
+++ b/packages/font-glyphs/src/letter/greek/psi.ptl
@@ -41,18 +41,18 @@ glyph-block Letter-Greek-Psi : begin
 		include : PsiBaseShape df 0 (XH * 0.3) XH XH SLAB false SLAB SLAB
 
 	define GrekLowerPsiConfig : SuffixCfg.weave
-		object # yBar
+		object # top
 			""                  Ascender
 			flatTop             XH
 		object # slab
 			serifless           false
 			serifed             true
 
-	foreach { suffix { yBar slab } } [Object.entries GrekLowerPsiConfig] : do
+	foreach { suffix { top slab } } [Object.entries GrekLowerPsiConfig] : do
 		create-glyph "grek/psi.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 3
-			include : if (yBar > XH) [df.markSet.bp] [df.markSet.p]
-			include : PsiBaseShape df Descender 0 XH yBar false false slab false
+			include : df.markSet.[if (top > XH) 'bp' 'p']
+			include : PsiBaseShape df Descender 0 XH top false false slab false
 
 	select-variant 'grek/psi' 0x3C8
 	link-reduced-variant 'grek/psi/sansSerif' 'grek/psi' MathSansSerif

--- a/packages/font-glyphs/src/letter/latin/upper-j.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-j.ptl
@@ -52,7 +52,7 @@ glyph-block Letter-Latin-Upper-J : begin
 
 	define [JDescendingBase df dfHook top] : glyph-proc
 		set-width df.width
-		include : df.markSet.[if (top > XH) 'bp' 'p']
+		include : df.markSet.[if (top > XH) 'capDesc' 'p']
 
 		local center : df.middle + JBalance + [HSwToV HalfStroke]
 		set-base-anchor 'above' (center - [HSwToV HalfStroke]) top
@@ -69,7 +69,7 @@ glyph-block Letter-Latin-Upper-J : begin
 			g4 hookx (Descender + JHook)
 
 	set JFullHookBase.WithCurlyTail   : function [df top] : JCurlyTailBaseT df (df.rightSB - [HSwToV HalfStroke] - JBalance2) (df.leftSB)                    top 0         'capital'
-	set JDescendingBase.WithCurlyTail : function [df top] : JCurlyTailBaseT df (df.middle + JBalance) (df.middle + JBalance - LongJut - [HSwToV HalfStroke]) top Descender 'bp'
+	set JDescendingBase.WithCurlyTail : function [df top] : JCurlyTailBaseT df (df.middle + JBalance) (df.middle + JBalance - LongJut - [HSwToV HalfStroke]) top Descender 'capDesc'
 	define [JCurlyTailBaseT df xc xCo top bottom markClass] : glyph-proc
 		set-width df.width
 		include : df.markSet.(markClass)
@@ -91,7 +91,7 @@ glyph-block Letter-Latin-Upper-J : begin
 
 	define [JDescendingFlatHookBase df dfHook top] : glyph-proc
 		set-width df.width
-		include : df.markSet.[if (top > XH) 'bp' 'p']
+		include : df.markSet.[if (top > XH) 'capDesc' 'p']
 		include : FlatHookDotlessJShape df dfHook top
 			crossLeft -- (df.middle - (dfHook.middle - [mix 0 dfHook.leftSB : mix 1 dfHook.div 2]))
 			barCenter -- (df.middle + 0.25 * JBalance * df.div * [mix 1 df.div 2])
@@ -99,7 +99,7 @@ glyph-block Letter-Latin-Upper-J : begin
 
 	define [JDescendingFlatHookSerifedBase df dfHook top] : glyph-proc
 		set-width df.width
-		include : df.markSet.[if (top > XH) 'bp' 'p']
+		include : df.markSet.[if (top > XH) 'capDesc' 'p']
 		include : FlatHookDotlessJShape df df top
 			crossLeft -- [mix 0 SB : mix 1 df.div 2]
 			barCenter -- (df.middle + JBalance * df.div)

--- a/packages/font-glyphs/src/letter/latin/upper-q.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-q.ptl
@@ -153,16 +153,16 @@ glyph-block Letter-Latin-Upper-Q : begin
 
 	define QInnerVertSw : Math.min [AdviceStroke 3.5] ((RightSB - SB - [HSwToV : 2 * Stroke]) / (2 * HVContrast))
 	define QConfig : object
-		straight            { QStdBody                Stroke             QStaraightTail     'bp'      'p' }
-		curlyTailed         { QStdBody                Stroke             QCurlyTail         'bp'      'p' }
-		crossingCurlyTailed { QStdBody                QInnerVertSw       QCrossingCurlyTail 'bp'      'p' }
+		straight            { QStdBody                Stroke             QStaraightTail     'capDesc' 'p' }
+		curlyTailed         { QStdBody                Stroke             QCurlyTail         'capDesc' 'p' }
+		crossingCurlyTailed { QStdBody                QInnerVertSw       QCrossingCurlyTail 'capDesc' 'p' }
 		crossing            { QStdBody               [AdviceStroke 4]    QCrossing          'capital' 'e' }
 		crossingBaseline    { QStdBody               [AdviceStroke 4]    QCrossingBaseline  'capital' 'e' }
-		verticalCrossing    { QStdBody                QInnerVertSw       QVerticalCrossing  'bp'      'p' }
+		verticalCrossing    { QStdBody                QInnerVertSw       QVerticalCrossing  'capDesc' 'p' }
 		horizontalTailed    { QHorizontalTailedBody  [AdviceStroke 3]    QHorizontalTail    'capital' 'e' }
-		detachedTailed      { QStdBody                Stroke             QDetachedTail      'bp'      'p' }
-		detachedBendTailed  { QStdBody                Stroke             QDetachedBendTail  'bp'      'p' }
-		openSwash           { QOpenSwashyBody         Stroke             QSwashyTail        'bp'      'p' }
+		detachedTailed      { QStdBody                Stroke             QDetachedTail      'capDesc' 'p' }
+		detachedBendTailed  { QStdBody                Stroke             QDetachedBendTail  'capDesc' 'p' }
+		openSwash           { QOpenSwashyBody         Stroke             QSwashyTail        'capDesc' 'p' }
 
 
 	foreach { suffix { body swTailInner tailShape mkCapital mkSmcp } } [Object.entries QConfig] : do

--- a/params/parameters.toml
+++ b/params/parameters.toml
@@ -15,7 +15,7 @@ descenderPad = 0   # Additional line height, added to descender.
 cap = 735          # Cap height.
 ascender = 735     # Ascender height.
 xHeight = 520      # X-height.
-#descender = -205  # Depth of descender. Currently unused.
+#descender = -215  # Depth of descender. Currently unused.
 winMetricAscenderPad  = 0 # Padding of Win ascnder metrics to avoid clipping. See #343
 winMetricDescenderPad = 0 # Padding of Win descender metrics to avoid clipping. See #343
 


### PR DESCRIPTION
This improves the use of metric overrides to disunify the heights of `cap` vs. `ascender` without making the MarkSet of `Q`/`J` no longer line up with its actual height.