### PR TITLE
Subtly optimize jut length of middle serif of `E`/`F`.

### DIFF
--- a/packages/font-glyphs/src/letter/latin-ext/upper-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/upper-ae-oe.ptl
@@ -110,7 +110,7 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 
 		local xMidRight : df.rightSB - sw / 4
 		local yBar : top * eBarPos
-		local { jutTop jutBot } : EFVJutLength top eBarPos sw
+		local { jutTop jutBot jutMid } : EFVJutLength top eBarPos sw
 
 		# E half
 		include : VBar.l eleft 0 top sw
@@ -125,7 +125,7 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 		match slabKind
 			[Just SLAB-E-CAPPED] : begin
 				local fine : swVJut * [AdviceStroke 3.5] / Stroke
-				include : VBar.r xMidRight (yBar - 0.5 * jutBot) (yBar + 0.5 * jutBot) fine
+				include : VBar.r xMidRight (yBar - jutMid) (yBar + jutMid) fine
 
 	do "P/Ya Half"
 		glyph-block-import Letter-Latin-Upper-P : PShape PBarPosY

--- a/packages/font-glyphs/src/letter/latin-ext/upper-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/upper-ae-oe.ptl
@@ -208,7 +208,7 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 
 		local xMidRight : df.rightSB - sw / 4
 		local yBar : top * eBarPos
-		local { jutTop jutBot } : EFVJutLength top eBarPos sw
+		local { jutTop jutBot jutMid } : EFVJutLength top eBarPos sw
 
 		# O half
 		include : dispiro
@@ -233,7 +233,7 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 		match slabKind
 			[Just SLAB-E-CAPPED] : begin
 				local fine : swVJut * [AdviceStroke 3.5] / Stroke
-				include : VBar.r xMidRight (yBar - 0.5 * jutBot) (yBar + 0.5 * jutBot) fine
+				include : VBar.r xMidRight (yBar - jutMid) (yBar + jutMid) fine
 
 	foreach { suffix { slabKind } } [Object.entries EConfig] : do
 		create-glyph "OE.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/upper-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-e.ptl
@@ -19,7 +19,7 @@ glyph-block Letter-Latin-Upper-E : begin
 	define [EShape] : with-params [top pyBar serifLT serifLB serifV serifM [stroke : AdviceStroke2 2 3 top]] : glyph-proc
 		local xMidRight : RightSB - [xMidBarShrink serifV]
 		local yBar : yMidBar top pyBar
-		local { jutTop jutBot } : EFVJutLength top pyBar stroke
+		local { jutTop jutBot jutMid } : EFVJutLength top pyBar stroke
 
 		include : VBar.l (xEBarLeft) 0 top stroke
 		include : HBar.t (xEBarLeft - O) RightSB top stroke
@@ -33,7 +33,7 @@ glyph-block Letter-Latin-Upper-E : begin
 			include : VSerif.ur RightSB 0 jutBot
 		if serifM : begin
 			local fine : stroke * [AdviceStroke 3.5] / Stroke
-			include : VBar.r xMidRight (yBar - 0.5 * jutBot) (yBar + 0.5 * jutBot) fine
+			include : VBar.r xMidRight (yBar - jutMid) (yBar + jutMid) fine
 
 	glyph-block-export RevEShape
 	define [RevEShape] : with-params [top pyBar serifRT serifRB serifV serifM [stroke : AdviceStroke2 2 3 top]] : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/upper-f.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-f.ptl
@@ -23,7 +23,8 @@ glyph-block Letter-Latin-Upper-F : begin
 			top - [mix (top - stroke) ([yMidBar top pyBar] + stroke / 2) 0.5]
 		local jutBot : Math.min VJut
 			mix stroke ([yMidBar top pyBar] - stroke / 2) 0.5
-		return { jutTop jutBot }
+		local jutMid : 0.5 * [Math.min jutTop jutBot]
+		return { jutTop jutBot jutMid }
 
 	define xFBarLeft : SB * 1.5
 	define xFBarRight : Width - SB * 1.5
@@ -31,7 +32,7 @@ glyph-block Letter-Latin-Upper-F : begin
 	define [FShape] : with-params [top pyBar serifLT serifLB serifV serifM [stroke : AdviceStroke2 2 3 top]] : glyph-proc
 		local xMidRight : RightSB - [xMidBarShrink serifV]
 		local yBar : yMidBar top pyBar
-		local { jutTop jutBot } : EFVJutLength top pyBar stroke
+		local { jutTop jutBot jutMid } : EFVJutLength top pyBar stroke
 
 		include : VBar.l (xFBarLeft) 0 top stroke
 		include : HBar.t (xFBarLeft - O) RightSB top stroke
@@ -44,7 +45,7 @@ glyph-block Letter-Latin-Upper-F : begin
 		if serifV : include : VSerif.dr RightSB top jutTop
 		if serifM : begin
 			local fine : stroke * [AdviceStroke 3.5] / Stroke
-			include : VBar.r xMidRight (yBar - 0.5 * jutBot) (yBar + 0.5 * jutBot) fine
+			include : VBar.r xMidRight (yBar - jutMid) (yBar + jutMid) fine
 
 	define FConfig : object
 		serifless      { false false false false }


### PR DESCRIPTION
Using minimum length between top jut and bottom jut, ensuring there is always enough room for it.
This mainly affects small capital letters.
Autohinting also seems to like this configuration more.

All `E` variants:
`E𝖤ƎÆŒԘᴇᴁɶ℡`
Thin:
![image](https://github.com/user-attachments/assets/20c5c990-c085-479a-bd56-d6e080c51aef)
Regular:
![image](https://github.com/user-attachments/assets/8da8f122-6173-4427-8d55-de79c0a937f8)
Heavy:
![image](https://github.com/user-attachments/assets/b9dd9dda-e781-4191-8eda-5cd6042c7cf7)
All `F` variants:
`F𝖥Ƒ₣ꜰ℻`
Thin:
![image](https://github.com/user-attachments/assets/2c5cd8e4-90aa-4b43-95cd-f51f0dba7487)
Regular:
![image](https://github.com/user-attachments/assets/b47899b0-2337-4882-b909-fc0e3f132232)
Heavy:
![image](https://github.com/user-attachments/assets/ff5690e6-5142-456d-87de-fd4c0dbeb1a5)
