### PR TITLE
Further optimize jut length of middle serif of `E`/`F`.

### DIFF
--- a/packages/font-glyphs/src/letter/latin/upper-f.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-f.ptl
@@ -14,8 +14,11 @@ glyph-block Letter-Latin-Upper-F : begin
 
 	glyph-block-export xMidBarShrink
 	define [xMidBarShrink serifV] : [Math.max HalfStroke ((RightSB - SB) * 0.15)] + [if serifV (Stroke * 0.25) 0]
+
+	define [yMidBarImpl y] : fallback y DesignParameters.upperEBarPos
+
 	glyph-block-export yMidBar
-	define [yMidBar top y] : top * [fallback y DesignParameters.upperEBarPos]
+	define [yMidBar top y] : top * [yMidBarImpl y]
 
 	glyph-block-export EFVJutLength
 	define [EFVJutLength top pyBar stroke] : begin
@@ -23,7 +26,7 @@ glyph-block Letter-Latin-Upper-F : begin
 			top - [mix (top - stroke) ([yMidBar top pyBar] + stroke / 2) 0.5]
 		local jutBot : Math.min VJut
 			mix stroke ([yMidBar top pyBar] - stroke / 2) 0.5
-		local jutMid : 0.5 * [Math.min jutTop jutBot]
+		local jutMid : 0.5 * [mix jutBot jutTop : yMidBarImpl pyBar]
 		return { jutTop jutBot jutMid }
 
 	define xFBarLeft : SB * 1.5


### PR DESCRIPTION
Polishing-up of #2480 .
Blends between the jut lengths of the top and bottom serifs based on the bar position; The bias is always towards the shorter one.

This is even finer of a tweak than before and so the difference is only visible on extreme weights and/or optical sizes, but suffice to say the autohinting tends to like this configuration _even more_.

The examples below are slightly more zoomed in than they were in #2480 .

All `E` variants:
`E𝖤ƎÆŒԘᴇᴁɶ℡`
Thin:
![image](https://github.com/user-attachments/assets/65054f3b-88bd-4443-9cdf-796f9266e2c7)
Regular:
![image](https://github.com/user-attachments/assets/cd5ecebf-d2b8-4cb1-b0e1-02ab0c1bdb4c)
Heavy:
![image](https://github.com/user-attachments/assets/c759e1e4-d16c-485c-a1c7-42e8d84f8f39)
All `F` variants:
`F𝖥Ƒ₣ꜰ℻`
Thin:
![image](https://github.com/user-attachments/assets/a8ee7baf-8c16-41cb-ae35-a8cd888483ca)
Regular:
![image](https://github.com/user-attachments/assets/61241435-9ba7-447b-8a5d-7ca90340ea2d)
Heavy:
![image](https://github.com/user-attachments/assets/a2f21c51-339c-4fd1-81c1-d0b7bd363cdb)
