### PR TITLE
Add localized forms for Bashkir and Chuvash.

### DIFF
--- a/changes/31.4.1.md
+++ b/changes/31.4.1.md
@@ -2,3 +2,4 @@
   - KAYAH LI SIGN CWI (`U+A92E`).
   - ZERO WIDTH NON-BREAKING SPACE (`U+FEFF`).
 * Add APL form (`APLF`) for `U+25E0` and `U+25E1`, for UIUA.
+* Add Cyrillic localization forms for Bashkir and Chuvash.

--- a/packages/font-glyphs/src/letter/cyrillic/orthography.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/orthography.ptl
@@ -82,3 +82,19 @@ glyph-block Letter-Cyrillic-Orthography : begin
 	link-gr LocalizedForm.BGR         'cyrl/tse'           'cyrl/tse.BGR'
 	link-gr LocalizedForm.BGR         'cyrl/yer'           'cyrl/yer.BGR'
 	link-gr LocalizedForm.BGR         'cyrl/yeri'          'cyrl/yeri.BGR'
+
+	link-gr LocalizedForm.BSH.Upright 'cyrl/Ghayn'         'cyrl/Ghayn.BSH'
+	link-gr LocalizedForm.BSH.Upright 'cyrl/ghayn'         'cyrl/ghayn.BSH'
+	link-gr LocalizedForm.BSH.Upright 'cyrl/Dhe'           'cyrl/Dhe.BSH'
+	link-gr LocalizedForm.BSH.Upright 'cyrl/dhe'           'cyrl/dhe.BSH'
+	link-gr LocalizedForm.BSH.Upright 'cyrl/The'           'cyrl/The.BSH'
+	link-gr LocalizedForm.BSH.Upright 'cyrl/the'           'cyrl/the.BSH'
+
+	link-gr LocalizedForm.BSH.Italic  'cyrl/Ghayn'         'cyrl/Ghayn.BSH'
+	link-gr LocalizedForm.BSH.Italic  'cyrl/Dhe'           'cyrl/Dhe.BSH'
+	link-gr LocalizedForm.BSH.Italic  'cyrl/dhe'           'cyrl/dhe.BSH'
+	link-gr LocalizedForm.BSH.Italic  'cyrl/The'           'cyrl/The.BSH'
+	link-gr LocalizedForm.BSH.Italic  'cyrl/the'           'cyrl/the.BSH'
+
+	link-gr LocalizedForm.CHU         'cyrl/The'           'cyrl/The.CHU'
+	link-gr LocalizedForm.CHU         'cyrl/the'           'cyrl/the.CHU'

--- a/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
@@ -101,7 +101,7 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 	glyph-block-export CyrZe
 	define [CyrZe] : with-params [
 		slabTop slabBot top bot left right blend hook _stroke
-		[xo OX] [op OverlayPos] [ada2 SmallArchDepthA] [adb2 SmallArchDepthB]
+		[xo OX] [yo O] [op OverlayPos] [ada2 SmallArchDepthA] [adb2 SmallArchDepthB]
 		] : namespace
 		export : define [Dim] : begin
 			local stroke : fallback _stroke : AdviceStroke2 2 3 (top - bot)
@@ -109,8 +109,8 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 			local midy : mix bot top op
 			local topHeight : top - bot
 			local midyHeight : midy - bot
-			local adb : topHeight - [mix (midyHeight + stroke / 2) (topHeight - O - stroke) (ArchDepthA / (ArchDepthA + ArchDepthB))] + [HSwToV TanSlope] * stroke
-			local ada : [mix (stroke + O) (midyHeight - stroke / 2) (ArchDepthA / (ArchDepthA + ArchDepthB))] - [HSwToV TanSlope] * stroke
+			local adb : topHeight - [mix (midyHeight + stroke / 2) (topHeight - yo - stroke) (ArchDepthA / (ArchDepthA + ArchDepthB))] + [HSwToV TanSlope] * stroke
+			local ada : [mix (stroke + yo) (midyHeight - stroke / 2) (ArchDepthA / (ArchDepthA + ArchDepthB))] - [HSwToV TanSlope] * stroke
 			local fine : stroke * CThin
 			local stemFine : stroke * (ShoulderFine / Stroke)
 			return : object stroke midx midy ada adb fine stemFine
@@ -241,6 +241,22 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 			include : MarkSet.p
 			include : let [ze : CyrZe slabTop slabBot XH Descender SB RightSB StdBlend SHook]
 				union [ze.Shape] [ze.AutoStartSerifL] [ze.AutoEndSerifL]
+
+		create-glyph "cyrl/Dhe.\(suffix)" : glyph-proc
+			include [refer-glyph "cyrl/Ze.\(suffix)"] AS_BASE ALSO_METRICS
+			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
+			include : let [zeNoO : CyrZe slabTop slabBot CAP 0 SB RightSB StdBlend Hook (xo -- 0) (yo -- 0)]
+				difference
+					VBar.m Middle (-LongJut + 0.5 * Stroke) (Stroke + O) [AdviceStroke 3.5]
+					zeNoO.ShapeMask
+
+		create-glyph "cyrl/dhe.\(suffix)" : glyph-proc
+			include [refer-glyph "cyrl/ze.\(suffix)"] AS_BASE ALSO_METRICS
+			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
+			include : let [zeNoO : CyrZe slabTop slabBot XH 0 SB RightSB StdBlend SHook (xo -- 0) (yo -- 0)]
+				difference
+					VBar.m Middle (-LongJut + 0.5 * Stroke) (Stroke + O) [AdviceStroke 3.5]
+					zeNoO.ShapeMask
 
 		create-glyph "cyrl/DzjeKomi.\(suffix)" : glyph-proc
 			include : MarkSet.capital
@@ -482,8 +498,22 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 	select-variant 'cyrl/DzjeKomi' 0x506 (follow -- 'cyrl/ZeTopSerifOnly')
 	select-variant 'cyrl/dzjeKomi' 0x507 (follow -- 'cyrl/zeTopSerifOnly')
 
-	derive-composites 'cyrl/Dhe' 0x498 'cyrl/Ze' 'cedillaExtShapeBelowOArc'
-	derive-composites 'cyrl/dhe' 0x499 'cyrl/ze' 'cedillaExtShapeBelowSOArc'
+	select-variant 'cyrl/Dhe' 0x498 (follow -- 'cyrl/Ze')
+	select-variant 'cyrl/dhe' 0x499 (follow -- 'cyrl/ze')
+
+	derive-multi-part-glyphs 'cyrl/Dhe.BSH' null { 'cyrl/Ze' 'invCommaBelow' } : lambda [srcs gr] : glyph-proc
+		local { base mark } srcs
+		include : refer-glyph mark
+		include : Translate Width AccentClearance
+		include [refer-glyph base] AS_BASE ALSO_METRICS
+		include : ExtendBelowBaseAnchors (-AccentHeight)
+
+	derive-multi-part-glyphs 'cyrl/dhe.BSH' null { 'cyrl/ze' 'invCommaBelow' } : lambda [srcs gr] : glyph-proc
+		local { base mark } srcs
+		include : refer-glyph mark
+		include : Translate Width AccentClearance
+		include [refer-glyph base] AS_BASE ALSO_METRICS
+		include : ExtendBelowBaseAnchors (-AccentHeight)
 
 	select-variant 'latn/epsilon/descBase' (shapeFrom -- 'latn/epsilon')
 	select-variant 'latn/epsilonRev/descBase' (shapeFrom -- 'cyrl/ze') (follow -- 'cyrl/ze/descBase')

--- a/packages/font-glyphs/src/letter/latin/c.ptl
+++ b/packages/font-glyphs/src/letter/latin/c.ptl
@@ -354,8 +354,38 @@ glyph-block Letter-Latin-C : begin
 
 	derive-composites 'CCedilla' 0xC7 'C' 'cedillaExtShapeBelowOArc'
 	derive-composites 'cCedilla' 0xE7 'c' 'cedillaExtShapeBelowOArc'
-	derive-composites 'cyrl/The' 0x4AA 'cyrl/Es' 'cedillaExtShapeBelowOArc'
-	derive-composites 'cyrl/the' 0x4AB 'cyrl/es' 'cedillaExtShapeBelowOArc'
+
+	derive-glyphs 'cyrl/The' 0x4AA "cyrl/Es" : function [src gr] : glyph-proc
+		include [refer-glyph src] AS_BASE ALSO_METRICS
+		include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
+		include : difference
+			VBar.m Middle (-LongJut + 0.5 * Stroke) (Stroke + O) [AdviceStroke 3.5]
+			OShapeOutline.NoOvershoot CAP 0 SB RightSB Stroke ArchDepthA ArchDepthB
+
+	derive-multi-part-glyphs 'cyrl/The.BSH' null { 'cyrl/Es' 'invCommaBelow' } : lambda [srcs gr] : glyph-proc
+		local { base mark } srcs
+		include : refer-glyph mark
+		include : Translate Width AccentClearance
+		include [refer-glyph base] AS_BASE ALSO_METRICS
+		include : ExtendBelowBaseAnchors (-AccentHeight)
+
+	derive-composites 'cyrl/The.CHU' null 'cyrl/Es' 'cedillaExtShapeBelowOArc'
+
+	derive-glyphs 'cyrl/the' 0x4AB "cyrl/es" : function [src gr] : glyph-proc
+		include [refer-glyph src] AS_BASE ALSO_METRICS
+		include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
+		include : difference
+			VBar.m Middle (-LongJut + 0.5 * Stroke) (Stroke + O) [AdviceStroke 3.5]
+			OShapeOutline.NoOvershoot XH 0 SB RightSB Stroke SmallArchDepthA SmallArchDepthB
+
+	derive-multi-part-glyphs 'cyrl/the.BSH' null { 'cyrl/es' 'invCommaBelow' } : lambda [srcs gr] : glyph-proc
+		local { base mark } srcs
+		include : refer-glyph mark
+		include : Translate Width AccentClearance
+		include [refer-glyph base] AS_BASE ALSO_METRICS
+		include : ExtendBelowBaseAnchors (-AccentHeight)
+
+	derive-composites 'cyrl/the.CHU' null 'cyrl/es' 'cedillaExtShapeBelowOArc'
 
 	create-glyph 'mathbb/C' 0x2102 : glyph-proc
 		include : MarkSet.capital

--- a/packages/font-glyphs/src/letter/latin/upper-f.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-f.ptl
@@ -96,6 +96,9 @@ glyph-block Letter-Latin-Upper-F : begin
 	select-variant 'FBar' 0xA798 (follow -- 'F')
 	select-variant 'currency/frenchFrancSign' 0x20A3
 
+	alias 'cyrl/Ghayn.BSH' null 'F'
+	alias 'cyrl/ghayn.BSH' null 'smcpF'
+
 	glyph-block-import Letter-Blackboard : BBS BBD
 	create-glyph 'mathbb/F' 0x1D53D : glyph-proc
 		include : MarkSet.capital

--- a/packages/font-glyphs/src/marks/below.ptl
+++ b/packages/font-glyphs/src/marks/below.ptl
@@ -211,6 +211,7 @@ glyph-block Mark-Below : begin
 	TurnAboveMarkToBelow 'elipsisBelow'            0x20E8 'elipsisAbove'
 	TurnAboveMarkToBelow 'leftArrowBelow'          0x20EE 'rightArrowAbove'
 	TurnAboveMarkToBelow 'rightArrowBelow'         0x20EF 'leftArrowAbove'
+	TurnAboveMarkToBelow 'invCommaBelow'           null   'revCommaAbove'
 	TurnAboveMarkToBelow 'upArrowHeadBelow'        null   'downArrowHeadAbove'
 	TurnAboveMarkToBelow 'downArrowHeadBelow'      null   'upArrowHeadAbove'
 	TurnAboveMarkToBelow 'descenderBarBelow'       null   'ascenderBarAbove'

--- a/packages/font-otl/src/gsub-locl.ptl
+++ b/packages/font-otl/src/gsub-locl.ptl
@@ -14,6 +14,8 @@ export : define [buildLOCL gsub para glyphStore] : begin
 	define cyrlMKD  : gsub.copyLanguage 'cyrl_MKD ' 'cyrl_DFLT'
 	define cyrlBOS  : gsub.copyLanguage 'cyrl_BOS ' 'cyrl_DFLT'
 	define cyrlBGR  : gsub.copyLanguage 'cyrl_BGR ' 'cyrl_DFLT'
+	define cyrlBSH  : gsub.copyLanguage 'cyrl_BSH ' 'cyrl_DFLT'
+	define cyrlCHU  : gsub.copyLanguage 'cyrl_CHU ' 'cyrl_DFLT'
 	define latnTRK  : gsub.copyLanguage 'latn_TRK ' 'latn_DFLT'
 	define latnAZE  : gsub.copyLanguage 'latn_AZE ' 'latn_DFLT'
 	define latnGAG  : gsub.copyLanguage 'latn_GAG ' 'latn_DFLT'
@@ -35,6 +37,15 @@ export : define [buildLOCL gsub para glyphStore] : begin
 	# BGR
 	define loclBGR : cyrlBGR.addFeature : gsub.createFeature 'locl'
 	loclBGR.addLookup : createGsubLookupFromGr gsub glyphStore LocalizedForm.BGR
+
+	# BSH
+	define loclBSH : cyrlBSH.addFeature : gsub.createFeature 'locl'
+	loclBSH.addLookup : createGsubLookupFromGr gsub glyphStore
+		if [not para.isItalic] LocalizedForm.BSH.Upright LocalizedForm.BSH.Italic
+
+	# CHU
+	define loclCHU : cyrlCHU.addFeature : gsub.createFeature 'locl'
+	loclCHU.addLookup : createGsubLookupFromGr gsub glyphStore LocalizedForm.CHU
 
 	# TRK
 	define loclTRK : gsub.createFeature 'locl'

--- a/packages/glyph/src/relation.mjs
+++ b/packages/glyph/src/relation.mjs
@@ -30,6 +30,11 @@ export const LocalizedForm = {
 		Italic: LinkedGlyphProp("SerbianLocItalic"),
 	},
 	BGR: LinkedGlyphProp("BulgarianLoc"),
+	BSH: {
+		Upright: LinkedGlyphProp("BashkirLocUpright"),
+		Italic: LinkedGlyphProp("BashkirLocItalic"),
+	},
+	CHU: LinkedGlyphProp("ChuvashLoc"),
 	IPPH: LinkedGlyphProp("IPALoc"),
 };
 
@@ -184,6 +189,9 @@ export const AnyLocalizedForm = {
 		if (LocalizedForm.SRB.Upright.get(glyph)) grs.push(LocalizedForm.SRB.Upright);
 		if (LocalizedForm.SRB.Italic.get(glyph)) grs.push(LocalizedForm.SRB.Italic);
 		if (LocalizedForm.BGR.get(glyph)) grs.push(LocalizedForm.BGR);
+		if (LocalizedForm.BSH.Upright.get(glyph)) grs.push(LocalizedForm.BSH.Upright);
+		if (LocalizedForm.BSH.Italic.get(glyph)) grs.push(LocalizedForm.BSH.Italic);
+		if (LocalizedForm.CHU.get(glyph)) grs.push(LocalizedForm.CHU);
 		if (LocalizedForm.IPPH.get(glyph)) grs.push(LocalizedForm.IPPH);
 		if (grs.length) return grs;
 		return null;


### PR DESCRIPTION
Bashkir sample:
```
Аслыҡ һәм күсенеү

¹ Исраилда хакимдар идара иткән осорҙа илдә йот башланды. Шул арҡала
Йәһүҙә биләмәһендәге Бейт-Ләхәм тигән ҡаланан бер кеше ҡатыны һәм ике улы
менән Моав еренә күсенде. ² Был кешенең исеме – Әлимәләх, ҡатыныныҡы –
Ноғоми, ә улдарыныҡы Махлон менән Килйон ине. Йәһүҙә биләмәһендәге Бейт-
Ләхәм ҡалаһынан, Әфраҫ ерҙәренән булған был ғаилә Моав иленә күсеп килеп,
шунда төйәкләнде. ³ Ноғомиҙың ире Әлимәләх ошонда вафат булды, ҡатын улдары
менән генә ҡалды. ⁴ Ике улы ла моав ҡыҙҙарына өйләнде: уларҙың береһенең исеме
– Ғорпа, икенсеһенеке Рут ине. Ун йыл самаһы унда йәшәгәс, ⁵ Махлон менән
Килйон да үлеп китте. Ноғоми ике улынан да, иренән дә мәхрүм ҡалды.
```
Using [this site](https://localfonts.eu/typography-basics/fonts-the-importance-of-localisation/local-features/bashkir-cyrillic-feature-locl/) as a reference:

![Local_Fonts_05-1](https://github.com/user-attachments/assets/05e9c831-e49b-4b6a-b6f0-d2874f33c96b)

Unlocalized for comparison:
<details>
  <summary>Expand (10 images)</summary>

Upright:
![image](https://github.com/user-attachments/assets/4977a7ba-34a5-461d-9338-07bec41472b9)
Italic:
![image](https://github.com/user-attachments/assets/8e3e06f0-4c32-4520-8d8f-2837b25aac4a)
Compared to PT Serif:
Upright:
![image](https://github.com/user-attachments/assets/cf5a43e5-6829-4183-9b1d-457c870c9460)
Italic:
![image](https://github.com/user-attachments/assets/0d3c81a3-b52d-4dc5-9cde-c86d419bd7b3)
Compared to Vollkorn:
Upright:
![image](https://github.com/user-attachments/assets/1b53e363-3469-4b03-b2d2-a913bb7d00b7)
Italic:
![image](https://github.com/user-attachments/assets/5e43180e-5b4f-4aef-9cc2-feb7d76c7ff0)
Compared to Merriweather:
Upright:
![image](https://github.com/user-attachments/assets/0c18d343-624b-452e-a6d8-8eadf931d5c1)
Italic:
![image](https://github.com/user-attachments/assets/1f4b4d1f-75a4-45f5-8081-7d3307f27ce6)
Compared to Piazzolla:
Upright:
![image](https://github.com/user-attachments/assets/0baaacbc-ef04-4f2c-9463-c092c4475ad1)
Italic:
![image](https://github.com/user-attachments/assets/997b923b-f25a-45bc-963d-d9f5e4508169)
Compared to Lora:
Upright:
![image](https://github.com/user-attachments/assets/5aa23e93-adf7-4e95-98af-a83357e62b8e)
Italic:
![image](https://github.com/user-attachments/assets/cb56dc2e-7e15-4462-af7c-605a9c2abe60)

</details>

Localized under `lang="ba"`:
<details>
  <summary>Expand (10 images)</summary>

Upright:
![image](https://github.com/user-attachments/assets/5be435fe-986c-437b-8719-3d456f71a66f)
Italic:
![image](https://github.com/user-attachments/assets/2d779e6a-6141-4c96-b850-d11d773aa0ce)
Compared to PT Serif:
Upright:
![image](https://github.com/user-attachments/assets/76e29072-74d9-4b6b-8183-8db0a0fb7ecc)
Italic:
![image](https://github.com/user-attachments/assets/d2261c8f-17f3-40cf-87a0-64b9768ccb15)
Compared to Vollkorn:
Upright:
![image](https://github.com/user-attachments/assets/434a2deb-c42d-4e2c-aedd-44368438a0fc)
Italic:
![image](https://github.com/user-attachments/assets/472db2f0-7601-4d5f-a630-3342678bd961)
Compared to Merriweather:
Upright:
![image](https://github.com/user-attachments/assets/ab66ee82-000b-4d02-a466-722c694ac5b1)
Italic:
![image](https://github.com/user-attachments/assets/6cedb80e-ece0-403b-8f8a-534a130b7cc7)
Compared to Piazzolla:
Upright:
![image](https://github.com/user-attachments/assets/2382302e-f892-439d-8101-59807973369d)
Italic:
![image](https://github.com/user-attachments/assets/708f21f7-d7c0-47f9-a443-3e4bd87ede34)
Compared to Lora:
Upright:
![image](https://github.com/user-attachments/assets/3629357c-0b81-4421-8d7e-97997ac17072)
Italic:
![image](https://github.com/user-attachments/assets/eb65c10d-aafe-452b-b955-3782c39015c6)

</details>

Chuvash Sample:

```
Хӗвелӗн икӗ арӑм: Ирхи Шуҫӑмпа Каҫхи Шуҫӑм.
Ир пулсан Хӗвел Ирхи Шуҫӑмран уйрӑлса каять
те яра кун тӑршшӗпе Каҫхи Шуҫӑм патнелле сулӑнать.
Ҫак икӗ мӑшӑрӗнчен унӑн ачасем:
Этем ятлӑ ывӑл тата Сывлӑм ятлӑ хӗр пур.
Этемпе Сывлӑм пӗррехинче Ҫӗр чӑмӑрӗ ҫинче тӗл пулнӑ та,
пӗр-пӗрне юратса ҫемье чӑмӑртанӑ.
Халь пурӑнакан этемсем ҫав мӑшӑрӑн тӑхӑмӗсем. 
```
Again using [this site](https://localfonts.eu/typography-basics/fonts-the-importance-of-localisation/local-features/chuvash-cyrillic-feature-locl/) for reference:

![Local_Fonts_06-1](https://github.com/user-attachments/assets/7ec7b72a-369c-4619-9fea-dd174fb6e56b)

Unlocalized for comparison:
<details>
  <summary>Expand (10 images)</summary>

Upright:
![image](https://github.com/user-attachments/assets/bc806ae1-e2e7-47a9-9049-6787db814a0f)
Italic:
![image](https://github.com/user-attachments/assets/145dd6d1-2762-4afc-b7c6-64c29edf107b)
Compared to PT Serif:
Upright:
![image](https://github.com/user-attachments/assets/070aafe7-fe07-4d3a-9187-7ce8d0daaf27)
Italic:
![image](https://github.com/user-attachments/assets/168aaade-e778-4ecd-a1df-d79010cc3b8f)
Compared to Vollkorn:
Upright:
![image](https://github.com/user-attachments/assets/e6f3d35e-1979-42b6-b6ef-6c0ca47f7ac3)
Italic:
![image](https://github.com/user-attachments/assets/1efa567b-a0b4-44e7-9834-bf2fabedb1ec)
Compared to Merriweather:
Upright:
![image](https://github.com/user-attachments/assets/b2330a22-02cd-4b75-9b7f-5b9e365a433b)
Italic:
![image](https://github.com/user-attachments/assets/0bb0c9cb-905a-4deb-9209-58b9d40c5ee2)
Compared to Piazzolla:
Upright:
![image](https://github.com/user-attachments/assets/237e6e14-bed7-456a-ad3a-cecbd61bf50c)
Italic:
![image](https://github.com/user-attachments/assets/295a3265-8156-4125-b7d7-88c9ec9d237c)
Compared to Lora:
Upright:
![image](https://github.com/user-attachments/assets/b7138ac8-1516-451f-8d4d-2be6efdd18d2)
Italic:
![image](https://github.com/user-attachments/assets/773f3d8d-ce58-4a33-b1df-9fa45a1cdf13)

</details>

Localized under `lang="cv"`:
<details>
  <summary>Expand (10 images)</summary>

Upright:
![image](https://github.com/user-attachments/assets/99716866-399a-4612-8323-c0f70380f2f2)
Italic:
![image](https://github.com/user-attachments/assets/6f8cef85-bfb0-4c64-af01-b37431e0f228)
Compared to PT Serif:
Upright:
![image](https://github.com/user-attachments/assets/385ab726-098d-416b-b434-131b2e26e59d)
Italic:
![image](https://github.com/user-attachments/assets/93fce419-993d-4df5-9712-94cbcc09ee33)
Compared to Vollkorn:
Upright:
![image](https://github.com/user-attachments/assets/ae0fca4b-c88d-407b-a13b-e646546fca42)
Italic:
![image](https://github.com/user-attachments/assets/5cd24213-d5db-4ee8-974b-e7421ff66387)
Compared to Merriweather:
Upright:
![image](https://github.com/user-attachments/assets/41eed492-20a0-4cad-baf8-f9d6b630b490)
Italic:
![image](https://github.com/user-attachments/assets/d185807a-ad4d-45a5-b2ea-0195b6e9715a)
Compared to Piazzolla:
Upright:
![image](https://github.com/user-attachments/assets/afae5476-1fdc-49a5-86a5-c22c6b28c8c8)
Italic:
![image](https://github.com/user-attachments/assets/d660a480-34da-47a4-9f09-4adcd1c1baa3)
Compared to Lora:
Upright:
![image](https://github.com/user-attachments/assets/aac6b77b-31eb-4ccc-9b4c-da95cd7b6a55)
Italic:
![image](https://github.com/user-attachments/assets/0506ee61-1a4d-4325-8a26-e5567292cf8e)

</details>