### PR TITLE
Potentially save some GIDs surrounding Greek Lower Alpha.

### DIFF
--- a/packages/font-glyphs/src/letter/greek.ptl
+++ b/packages/font-glyphs/src/letter/greek.ptl
@@ -12,6 +12,7 @@ export : define [apply] : begin
 	run-glyph-module "./greek/psi.mjs"
 	run-glyph-module "./greek/upper-omega.mjs"
 
+	run-glyph-module "./greek/lower-alpha.mjs"
 	run-glyph-module "./greek/lower-delta.mjs"
 	run-glyph-module "./greek/lower-epsilon.mjs"
 	run-glyph-module "./greek/lower-lunate-epsilon.mjs"

--- a/packages/font-glyphs/src/letter/greek/lower-alpha.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-alpha.ptl
@@ -1,0 +1,45 @@
+$$include '../../meta/macros.ptl'
+
+import [mix linreg fallback SuffixCfg] from "@iosevka/util"
+import [MathSansSerif] from "@iosevka/glyph/relation"
+
+glyph-module
+
+glyph-block Letter-Greek-Lower-Alpha : begin
+	glyph-block-import CommonShapes
+	glyph-block-import Common-Derivatives
+	glyph-block-import Letter-Latin-Lower-A : SingleStoreyConfig
+
+	###########################################################################################
+	# UNIFIED LETTERFORMS : GREEK ORIGINALS
+	###########################################################################################
+	create-glyph 'grek/alpha.crossing' : glyph-proc
+		include : MarkSet.e
+
+		local middle : mix SB RightSB 0.42
+		local fine   : AdviceStroke 3.25
+		local k1 0.25
+		local k2 0.5
+		local k3 0.35
+		include : dispiro
+			widths.rhs fine
+			g4   (RightSB - OX * 1.75) XH [heading Downward]
+			bezControls k1 k2 k3 1 6
+			arch.rhs.centerAt.rtl.b middle 0
+			archv
+			flat (SB + OX * 2) SmallArchDepthB
+			curl (SB + OX * 2) (XH - SmallArchDepthA)
+			arcvh
+			arch.rhs.centerAt.ltr.t middle XH
+			bezControls (1 - k3) 0 (1 - k1) (1 - k2) 6
+			g4   (RightSB - OX * 2) 0 [widths.heading 0 fine Downward]
+
+		set-base-anchor 'overlay' (middle - OX) (XH * OverlayPos)
+
+	foreach { suffix { body bar } } [Object.entries SingleStoreyConfig] : do
+		create-glyph "grek/alpha.\(suffix)" : glyph-proc
+			include : MarkSet.e
+			include : body [DivFrame 1] XH bar no-shape
+
+	select-variant 'grek/alpha' 0x3B1
+	link-reduced-variant 'grek/alpha/sansSerif' 'grek/alpha' MathSansSerif

--- a/packages/font-glyphs/src/letter/latin/lower-a.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-a.ptl
@@ -139,30 +139,6 @@ glyph-block Letter-Latin-Lower-A : begin
 			Rect XH 0 (RightSB - BBD) Width
 		include : HBar.b (RightSB - BBD) RightSB 0 BBS
 
-	# Greek Lower Alpha
-	create-glyph 'a.crossing' : glyph-proc
-		include : MarkSet.e
-
-		local middle : mix SB RightSB 0.42
-		local fine   : AdviceStroke 3.25
-		local k1 0.25
-		local k2 0.5
-		local k3 0.35
-		include : dispiro
-			widths.rhs fine
-			g4   (RightSB - OX * 1.75) XH [heading Downward]
-			bezControls k1 k2 k3 1 6
-			arch.rhs.centerAt.rtl.b middle 0
-			archv
-			flat (SB + OX * 2) SmallArchDepthB
-			curl (SB + OX * 2) (XH - SmallArchDepthA)
-			arcvh
-			arch.rhs.centerAt.ltr.t middle XH
-			bezControls (1 - k3) 0 (1 - k1) (1 - k2) 6
-			g4   (RightSB - OX * 2) 0 [widths.heading 0 fine Downward]
-
-		set-base-anchor 'overlay' (middle - OX) (XH * OverlayPos)
-
 	glyph-block-export SingleStorey SingleStoreyConfig
 	define SingleStorey : namespace
 		export : define [FullBarBody df height bar mask _sw] : glyph-proc
@@ -296,11 +272,8 @@ glyph-block Letter-Latin-Lower-A : begin
 
 	CreateTurnedLetter 'turna' 0x250 'a/turnABase' HalfAdvance (XH / 2)
 
-	derive-composites 'artail' 0x1D8F 'a/rtailBase'
+	derive-composites 'aRetroflexHook' 0x1D8F 'a/rtailBase'
 		RetroflexHook.rSideJut RightSB 0 (yOverflow -- Stroke)
-
-	select-variant 'grek/alpha' 0x3B1 (shapeFrom -- 'a')
-	link-reduced-variant 'grek/alpha/sansSerif' 'grek/alpha' MathSansSerif (shapeFrom -- 'a')
 
 	select-variant 'scripta' 0x0251
 	select-variant 'largescripta' 0x2C6D (follow -- 'scripta')


### PR DESCRIPTION
Returning of `lower-alpha.ptl` so that characters derived from Greek Lower Alpha don't also inherit the double-storey variants of `a`.

Additionally, characters derived from Latin Lower `a` no longer inherit `grek/alpha.crossing`.