### PR TITLE
Improve widths of overlines in Serbian italics.

### DIFF
--- a/changes/31.6.2.md
+++ b/changes/31.6.2.md
@@ -1,1 +1,2 @@
 - Fix Macedonian Cyrillic Gje under italics (#2493).
+- Improve widths of overline marks of Serbian italic lower Ghe/Pe/Te.

--- a/packages/font-glyphs/src/letter/latin/lower-il.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-il.ptl
@@ -10,8 +10,7 @@ glyph-block Letter-Latin-Lower-I : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Adjustment : LeaningAnchor ExtendBelowBaseAnchors
 	glyph-block-import Letter-Shared : CreateAccentedComposition CreateMultiAccentedComposition
-	glyph-block-import Letter-Shared : CreateCommaCaronComposition
-	glyph-block-import Letter-Shared : CreateTurnedLetter
+	glyph-block-import Letter-Shared : CreateCommaCaronComposition CreateTurnedLetter
 	glyph-block-import Letter-Shared-Shapes : FlatHookDepth DiagTail
 	glyph-block-import Letter-Shared-Shapes : CurlyTail BeltOverlay PalatalHook
 	glyph-block-import Letter-Shared-Shapes : RetroflexHook LetterBarOverlay RightwardTailedBar
@@ -265,8 +264,8 @@ glyph-block Letter-Latin-Lower-I : begin
 				maskOut -- [MaskAbove maskY]
 
 		create-glyph "lHighBar.\(suffix)" : glyph-proc
-			include [refer-glyph "l.\(suffix)"] AS_BASE ALSO_METRICS
 			local df : DivFrame div
+			include [refer-glyph "l.\(suffix)"] AS_BASE ALSO_METRICS
 			include : LetterBarOverlay.m.in [xMiddleT df] XH (Ascender - [if Serif Stroke 0])
 
 		create-glyph "grek/tau.\(suffix)" : glyph-proc
@@ -276,7 +275,6 @@ glyph-block Letter-Latin-Lower-I : begin
 			include : Body df XH xMiddle
 			include : Marks df XH xMiddle
 			include : HBar.t df.leftSB df.rightSB XH
-
 			currentGlyph.deleteBaseAnchor 'trailing'
 
 		create-glyph "cyrl/Twe/middle.\(suffix)" : glyph-proc
@@ -288,8 +286,8 @@ glyph-block Letter-Latin-Lower-I : begin
 
 		create-glyph "cyrl/twe/middle.\(suffix)" : glyph-proc
 			local df : include : DivFrame div
-			include : Body df XH  [XMiddle.Center df]
-			include : Marks df XH  [XMiddle.Center df]
+			include : Body df XH [XMiddle.Center df]
+			include : Marks df XH [XMiddle.Center df]
 			currentGlyph.deleteBaseAnchor 'trailing'
 			set-mark-anchor 'cvDecompose' (df.width / 2) XH
 
@@ -319,8 +317,8 @@ glyph-block Letter-Latin-Lower-I : begin
 		alias 'cyrl/Iota' 0xA646 'latn/Iota'
 
 		select-variant 'cyrl/ghe.SRB/base' (shapeFrom -- 'dotlessi') (follow -- 'cyrl/ghe.SRB')
-		CreateAccentedComposition      'cyrl/ghe.SRB' null 'cyrl/ghe.SRB/base'   'macronAbove'
-		CreateMultiAccentedComposition 'cyrl/gje.SRB' null 'cyrl/ghe.SRB/base' { 'macronAbove' 'acuteAbove' }
+		CreateAccentedComposition      'cyrl/ghe.SRB' null 'cyrl/ghe.SRB/base'   'sbRsbOverlineAbove/diversityI'
+		CreateMultiAccentedComposition 'cyrl/gje.SRB' null 'cyrl/ghe.SRB/base' { 'sbRsbOverlineAbove/diversityI' 'acuteAbove' }
 
 		CreateTurnedLetter 'turni' 0x1D09 'i' HalfAdvance (XH / 2)
 		CreateTurnedLetter 'grek/turniota' 0x2129 'latn/iota' HalfAdvance (XH / 2)

--- a/packages/font-glyphs/src/letter/latin/lower-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-m.ptl
@@ -422,8 +422,8 @@ glyph-block Letter-Latin-Lower-M : begin
 	select-variant 'cyrl/shcha/reduced.italic' (shapeFrom -- 'cyrl/shcha.italic') (follow -- 'cyrl/shcha.italic/reduced')
 	alias 'cyrl/shcha/reduced.BGR' null 'cyrl/shcha/reduced.italic'
 
-	derive-composites 'cyrl/te.SRB' null 'cyrl/sha.italic' 'macronAbove'
-	derive-composites 'cyrl/te/reduced.SRB' null 'cyrl/sha/reduced.italic' 'macronAbove'
+	derive-composites 'cyrl/te.SRB' null 'cyrl/sha.italic' 'sbRsbOverlineAbove/diversityM'
+	derive-composites 'cyrl/te/reduced.SRB' null 'cyrl/sha/reduced.italic' 'sbRsbOverlineAbove/diversityM'
 
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarLeft
 	create-glyph 'mathbb/m' 0x1D55E : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -352,7 +352,7 @@ glyph-block Letter-Latin-U : begin
 
 	derive-glyphs 'cyrl/pe.SRB' null 'cyrl/i.italic' : lambda [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
-		include [refer-glyph 'macronAbove']
+		include [refer-glyph 'sbRsbOverlineAbove']
 
 	derive-glyphs 'cyrl/tetse.italic' null 'cyrl/tse.italic' : lambda [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
@@ -418,6 +418,22 @@ glyph-block Letter-Latin-U : begin
 		if SLAB : begin
 			include : HSerif.lt SB XH SideJut
 
+	CreateAccentedComposition 'uDieresis' 0xFC 'u' 'dieresisAbove'
+	CreateAccentedComposition 'uLongBarOver' 0x289 'u' 'hStrike'
+	CreateAccentedComposition 'smcpUStroke' 0x1D7E 'smcpU' 'hStrike'
+
+	# Sideways dieresis for U+1D1E
+	derive-glyphs "uDieresisSidewaysMark" null "dieresisAboveAlwaysUpright" : function [gns] : glyph-proc
+		local ww : Width * para.diversityM
+		set-width 0
+		set-mark-anchor 'cvDecompose' 0 0
+		include : PointingTo ww XH ww 0 : function [] : glyph-proc
+			include : refer-glyph gns
+			include : Translate (XH / 2 + Width / 2) (ww - SB - XH - AccentHeight)
+			include : Translate 0 (SB / 2)
+
+	CreateAccentedComposition 'uDieresisSideways' 0x1D1E 'uDieresisSidewaysBase' 'uDieresisSidewaysMark'
+
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarRight
 	create-glyph 'mathbb/U' 0x1D54C : glyph-proc
 		include : MarkSet.capital
@@ -436,19 +452,3 @@ glyph-block Letter-Latin-U : begin
 		include : df.markSet.e
 		include [refer-glyph 'mathbb/n']
 		include : FlipAround Middle (XH / 2)
-
-	CreateAccentedComposition 'uDieresis' 0xFC 'u' 'dieresisAbove'
-	CreateAccentedComposition 'uLongBarOver' 0x289 'u' 'hStrike'
-	CreateAccentedComposition 'smcpUStroke' 0x1D7E 'smcpU' 'hStrike'
-
-	# Sideways dieresis for U+1D1E
-	derive-glyphs "uDieresisSidewaysMark" null "dieresisAboveAlwaysUpright" : function [gns] : glyph-proc
-		local ww : Width * para.diversityM
-		set-width 0
-		set-mark-anchor 'cvDecompose' 0 0
-		include : PointingTo ww XH ww 0 : function [] : glyph-proc
-			include : refer-glyph gns
-			include : Translate (XH / 2 + Width / 2) (ww - SB - XH - AccentHeight)
-			include : Translate 0 (SB / 2)
-
-	CreateAccentedComposition 'uDieresisSideways' 0x1D1E 'uDieresisSidewaysBase' 'uDieresisSidewaysMark'

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -469,8 +469,8 @@ glyph-block Mark-Above : begin
 		set-width 0
 		include : StdAnchors.wide
 
-		local leftEnd  (markMiddle - markExtend * 1.5)
-		local rightEnd (markMiddle + markExtend * 1.5)
+		local leftEnd  : markMiddle - markExtend * 1.5
+		local rightEnd : markMiddle + markExtend * 1.5
 
 		include : dispiro
 			flat leftEnd  aboveMarkMid [widths.center : 2 * markHalfStroke]
@@ -489,6 +489,30 @@ glyph-block Mark-Above : begin
 		include : dispiro
 			flat (SB - Width)      aboveMarkMid [widths.center : 2 * markHalfStroke]
 			curl (RightSB - Width) aboveMarkMid
+
+	create-glyph 'sbRsbOverlineAbove/diversityI' : glyph-proc
+		local df : DivFrame para.diversityI
+		set-width 0
+		include : StdAnchors.impl 'above' 0 (1.5 * df.div)
+
+		local leftEnd  : markMiddle - (df.rightSB - df.leftSB) / 2
+		local rightEnd : markMiddle + (df.rightSB - df.leftSB) / 2
+
+		include : dispiro
+			flat leftEnd  aboveMarkMid [widths.center : 2 * markHalfStroke]
+			curl rightEnd aboveMarkMid
+
+	create-glyph 'sbRsbOverlineAbove/diversityM' : glyph-proc
+		local df : DivFrame para.diversityM
+		set-width 0
+		include : StdAnchors.impl 'above' 0 (1.5 * df.div)
+
+		local leftEnd  : markMiddle - (df.rightSB - df.leftSB) / 2
+		local rightEnd : markMiddle + (df.rightSB - df.leftSB) / 2
+
+		include : dispiro
+			flat leftEnd  aboveMarkMid [widths.center : 2 * markHalfStroke]
+			curl rightEnd aboveMarkMid
 
 	create-glyph 'latin1macron' 0xAF : glyph-proc
 		local df : include : DivFrame 1


### PR DESCRIPTION
Basically making the overline span the width of the character, which is how it's treated in Southwestern Cyrillic handwriting and by extension other fonts (examples below). This also improves legibility, particularly under Quasi-Proportional, as a string of similar characters is made easier to discern where one stops and another starts; A nonsense string "`итигшпшг`" is provided as a hypothetical edge case.
```
Ѕидарски пејзаж: шугав билмез со чудење џвака ќофте и кељ на туѓ цех.
Ѕидарски пејзаж: шугав билмез со чудење џвака ќофте и кељ на туѓ цех.
г᪻ п᪻ т᪻ ѓ п́
итигшпшг
```
Default Monospace:
![image](https://github.com/user-attachments/assets/a422f6df-9f6d-4823-b6ed-f682f0aba049)
ss16 Monospace:
![image](https://github.com/user-attachments/assets/9d6e672b-5ab7-448e-b86f-98ee86ec27e8)
Default QP (Aile):
![image](https://github.com/user-attachments/assets/87f4421e-93aa-4070-b24e-3d6e89260e22)
ss16 QP:
![image](https://github.com/user-attachments/assets/940e6595-fc74-42e5-83bf-2393ded286b3)

Compared to Vollkorn:
![image](https://github.com/user-attachments/assets/d3193866-7375-475d-bb9b-0a0056ab8dec)
Compared to DejaVu Serif:
![image](https://github.com/user-attachments/assets/5e31acfe-dbfa-4028-9b06-b39bca7c9ee7)
