### PR TITLE
Add more character overrides to two Latin locales.

### DIFF
--- a/changes/31.7.0.md
+++ b/changes/31.7.0.md
@@ -1,7 +1,7 @@
 * Fix Macedonian Cyrillic Gje under italics (#2493).
 * Improve widths of overline marks of Serbian italic lower Ghe/Pe/Te.
 * Remove crossbar variants for `Z`/`z` when under Polish locale (`PLK`) to avoid confusion with the handwritten `Ż`/`ż` allograph, `Ƶ`/`ƶ`.
-* Make serif variants for Latin Capital/Small Schwa (`Ə`/`ə`) only appear under Turkic (Turkish/Azerbaijani/etc.) locales (`TRK`, `AZE`, `GAG`, `KAZ`, `TAT`, `CRT`) as other languages that use schwa as well as the IPA unify its metrics with Open O (`Ɔ`/`ɔ`).
+* Make serif variants for Latin Capital/Small Schwa (`Ə`/`ə`) only appear under Turkic (Turkish/Azerbaijani/etc.) locales (`TRK`, `AZE`, `GAG`, `KAZ`, `TAT`, `CRT`) as other languages that use schwa as well as the IPA unify its metrics with Open O (`Ɔ`/`ɔ`) or a literal turned e (`Ǝ`/`ǝ`).
 * Add Characters:
   - COUNTING ROD UNIT DIGIT ONE (`U+1D360`) ... COUNTING ROD TENS DIGIT NINE (`U+1D371`).
   - COMPOSITION SYMBOL (`U+2384`).

--- a/changes/31.7.0.md
+++ b/changes/31.7.0.md
@@ -1,5 +1,7 @@
 * Fix Macedonian Cyrillic Gje under italics (#2493).
 * Improve widths of overline marks of Serbian italic lower Ghe/Pe/Te.
+* Remove crossbar variants for `Z`/`z` when under Polish locale (`PLK`).
+* Make serif variants for Latin Capital/Small Schwa (`Ə`/`ə`) only appear under Turkic (Turkish/Azerbaijani/etc.) locales (`TRK`, `AZE`, `GAG`, `KAZ`, `TAT`, `CRT`).
 * Add Characters:
   - COUNTING ROD UNIT DIGIT ONE (`U+1D360`) ... COUNTING ROD TENS DIGIT NINE (`U+1D371`).
   - COMPOSITION SYMBOL (`U+2384`).

--- a/changes/31.7.0.md
+++ b/changes/31.7.0.md
@@ -1,7 +1,7 @@
 * Fix Macedonian Cyrillic Gje under italics (#2493).
 * Improve widths of overline marks of Serbian italic lower Ghe/Pe/Te.
-* Remove crossbar variants for `Z`/`z` when under Polish locale (`PLK`).
-* Make serif variants for Latin Capital/Small Schwa (`Ə`/`ə`) only appear under Turkic (Turkish/Azerbaijani/etc.) locales (`TRK`, `AZE`, `GAG`, `KAZ`, `TAT`, `CRT`).
+* Remove crossbar variants for `Z`/`z` when under Polish locale (`PLK`) to avoid confusion with the handwritten `Ż`/`ż` allograph, `Ƶ`/`ƶ`.
+* Make serif variants for Latin Capital/Small Schwa (`Ə`/`ə`) only appear under Turkic (Turkish/Azerbaijani/etc.) locales (`TRK`, `AZE`, `GAG`, `KAZ`, `TAT`, `CRT`) as other languages that use schwa as well as the IPA unify its metrics with Open O (`Ɔ`/`ɔ`).
 * Add Characters:
   - COUNTING ROD UNIT DIGIT ONE (`U+1D360`) ... COUNTING ROD TENS DIGIT NINE (`U+1D371`).
   - COMPOSITION SYMBOL (`U+2384`).

--- a/packages/font-glyphs/src/letter/cyrillic/orthography.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/orthography.ptl
@@ -34,6 +34,7 @@ glyph-block Letter-Cyrillic-Orthography : begin
 	orthographic-italic 'cyrl/dche'           0x52D
 	orthographic-italic 'cyrl/teTall'         0x1C84
 	orthographic-italic 'cyrl/teThreeLeg'     0x1C85
+	orthographic-italic 'cyrl/este'             null
 	orthographic-italic 'cyrl/tseRev'         0xA661
 	orthographic-italic 'cyrl/dzze'           0xA689
 	orthographic-italic 'cyrl/teMidHook'      0xA68B

--- a/packages/font-glyphs/src/letter/latin-ext/orthography.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/orthography.ptl
@@ -1,8 +1,0 @@
-$$include '../../meta/macros.ptl'
-
-glyph-module
-
-glyph-block Letter-Latin-Orthography : begin
-	glyph-block-import Common-Derivatives
-
-	orthographic-italic "cyrl/este"

--- a/packages/font-glyphs/src/letter/latin.ptl
+++ b/packages/font-glyphs/src/letter/latin.ptl
@@ -46,6 +46,8 @@ export : define [apply] : begin
 	run-glyph-module "./latin/lower-y.mjs"
 	run-glyph-module "./latin/z.mjs"
 
+	run-glyph-module "./latin/orthography.mjs"
+
 	run-glyph-module "./latin-ext/bidental-percussive.mjs"
 	run-glyph-module "./latin-ext/egyptological.mjs"
 	run-glyph-module "./latin-ext/eszet.mjs"
@@ -71,5 +73,3 @@ export : define [apply] : begin
 	run-glyph-module "./latin-ext/upper-aa-ao.mjs"
 	run-glyph-module "./latin-ext/wynn.mjs"
 	run-glyph-module "./latin-ext/yogh.mjs"
-
-	run-glyph-module "./latin-ext/orthography.mjs"

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -198,6 +198,15 @@ glyph-block Letter-Latin-Lower-E : begin
 				y -- 0
 				yAttach -- lastKnot.y
 
+		create-glyph "Schwa.\(suffix)" : glyph-proc
+			include : MarkSet.capital
+			include : Body [DivFrame 1] CAP [AdviceStroke2 2 3 CAP]
+			include : FlipAround Middle (CAP / 2)
+
+		create-glyph "schwa.\(suffix)" : glyph-proc
+			include [refer-glyph "e.\(suffix)"] AS_BASE ALSO_METRICS
+			include : FlipAround Middle (XH / 2)
+
 		create-glyph "eRev.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : RevBody [DivFrame 1] XH [AdviceStroke2 2 3 XH]
@@ -207,8 +216,8 @@ glyph-block Letter-Latin-Lower-E : begin
 			include : HBar.m [mix SB 0 0.7] [mix RightSB Width 0.7] (XH * 0.25 + Stroke * 0.25)
 				Math.min [AdviceStroke 5] (0.25 * (XH - 3 * Stroke))
 
-		DefineSelectorGlyph "Schwa" suffix [DivFrame 1] 'capital'
-		DefineSelectorGlyph "schwa" suffix [DivFrame 1] 'e'
+		DefineSelectorGlyph "cyrl/Schwa" suffix [DivFrame 1] 'capital'
+		DefineSelectorGlyph "cyrl/schwa" suffix [DivFrame 1] 'e'
 
 		define abkCheDf : DivFrame para.diversityM 3
 
@@ -218,12 +227,12 @@ glyph-block Letter-Latin-Lower-E : begin
 		DefineSelectorGlyph "cyrl/abk/cheDescender" suffix abkCheDf 'p'
 
 		foreach { suffixSerif { styTop styBot } } [Object.entries CConfig] : do
-			create-glyph "Schwa.\(suffix).\(suffixSerif)" : glyph-proc
+			create-glyph "cyrl/Schwa.\(suffix).\(suffixSerif)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
 				include : Body [DivFrame 1] CAP [AdviceStroke2 2 3 CAP] (tailSlab -- styTop) (schwaTail -- true)
 				include : FlipAround Middle (CAP / 2)
-			create-glyph "schwa.\(suffix).\(suffixSerif)" : glyph-proc
+			create-glyph "cyrl/schwa.\(suffix).\(suffixSerif)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
 				include : Body [DivFrame 1] XH [AdviceStroke2 2 3 XH] (tailSlab -- styTop) (schwaTail -- true)
@@ -246,8 +255,8 @@ glyph-block Letter-Latin-Lower-E : begin
 				set-mark-anchor 'cvDecompose' 0 0
 				include : AbkCheShape 1 Body abkCheDf XH (tailSlab -- styBot)
 
-		select-variant "Schwa.\(suffix)" (follow -- 'cyrl/ETopSerifOnly')
-		select-variant "schwa.\(suffix)" (follow -- 'cyrl/eTopSerifOnly')
+		select-variant "cyrl/Schwa.\(suffix)" (follow -- 'cyrl/ETopSerifOnly')
+		select-variant "cyrl/schwa.\(suffix)" (follow -- 'cyrl/eTopSerifOnly')
 		select-variant "cyrl/abk/Che.\(suffix)" (follow -- 'CBottomSerifOnly')
 		select-variant "cyrl/abk/che.\(suffix)" (follow -- 'cBottomSerifOnly')
 		select-variant "cyrl/abk/CheDescender.\(suffix)" (follow -- 'CBottomSerifOnly')
@@ -261,20 +270,23 @@ glyph-block Letter-Latin-Lower-E : begin
 	select-variant 'eRetroflexHook' 0x1D92 (follow -- 'e')
 	select-variant 'eWithNotch' 0x2C78 (follow -- 'e')
 
+	select-variant 'Schwa' 0x18F
+	select-variant 'schwa' 0x259
+
 	select-variant 'eRev' 0x258 (follow -- 'e')
 
 	select-variant 'eBar' 0xAB33 (follow -- 'e')
 
-	CreateSelectorVariants 'Schwa' 0x18F [Object.keys SmallEConfig] (follow -- 'e')
-	alias 'cyrl/Schwa' 0x4D8 'Schwa'
+	CreateSelectorVariants 'cyrl/Schwa' 0x4D8 [Object.keys SmallEConfig] (follow -- 'Schwa')
+	alias 'Schwa.TRK' null 'cyrl/Schwa'
 
-	CreateSelectorVariants 'schwa' 0x259 [Object.keys SmallEConfig] (follow -- 'e')
-	alias 'cyrl/schwa' 0x4D9 'schwa'
+	CreateSelectorVariants 'cyrl/schwa' 0x4D9 [Object.keys SmallEConfig] (follow -- 'schwa')
+	alias 'schwa.TRK' null 'cyrl/schwa'
 
-	CreateSelectorVariants 'cyrl/abk/Che' 0x4BC [Object.keys SmallEConfig] (follow -- 'e')
-	CreateSelectorVariants 'cyrl/abk/che' 0x4BD [Object.keys SmallEConfig] (follow -- 'e')
-	CreateSelectorVariants 'cyrl/abk/CheDescender' 0x4BE [Object.keys SmallEConfig] (follow -- 'e')
-	CreateSelectorVariants 'cyrl/abk/cheDescender' 0x4BF [Object.keys SmallEConfig] (follow -- 'e')
+	CreateSelectorVariants 'cyrl/abk/Che' 0x4BC [Object.keys SmallEConfig]
+	CreateSelectorVariants 'cyrl/abk/che' 0x4BD [Object.keys SmallEConfig]
+	CreateSelectorVariants 'cyrl/abk/CheDescender' 0x4BE [Object.keys SmallEConfig] (follow -- 'cyrl/abk/Che')
+	CreateSelectorVariants 'cyrl/abk/cheDescender' 0x4BF [Object.keys SmallEConfig] (follow -- 'cyrl/abk/che')
 
 	glyph-block-import Letter-Blackboard : BBS BBD
 	create-glyph 'mathbb/e' 0x1D556 : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/orthography.ptl
+++ b/packages/font-glyphs/src/letter/latin/orthography.ptl
@@ -1,0 +1,28 @@
+$$include '../../meta/macros.ptl'
+
+import [LocalizedForm] from "@iosevka/glyph/relation"
+
+glyph-module
+
+glyph-block Letter-Latin-Orthography : begin
+	glyph-block-import Common-Derivatives
+
+	# Link localization forms
+	link-gr LocalizedForm.PLK 'CAcute' 'CAcute.PLK'
+	link-gr LocalizedForm.PLK 'cAcute' 'cAcute.PLK'
+	link-gr LocalizedForm.PLK 'NAcute' 'NAcute.PLK'
+	link-gr LocalizedForm.PLK 'nAcute' 'nAcute.PLK'
+	link-gr LocalizedForm.PLK 'OAcute' 'OAcute.PLK'
+	link-gr LocalizedForm.PLK 'oAcute' 'oAcute.PLK'
+	link-gr LocalizedForm.PLK 'SAcute' 'SAcute.PLK'
+	link-gr LocalizedForm.PLK 'sAcute' 'sAcute.PLK'
+	link-gr LocalizedForm.PLK 'Z'      'Z.PLK'
+	link-gr LocalizedForm.PLK 'z'      'z.PLK'
+	link-gr LocalizedForm.PLK 'ZAcute' 'ZAcute.PLK'
+	link-gr LocalizedForm.PLK 'zAcute' 'zAcute.PLK'
+	link-gr LocalizedForm.PLK 'ZDot'   'ZDot.PLK'
+	link-gr LocalizedForm.PLK 'zDot'   'zDot.PLK'
+
+	link-gr LocalizedForm.TRK 'Schwa' 'Schwa.TRK'
+	link-gr LocalizedForm.TRK 'schwa' 'schwa.TRK'
+	link-gr LocalizedForm.TRK 'i'     'i.TRK'

--- a/packages/font-glyphs/src/letter/latin/z.ptl
+++ b/packages/font-glyphs/src/letter/latin/z.ptl
@@ -361,10 +361,12 @@ glyph-block Letter-Latin-Z : begin
 	CreateAccentedComposition 'ZCaron' 0x17D 'Z' 'caronAbove' true
 	CreateAccentedComposition 'zCaron' 0x17E 'z' 'caronAbove' true
 
-	CreateAccentedComposition 'ZAcute.PLK' null 'Z' 'kreskaAbove'
-	CreateAccentedComposition 'zAcute.PLK' null 'z' 'kreskaAbove'
-	CreateAccentedComposition 'ZDot.PLK'   null 'Z' 'kropkaAbove'
-	CreateAccentedComposition 'zDot.PLK'   null 'z' 'kropkaAbove'
+	alias 'Z.PLK' null 'Z/reduced'
+	alias 'z.PLK' null 'z/reduced'
+	CreateAccentedComposition 'ZAcute.PLK' null 'Z/reduced' 'kreskaAbove'
+	CreateAccentedComposition 'zAcute.PLK' null 'z/reduced' 'kreskaAbove'
+	CreateAccentedComposition 'ZDot.PLK'   null 'Z/reduced' 'kropkaAbove'
+	CreateAccentedComposition 'zDot.PLK'   null 'z/reduced' 'kropkaAbove'
 
 	CreateAccentedComposition 'ZStroke' 0x1B5 'Z/reduced' 'barOver'
 	CreateAccentedComposition 'zStroke' 0x1B6 'z/reduced' 'barOver'

--- a/packages/font-otl/src/gsub-locl.ptl
+++ b/packages/font-otl/src/gsub-locl.ptl
@@ -52,21 +52,7 @@ export : define [buildLOCL gsub para glyphStore] : begin
 
 	# PLK
 	define loclPLK : latnPLK.addFeature : gsub.createFeature 'locl'
-	loclPLK.addLookup : gsub.createLookup
-		.type 'gsub_single'
-		.substitutions : object
-			'CAcute' : glyphStore.ensureExists 'CAcute.PLK'
-			'cAcute' : glyphStore.ensureExists 'cAcute.PLK'
-			'NAcute' : glyphStore.ensureExists 'NAcute.PLK'
-			'nAcute' : glyphStore.ensureExists 'nAcute.PLK'
-			'OAcute' : glyphStore.ensureExists 'OAcute.PLK'
-			'oAcute' : glyphStore.ensureExists 'oAcute.PLK'
-			'SAcute' : glyphStore.ensureExists 'SAcute.PLK'
-			'sAcute' : glyphStore.ensureExists 'sAcute.PLK'
-			'ZAcute' : glyphStore.ensureExists 'ZAcute.PLK'
-			'zAcute' : glyphStore.ensureExists 'zAcute.PLK'
-			'ZDot'   : glyphStore.ensureExists 'ZDot.PLK'
-			'zDot'   : glyphStore.ensureExists 'zDot.PLK'
+	loclPLK.addLookup : createGsubLookupFromGr gsub glyphStore LocalizedForm.PLK
 
 	# ROM
 	define loclROM : gsub.createFeature 'locl'
@@ -88,10 +74,7 @@ export : define [buildLOCL gsub para glyphStore] : begin
 	latnKAZ.addFeature loclTRK
 	latnTAT.addFeature loclTRK
 	latnCRT.addFeature loclTRK
-	loclTRK.addLookup : gsub.createLookup
-		.type 'gsub_single'
-		.substitutions : object
-			'i' : glyphStore.ensureExists 'i.TRK'
+	loclTRK.addLookup : createGsubLookupFromGr gsub glyphStore LocalizedForm.TRK
 
 	# VIT
 	define loclVIT : latnVIT.addFeature : gsub.createFeature 'locl'

--- a/packages/glyph/src/relation.mjs
+++ b/packages/glyph/src/relation.mjs
@@ -35,6 +35,8 @@ export const LocalizedForm = {
 		Italic: LinkedGlyphProp("BashkirLocItalic"),
 	},
 	CHU: LinkedGlyphProp("ChuvashLoc"),
+	PLK: LinkedGlyphProp("PolishLoc"),
+	TRK: LinkedGlyphProp("TurkishLoc"),
 	IPPH: LinkedGlyphProp("IPALoc"),
 };
 
@@ -192,6 +194,8 @@ export const AnyLocalizedForm = {
 		if (LocalizedForm.BSH.Upright.get(glyph)) grs.push(LocalizedForm.BSH.Upright);
 		if (LocalizedForm.BSH.Italic.get(glyph)) grs.push(LocalizedForm.BSH.Italic);
 		if (LocalizedForm.CHU.get(glyph)) grs.push(LocalizedForm.CHU);
+		if (LocalizedForm.PLK.get(glyph)) grs.push(LocalizedForm.PLK);
+		if (LocalizedForm.TRK.get(glyph)) grs.push(LocalizedForm.TRK);
 		if (LocalizedForm.IPPH.get(glyph)) grs.push(LocalizedForm.IPPH);
 		if (grs.length) return grs;
 		return null;

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2569,11 +2569,19 @@ tagKind = "letter"
 rank = 1
 description = "`e` with flat crossbar"
 selector.e = "flatCrossbar"
+selector.Schwa = "flatCrossbar"
+selector.schwa = "flatCrossbar"
+selector."cyrl/abk/Che" = "flatCrossbar"
+selector."cyrl/abk/che" = "flatCrossbar"
 
 [prime.e.variants.rounded]
 rank = 2
 description = "`e` with more rounded shape"
 selector.e = "rounded"
+selector.Schwa = "flatCrossbar"
+selector.schwa = "rounded"
+selector."cyrl/abk/Che" = "flatCrossbar"
+selector."cyrl/abk/che" = "rounded"
 
 
 


### PR DESCRIPTION
Firstly, removal of serif variants for specifically the _Latin_ version of Capital/small Schwa unless under a supported Turkic locale, namely Azerbaijani whose usage of schwa comes directly from formerly using the Cyrillic script. This also incidentally returns it to its behavior from before engineering serif variants onto it (the serifs of the Cyrillic version are unchanged)

Secondly, removal of crossbar variants for Latin `Z`/`z` when under a Polish locale because, much like the reason Greek Zeta doesn't use crossbars, it makes it confusable with the handwritten form of another letter, which in this case is `Ż`/`ż` (whereas for Greek it's `Ξ`). Letters not used in Polish such as `Ž`/`ž` etc. are not affected.

Thirdly, make {super|sub|over|under}script forms of schwa, `z`, and `i` respond to localization overrides.