### PR TITLE
Add five new Latin letters from Unicode 16.0

### DIFF
--- a/changes/31.7.0.md
+++ b/changes/31.7.0.md
@@ -1,13 +1,14 @@
 * Fix Macedonian Cyrillic Gje under italics (#2493).
 * Improve widths of overline marks of Serbian italic lower Ghe/Pe/Te.
 * Remove crossbar variants for `Z`/`z` when under Polish locale (`PLK`) to avoid confusion with the handwritten `Ż`/`ż` allograph, `Ƶ`/`ƶ`.
-* Make serif variants for Latin Capital/Small Schwa (`Ə`/`ə`) only appear under Turkic (Turkish/Azerbaijani/etc.) locales (`TRK`, `AZE`, `GAG`, `KAZ`, `TAT`, `CRT`) as other languages that use schwa as well as the IPA unify its metrics with Open O (`Ɔ`/`ɔ`) or a literal turned e (`Ǝ`/`ǝ`).
+* Make serif variants for Latin Capital/Small Schwa (`Ə`/`ə`) only appear under Turkic (Turkish/Azerbaijani/etc.) locales (`TRK`, `AZE`, `GAG`, `KAZ`, `TAT`, `CRT`) as other languages that use Latin Schwa (including the IPA) unify its metrics with Open O (`Ɔ`/`ɔ`) or a literal Turned E (`Ǝ`/`ǝ`).
 * Add Characters:
-  - COUNTING ROD UNIT DIGIT ONE (`U+1D360`) ... COUNTING ROD TENS DIGIT NINE (`U+1D371`).
   - COMPOSITION SYMBOL (`U+2384`).
-  - HEAVY CIRCLED SALTIRE (`U+2B59`).
-  - DRIVE SLOW SIGN (`U+26DA`).
   - WHITE DIAMOND IN SQUARE (`U+26CB`).
-  - SQUARED SALTIRE (`U+26DD`).
-  - FALLING DIAGONAL IN WHITE CIRCLE IN BLACK SQUARE (`U+26DE`).
+  - DRIVE SLOW SIGN (`U+26DA`).
+  - SQUARED SALTIRE (`U+26DD`) ... FALLING DIAGONAL IN WHITE CIRCLE IN BLACK SQUARE (`U+26DE`).
+  - HEAVY CIRCLED SALTIRE (`U+2B59`).
   - TOP HALF LEFT PARENTHESIS (`U+2E59`) ... BOTTOM HALF RIGHT PARENTHESIS (`U+2E5C`).
+  - LATIN CAPITAL LETTER S WITH DIAGONAL STROKE (`U+A7CC`) ... LATIN SMALL LETTER S WITH DIAGONAL STROKE (`U+A7CD`).
+  - LATIN CAPITAL LETTER LAMBDA (`U+A7DA`) ... LATIN CAPITAL LETTER LAMBDA WITH STROKE (`U+A7DC`).
+  - COUNTING ROD UNIT DIGIT ONE (`U+1D360`) ... COUNTING ROD TENS DIGIT NINE (`U+1D371`).

--- a/packages/font-glyphs/src/letter/latin/lower-y.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-y.ptl
@@ -313,13 +313,13 @@ glyph-block Letter-Latin-Lower-Y : begin
 			include : MarkSet.b
 			include : Shapes.SmallLambdaShapeFromHookTop Ascender 0
 
-		create-glyph "lambdaSlash.\(suffix)" : glyph-proc
+		create-glyph "latn/lambdaStroke.\(suffix)" : glyph-proc
 			include : MarkSet.b
 			include : union
 				FlatSlashShape [mix SB RightSB 0.45] [mix 0 CAP 0.8] (OverlayStroke / 2)
 				Shapes.SmallLambdaShape Ascender 0
 
-		create-glyph "lambdaSlashFHT.\(suffix)" : glyph-proc
+		create-glyph "latn/lambdaStrokeFHT.\(suffix)" : glyph-proc
 			include : MarkSet.b
 			include : union
 				FlatSlashShape [mix SB RightSB 0.45] [mix 0 CAP 0.8] (OverlayStroke / 2)
@@ -336,10 +336,10 @@ glyph-block Letter-Latin-Lower-Y : begin
 			set-base-anchor 'strike' Middle (XH / 2 - Descender)
 			include : Shapes.SmallYShape CAP 0
 
-	alias 'grek/lambda.tailedTurnSerifless' null 'grek/lambdaFHT.straightTurnSerifless'
-	alias 'lambdaSlash.tailedTurnSerifless' null 'lambdaSlashFHT.straightTurnSerifless'
-	alias 'grek/lambda.curlyTailedTurnSerifless' null 'grek/lambdaFHT.curlyTurnSerifless'
-	alias 'lambdaSlash.curlyTailedTurnSerifless' null 'lambdaSlashFHT.curlyTurnSerifless'
+	alias 'grek/lambda.tailedTurnSerifless'            null 'grek/lambdaFHT.straightTurnSerifless'
+	alias 'latn/lambdaStroke.tailedTurnSerifless'      null 'latn/lambdaStrokeFHT.straightTurnSerifless'
+	alias 'grek/lambda.curlyTailedTurnSerifless'       null 'grek/lambdaFHT.curlyTurnSerifless'
+	alias 'latn/lambdaStroke.curlyTailedTurnSerifless' null 'latn/lambdaStrokeFHT.curlyTurnSerifless'
 
 	define Cursive : namespace
 		export : define [Arc top bottom] : new-glyph : glyph-proc
@@ -434,7 +434,8 @@ glyph-block Letter-Latin-Lower-Y : begin
 	select-variant 'yLoop' 0x1EFF (shapeFrom -- 'y')
 
 	select-variant 'grek/lambda' 0x3BB
-	select-variant 'lambdaSlash' 0x19B (follow -- 'grek/lambda')
+	alias 'latn/lambda' 0xA7DB 'grek/lambda'
+	select-variant 'latn/lambdaStroke' 0x19B (follow -- 'grek/lambda')
 
 	# Blackboard
 	glyph-block-import Letter-Blackboard : BBS BBD

--- a/packages/font-glyphs/src/letter/latin/upper-y.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-y.ptl
@@ -129,6 +129,7 @@ glyph-block Letter-Latin-Upper-Y : begin
 	link-reduced-variant 'Y/sansSerif' 'Y' MathSansSerif
 	select-variant 'smcpY' 0x28F (follow -- 'Y')
 	select-variant 'YHookTop' 0x1B3 (follow -- 'Y')
+	CreateAccentedComposition 'YBar' null 'Y' 'barOver'
 
 	CreateTurnedLetter 'turnY/sansSerif' 0x2144 'Y/sansSerif' HalfAdvance (CAP / 2)
 
@@ -143,6 +144,9 @@ glyph-block Letter-Latin-Upper-Y : begin
 
 	create-glyph 'YStroke/Overlay' : HOverlayBar ([mix 0 SB 0.5]) ([mix Width RightSB 0.5]) [mix 0 CAP 0.75]
 	derive-composites 'YStroke' 0x24E 'Y' 'YStroke/Overlay'
+
+	CreateTurnedLetter 'latn/Lambda'       0xA7DA 'Y'    HalfAdvance (CAP / 2)
+	CreateTurnedLetter 'latn/LambdaStroke' 0xA7DC 'YBar' HalfAdvance (CAP / 2)
 
 	select-variant 'currency/yenSign' 0xA5 (follow -- 'Y')
 

--- a/packages/font-glyphs/src/meta/unicode-knowledge.ptl
+++ b/packages/font-glyphs/src/meta/unicode-knowledge.ptl
@@ -182,24 +182,13 @@ export : define decompOverrides : object
 	0x1FE2 { 'grek/upsilon' 'dialytikaVariaAbove' }
 	0x1FE3 { 'grek/upsilon' 'dialytikaOxiaAbove' }
 
-	0x2c61 { 'l' 'dblBarOver' }
-	0x2c65 { 'a' 'shortSlash' }
-	0x2c66 { 't' 'longSlash' }
+	0x2C61 { 'l' 'dblBarOver' }
+	0x2C65 { 'a' 'shortSlash' }
+	0x2C66 { 't' 'longSlash' }
 
 	0xA74A { 'O' 'hStrike' }
 	0xA74B { 'o' 'hStrike' }
 	0xA799 { 'f' 'barOver' }
-	0xA7B8 { 'U' 'longSlash' }
-	0xA7B9 { 'u' 'shortSlash' }
-	0xA7BA { 'grek/Alpha'  'EgyptologicalYodTonos' }
-	0xA7BC { 'grek/Iota'   'EgyptologicalYodTonos' }
-	0xA7BE { 'U/withTonos' 'EgyptologicalYodTonos' }
-	0xA7BB { 'a' 'EgyptologicalYodAbove' }
-	0xA7BD { 'i' 'EgyptologicalYodAbove' }
-	0xA7BF { 'u' 'EgyptologicalYodAbove' }
-	0xA7C9 { 'S' 'hStrike' }
-	0xA7CA { 's' 'hStrike' }
-
 	0xA7A0 { 'G' 'oblStrike' }
 	0xA7A1 { 'g' 'oblStrike' }
 	0xA7A2 { 'K' 'oblStrike' }
@@ -210,6 +199,18 @@ export : define decompOverrides : object
 	0xA7A7 { 'r' 'oblStrike' }
 	0xA7A8 { 'S' 'oblStrike' }
 	0xA7A9 { 's' 'oblStrike' }
+	0xA7B8 { 'U' 'longSlash' }
+	0xA7B9 { 'u' 'shortSlash' }
+	0xA7BA { 'grek/Alpha'  'EgyptologicalYodTonos' }
+	0xA7BC { 'grek/Iota'   'EgyptologicalYodTonos' }
+	0xA7BE { 'U/withTonos' 'EgyptologicalYodTonos' }
+	0xA7BB { 'a' 'EgyptologicalYodAbove' }
+	0xA7BD { 'i' 'EgyptologicalYodAbove' }
+	0xA7BF { 'u' 'EgyptologicalYodAbove' }
+	0xA7C9 { 'S' 'hStrike' }
+	0xA7CA { 's' 'hStrike' }
+	0xA7CC { 'S' 'longSlash' }
+	0xA7CD { 's' 'shortSlash' }
 
 	0xAB30 { 'scripta'   'hStrike' }
 	0xAB3E { 'frak/o'    'shortSlash' }


### PR DESCRIPTION
When I tried creating capital Lambda with stroke (`Ƛ`) by turning first and accenting second, the overlay anchors were at the wrong height, or (possibly) at the height defined by the original (un-turned) character; However, accenting first and turning second works fine.
I also may need some help implementing capital Rams Horn (`Ɤ`), which is the only other new character remaining in Latin Extended-D.
```
Ꟍẜꟍ
ꟚꟛꟜƛ
```
![image](https://github.com/user-attachments/assets/6258a679-eb33-4420-8898-4327638f3eb3)
