### PR TITLE
Miscellaneous optimizations for metrics of certain phonetic/etc. characters.

### DIFF
--- a/changes/31.7.0.md
+++ b/changes/31.7.0.md
@@ -3,6 +3,7 @@
 * Remove crossbar variants for `Z`/`z` when under Polish locale (`PLK`) to avoid confusion with the handwritten `Ż`/`ż` allograph, `Ƶ`/`ƶ`.
 * Make serif variants for Latin Capital/Small Schwa (`Ə`/`ə`) only appear under Turkic (Turkish/Azerbaijani/etc.) locales (`TRK`, `AZE`, `GAG`, `KAZ`, `TAT`, `CRT`) as other languages that use Latin Schwa (including the IPA) unify its metrics with Open O (`Ɔ`/`ɔ`) or a literal Turned E (`Ǝ`/`ǝ`).
 * Make serifs of Latin Letter Small Capital I (`ɪ`) slightly wider under Quasi-Proportional.
+* Make Cyrillic Small Letter Komi Dje (`ԃ`) slightly wider under Quasi-Proportional.
 * Make Latin Capital Letter Small Capital I (`Ɪ`) slightly wider under Etoile.
 * Add Characters:
   - CYRILLIC CAPITAL LETTER TJE (`U+1C89`) ... CYRILLIC SMALL LETTER TJE (`U+1C8A`).

--- a/changes/31.7.0.md
+++ b/changes/31.7.0.md
@@ -2,6 +2,8 @@
 * Improve widths of overline marks of Serbian italic lower Ghe/Pe/Te.
 * Remove crossbar variants for `Z`/`z` when under Polish locale (`PLK`) to avoid confusion with the handwritten `Ż`/`ż` allograph, `Ƶ`/`ƶ`.
 * Make serif variants for Latin Capital/Small Schwa (`Ə`/`ə`) only appear under Turkic (Turkish/Azerbaijani/etc.) locales (`TRK`, `AZE`, `GAG`, `KAZ`, `TAT`, `CRT`) as other languages that use Latin Schwa (including the IPA) unify its metrics with Open O (`Ɔ`/`ɔ`) or a literal Turned E (`Ǝ`/`ǝ`).
+* Make serifs of Latin Letter Small Capital I (`ɪ`) slightly wider under Quasi-Proportional.
+* Make Latin Capital Letter Small Capital I (`Ɪ`) slightly wider under Etoile.
 * Add Characters:
   - CYRILLIC CAPITAL LETTER TJE (`U+1C89`) ... CYRILLIC SMALL LETTER TJE (`U+1C8A`).
   - COMPOSITION SYMBOL (`U+2384`).

--- a/packages/font-glyphs/src/letter/cyrillic/tje.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/tje.ptl
@@ -36,7 +36,7 @@ glyph-block Letter-Cyrillic-Tje : begin
 			left   -- [mix df.leftSB df.rightSB 0.3] + OX
 			right  -- df.rightSB
 			stroke -- df.mvs
-			bowl   -- [Math.min (YeriBarPos * top + HalfStroke) (top - 1.25 * jutTop)]
+			bowl   -- YeriBarPos * top + [Math.min HalfStroke jutMid]
 		eject-contour 'serifYeriLT'
 		eject-contour 'serifYeriLB'
 

--- a/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
@@ -100,11 +100,10 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 
 	glyph-block-export CyrZe
 	define [CyrZe] : with-params [
-		slabTop slabBot top bot left right blend hook _stroke
+		slabTop slabBot top bot left right blend hook [stroke : AdviceStroke2 2 3 (top - bot)]
 		[xo OX] [yo O] [op OverlayPos] [ada2 SmallArchDepthA] [adb2 SmallArchDepthB]
 		] : namespace
 		export : define [Dim] : begin
-			local stroke : fallback _stroke : AdviceStroke2 2 3 (top - bot)
 			local midx : mix right left blend
 			local midy : mix bot top op
 			local topHeight : top - bot
@@ -247,7 +246,7 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
 			include : let [zeNoO : CyrZe slabTop slabBot CAP 0 SB RightSB StdBlend Hook (xo -- 0) (yo -- 0)]
 				difference
-					VBar.m Middle (-LongJut + 0.5 * Stroke) (Stroke + O) [AdviceStroke 3.5]
+					VBar.m [arch.adjust-x.bot Middle] (-LongJut + 0.5 * Stroke) (Stroke + O) [AdviceStroke 3.5]
 					zeNoO.ShapeMask
 
 		create-glyph "cyrl/dhe.\(suffix)" : glyph-proc
@@ -255,7 +254,7 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
 			include : let [zeNoO : CyrZe slabTop slabBot XH 0 SB RightSB StdBlend SHook (xo -- 0) (yo -- 0)]
 				difference
-					VBar.m Middle (-LongJut + 0.5 * Stroke) (Stroke + O) [AdviceStroke 3.5]
+					VBar.m [arch.adjust-x.bot Middle] (-LongJut + 0.5 * Stroke) (Stroke + O) [AdviceStroke 3.5]
 					zeNoO.ShapeMask
 
 		create-glyph "cyrl/DzjeKomi.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/c.ptl
+++ b/packages/font-glyphs/src/letter/latin/c.ptl
@@ -359,7 +359,7 @@ glyph-block Letter-Latin-C : begin
 		include [refer-glyph src] AS_BASE ALSO_METRICS
 		include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
 		include : difference
-			VBar.m Middle (-LongJut + 0.5 * Stroke) (Stroke + O) [AdviceStroke 3.5]
+			VBar.m [arch.adjust-x.bot Middle] (-LongJut + 0.5 * Stroke) (Stroke + O) [AdviceStroke 3.5]
 			OShapeOutline.NoOvershoot CAP 0 SB RightSB Stroke ArchDepthA ArchDepthB
 
 	derive-multi-part-glyphs 'cyrl/The.BSH' null { 'cyrl/Es' 'invCommaBelow' } : lambda [srcs gr] : glyph-proc
@@ -375,7 +375,7 @@ glyph-block Letter-Latin-C : begin
 		include [refer-glyph src] AS_BASE ALSO_METRICS
 		include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
 		include : difference
-			VBar.m Middle (-LongJut + 0.5 * Stroke) (Stroke + O) [AdviceStroke 3.5]
+			VBar.m [arch.adjust-x.bot Middle] (-LongJut + 0.5 * Stroke) (Stroke + O) [AdviceStroke 3.5]
 			OShapeOutline.NoOvershoot XH 0 SB RightSB Stroke SmallArchDepthA SmallArchDepthB
 
 	derive-multi-part-glyphs 'cyrl/the.BSH' null { 'cyrl/es' 'invCommaBelow' } : lambda [srcs gr] : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/lower-d.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-d.ptl
@@ -124,7 +124,7 @@ glyph-block Letter-Latin-Lower-D : begin
 			include : LeaningAnchor.Above.VBar.r df.rightSB
 
 		if [not bottomSerif] : create-glyph "cyrl/djeKomi.\(suffix)" : glyph-proc
-			local df : DivFrame 1 3
+			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.b
 
 			local dfHalf : df.slice 3 2

--- a/packages/font-glyphs/src/letter/latin/upper-i.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-i.ptl
@@ -14,11 +14,13 @@ glyph-block Letter-Latin-Upper-I : begin
 	define [ISeriflessShape df top bot jut] : glyph-proc
 		include : VBar.m df.middle bot top
 
-	define [ISerifShape df top bot jut] : glyph-proc
+	define [ISerifShapeImpl df top bot jut] : glyph-proc
 		include : VBar.m df.middle bot top
-		include : HSerif.mb df.middle bot (jut * df.div)
-		include : HSerif.mt df.middle top (jut * df.div)
-		set-base-anchor 'trailing' (df.middle + jut * df.div) bot
+		include : HSerif.mb df.middle bot jut
+		include : HSerif.mt df.middle top jut
+		set-base-anchor 'trailing' (df.middle + jut) bot
+
+	define [ISerifShape df top bot jut] : ISerifShapeImpl df top bot (jut * df.div)
 
 	define UpperIConfig : object
 		'straight'     { para.diversityI  ISeriflessShape LongJut      }
@@ -63,7 +65,9 @@ glyph-block Letter-Latin-Upper-I : begin
 	create-glyph 'smcpI' 0x26A : glyph-proc
 		local df : include : DivFrame para.diversityI
 		include : df.markSet.e
-		include : ISerifShape df XH 0 MidJutCenter
+		include : ISerifShapeImpl df XH 0 MidJutCenter
+
+	CreateAccentedComposition 'smcpIBarOver' 0x1D7B 'smcpI' 'barOver'
 
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarCenter
 	create-glyph 'mathbb/I' 0x1D540 : glyph-proc
@@ -71,5 +75,3 @@ glyph-block Letter-Latin-Upper-I : begin
 		include : BBBarCenter Middle 0 CAP
 		include : HBar.t    (Middle - BBD / 2 - Jut) (Middle + BBD / 2 + Jut) CAP BBS
 		include : HBar.b (Middle - BBD / 2 - Jut) (Middle + BBD / 2 + Jut) 0   BBS
-
-	CreateAccentedComposition 'smcpIBarOver' 0x1D7B 'smcpI' 'barOver'

--- a/packages/font-glyphs/src/letter/latin/upper-t.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-t.ptl
@@ -195,16 +195,8 @@ glyph-block Letter-Latin-Upper-T : begin
 	CreateAccentedComposition 'TCedilla' 0x0162 'T' 'cedillaBelow'
 	CreateAccentedComposition 'TComma'   0x021A 'T' 'commaBelow'
 
-	create-glyph 'mathbb/T' 0x1D54B : glyph-proc
-		local df : DivFrame 1
-		include : df.markSet.capital
-		include : HBar.t [TLeftX df] [TRightX df] CAP BBS
-		include : VBar.m (df.middle - BBD / 2) 0 CAP BBS
-		include : VBar.m (df.middle + BBD / 2) 0 CAP BBS
-		include : HBar.b (df.middle - BBD / 2) (df.middle + BBD / 2) 0 BBS
-
 	create-glyph 'capitalSmcpI' 0xA7AE : glyph-proc
-		local df : include : DivFrame 1
+		local df : include : DivFrame [if SLAB [mix 1 para.diversityM 0.5] 1]
 		include : df.markSet.capital
 		local l : TLeftX df
 		local r : TRightX df
@@ -218,3 +210,11 @@ glyph-block Letter-Latin-Upper-T : begin
 			include : tagged 'serifLT' : VSerif.dl l CAP VJut
 			include : tagged 'serifRB' : VSerif.ur r 0 VJut
 			include : tagged 'serifLB' : VSerif.ul l 0 VJut
+
+	create-glyph 'mathbb/T' 0x1D54B : glyph-proc
+		local df : DivFrame 1
+		include : df.markSet.capital
+		include : HBar.t [TLeftX df] [TRightX df] CAP BBS
+		include : VBar.m (df.middle - BBD / 2) 0 CAP BBS
+		include : VBar.m (df.middle + BBD / 2) 0 CAP BBS
+		include : HBar.b (df.middle - BBD / 2) (df.middle + BBD / 2) 0 BBS

--- a/packages/font-glyphs/src/symbol/punctuation/brackets.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/brackets.ptl
@@ -102,10 +102,25 @@ glyph-block Symbol-Punctuation-Brackets : begin
 			turned "parenRight.\(suffix)" null "parenLeft.\(suffix)" Middle SymbolMid
 			turned "doubleParenRight.\(suffix)" null "doubleParenLeft.\(suffix)" Middle SymbolMid
 
+			create-glyph "parenLeftUHalf.\(suffix)" : intersection
+				refer-glyph "parenLeft.\(suffix)"
+				MaskAbove SymbolMid
+			create-glyph "parenLeftLHalf.\(suffix)" : intersection
+				refer-glyph "parenLeft.\(suffix)"
+				MaskBelow SymbolMid
+
+			turned "parenRightUHalf.\(suffix)" null "parenLeftLHalf.\(suffix)" Middle SymbolMid
+			turned "parenRightLHalf.\(suffix)" null "parenLeftUHalf.\(suffix)" Middle SymbolMid
+
 		select-variant 'parenLeft'  '('
 		select-variant 'parenRight' ')'
 		select-variant 'doubleParenLeft'  0x2E28 (follow -- 'parenLeft')
 		select-variant 'doubleParenRight' 0x2E29 (follow -- 'parenRight')
+
+		select-variant 'parenLeftUHalf'   0x2E59 (follow -- 'parenLeft')
+		select-variant 'parenRightUHalf'  0x2E5A (follow -- 'parenRight')
+		select-variant 'parenLeftLHalf'   0x2E5B (follow -- 'parenLeft')
+		select-variant 'parenRightLHalf'  0x2E5C (follow -- 'parenRight')
 
 		alias 'flattenedParenLeft'  0x27EE 'parenLeft.flatArc'
 		alias 'flattenedParenRight' 0x27EF 'parenRight.flatArc'
@@ -139,15 +154,6 @@ glyph-block Symbol-Punctuation-Brackets : begin
 						Paren.ShapeMask df fine O
 
 		turned 'zNotationParenRight' 0x2988 'zNotationParenLeft' Middle SymbolMid
-
-		create-glyph 'parenLeftUHalf' 0x2E59 : intersection
-			refer-glyph 'parenLeft'
-			MaskAbove SymbolMid
-		create-glyph 'parenLeftLHalf' 0x2E5B : intersection
-			refer-glyph 'parenLeft'
-			MaskBelow SymbolMid
-		turned 'parenRightUHalf' 0x2E5A 'parenLeftLHalf' Middle SymbolMid
-		turned 'parenRightLHalf' 0x2E5C 'parenLeftUHalf' Middle SymbolMid
 
 	define Bracket : namespace
 		export : define [HDim barLeft ext] : namespace


### PR DESCRIPTION
```
Ԃԃ
ŦTꞱꞮɪᵻiɨIƗlƚ𝕀
```
Sans Monospace for comparison (unchanged):
![image](https://github.com/user-attachments/assets/1e222767-198b-4b64-8b50-d8a273998b32)
Aile Before:
![image](https://github.com/user-attachments/assets/e44e888b-adf6-410b-a63b-5de905194dc3)
Aile After:
![image](https://github.com/user-attachments/assets/409e8870-6496-418e-b637-8e9056634a1e)
Slab Monospace for comparison (unchanged):
![image](https://github.com/user-attachments/assets/6b51abb9-977b-4303-b52b-3c8d184a887b)
Etoile Before:
![image](https://github.com/user-attachments/assets/97d5b39e-ac3b-4aed-856e-8bf27bd8cd95)
Etoile After:
![image](https://github.com/user-attachments/assets/67e24586-e3c1-4e58-9a2c-904e76953aba)
