### PR TITLE
Miscellaneous variant/code cleanup.

### DIFF
--- a/changes/31.7.0.md
+++ b/changes/31.7.0.md
@@ -4,6 +4,7 @@
 * Make serif variants for Latin Capital/Small Schwa (`Ə`/`ə`) only appear under Turkic (Turkish/Azerbaijani/etc.) locales (`TRK`, `AZE`, `GAG`, `KAZ`, `TAT`, `CRT`) as other languages that use Latin Schwa (including the IPA) unify its metrics with Open O (`Ɔ`/`ɔ`) or a literal Turned E (`Ǝ`/`ǝ`).
 * Make serifs of Latin Letter Small Capital I (`ɪ`) slightly wider under Quasi-Proportional.
 * Make Cyrillic Small Letter Komi Dje (`ԃ`) slightly wider under Quasi-Proportional.
+* Make serifs of Small Capital and Modifier Letter Reversed N (`ᴎ`/`ᴻ`) more accurately follow the serifs of `N`.
 * Make Latin Capital Letter Small Capital I (`Ɪ`) slightly wider under Etoile.
 * Add Characters:
   - CYRILLIC CAPITAL LETTER TJE (`U+1C89`) ... CYRILLIC SMALL LETTER TJE (`U+1C8A`).

--- a/changes/31.7.0.md
+++ b/changes/31.7.0.md
@@ -5,6 +5,7 @@
 * Make serifs of Latin Letter Small Capital I (`ɪ`) slightly wider under Quasi-Proportional.
 * Make Cyrillic Small Letter Komi Dje (`ԃ`) slightly wider under Quasi-Proportional.
 * Make serifs of Small Capital and Modifier Letter Reversed N (`ᴎ`/`ᴻ`) more accurately follow the serifs of `N`.
+* Make Som Sign (`⃀`) follow variants of capital `C`.
 * Make Latin Capital Letter Small Capital I (`Ɪ`) slightly wider under Etoile.
 * Add Characters:
   - CYRILLIC CAPITAL LETTER TJE (`U+1C89`) ... CYRILLIC SMALL LETTER TJE (`U+1C8A`).

--- a/packages/font-glyphs/src/letter/cyrillic/tje.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/tje.ptl
@@ -85,7 +85,9 @@ glyph-block Letter-Cyrillic-Tje : begin
 		shapeFrom -- 'cyrl/tje.upright/leftHalf'
 
 	select-variant 'cyrl/Tje/rightHalf'
+		follow -- 'cyrl/Tje/rightHalf'
 	select-variant 'cyrl/tje.upright/rightHalf'
+		follow -- 'cyrl/tje/rightHalf'
 
 	CreateDependentComposite 'cyrl/Tje' 0x1C89 'cyrl/Tje/rightHalf' : object
 		full    'cyrl/Tje/leftHalf/full'

--- a/packages/font-glyphs/src/letter/cyrillic/yat.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/yat.ptl
@@ -139,7 +139,7 @@ glyph-block Letter-Cyrillic-Yat : begin
 		full    'cyrl/yat.italic/base/corner'
 		reduced 'cyrl/yat.italic/base/cursive'
 
-	select-variant 'cyrl/tje.italic/yeri' (follow -- 'cyrl/yeri')
+	select-variant 'cyrl/tje.italic/yeri' (follow -- 'cyrl/tje/rightHalf')
 	CreateDependentComposite 'cyrl/tje.italic' null 'cyrl/tje.italic/yeri' : object
 		full    'cyrl/tje.italic/base/corner'
 		reduced 'cyrl/tje.italic/base/cursive'

--- a/packages/font-glyphs/src/letter/latin/upper-n.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-n.ptl
@@ -19,7 +19,8 @@ glyph-block Letter-Latin-Upper-N : begin
 	define SLAB-AUTO    1
 	define SLAB-MOTION  2
 	define SLAB-ALL     3
-	define SLAB-DIGAMMA 4
+	define SLAB-CYRL-I  4
+	define SLAB-DIGAMMA 5
 
 	define [NShape] : with-params [bodyType slabType top left right [crowd 2] [crDiag 4]] : glyph-proc
 		local swDiag : AdviceStroke crDiag
@@ -83,23 +84,21 @@ glyph-block Letter-Latin-Upper-N : begin
 				ExtLineCenter 2 swDiag (left + swDiag) yEnd (right - swDiag) top
 
 		local sf : SerifFrame top 0 left right (swRef -- stroke)
-		local lbSerifs : match bodyType
-			[Just BODY-SYMMETRIC]  sf.lb.outer
-			[Just BODY-ASYMMETRIC] sf.lb.full
 		include : match slabType
-			[Just SLAB-ALL]     : composite-proc sf.lt.full lbSerifs sf.rt.outer sf.rb.full
-			[Just SLAB-AUTO]    : NeedSlab SLAB : composite-proc sf.lt.full lbSerifs sf.rt.outer sf.rb.full
-			[Just SLAB-MOTION]  : composite-proc sf.lt.outer
+			[Just SLAB-ALL]     : composite-proc sf.lt.full sf.rt.outer sf.rb.full
+			[Just SLAB-AUTO]    : NeedSlab SLAB : composite-proc sf.lt.full sf.rt.outer sf.rb.full
+			[Just SLAB-MOTION]  : composite-proc sf.rt.outer
 			[Just SLAB-NONE]    : no-shape
+			[Just SLAB-CYRL-I]  : NeedSlab SLAB : composite-proc sf.lt.full sf.lb.outer sf.rt.outer sf.rb.full
 			[Just SLAB-DIGAMMA] : NeedSlab SLAB : composite-proc sf.lt.full sf.rb.full
 
 	define NConfig : object
 		standardSerifless       { BODY-SYMMETRIC  4 SLAB-NONE   }
 		standardMotionSerifed   { BODY-SYMMETRIC  4 SLAB-MOTION }
-		standardSerifed         { BODY-SYMMETRIC  4 SLAB-ALL   }
+		standardSerifed         { BODY-SYMMETRIC  4 SLAB-ALL    }
 		asymmetricSerifless     { BODY-ASYMMETRIC 3 SLAB-NONE   }
 		asymmetricMotionSerifed { BODY-ASYMMETRIC 3 SLAB-MOTION }
-		asymmetricSerifed       { BODY-ASYMMETRIC 3 SLAB-ALL   }
+		asymmetricSerifed       { BODY-ASYMMETRIC 3 SLAB-ALL    }
 
 	foreach { suffix { bodyType crD slabType } } [Object.entries NConfig] : do
 		create-glyph "N.\(suffix)" : glyph-proc
@@ -114,7 +113,7 @@ glyph-block Letter-Latin-Upper-N : begin
 		create-glyph "Eng.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
 			local [object swEnd] : include : NShape bodyType slabType CAP SB RightSB (crDiag -- crD)
-			include : EngHook RightSB 0 Descender (sw -- [Math.min Stroke (swEnd * 1.5)])
+			include : EngHook RightSB 0 Descender (sw -- [Math.min Stroke (swEnd * 4/3)])
 
 		create-glyph "NHookLeft.\(suffix)" : glyph-proc
 			include [refer-glyph "N.\(suffix)"] AS_BASE ALSO_METRICS
@@ -152,10 +151,10 @@ glyph-block Letter-Latin-Upper-N : begin
 
 	create-glyph 'cyrl/I' 0x418 : glyph-proc
 		include : MarkSet.capital
-		include : NRevShape BODY-SYMMETRIC SLAB-AUTO CAP SB RightSB (crDiag -- crD)
+		include : NRevShape BODY-SYMMETRIC SLAB-CYRL-I CAP SB RightSB (crDiag -- crD)
 	create-glyph 'cyrl/i.upright' : glyph-proc
 		include : MarkSet.e
-		include : NRevShape BODY-SYMMETRIC SLAB-AUTO XH  SB RightSB (crDiag -- crD)
+		include : NRevShape BODY-SYMMETRIC SLAB-CYRL-I XH  SB RightSB (crDiag -- crD)
 
 	create-glyph 'grek/DigammaPamphylian' 0x376 : glyph-proc
 		include : MarkSet.capital

--- a/packages/font-glyphs/src/symbol/counting-rod.ptl
+++ b/packages/font-glyphs/src/symbol/counting-rod.ptl
@@ -8,7 +8,6 @@ glyph-block Symbol-Counting-Rod : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 
-	define isProportional : para.diversityII < 1
 	define rodDiv : mix 1 para.diversityM 2
 	define rodDf : DivFrame rodDiv 5
 	define rodSw rodDf.mvs
@@ -89,7 +88,7 @@ glyph-block Symbol-Counting-Rod : begin
 
 	do "Tally Marks"
 		create-glyph 'tallyMarkOne' 0x1D377 : glyph-proc
-			local df : include : DivFrame : if isProportional (rodDiv / 4) 1
+			local df : include : DivFrame : if (para.diversityII < 1) (rodDiv / 4) 1
 			include : df.markSet.capital
 			include : VBar.m df.middle 0 CAP df.mvs
 

--- a/packages/font-glyphs/src/symbol/letter.ptl
+++ b/packages/font-glyphs/src/symbol/letter.ptl
@@ -100,7 +100,7 @@ glyph-block Symbol-Currency-Letter-Derived : begin
 	derive-composites 'currency/guaraniSign' 0x20B2 'G' 'longVStrokeOver'
 	derive-composites 'currency/cediSign' 0x20B5 'C' 'longVStrokeOver'
 
-	derive-composites 'currency/somSign' 0x20C0 'cyrl/es' 'sbRsbUnderlineBelow'
+	derive-composites 'currency/somSign' 0x20C0 'smcpC' 'sbRsbUnderlineBelow'
 
 glyph-block Symbol-Letter : begin
 	glyph-block-import CommonShapes

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -7347,7 +7347,7 @@ selector."cyrl/yeri" = "corner"
 selector."cyrl/yeri.BGR" = "round" # Bulgarian
 selector."cyrl/nje/rightHalf"  = "corner"
 selector."cyrl/lje"  = "corner"
-selector."cyrl/tje.upright/rightHalf" = "corner"
+selector."cyrl/tje/rightHalf" = "corner"
 
 [prime.cyrl-yeri.variants.round]
 rank = 2
@@ -7358,7 +7358,7 @@ selector."cyrl/yeri" = "round"
 selector."cyrl/yeri.BGR" = "round"
 selector."cyrl/nje/rightHalf"  = "round"
 selector."cyrl/lje"  = "round"
-selector."cyrl/tje.upright/rightHalf" = "round"
+selector."cyrl/tje/rightHalf" = "round"
 
 [prime.cyrl-yeri.variants.cursive]
 rank = 3
@@ -7369,7 +7369,7 @@ selector."cyrl/yeri" = "cursive"
 selector."cyrl/yeri.BGR" = "cursive"
 selector."cyrl/nje/rightHalf"  = "cursive"
 selector."cyrl/lje"  = "cursive"
-selector."cyrl/tje.upright/rightHalf" = "cursive"
+selector."cyrl/tje/rightHalf" = "cursive"
 
 
 


### PR DESCRIPTION
Outside of what's shown here, the rest is just minor code cleanup.
All `C` variants:
`C𝖢ƇꟄҀҼ⃀`
![image](https://github.com/user-attachments/assets/7c48e6a7-6ed7-4a08-ba13-94d6e6aa849a)
All `N` variants (Cyrillic I is unchanged):
`NɴᴎᴺᶰᴻŊ`
![image](https://github.com/user-attachments/assets/88bede5c-5904-4a3f-9cd7-e4f8ff3d7bca)
