### PR TITLE
Cleanup of #2511

### DIFF
--- a/packages/font-glyphs/src/letter/latin/upper-n.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-n.ptl
@@ -65,7 +65,7 @@ glyph-block Letter-Latin-Upper-N : begin
 		local yEnd : match bodyType
 			[Just BODY-SYMMETRIC]    0
 			[Just BODY-ASYMMETRIC] : top * 0.375
-			[Just BODY-COMPRESSED] : if SLAB (stroke * 1.25) 0
+			[Just BODY-COMPRESSED] : if SLAB (swDiag * 1.5) 0
 		local yStart : match bodyType
 			[Just BODY-COMPRESSED] : top - yEnd
 			__                       top
@@ -145,16 +145,18 @@ glyph-block Letter-Latin-Upper-N : begin
 	alias 'grek/Nu' 0x39D 'N'
 	alias-reduced-variant 'grek/Nu/sansSerif' 'grek/Nu' 'N/sansSerif' MathSansSerif
 	select-variant 'NRev' (follow -- 'N')
-	select-variant 'smcpNRev' 0x1D0E (follow -- 'N')
 
 	derive-composites 'NDescender' 0xA790 'N' [CyrDescender.rSideJut RightSB 0]
 
-	CreateAccentedComposition 'NAcute' 0x143 'N' 'acuteAbove'
+	CreateAccentedComposition 'NAcute'    0x143 'N' 'acuteAbove'
 	CreateAccentedComposition 'NAcute.PLK' null 'N' 'kreskaAbove'
 
-	select-variant 'Eng'       0x14A  (follow -- 'N')
-	select-variant 'smcpN'     0x274  (follow -- 'N')
-	select-variant 'NHookLeft' 0x19D  (follow -- 'N')
+	select-variant 'Eng'       0x14A (follow -- 'N')
+	select-variant 'NHookLeft' 0x19D (follow -- 'N')
+
+	select-variant 'smcpN'     0x274 (follow -- 'N')
+	select-variant 'smcpNRev' 0x1D0E (follow -- 'N')
+
 	select-variant 'currency/nairaSignBase' (follow -- 'N')
 
 	create-glyph 'cyrl/I' 0x418 : glyph-proc


### PR DESCRIPTION
Due to the math involved of subtracting a piece of `swDiag` from `stroke`, I've found that a slightly better value to use for `yEnd` than `stroke * 1.25` is `swDiag * 1.5` for weights Regular and heavier.
```
синий
СИНИЙ
```
Thin (not really optically any different):
![image](https://github.com/user-attachments/assets/83f6aaa6-8d32-45e1-9cac-a73a9a315b54)
Regular (doesn't get as crowded near the corners as before):
![image](https://github.com/user-attachments/assets/bd2214aa-51ef-4b0d-9866-32c6555325d7)
Heavy (this is actually _less_ compressed than before):
![image](https://github.com/user-attachments/assets/99f97738-42e5-4677-b064-7c9e1baf0d7c)
