### PR TITLE
Add six sub-locales for `'TRK '`.

### DIFF
--- a/packages/font-glyphs/src/letter/latin/lower-il.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-il.ptl
@@ -302,7 +302,7 @@ glyph-block Letter-Latin-Lower-I : begin
 		CreateAccentedComposition 'i/compLigRight' null 'dotlessi/compLigRight' 'tittleAbove'
 		link-reduced-variant 'i/sansSerif' 'i' MathSansSerif
 
-		CreateAccentedComposition 'i.TRK' null 'dotlessi' 'dotAbove'
+		CreateAccentedComposition 'i.TRK' null 'dotlessi' 'i.TRK/tittleAbove'
 
 		alias 'cyrl/iUkrainian' 0x456 'i'
 		CreateAccentedComposition 'cyrl/yi' 0x457 'dotlessi' 'dieresisAbove'
@@ -344,16 +344,16 @@ glyph-block Letter-Latin-Lower-I : begin
 		select-variant 'lPalatalHook/decompress' (shapeFrom -- 'lPalatalHook') (follow -- 'l/reduced/decompress')
 		select-variant 'lHighBar' 0xA749 (follow -- 'l')
 
-		derive-composites 'lTildeOver' 0x26B 'l/reduced/decompress' 'tildeOver'
+		derive-composites 'lTildeOver'    0x26B  'l/reduced/decompress' 'tildeOver'
 		derive-composites 'lInvLazySOver' 0xAB37 'l/reduced/decompress' 'invLazySOver'
 		derive-composites 'lDblTildeOver' 0xAB38 'l/reduced/decompress' 'dblTildeOver'
-		derive-composites 'lRingOver' 0xAB39 'l/reduced/decompress' 'ringOver'
+		derive-composites 'lRingOver'     0xAB39 'l/reduced/decompress' 'ringOver'
 
 		create-glyph 'lBeltOverlay' : glyph-proc
 			set-mark-anchor 'overlay' 0 0
 			include : BeltOverlay.at 0 0
-		derive-composites 'lBelt' 0x26C  'l/reduced/decompress' 'lBeltOverlay'
-		derive-composites 'lBeltRTail' 0xA78E 'lRTail/decompress' 'lBeltOverlay'
+		derive-composites 'lBelt'            0x26C   'l/reduced/decompress'    'lBeltOverlay'
+		derive-composites 'lBeltRTail'       0xA78E  'lRTail/decompress'       'lBeltOverlay'
 		derive-composites 'lBeltPalatalHook' 0x1DF13 'lPalatalHook/decompress' 'lBeltOverlay'
 
 		derive-composites 'lDot' 0x140 'lDotBase' 'LDotDot'

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -28,7 +28,7 @@ glyph-block Letter-Shared : begin
 			foreach part [items-of : glyphParts.slice 1] : if part : include part
 
 			if (!gr) : begin
-				if (gns.length === 2 && [gns.1.endsWith 'tittleAbove'])
+				if (gns.length === 2 && ([gns.1.endsWith 'tittleAbove'] || [gns.1.endsWith 'dotAbove']))
 				: then : Dotless.set currentGlyph gns.0
 				: else : CvDecompose.set currentGlyph gns
 

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -28,7 +28,7 @@ glyph-block Letter-Shared : begin
 			foreach part [items-of : glyphParts.slice 1] : if part : include part
 
 			if (!gr) : begin
-				if (gns.length === 2 && ([gns.1.endsWith 'tittleAbove'] || [gns.1.endsWith 'dotAbove']))
+				if (gns.length === 2 && [gns.1.endsWith 'tittleAbove'])
 				: then : Dotless.set currentGlyph gns.0
 				: else : CvDecompose.set currentGlyph gns
 

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -109,8 +109,9 @@ glyph-block Mark-Above : begin
 	select-variant 'tripleDotAbove'      0x1AB4 (follow -- 'diacriticDot')
 	select-variant 'elipsisAbove'        0x20DB (follow -- 'diacriticDot')
 	select-variant 'fourDotsAbove'       0x20DC (follow -- 'diacriticDot')
-	select-variant 'tittleAbove' (shapeFrom -- "dotAbove") (follow -- 'tittle')
-	select-variant 'kropkaAbove' (shapeFrom -- "dotAbove") (follow -- 'tittle')
+	select-variant 'tittleAbove'       (shapeFrom -- "dotAbove") (follow -- 'tittle')
+	select-variant 'i.TRK/tittleAbove' (shapeFrom -- "dotAbove") (follow -- 'diacriticDot')
+	select-variant 'kropkaAbove'       (shapeFrom -- "dotAbove") (follow -- 'tittle')
 
 	glyph-block-export RingDims RingShape
 	define [RingDims _radiusOut] : begin

--- a/packages/font-otl/src/gsub-locl.ptl
+++ b/packages/font-otl/src/gsub-locl.ptl
@@ -21,13 +21,19 @@ export : define [buildLOCL gsub para glyphStore] : begin
 	define latnMOL  : gsub.copyLanguage 'latn_MOL ' 'latn_DFLT'
 	define latnTRK  : gsub.copyLanguage 'latn_TRK ' 'latn_DFLT'
 	define latnAZE  : gsub.copyLanguage 'latn_AZE ' 'latn_DFLT'
-	define latnGAG  : gsub.copyLanguage 'latn_GAG ' 'latn_DFLT'
-	define latnKAZ  : gsub.copyLanguage 'latn_KAZ ' 'latn_DFLT'
-	define latnTAT  : gsub.copyLanguage 'latn_TAT ' 'latn_DFLT'
 	define latnCRT  : gsub.copyLanguage 'latn_CRT ' 'latn_DFLT'
+	define latnGAG  : gsub.copyLanguage 'latn_GAG ' 'latn_DFLT'
+	define latnJCT  : gsub.copyLanguage 'latn_JCT ' 'latn_DFLT'
+	define latnKAZ  : gsub.copyLanguage 'latn_KAZ ' 'latn_DFLT'
+	define latnKJJ  : gsub.copyLanguage 'latn_KJJ ' 'latn_DFLT'
+	define latnKMZ  : gsub.copyLanguage 'latn_KMZ ' 'latn_DFLT'
+	define latnTAT  : gsub.copyLanguage 'latn_TAT ' 'latn_DFLT'
+	define latnTLY  : gsub.copyLanguage 'latn_TLY ' 'latn_DFLT'
+	define latnUDI  : gsub.copyLanguage 'latn_UDI ' 'latn_DFLT'
+	define latnZZA  : gsub.copyLanguage 'latn_ZZA ' 'latn_DFLT'
 	define latnVIT  : gsub.copyLanguage 'latn_VIT ' 'latn_DFLT'
-	define grekIPPH : gsub.copyLanguage 'grek_IPPH ' 'grek_DFLT'
-	define grekAPPH : gsub.copyLanguage 'grek_APPH ' 'grek_DFLT'
+	define grekIPPH : gsub.copyLanguage 'grek_IPPH' 'grek_DFLT'
+	define grekAPPH : gsub.copyLanguage 'grek_APPH' 'grek_DFLT'
 
 	# SRB
 	define loclSRB : gsub.createFeature 'locl'
@@ -70,10 +76,16 @@ export : define [buildLOCL gsub para glyphStore] : begin
 	define loclTRK : gsub.createFeature 'locl'
 	latnTRK.addFeature loclTRK
 	latnAZE.addFeature loclTRK
-	latnGAG.addFeature loclTRK
-	latnKAZ.addFeature loclTRK
-	latnTAT.addFeature loclTRK
 	latnCRT.addFeature loclTRK
+	latnGAG.addFeature loclTRK
+	latnJCT.addFeature loclTRK
+	latnKAZ.addFeature loclTRK
+	latnKJJ.addFeature loclTRK
+	latnKMZ.addFeature loclTRK
+	latnTAT.addFeature loclTRK
+	latnTLY.addFeature loclTRK
+	latnUDI.addFeature loclTRK
+	latnZZA.addFeature loclTRK
 	loclTRK.addLookup : createGsubLookupFromGr gsub glyphStore LocalizedForm.TRK
 
 	# VIT


### PR DESCRIPTION
Inspired by https://github.com/MicrosoftDocs/typography-issues/issues/1065

Also make lowercase `i.TRK` soft-dotted since many Turkic languages use `Î`/`î` which is apparently supposed to be derived from `İ`/`i` and not `I`/`ı`.