### PR TITLE
Minor fixup of vertical stroke width of combining box below under heavy weight.

### DIFF
--- a/packages/font-glyphs/src/marks/below.ptl
+++ b/packages/font-glyphs/src/marks/below.ptl
@@ -121,7 +121,7 @@ glyph-block Mark-Below : begin
 		include : StdAnchors.mediumWide
 
 		local boxhs : Math.min (markFine * 2) ((belowMarkTop - belowMarkBot) / 3)
-		local boxvs : Math.min (markFine * 2) (markExtend * 2 / 3)
+		local boxvs : Math.min (markFine * 2) ((markExtend * 2) / (HVContrast * 3))
 
 		include : VBar.l (markMiddle - markExtend) belowMarkBot belowMarkTop boxvs
 		include : VBar.r (markMiddle + markExtend) belowMarkBot belowMarkTop boxvs
@@ -132,10 +132,10 @@ glyph-block Mark-Below : begin
 		set-width 0
 		include : StdAnchors.mediumWide
 
-		local boxsw : Math.min (markFine * 2) ((belowMarkTop - belowMarkBot) / 3)
+		local eqsw : Math.min (markFine * 2) ((belowMarkTop - belowMarkBot) / 3)
 
-		include : HBar.b (markMiddle - markExtend) (markMiddle + markExtend) belowMarkBot boxsw
-		include : HBar.t (markMiddle - markExtend) (markMiddle + markExtend) belowMarkTop boxsw
+		include : HBar.b (markMiddle - markExtend) (markMiddle + markExtend) belowMarkBot eqsw
+		include : HBar.t (markMiddle - markExtend) (markMiddle + markExtend) belowMarkTop eqsw
 
 	create-glyph 'shelfBelow' : glyph-proc
 		set-width 0


### PR DESCRIPTION
I was wondering why it wasn't respecting being clamped to `markExtend * 2 / 3` via `Math.min` and I finally figured out why.
`ð̻˗˕ˠ`
Regular for comparison (unchanged):
![image](https://github.com/user-attachments/assets/d8bb5206-15cc-4d10-9af5-868c2c6579dd)
Heavy Before:
![image](https://github.com/user-attachments/assets/9096f7da-ee98-419b-8a1b-69058c6cd2a1)
Heavy After:
![image](https://github.com/user-attachments/assets/7132504f-89f8-4f7c-b2b6-43ad9ee9aac6)
