### PR TITLE
Optimize stroke terminal angle for Tonos Above.

### DIFF
--- a/changes/31.8.0.md
+++ b/changes/31.8.0.md
@@ -3,3 +3,4 @@
   - MUSICAL SYMBOL RINFORZANDO (`U+1D18C`) ... MUSICAL SYMBOL FORTE (`U+1D191`) (#2522).
 * Improve glyph for Cyrillic I (`И`/`и`) under slab (#2489).
   - Bulgarian locale (`'BGR'`) uses original style for capital.
+* Optimize glyph for Tonos Above (`U+0384`) in accented Greek letters.

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -818,8 +818,7 @@ glyph-block Mark-Above : begin
 		include : StdAnchors.narrow
 		local shift : 0.05 * markExtend + [HSwToV : markStress - markFine]
 		include : dispiro
-			widths.center : markStress * 2
-			flat (markMiddle + shift) (aboveMarkTop + 0.4 * markStress)
+			flat (markMiddle + shift) (aboveMarkTop + 0.4 * markStress) [widths.center.heading (markStress * 2) Downward]
 			curl (markMiddle - 0.5 * shift) aboveMarkBot [widths.center.heading (markFine * 2) Downward]
 
 	create-glyph 'tonosGrekUpperTonos' : glyph-proc

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -818,8 +818,9 @@ glyph-block Mark-Above : begin
 		include : StdAnchors.narrow
 		local shift : 0.05 * markExtend + [HSwToV : markStress - markFine]
 		include : dispiro
-			flat (markMiddle + shift) (aboveMarkTop + 0.4 * markStress) [widths.center : markStress * 2]
-			curl (markMiddle - 0.5 * shift) aboveMarkBot [widths.center : markFine * 2]
+			widths.center : markStress * 2
+			flat (markMiddle + shift) (aboveMarkTop + 0.4 * markStress)
+			curl (markMiddle - 0.5 * shift) aboveMarkBot [widths.center.heading (markFine * 2) Downward]
 
 	create-glyph 'tonosGrekUpperTonos' : glyph-proc
 		set-width 0


### PR DESCRIPTION
A compromise from what was done in #2486 .
The bottom terminal is made flat; It already kind of looked like this at smaller optical sizes due to rasterization.
The top terminal is left alone.
```
άέήίΐόύΰώ
ΆΈΉΊΪΌΎΫΏ
```
Before:
![image](https://github.com/user-attachments/assets/c16f07c2-274f-4f9f-b262-f7b1d72446d6)
After:
![image](https://github.com/user-attachments/assets/34902b57-da70-4077-a739-9b95b278afd2)
