### PR TITLE
Cleanup `transformed-jobs-data.ptl`.

### DIFF
--- a/packages/font-glyphs/src/auto-build/transformed-jobs-data.ptl
+++ b/packages/font-glyphs/src/auto-build/transformed-jobs-data.ptl
@@ -351,8 +351,6 @@ export : define MedievalComb_e : list
 	list 0x366 'o'
 	list 0x367 'u'
 	list 0x368 'c'
-	list 0x369 'd'
-	list 0x36A 'h'
 	list 0x36B 'm'
 	list 0x36C 'r'
 	list 0x36E 'v'
@@ -399,7 +397,6 @@ export : define MedievalComb_e : list
 	list 0x2DF6 'cyrl/a'
 	list 0x2DF7 'cyrl/ie'
 	list 0x2DF8 'cyrl/djerv'
-	list 0x2DF9 'cyrl/uk'
 	list 0x2DFB 'cyrl/yu'
 	list 0x2DFC 'cyrl/aIotified'
 	list 0x2DFD 'cyrl/smallYus'
@@ -415,8 +412,9 @@ export : define MedievalComb_e : list
 
 export : define MedievalComb_b : list
 	list 0x365 'i'
+	list 0x369 'd'
+	list 0x36A 'h'
 	list 0x36D 't'
-	list 0x1AC6 'numberSign/cap'
 	list 0x1DD8 'dInsular'
 	list 0x1DD9 'eth'
 	list 0x1DDC 'k'
@@ -427,6 +425,7 @@ export : define MedievalComb_b : list
 	list 0x1DF3 'oDieresis'
 	list 0x1DF4 'uDieresis'
 	list 0x2DE0 'cyrl/be'
+	list 0x2DF9 'cyrl/uk'
 	list 0x2DFA 'cyrl/yat'
 	list 0xA676 'cyrl/yi'
 	list 0x1E08F 'cyrl/iUkrainian'
@@ -436,17 +435,17 @@ export : define MedievalComb_CAP : list
 
 export : define MedievalComb_p : list
 	list 0x1ACC 'gInsular'
-	list 0x1DDA 'g'
+	list 0x1ACD 'rInsular'
 	list 0x1DD7 'cCedilla'
-	list 0x1DE9 'latn/beta'
+	list 0x1DDA 'g'
 	list 0x1DEE 'p'
 	list 0x2DEC 'cyrl/er'
 	list 0xA677 'cyrl/u'
 
 export : define MedievalComb_bp : list
-	list 0x1ACD 'rInsular'
 	list 0x1DEB 'f'
 	list 0x1DE5 'longs'
+	list 0x1DE9 'latn/beta'
 	list 0x1DEF 'esh'
 	list 0xA69E 'cyrl/ef'
 


### PR DESCRIPTION
Some overscript characters were grouped by the wrong mark sets, and also overscript number sign was listed twice after disunifying `b` from `CAP`.