### PR TITLE
Optimize bar stroke width for Cyrillic Lower Ef for split bowl variants.

### DIFF
--- a/changes/31.8.0.md
+++ b/changes/31.8.0.md
@@ -2,5 +2,7 @@
   - LATIN EPIGRAPHIC LETTER ARCHAIC M (`U+A7FF`) (#2517).
   - MUSICAL SYMBOL RINFORZANDO (`U+1D18C`) ... MUSICAL SYMBOL FORTE (`U+1D191`) (#2522).
 * Improve glyph for Cyrillic I (`И`/`и`) under slab (#2489).
-  - Bulgarian locale (`'BGR'`) uses original style for capital.
+  - Bulgarian locale (`'BGR '`) uses original style for capital.
 * Optimize glyph for Tonos Above (`U+0384`) in accented Greek letters.
+* Optimize stroke width of bar for split bowl variants of Cyrillic Lower Ef (`ф`).
+* Optimize glyph for Cyrillic Capital Ef (`Ф`) under Bulgarian locale (`'BGR '`) under slab.

--- a/packages/font-glyphs/src/letter/greek/phi.ptl
+++ b/packages/font-glyphs/src/letter/greek/phi.ptl
@@ -59,52 +59,52 @@ glyph-block Letter-Greek-Phi : begin
 			flat (df.middle - [HSwToV : 0.5 * df.mvs]) [mix y2 y3 0.66]
 			curl (df.middle - [HSwToV : 0.5 * df.mvs]) (y2 + 0.2 * df.mvs) [heading Downward]
 
-	define [StraightBar df y1 y2 y3 y4] : glyph-proc
-		include : VBar.m df.middle y1 (y2 + HalfStroke)
-		include : VBar.m df.middle (y3 - HalfStroke) y4
+	define [StraightBar df y1 y2 y3 y4 sw] : glyph-proc
+		include : VBar.m df.middle y1 (y2 + HalfStroke) sw
+		include : VBar.m df.middle (y3 - HalfStroke) y4 sw
 
-	define [CursiveBar df y1 y2 y3 y4] : glyph-proc
+	define [CursiveBar df y1 y2 y3 y4 sw] : glyph-proc
 		local hd : FlatHookDepth df
 
 		local xCrossLeft  : mix 0         df.leftSB   [mix 1 df.div 2]
 		local xCrossRight : mix df.width  df.rightSB  [mix 1 df.div 2]
 
-		local xBarLeft    : df.middle - [HSwToV HalfStroke]
-		local xBarRight   : df.middle + [HSwToV HalfStroke]
+		local xBarLeft    : df.middle - [HSwToV : 0.5 * sw]
+		local xBarRight   : df.middle + [HSwToV : 0.5 * sw]
 
 		include : dispiro
-			flat xCrossRight y4 [widths.lhs]
+			flat xCrossRight y4 [widths.lhs sw]
 			curl [Math.min (xBarLeft + hd.x) (xCrossRight - TINY)] y4
 			archv
 			flat xBarLeft [Math.max y3 (y4 - hd.y)]
 			curl xBarLeft (y3 + O)
 
 		include : dispiro
-			flat xCrossLeft y1 [widths.lhs]
+			flat xCrossLeft y1 [widths.lhs sw]
 			curl [Math.max (xBarRight - hd.x) (xCrossLeft + TINY)] y1
 			archv
 			flat xBarRight [Math.min y2 (y1 + hd.y)]
 			curl xBarRight (y2 - O)
 
-	define [DiagonalTailCursiveBar df y1 y2 y3 y4] : glyph-proc
+	define [DiagonalTailCursiveBar df y1 y2 y3 y4 sw] : glyph-proc
 		local hd : FlatHookDepth df
 
 		local xCrossRight : mix df.width  df.rightSB  [mix 1 df.div 2]
-		local xBarLeft    : df.middle - [HSwToV HalfStroke]
+		local xBarLeft    : df.middle - [HSwToV : 0.5 * sw]
 
 		include : dispiro
-			flat xCrossRight y4 [widths.lhs]
+			flat xCrossRight y4 [widths.lhs sw]
 			curl [Math.min (xBarLeft + hd.x) (xCrossRight - TINY)] y4
 			archv
 			flat xBarLeft [Math.max y3 (y4 - hd.y)]
 			curl xBarLeft (y3 + O)
 
 		include : dispiro
-			flat df.middle (y2 - O) [widths.center.heading Stroke Downward]
-			DiagTail.L df.middle y1 [DiagTail.StdDepth df Stroke] Stroke
+			flat df.middle (y2 - O) [widths.center.heading sw Downward]
+			DiagTail.L df.middle y1 [DiagTail.StdDepth df sw] sw
 
-	define [MtSerif df y] : tagged 'serifMT' : HSerif.lt df.middle y Jut
-	define [MbSerif df y] : tagged 'serifMB' : HSerif.mb df.middle y Jut
+	define [MtSerif df y sw] : tagged 'serifMT' : HSerif.lt df.middle y Jut sw
+	define [MbSerif df y sw] : tagged 'serifMB' : HSerif.mb df.middle y Jut sw
 
 	define [GrekCapitalPhiImpl fFlatTB df] : glyph-proc
 		local y2 : mix [if SLAB Stroke 0] [if SLAB (CAP - Stroke) CAP] 0.125
@@ -114,7 +114,7 @@ glyph-block Letter-Greek-Phi : begin
 
 		if SLAB : begin
 			include : tagged 'serifMT' : HSerif.mt df.middle CAP MidJutSide
-			include : tagged 'serifMB' : HSerif.mb df.middle 0 MidJutSide
+			include : tagged 'serifMB' : HSerif.mb df.middle 0   MidJutSide
 
 	create-glyph 'grek/Phi' 0x3A6 : glyph-proc
 		local df : include : DivFrame para.diversityM 3
@@ -130,8 +130,10 @@ glyph-block Letter-Greek-Phi : begin
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.capital
 
-		local top : CAP + LongJut - [if SLAB 0 HalfStroke]
-		local bot : 0   - LongJut + [if SLAB 0 HalfStroke]
+		local vJut : Math.max (LongJut - 0.5 * Stroke) : if SLAB (1.25 * Stroke - O) 0
+
+		local top : CAP + vJut
+		local bot : 0 - vJut
 
 		include : ExtendAboveBaseAnchors top
 		include : ExtendBelowBaseAnchors bot
@@ -174,13 +176,13 @@ glyph-block Letter-Greek-Phi : begin
 		include [refer-glyph 'grek/varphi'] AS_BASE ALSO_METRICS
 
 		if SLAB : begin
-			include : tagged 'serifMT' : HSerif.mt df.middle Ascender Jut
+			include : tagged 'serifMT' : HSerif.mt df.middle Ascender  Jut
 			include : tagged 'serifMB' : HSerif.mb df.middle Descender Jut
 
 	define CyrlLowerEfConfig : SuffixCfg.weave
 		object # bowl
-			""                      VarPhiRing
-			splitBowl               CyrlEfSplitRing
+			""                    { VarPhiRing Stroke }
+			splitBowl             { CyrlEfSplitRing [DivFrame para.diversityM 3].mvs }
 		object # bar
 			serifless             { StraightBar nothing nothing }
 			topSerifed            { StraightBar MtSerif nothing }
@@ -188,21 +190,21 @@ glyph-block Letter-Greek-Phi : begin
 			cursive               { CursiveBar  nothing nothing }
 			diagonalTailedCursive { DiagonalTailCursiveBar nothing nothing }
 
-	foreach { suffix { Bowl { Bar sMT sMB } } } [Object.entries CyrlLowerEfConfig] : do
+	foreach { suffix { { Bowl barSw } { Bar sMT sMB } } } [Object.entries CyrlLowerEfConfig] : do
 		create-glyph "cyrl/ef.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.bp
 			include : Bowl 1 df 0 XH
-			include : Bar df Descender 0 XH Ascender
-			if sMT : include : sMT df Ascender
-			if sMB : include : sMB df Descender
+			include : Bar df Descender 0 XH Ascender barSw
+			if sMT : include : sMT df Ascender  barSw
+			if sMB : include : sMB df Descender barSw
 		create-glyph "cyrl/ef.BGR.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.bp
 			include : VarPhiRing 0 df 0 XH
-			include : Bar df Descender 0 XH Ascender
-			if sMT : include : sMT df Ascender
-			if sMB : include : sMB df Descender
+			include : Bar df Descender 0 XH Ascender barSw
+			if sMT : include : sMT df Ascender  barSw
+			if sMB : include : sMB df Descender barSw
 
 	select-variant 'cyrl/ef' 0x444
 	select-variant 'cyrl/ef.BGR'


### PR DESCRIPTION
`ф𞁂𞁠`
Heavy before (in particular look at 08 and 10):
![image](https://github.com/user-attachments/assets/3346638a-194c-442c-a1ec-ccf07f29df40)
Heavy after:
![image](https://github.com/user-attachments/assets/64d0ded2-1704-4de2-bd7e-2d5fc95dfba6)
Also optimize ascending/descending height of Bulgarian Capital Ef under slab:
`Фф𞁂`
Thin before:
![image](https://github.com/user-attachments/assets/b4dfdeca-1f73-4555-87c8-36a18502d86a)
Thin after:
![image](https://github.com/user-attachments/assets/a431ed7b-8d85-4c34-b052-03c98a9e05e9)
Regular Before:
![image](https://github.com/user-attachments/assets/1c44cfb8-4a86-4e4e-9827-6c2272d6fe9a)
Regular after:
![image](https://github.com/user-attachments/assets/cb2c8288-b9de-4316-88c0-bc582974b889)
Heavy Before:
![image](https://github.com/user-attachments/assets/dece5eb4-bfe5-4e3d-8093-babcd58e310e)
Heavy after:
![image](https://github.com/user-attachments/assets/1bf961aa-baf1-4433-b851-327b2c854b60)