### PR TITLE
Fix seam in glyphs of Cyrillic Capital/Small Letter Zhwe.

### DIFF
--- a/changes/31.8.0.md
+++ b/changes/31.8.0.md
@@ -6,3 +6,4 @@
 * Optimize glyph for Tonos Above (`U+0384`) in accented Greek letters.
 * Optimize stroke width of bar for split bowl variants of Cyrillic Lower Ef (`ф`).
 * Optimize glyph for Cyrillic Capital Ef (`Ф`) under Bulgarian locale (`'BGR '`) under slab.
+* Fix seam in glyphs of Cyrillic Capital/Small Letter Zhwe (`U+A684`..`U+A685`).

--- a/packages/font-glyphs/src/letter/cyrillic/de.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/de.ptl
@@ -121,7 +121,13 @@ glyph-block Letter-Cyrillic-De : begin
 			local sw : AdviceStroke 2.5 ((sr - sl + 2 * SB) / Width)
 			local shapeBot : de.desc - 0.5 * sw
 			local hook : Hook * (0 - shapeBot) / CAP
-			local ze : CyrZe 3 sb sw shapeBot sl sr 0.65 hook sw (0.5 * O) (op -- 0.5)
+			local ze : CyrZe 3 sb sw shapeBot
+				left   -- sl
+				right  -- sr
+				hook   -- hook
+				stroke -- sw
+				xo     -- 0.5 * O
+				op     -- 0.5
 			return : union [ze.Shape] [ze.AutoEndSerifL]
 
 		create-glyph "cyrl/Dzze.\(suffix)" : glyph-proc
@@ -176,7 +182,11 @@ glyph-block Letter-Cyrillic-De : begin
 
 			local xZeLeft : dfLeft.leftSB + df.width - dfLeft.width + OX
 			local xZeRight : dfLeft.rightSB + df.width - dfLeft.width - OX
-			local ze : CyrZe 1 sb XH Descender xZeLeft xZeRight 0.65 Hook df.mvs
+			local ze : CyrZe 1 sb XH Descender
+				left   -- xZeLeft
+				right  -- xZeRight
+				hook   -- Hook
+				stroke -- df.mvs
 			include : union [ze.Shape] [ze.AutoEndSerifL]
 
 	select-variant 'cyrl/Dzze' 0xA688 (follow -- 'cyrl/ZeBottomSerifOnly')

--- a/packages/font-glyphs/src/letter/cyrillic/dzzhe-zhwe.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/dzzhe-zhwe.ptl
@@ -53,7 +53,12 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 	do "ze subglyph"
 		define [CyrZhweZeShape slabTop slabBot df top hook] : glyph-proc
 			local [object subDf sw] : SubDfDimBy4 0 2 df OX
-			local ze : CyrZe slabTop slabBot top 0 subDf.leftSB subDf.rightSB 0.65 hook sw (xo -- 0.33 * OX)
+			local ze : CyrZe slabTop slabBot top 0
+				left   -- subDf.leftSB
+				right  -- subDf.rightSB
+				hook   -- hook
+				stroke -- sw
+				xo     -- 0.33 * OX
 			include : ze.Shape
 			include : ze.AutoStartSerifL
 			include : ze.AutoEndSerifL
@@ -85,8 +90,14 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 
 		define [ZhweZheShape legShape fSlab fMidSlab df top hook] : glyph-proc
 			local [object subDf sw] : SubDfDimBy4 0 2 df OX
-			local ze : CyrZe 0 0 top 0 subDf.leftSB subDf.rightSB 0.65 hook (0.5 * sw)
-			include : difference [CyrRightZheShape legShape fSlab fMidSlab df top subDf.middle] [ze.ShapeMask]
+			local zeNoO : CyrZe 0 0 top 0
+				left   -- subDf.leftSB
+				right  -- subDf.rightSB
+				hook   -- hook
+				stroke -- 0.5 * sw
+				xo     -- 0
+				yo     -- 0
+			include : difference [CyrRightZheShape legShape fSlab fMidSlab df top subDf.middle] [zeNoO.ShapeMask]
 
 		glyph-block-import Letter-Cyrillic-De : CyrDeItalicShapeT
 		define [DzzheZheItalicShape legShape fSlab fMidSlab df top] : glyph-proc

--- a/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
@@ -31,7 +31,8 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 	define VolBlend 0.52
 
 	define [SmallEpsilon] : with-params [
-			slabTop slabBot top bot blend hook
+			slabTop slabBot top bot
+			[blend StdBlend] [hook Hook]
 			[ada2 SmallArchDepthA] [adb2 SmallArchDepthB]
 		] : namespace
 		export : define [Dim] : begin
@@ -100,7 +101,8 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 
 	glyph-block-export CyrZe
 	define [CyrZe] : with-params [
-		slabTop slabBot top bot left right blend hook [stroke : AdviceStroke2 2 3 (top - bot)]
+		slabTop slabBot top bot [left SB] [right RightSB]
+		[blend StdBlend] [hook Hook] [stroke : AdviceStroke2 2 3 (top - bot)]
 		[xo OX] [yo O] [op OverlayPos] [ada2 SmallArchDepthA] [adb2 SmallArchDepthB]
 		] : namespace
 		export : define [Dim] : begin
@@ -218,33 +220,33 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 	foreach { suffix { slabTop slabBot } } [Object.entries EpsilonConfig] : do
 		create-glyph "latn/Epsilon.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : let [eps : SmallEpsilon slabTop slabBot CAP 0 StdBlend Hook]
+			include : let [eps : SmallEpsilon slabTop slabBot CAP 0 (hook -- Hook)]
 				union [eps.Shape] [eps.AutoStartSerifR] [eps.AutoEndSerifR]
 
 		create-glyph "latn/epsilon.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			include : let [eps : SmallEpsilon slabTop slabBot XH 0 StdBlend SHook]
+			include : let [eps : SmallEpsilon slabTop slabBot XH 0 (hook -- SHook)]
 				union [eps.Shape] [eps.AutoStartSerifR] [eps.AutoEndSerifR]
 
 		create-glyph "cyrl/Ze.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : let [ze : CyrZe slabTop slabBot CAP 0 SB RightSB StdBlend Hook]
+			include : let [ze : CyrZe slabTop slabBot CAP 0 (hook -- Hook)]
 				union [ze.Shape] [ze.AutoStartSerifL] [ze.AutoEndSerifL]
 
 		create-glyph "cyrl/ze.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			include : let [ze : CyrZe slabTop slabBot XH 0 SB RightSB StdBlend SHook]
+			include : let [ze : CyrZe slabTop slabBot XH 0 (hook -- SHook)]
 				union [ze.Shape] [ze.AutoStartSerifL] [ze.AutoEndSerifL]
 
 		create-glyph "cyrl/ze.BGR.\(suffix)" : glyph-proc
 			include : MarkSet.p
-			include : let [ze : CyrZe slabTop slabBot XH Descender SB RightSB StdBlend SHook]
+			include : let [ze : CyrZe slabTop slabBot XH Descender (hook -- SHook)]
 				union [ze.Shape] [ze.AutoStartSerifL] [ze.AutoEndSerifL]
 
 		create-glyph "cyrl/Dhe.\(suffix)" : glyph-proc
 			include [refer-glyph "cyrl/Ze.\(suffix)"] AS_BASE ALSO_METRICS
 			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
-			include : let [zeNoO : CyrZe slabTop slabBot CAP 0 SB RightSB StdBlend Hook (xo -- 0) (yo -- 0)]
+			include : let [zeNoO : CyrZe slabTop slabBot CAP 0 (hook -- Hook) (xo -- 0) (yo -- 0)]
 				difference
 					VBar.m [arch.adjust-x.bot Middle] (-LongJut + 0.5 * Stroke) (Stroke + O) [AdviceStroke 3.5]
 					zeNoO.ShapeMask
@@ -252,21 +254,21 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 		create-glyph "cyrl/dhe.\(suffix)" : glyph-proc
 			include [refer-glyph "cyrl/ze.\(suffix)"] AS_BASE ALSO_METRICS
 			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
-			include : let [zeNoO : CyrZe slabTop slabBot XH 0 SB RightSB StdBlend SHook (xo -- 0) (yo -- 0)]
+			include : let [zeNoO : CyrZe slabTop slabBot XH 0 (hook -- SHook) (xo -- 0) (yo -- 0)]
 				difference
 					VBar.m [arch.adjust-x.bot Middle] (-LongJut + 0.5 * Stroke) (Stroke + O) [AdviceStroke 3.5]
 					zeNoO.ShapeMask
 
 		create-glyph "cyrl/DzjeKomi.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			local ze : CyrZe slabTop OPEN-VERTICAL CAP 0 SB RightSB StdBlend Hook
+			local ze : CyrZe slabTop OPEN-VERTICAL CAP 0 (hook -- Hook)
 			include : ze.Shape
 			include : ze.AutoStartSerifL
 			include : CyrDescender.rSideJut (RightSB - OX * 2) 0
 
 		create-glyph "cyrl/dzjeKomi.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			local ze : CyrZe slabTop OPEN-VERTICAL XH 0 SB RightSB StdBlend SHook
+			local ze : CyrZe slabTop OPEN-VERTICAL XH 0 (hok -- SHook)
 			include : ze.Shape
 			include : ze.AutoStartSerifL
 			include : CyrDescender.rSideJut (RightSB - OX * 2) 0
@@ -276,17 +278,21 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 			include : df.markSet.capital
 
 			local xm : df.middle + [HSwToV : 0.5 * df.mvs]
-			local ze : CyrZe slabTop OPEN-HALF CAP 0 df.leftSB xm StdBlend Hook df.mvs
+			local ze : CyrZe slabTop OPEN-HALF CAP 0
+				left   -- df.leftSB
+				right  -- xm
+				hook   -- Hook
+				stroke -- df.mvs
 			define [object stroke midy] : ze.Dim
 			include : ze.Shape
 			include : UpwardHookShape
-				left -- xm - OX * 2 - [HSwToV stroke]
-				right -- df.rightSB
+				left   -- (xm - OX * 2 - [HSwToV stroke])
+				right  -- df.rightSB
 				ybegin -- [YSmoothMidR (midy + stroke / 2) 0]
-				yend -- (CAP / 2)
-				ada -- (ArchDepthA * 0.6 * df.div)
-				adb -- (ArchDepthB * 0.6 * df.div)
-				sw -- stroke
+				yend   -- (CAP / 2)
+				ada    -- (ArchDepthA * 0.6 * df.div)
+				adb    -- (ArchDepthB * 0.6 * df.div)
+				sw     -- stroke
 			include : ze.AutoStartSerifL
 			local sf2 : [SerifFrame.fromDf df (CAP / 2) 0].slice 1 2
 			if SLAB : include sf2.rt.full
@@ -296,83 +302,99 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 			include : df.markSet.e
 
 			local xm : df.middle + [HSwToV : 0.5 * df.mvs]
-			local ze : CyrZe slabTop OPEN-HALF XH 0 df.leftSB xm StdBlend SHook df.mvs
+			local ze : CyrZe slabTop OPEN-HALF XH 0
+				left   -- df.leftSB
+				right  -- xm
+				hook   -- SHook
+				stroke -- df.mvs
 			define [object stroke midy] : ze.Dim
 			include : ze.Shape
 			include : UpwardHookShape
-				left -- xm - OX * 2 - [HSwToV stroke]
-				right -- df.rightSB
+				left   -- (xm - OX * 2 - [HSwToV stroke])
+				right  -- df.rightSB
 				ybegin -- [YSmoothMidR (midy + stroke / 2) 0]
-				yend -- (XH / 2)
-				ada -- (SmallArchDepthA * 0.6 * df.div)
-				adb -- (SmallArchDepthB * 0.6 * df.div)
-				sw -- stroke
+				yend   -- (XH / 2)
+				ada    -- (SmallArchDepthA * 0.6 * df.div)
+				adb    -- (SmallArchDepthB * 0.6 * df.div)
+				sw     -- stroke
 			include : ze.AutoStartSerifL
 			local sf2 : [SerifFrame.fromDf df (XH / 2) 0].slice 1 2
 			if SLAB : include sf2.rt.full
 
 		create-glyph "cyrl/KsiBase.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
-			include : let [ze : CyrZe slabTop SLAB-NONE CAP 0 SB RightSB StdBlend Hook]
+			include : let [ze : CyrZe slabTop SLAB-NONE CAP 0 (hook -- Hook)]
 				union [ze.KsiBaseShape] [ze.AutoStartSerifL]
 
 		create-glyph "cyrl/ksiBase.\(suffix)" : glyph-proc
 			include : MarkSet.p
-			include : let [ze : CyrZe slabTop SLAB-NONE XH 0 SB RightSB StdBlend SHook]
+			include : let [ze : CyrZe slabTop SLAB-NONE XH 0 (hook -- SHook)]
 				union [ze.KsiBaseShape] [ze.AutoStartSerifL]
 
 	do "Closed Epsilon Shapes"
 		create-glyph 'epsilonClosed' 0x29A : glyph-proc
 			include : MarkSet.e
-			local eps : SmallEpsilon CLOSED-CIRCLE CLOSED-CIRCLE XH 0 StdBlend SHook
+			local eps : SmallEpsilon CLOSED-CIRCLE CLOSED-CIRCLE XH 0
+				hook -- SHook
 				ada2 -- SmallArchDepthA
 				adb2 -- SmallArchDepthB
 			include : eps.Shape
 
 		create-glyph 'epsilonRevClosed' 0x25E : glyph-proc
 			include : MarkSet.e
-			local ze : CyrZe CLOSED-CIRCLE CLOSED-CIRCLE XH 0 SB RightSB StdBlend SHook
+			local ze : CyrZe CLOSED-CIRCLE CLOSED-CIRCLE XH 0
+				hook -- SHook
 				ada2 -- SmallArchDepthA
 				adb2 -- SmallArchDepthB
 			include : ze.Shape
 
 		create-glyph 'OeVolapuk' 0xA79C : glyph-proc
 			include : MarkSet.capital
-			local eps : SmallEpsilon CLOSED-CIRCLE CLOSED-CIRCLE CAP 0 VolBlend Hook
-				ada2 -- ArchDepthA
-				adb2 -- ArchDepthB
+			local eps : SmallEpsilon CLOSED-CIRCLE CLOSED-CIRCLE CAP 0
+				blend -- VolBlend
+				hook  -- Hook
+				ada2  -- ArchDepthA
+				adb2  -- ArchDepthB
 			include : eps.Shape
 
 		create-glyph 'oeVolapuk' 0xA79D : glyph-proc
 			include : MarkSet.e
-			local eps : SmallEpsilon CLOSED-CIRCLE CLOSED-CIRCLE XH 0 VolBlend SHook
-				ada2 -- SmallArchDepthA
-				adb2 -- SmallArchDepthB
+			local eps : SmallEpsilon CLOSED-CIRCLE CLOSED-CIRCLE XH 0
+				blend -- VolBlend
+				hook  -- SHook
+				ada2  -- SmallArchDepthA
+				adb2  -- SmallArchDepthB
 			include : eps.Shape
 
 	do "Volapuk AE"
 		glyph-block-import Letter-Latin-Lower-A : SingleStorey
 
 		define [FullBarBody df height bar hook ada2 adb2] : glyph-proc
-			local eps : SmallEpsilon CLOSED-STEM CLOSED-STEM height 0 VolBlend hook
-				ada2 -- ada2
-				adb2 -- adb2
+			local eps : SmallEpsilon CLOSED-STEM CLOSED-STEM height 0
+				blend -- VolBlend
+				hook  -- hook
+				ada2  -- ada2
+				adb2  -- adb2
 			define [object stroke] : eps.Dim
 			include : eps.Shape
 			include : bar df height no-shape stroke
 
 		define [EarlessCornerBody df height bar hook ada2 adb2] : glyph-proc
-			local eps : SmallEpsilon SLAB-INWARD CLOSED-STEM height 0 VolBlend hook
-				ada2 -- ada2
-				adb2 -- adb2
+			local eps : SmallEpsilon SLAB-INWARD CLOSED-STEM height 0
+				blend -- VolBlend
+				hook  -- hook
+				ada2  -- ada2
+				adb2  -- adb2
 			define [object stroke] : eps.Dim
 			include : eps.Shape
 			include : bar df (height - DToothlessRise) no-shape stroke
 
 		define [EarlessRoundedBody df height bar hook ada2 adb2] : glyph-proc
-			local eps : SmallEpsilon CLOSED-ROUND CLOSED-STEM height 0 VolBlend hook
-				ada2 -- ada2
-				adb2 -- adb2
+			local eps : SmallEpsilon CLOSED-ROUND CLOSED-STEM height 0
+				blend -- VolBlend
+				hook  -- hook
+				ada2  -- ada2
+				adb2  -- adb2
 			define [object stroke] : eps.Dim
 			include : eps.Shape
 			include : bar df (height - adb2) no-shape stroke
@@ -408,9 +430,11 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 
 		define [UToothed df height slab hook ada2 adb2] : glyph-proc
 			set-base-anchor 'trailing' df.rightSB 0
-			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-STEM height 0 VolBlend hook
-				ada2 -- ada2
-				adb2 -- adb2
+			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-STEM height 0
+				blend -- VolBlend
+				hook  -- hook
+				ada2  -- ada2
+				adb2  -- adb2
 			define [object stroke] : eps.Dim
 			include : eps.Shape
 			include : VBar.r df.rightSB 0 height stroke
@@ -418,27 +442,33 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 
 		define [UTailed df height slab hook ada2 adb2] : glyph-proc
 			set-base-anchor 'trailing' (df.rightSB + SideJut) 0
-			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-STEM height 0 VolBlend hook
-				ada2 -- ada2
-				adb2 -- adb2
+			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-STEM height 0
+				blend -- VolBlend
+				hook  -- hook
+				ada2  -- ada2
+				adb2  -- adb2
 			define [object stroke] : eps.Dim
 			include : eps.Shape
 			include : RightwardTailedBar df.rightSB 0 height stroke
 			include : slab df height
 
 		define [UToothlessRounded df height slab hook ada2 adb2] : glyph-proc
-			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-ROUND height 0 VolBlend hook
-				ada2 -- ada2
-				adb2 -- adb2
+			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-ROUND height 0
+				blend -- VolBlend
+				hook  -- hook
+				ada2  -- ada2
+				adb2  -- adb2
 			define [object stroke] : eps.Dim
 			include : eps.Shape
 			include : VBar.r df.rightSB ada2 height stroke
 			include : slab df height
 
 		define [UToothlessCorner df height slab hook ada2 adb2] : glyph-proc
-			local eps : SmallEpsilon OPEN-VERTICAL SLAB-INWARD height 0 VolBlend hook
-				ada2 -- ada2
-				adb2 -- adb2
+			local eps : SmallEpsilon OPEN-VERTICAL SLAB-INWARD height 0
+				blend -- VolBlend
+				hook  -- hook
+				ada2  -- ada2
+				adb2  -- adb2
 			define [object stroke] : eps.Dim
 			include : eps.Shape
 			include : VBar.r df.rightSB DToothlessRise height stroke
@@ -528,10 +558,10 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 		local blend 0.505
 		local midGap : Math.max [AdviceStroke2 3 12 CAP] (CAP / 8 - [AdviceStroke2 3 6 XH])
 		local strokeV : AdviceStroke 4
-		local ze : CyrZe SLAB-NONE SLAB-NONE CAP midGap SB RightSB blend Hook
+		local ze : CyrZe SLAB-NONE SLAB-NONE CAP midGap (blend -- blend) (hook -- Hook)
 		local dimUpper : ze.Dim
 
-		local epsilon : SmallEpsilon SLAB-NONE SLAB-NONE (CAP - midGap) 0 blend Hook
+		local epsilon : SmallEpsilon SLAB-NONE SLAB-NONE (CAP - midGap) 0 (blend -- blend) (hook -- Hook)
 		local dimLower : epsilon.Dim
 		include : union [epsilon.LowerShape] [ze.UpperShape]
 			Rect (dimUpper.midy + dimUpper.stroke / 2) (dimLower.midy - dimLower.stroke / 2) (Middle - [HSwToV : 0.5 * strokeV]) (Middle + [HSwToV : 0.5 * strokeV])


### PR DESCRIPTION
The solution was simply to make the mask have no overshoot (the visible ze-part glyph itself still has overshoot).
Also cleanup epsilon code using default values for `left`, `right`, and `blend` (also `hook` too, technically, although this pretends it's still needed).

`Ꚅꚅ`

Thin before:
![image](https://github.com/user-attachments/assets/4a63d1c2-6def-4072-b8fd-83c2d0bbe202)
Thin after:
![image](https://github.com/user-attachments/assets/cbe4b02d-3521-4aa5-98e6-bd11fc17e389)

Regular before:
![image](https://github.com/user-attachments/assets/e4ed3aff-33fb-4931-904d-2341c777d030)
Regular after:
![image](https://github.com/user-attachments/assets/bfd4413b-3176-4bad-809f-4b8b2ab24517)

Heavy before:
![image](https://github.com/user-attachments/assets/bafa6c32-3715-412b-971d-c4c679f23b3d)
Heavy after:
![image](https://github.com/user-attachments/assets/e38b22ee-9826-483e-bd5b-ba2cc21cd0f9)
