### PR TITLE
Optimize glyphs for rounded variants for Capital Eszett.

### DIFF
--- a/changes/31.8.1.md
+++ b/changes/31.8.1.md
@@ -1,0 +1,1 @@
+* Optimize glyphs for `rounded-serifless` and `rounded-serifed` variants for Capital Eszett (`ẞ`).

--- a/packages/font-glyphs/src/letter/latin-ext/eszet.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/eszet.ptl
@@ -199,9 +199,9 @@ glyph-block Letter-Latin-Upper-Eszet : begin
 		define xFinal : Math.max
 			mix (SB + [HSwToV Stroke]) RightSB 0.1
 			mix SB RightSB 0.3
-		define xMiddle : RightSB - ymiddle / 2 - Stroke * 0.75
-		define xMiddleBot : RightSB - ymiddle / 2 - HalfStroke
-		define rightTopX : RightSB + O * 2
+		define xMiddle : Math.max xFinal (SB + [HSwToV : 1.2 * Stroke]) (RightSB - ymiddle / 2 - Stroke * 0.75)
+		define xMiddleBot : Math.max xMiddle (xFinal + TINY + TanSlope * Stroke)
+		define rightTopX : RightSB + O
 
 		include : dispiro
 			widths.lhs
@@ -211,16 +211,16 @@ glyph-block Letter-Latin-Upper-Eszet : begin
 			curl SB 0 [heading Downward]
 		include : dispiro
 			widths.rhs
-			g4   xMiddle ymiddleCap
+			g4   xMiddle ymiddleCap [heading Rightward]
 			archv
-			g4   (RightSB - O) [mix 0 ymiddleCap 0.5]
+			g4   (RightSB - O * 2) [YSmoothMidR ymiddleCap 0]
 			arcvh
 			flat xMiddleBot 0
 			curl xFinal 0 [heading Leftward]
 		include : dispiro
 			widths.rhs
 			g4 rightTopX (CAP - ArchDepthB)
-			g4 xMiddle ymiddleCap [widths Stroke 0]
+			g4 xMiddle ymiddleCap [widths.lhs Stroke]
 
 		include : CapitalEszetSerifs slab
 


### PR DESCRIPTION
This basically unifies most of its parameters with the other variants, except for its `B`-esque bar height (`ymiddleCap`).
`ẞ`
Flat top for comparison (unchanged):
Thin:
![image](https://github.com/user-attachments/assets/367fdf6e-6c2c-43fb-99e0-3638a6b93bcf)
Regular:
![image](https://github.com/user-attachments/assets/3fb3d969-05ae-480e-a533-48ad978a30f9)
Heavy:
![image](https://github.com/user-attachments/assets/c7b3b042-1950-425d-926c-9203994a85ab)

Rounded variants:
Thin before:
![image](https://github.com/user-attachments/assets/d8a64e80-4a37-4905-93e8-7c90e3aac3c3)
Thin after:
![image](https://github.com/user-attachments/assets/7d510ac1-6b63-4713-b5a1-8d888e4ba7d8)
Regular before:
![image](https://github.com/user-attachments/assets/cdafa00e-b43a-4548-9bfb-9d4ce1e288dc)
Regular after:
![image](https://github.com/user-attachments/assets/7977d938-0ff1-4780-a252-646b3bf52be2)
Heavy before:
![image](https://github.com/user-attachments/assets/31218b87-6d9a-4ae7-ad8b-884fa11885a2)
Heavy after:
![image](https://github.com/user-attachments/assets/8c9f6c97-efbf-42f9-b5d9-b921f938a1dc)
