### PR TITLE
Optimize closed epsilon shapes under heavier weights.

### DIFF
--- a/changes/31.8.1.md
+++ b/changes/31.8.1.md
@@ -1,1 +1,5 @@
 * Optimize glyphs for `rounded-serifless` and `rounded-serifed` variants for Capital Eszett (`ẞ`).
+* Optimize glyphs for closed epsilon shapes (`U+025E`, `U+029A`).
+* Optimize glyphs for cursive variants for Greek Lower Beta (`β`) and Cyrillic Lower Ve (`в`).
+* Optimize glyphs for Volapük Ae/Oe/Ue (`U+A79A`..`U+A79F`).
+* Optimize glyph for Cyrillic Lower Dzze (`U+A689`) under italics.

--- a/packages/font-glyphs/src/letter/cyrillic/de.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/de.ptl
@@ -183,10 +183,12 @@ glyph-block Letter-Cyrillic-De : begin
 			local xZeLeft : dfLeft.leftSB + df.width - dfLeft.width + OX
 			local xZeRight : dfLeft.rightSB + df.width - dfLeft.width - OX
 			local ze : CyrZe 1 sb XH Descender
-				left   -- xZeLeft
-				right  -- xZeRight
-				hook   -- Hook
-				stroke -- df.mvs
+				left     -- xZeLeft
+				right    -- xZeRight
+				blend    -- 0.7
+				hook     -- Hook
+				overflow -- 0
+				stroke   -- df.mvs
 			include : union [ze.Shape] [ze.AutoEndSerifL]
 
 	select-variant 'cyrl/Dzze' 0xA688 (follow -- 'cyrl/ZeBottomSerifOnly')

--- a/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
@@ -28,16 +28,16 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 	define CLOSED-STEM     8
 
 	define StdBlend 0.65
-	define VolBlend 0.52
+	define VolBlend 0.56
 
 	define [SmallEpsilon] : with-params [
 			slabTop slabBot top bot
 			[blend StdBlend] [hook Hook]
+			[stroke : AdviceStroke2 2 3 (top - bot)] [overflow : HSwToV stroke]
 			[ada2 SmallArchDepthA] [adb2 SmallArchDepthB]
 		] : namespace
 		export : define [Dim] : begin
-			local stroke : AdviceStroke2 2 3 (top - bot)
-			local midx : mix SB RightSB blend
+			local midx : mix (SB + [HSwToV stroke] - overflow) (RightSB - [HSwToV stroke] + overflow) blend
 			local midy : mix bot top OverlayPos
 			local topHeight : top - bot
 			local midyHeight : midy - bot
@@ -101,12 +101,13 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 
 	glyph-block-export CyrZe
 	define [CyrZe] : with-params [
-		slabTop slabBot top bot [left SB] [right RightSB]
-		[blend StdBlend] [hook Hook] [stroke : AdviceStroke2 2 3 (top - bot)]
+		slabTop slabBot top bot
+		[left SB] [right RightSB] [blend StdBlend] [hook Hook]
+		[stroke : AdviceStroke2 2 3 (top - bot)] [overflow : HSwToV stroke]
 		[xo OX] [yo O] [op OverlayPos] [ada2 SmallArchDepthA] [adb2 SmallArchDepthB]
 		] : namespace
 		export : define [Dim] : begin
-			local midx : mix right left blend
+			local midx : mix (right - [HSwToV stroke] + overflow) (left + [HSwToV stroke] - overflow) blend
 			local midy : mix bot top op
 			local topHeight : top - bot
 			local midyHeight : midy - bot
@@ -268,7 +269,7 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 
 		create-glyph "cyrl/dzjeKomi.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			local ze : CyrZe slabTop OPEN-VERTICAL XH 0 (hok -- SHook)
+			local ze : CyrZe slabTop OPEN-VERTICAL XH 0 (hoоk -- SHook)
 			include : ze.Shape
 			include : ze.AutoStartSerifL
 			include : CyrDescender.rSideJut (RightSB - OX * 2) 0
@@ -335,35 +336,41 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 		create-glyph 'epsilonClosed' 0x29A : glyph-proc
 			include : MarkSet.e
 			local eps : SmallEpsilon CLOSED-CIRCLE CLOSED-CIRCLE XH 0
-				hook -- SHook
-				ada2 -- SmallArchDepthA
-				adb2 -- SmallArchDepthB
+				blend    -- 0.7
+				hook     -- SHook
+				overflow -- 0
+				ada2     -- SmallArchDepthA
+				adb2     -- SmallArchDepthB
 			include : eps.Shape
 
 		create-glyph 'epsilonRevClosed' 0x25E : glyph-proc
 			include : MarkSet.e
 			local ze : CyrZe CLOSED-CIRCLE CLOSED-CIRCLE XH 0
-				hook -- SHook
-				ada2 -- SmallArchDepthA
-				adb2 -- SmallArchDepthB
+				blend    -- 0.7
+				hook     -- SHook
+				overflow -- 0
+				ada2     -- SmallArchDepthA
+				adb2     -- SmallArchDepthB
 			include : ze.Shape
 
 		create-glyph 'OeVolapuk' 0xA79C : glyph-proc
 			include : MarkSet.capital
 			local eps : SmallEpsilon CLOSED-CIRCLE CLOSED-CIRCLE CAP 0
-				blend -- VolBlend
-				hook  -- Hook
-				ada2  -- ArchDepthA
-				adb2  -- ArchDepthB
+				blend    -- VolBlend
+				hook     -- Hook
+				overflow -- 0
+				ada2     -- ArchDepthA
+				adb2     -- ArchDepthB
 			include : eps.Shape
 
 		create-glyph 'oeVolapuk' 0xA79D : glyph-proc
 			include : MarkSet.e
 			local eps : SmallEpsilon CLOSED-CIRCLE CLOSED-CIRCLE XH 0
-				blend -- VolBlend
-				hook  -- SHook
-				ada2  -- SmallArchDepthA
-				adb2  -- SmallArchDepthB
+				blend    -- VolBlend
+				hook     -- SHook
+				overflow -- 0
+				ada2     -- SmallArchDepthA
+				adb2     -- SmallArchDepthB
 			include : eps.Shape
 
 	do "Volapuk AE"
@@ -371,30 +378,33 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 
 		define [FullBarBody df height bar hook ada2 adb2] : glyph-proc
 			local eps : SmallEpsilon CLOSED-STEM CLOSED-STEM height 0
-				blend -- VolBlend
-				hook  -- hook
-				ada2  -- ada2
-				adb2  -- adb2
+				blend    -- VolBlend
+				hook     -- hook
+				overflow -- 0
+				ada2     -- ada2
+				adb2     -- adb2
 			define [object stroke] : eps.Dim
 			include : eps.Shape
 			include : bar df height no-shape stroke
 
 		define [EarlessCornerBody df height bar hook ada2 adb2] : glyph-proc
 			local eps : SmallEpsilon SLAB-INWARD CLOSED-STEM height 0
-				blend -- VolBlend
-				hook  -- hook
-				ada2  -- ada2
-				adb2  -- adb2
+				blend    -- VolBlend
+				hook     -- hook
+				overflow -- 0
+				ada2     -- ada2
+				adb2     -- adb2
 			define [object stroke] : eps.Dim
 			include : eps.Shape
 			include : bar df (height - DToothlessRise) no-shape stroke
 
 		define [EarlessRoundedBody df height bar hook ada2 adb2] : glyph-proc
 			local eps : SmallEpsilon CLOSED-ROUND CLOSED-STEM height 0
-				blend -- VolBlend
-				hook  -- hook
-				ada2  -- ada2
-				adb2  -- adb2
+				blend    -- VolBlend
+				hook     -- hook
+				overflow -- 0
+				ada2     -- ada2
+				adb2     -- adb2
 			define [object stroke] : eps.Dim
 			include : eps.Shape
 			include : bar df (height - adb2) no-shape stroke
@@ -431,10 +441,11 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 		define [UToothed df height slab hook ada2 adb2] : glyph-proc
 			set-base-anchor 'trailing' df.rightSB 0
 			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-STEM height 0
-				blend -- VolBlend
-				hook  -- hook
-				ada2  -- ada2
-				adb2  -- adb2
+				blend    -- VolBlend
+				hook     -- hook
+				overflow -- 0
+				ada2     -- ada2
+				adb2     -- adb2
 			define [object stroke] : eps.Dim
 			include : eps.Shape
 			include : VBar.r df.rightSB 0 height stroke
@@ -443,10 +454,11 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 		define [UTailed df height slab hook ada2 adb2] : glyph-proc
 			set-base-anchor 'trailing' (df.rightSB + SideJut) 0
 			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-STEM height 0
-				blend -- VolBlend
-				hook  -- hook
-				ada2  -- ada2
-				adb2  -- adb2
+				blend    -- VolBlend
+				hook     -- hook
+				overflow -- 0
+				ada2     -- ada2
+				adb2     -- adb2
 			define [object stroke] : eps.Dim
 			include : eps.Shape
 			include : RightwardTailedBar df.rightSB 0 height stroke
@@ -454,10 +466,11 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 
 		define [UToothlessRounded df height slab hook ada2 adb2] : glyph-proc
 			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-ROUND height 0
-				blend -- VolBlend
-				hook  -- hook
-				ada2  -- ada2
-				adb2  -- adb2
+				blend    -- VolBlend
+				hook     -- hook
+				overflow -- 0
+				ada2     -- ada2
+				adb2     -- adb2
 			define [object stroke] : eps.Dim
 			include : eps.Shape
 			include : VBar.r df.rightSB ada2 height stroke
@@ -465,10 +478,11 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 
 		define [UToothlessCorner df height slab hook ada2 adb2] : glyph-proc
 			local eps : SmallEpsilon OPEN-VERTICAL SLAB-INWARD height 0
-				blend -- VolBlend
-				hook  -- hook
-				ada2  -- ada2
-				adb2  -- adb2
+				blend    -- VolBlend
+				hook     -- hook
+				overflow -- 0
+				ada2     -- ada2
+				adb2     -- adb2
 			define [object stroke] : eps.Dim
 			include : eps.Shape
 			include : VBar.r df.rightSB DToothlessRise height stroke

--- a/packages/font-glyphs/src/letter/latin/upper-b.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-b.ptl
@@ -190,25 +190,26 @@ glyph-block Letter-Latin-Upper-B : begin
 
 	define [CursiveCyrveShape top] : glyph-proc
 		local stroke : AdviceStroke2 2 3 top
-		local mid : mix (RightSB - [HSwToV Stroke]) (SB + [HSwToV Stroke]) 0.7
-		local midy : top * HBarPos
-		local adb : top - [mix (midy + stroke / 2) (top - O - stroke) (ArchDepthA / (ArchDepthA + ArchDepthB))] + [HSwToV TanSlope] * stroke
-		local ada : [mix (stroke + O) (midy - stroke / 2) (ArchDepthA / (ArchDepthA + ArchDepthB))] - [HSwToV TanSlope] * stroke
 		local fine : stroke * CThin
+		local yMiddle : top * HBarPos
+		local adb : top - [mix (yMiddle + stroke / 2) (top - O - stroke) (ArchDepthA / (ArchDepthA + ArchDepthB))] + [HSwToV TanSlope] * stroke
+		local ada : [mix (stroke + O) (yMiddle - stroke / 2) (ArchDepthA / (ArchDepthA + ArchDepthB))] - [HSwToV TanSlope] * stroke
+		local xMidLeft : mix (RightSB - [HSwToV stroke]) (SB + [HSwToV stroke]) 0.7
+		local xMidArc : Math.max [mix xMidLeft RightSB 0.1] [mix SB RightSB 0.5]
 		include : dispiro
 			widths.lhs fine
-			flat mid (midy - (fine - stroke / 2)) [heading Rightward]
-			curl Middle (midy - (fine - stroke / 2)) [heading Rightward]
+			flat xMidLeft (yMiddle - (fine - stroke / 2)) [heading Rightward]
+			curl xMidArc  (yMiddle - (fine - stroke / 2)) [heading Rightward]
 			archv
 			g4   (RightSB - (OX - O)) (top - adb) [widths.lhs stroke]
 			arch.lhs top
 			flat (SB + O) (top - SmallArchDepthA)
-			curl (SB + O) SmallArchDepthB
+			curl (SB + O) (0   + SmallArchDepthB)
 			arch.lhs 0
-			g4   (RightSB - (OX - O) - O * 2) (ada)
+			g4   (RightSB - (OX + O)) (0 + ada)
 			arcvh
-			flat Middle (midy + (fine - stroke / 2)) [widths.heading fine 0 Leftward]
-			curl mid (midy + (fine - stroke / 2)) [widths.heading fine 0 Leftward]
+			flat xMidArc  (yMiddle + (fine - stroke / 2)) [widths.heading fine 0 Leftward]
+			curl xMidLeft (yMiddle + (fine - stroke / 2)) [widths.heading fine 0 Leftward]
 
 	create-glyph 'cyrl/ve.cursive' : glyph-proc
 		include : MarkSet.e

--- a/packages/font-glyphs/src/letter/latin/upper-b.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-b.ptl
@@ -190,7 +190,7 @@ glyph-block Letter-Latin-Upper-B : begin
 
 	define [CursiveCyrveShape top] : glyph-proc
 		local stroke : AdviceStroke2 2 3 top
-		local mid : mix RightSB SB 0.65
+		local mid : mix (RightSB - [HSwToV Stroke]) (SB + [HSwToV Stroke]) 0.7
 		local midy : top * HBarPos
 		local adb : top - [mix (midy + stroke / 2) (top - O - stroke) (ArchDepthA / (ArchDepthA + ArchDepthB))] + [HSwToV TanSlope] * stroke
 		local ada : [mix (stroke + O) (midy - stroke / 2) (ArchDepthA / (ArchDepthA + ArchDepthB))] - [HSwToV TanSlope] * stroke
@@ -241,7 +241,7 @@ glyph-block Letter-Latin-Upper-B : begin
 		define yMiddle : [mix 0 Ascender pBar] - Stroke * 0.7 # Bottom edge
 		define ada : ArchDepthAOf (ArchDepth * 0.75) (0.5 * Width)
 		define adb : ArchDepthBOf (ArchDepth * 0.75) (0.5 * Width)
-		define xMidLeft : mix (SB + [HSwToV Stroke]) (RightSB - [HSwToV Stroke]) 0.3
+		define xMidLeft : mix (RightSB - [HSwToV Stroke]) (SB + [HSwToV Stroke]) 0.7
 		define xMidArc  : Math.max [mix xMidLeft RightSB 0.1] [mix SB RightSB 0.5]
 		include : dispiro
 			widths.rhs


### PR DESCRIPTION
```
Ɛɛɞʚβϐв
ЗзꚉꞚꞛꞜꞝꞞꞟ
```
Thin upright before:
![image](https://github.com/user-attachments/assets/62f6915c-708d-4fb3-9610-825f07125c6b)
Thin upright after:
![image](https://github.com/user-attachments/assets/737edd3c-342e-412f-92e0-0f1865749026)
Regular upright before:
![image](https://github.com/user-attachments/assets/3570ac26-f50d-4b60-bb37-0cdc9f902195)
Regular upright after:
![image](https://github.com/user-attachments/assets/42e0ba88-5ab1-4908-99e4-994a49891daf)
Heavy upright before:
![image](https://github.com/user-attachments/assets/3a7c9dd3-6596-4125-b9f4-cda5a6a8fb63)
Heavy upright after:
![image](https://github.com/user-attachments/assets/1cad640b-4ac9-4501-b671-8d6065a302dd)
Thin italic before:
![image](https://github.com/user-attachments/assets/cf281a48-e282-4a66-b693-be3d154edec2)
Thin italic after:
![image](https://github.com/user-attachments/assets/21fe2330-e8ab-4040-91de-6feff7b74e89)
Regular italic before:
![image](https://github.com/user-attachments/assets/427b11a7-2565-4803-9481-895fabf7240f)
Regular italic after:
![image](https://github.com/user-attachments/assets/a71e1438-3d2a-4883-a604-787b88783251)
Heavy italic before:
![image](https://github.com/user-attachments/assets/300763ab-fea6-4de4-820e-0c0a10ee71d5)
Heavy italic after:
![image](https://github.com/user-attachments/assets/21dec9af-44ca-45ae-9c60-0c37bd927ca0)
