### PR TITLE
Optimize glyph for Latin Lower Dezh Digraph with Palatal Hook.

### DIFF
--- a/changes/31.8.1.md
+++ b/changes/31.8.1.md
@@ -3,5 +3,6 @@
 * Optimize glyphs for `rounded-serifless` and `rounded-serifed` variants for Capital Eszett (`ẞ`).
 * Optimize glyphs for closed epsilon shapes (`U+025E`, `U+029A`).
 * Optimize glyphs for cursive variants for Greek Lower Beta (`β`) and Cyrillic Lower Ve (`в`).
-* Optimize glyphs for Volapük Ae/Oe/Ue (`U+A79A`..`U+A79F`).
 * Optimize glyph for Cyrillic Lower Dzze (`U+A689`) under italics.
+* Optimize glyphs for Volapük Ae/Oe/Ue (`U+A79A`..`U+A79F`).
+* Optimize glyph for Latin Lower Dezh Digraph with Palatal Hook (`U+1DF12`).

--- a/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
@@ -179,6 +179,21 @@ glyph-block Letter-Latin-Ezh : begin
 				refSw -- dfSub.mvs
 				maskOut -- [intersection [MaskBelow y] [MaskLeft dfSub.rightSB]]
 
+		if [not isSerifed] : begin
+			create-glyph "ezhPalatalHook/phoneticRight.\(suffix)" : glyph-proc
+				include : MarkSet.p
+				local p : SmallArchDepthB / (SmallArchDepthA + SmallArchDepthB)
+				local [object yMidBar] : include : EzhShape [DivFrame 1] XH Descender
+					isCursive -- isCursive
+					isSerifed -- isSerifed
+				local y : [mix yMidBar Descender p] - HalfStroke
+				include : PalatalHook.r
+					x -- [mix SB RightSB (4/3)]
+					y -- y
+					xLink -- RightSB
+					refSw -- [AdviceStroke 3]
+					maskOut -- [intersection [MaskBelow y] [MaskLeft RightSB]]
+
 	select-variant 'Ezh' 0x1B7
 	select-variant 'smcpEzh' 0x1D23 (follow -- 'Ezh')
 	select-variant 'ezh' 0x292
@@ -187,7 +202,7 @@ glyph-block Letter-Latin-Ezh : begin
 	select-variant 'ezhRetroflexHook' 0x1D9A (follow -- 'ezh')
 	select-variant 'ezhPalatalHook' 0x1DF18 (follow -- 'ezh')
 	select-variant 'ezh/phoneticRight' (shapeFrom -- 'ezh')
-	select-variant 'ezhPalatalHook/phoneticRight' (shapeFrom -- 'ezhPalatalHook') (follow -- 'ezh/phoneticRight')
+	select-variant 'ezhPalatalHook/phoneticRight' (follow -- 'ezh/phoneticRight')
 
 	alias 'cyrl/abk/Dze' 0x4E0 'Ezh'
 	alias 'cyrl/abk/dze' 0x4E1 'ezh'


### PR DESCRIPTION
In particular the ezh part is less squashed; As a "phonetic right" sub-character, it now effectively uses a diversity of `1`, with the palatal hook jutting _slightly_ to the right, but with no worse of an overflow than some other existing characters, including those with hooks.
```
ts dz tʃ dʒ
ʦ  ʣ  ʧ  ʤ 
tɕ dʑ tᶋ d𝼘
ʨ  ʥ  𝼗  𝼒 
```
Monospace thin before:
![image](https://github.com/user-attachments/assets/446a0b13-311e-4fb5-8d9a-a1c90c4c425c)
Monospace thin after:
![image](https://github.com/user-attachments/assets/f03a8fb7-5ddb-4d58-98a7-5baddde35efb)
Monospace regular before:
![image](https://github.com/user-attachments/assets/2ef134b8-62ba-43cb-b178-53c5e4c01071)
Monospace regular after:
![image](https://github.com/user-attachments/assets/24dfbe22-7601-495f-bda7-ca05e87a9011)
Monospace heavy before:
![image](https://github.com/user-attachments/assets/762a9b27-6bc7-4c5e-a48c-16dd561ead87)
Monospace heavy after:
![image](https://github.com/user-attachments/assets/8ecd237f-0e2c-4402-8267-d20dc4120fd7)

Aile thin before:
![image](https://github.com/user-attachments/assets/05bc73ec-c7a8-4946-b5bb-5681e290e539)
Aile thin after:
![image](https://github.com/user-attachments/assets/02acd24f-b3e2-46aa-a01d-7010adb001f9)
Aile regular before:
![image](https://github.com/user-attachments/assets/1d3d804a-53e0-4e87-8b61-8fb9c59cd477)
Aile regular after:
![image](https://github.com/user-attachments/assets/8dc00953-d126-41ed-8ac6-e36d142d9e69)
Aile heavy before:
![image](https://github.com/user-attachments/assets/d1174b99-b9dd-4370-9cbf-4ee97303f182)
Aile heavy after:
![image](https://github.com/user-attachments/assets/ea167721-29c2-4271-a068-63f6c2931faa)
