### PR TITLE
Optimize glyphs for Roman Numeral CD shapes.

### DIFF
--- a/changes/31.9.0.md
+++ b/changes/31.9.0.md
@@ -3,6 +3,8 @@
 * Optimize glyphs for `rounded-serifless` and `rounded-serifed` variants for Capital Eszett (`ẞ`).
 * Optimize glyphs for closed epsilon shapes (`U+025E`, `U+029A`).
 * Optimize glyphs for cursive variants for Greek Lower Beta (`β`) and Cyrillic Lower Ve (`в`).
+* Optimize glyphs for Cyrillic Capital/Lower Broad On (`U+047A`, `U+047B`).
+* Optimize glyphs for Roman Numeral CD shapes (`U+2180`, `U+2182`, `U+2188`).
 * Optimize glyph for Cyrillic Lower Dzze (`U+A689`) under italics.
 * Optimize glyphs for Volapük Ae/Oe/Ue (`U+A79A`..`U+A79F`).
 * Optimize glyph for Latin Lower Dezh Digraph with Palatal Hook (`U+1DF12`).

--- a/packages/font-glyphs/src/letter/latin/o.ptl
+++ b/packages/font-glyphs/src/letter/latin/o.ptl
@@ -64,7 +64,7 @@ glyph-block Letter-Latin-O : begin
 	create-glyph 'cyrl/BroadOn' 0x47A : glyph-proc
 		define df : include : DivFrame [mix 1 para.diversityM 0.5] 3
 		include : df.markSet.capital
-		local gap : Math.max df.mvs : 0.25 * (df.rightSB - df.leftSB)
+		local gap : Math.max (0.25 * (df.rightSB - df.leftSB)) : HSwToV (rBroadOn * Math.SQRT2)
 		local ada : ArchDepthA * df.div
 		local adb : ArchDepthB * df.div
 		include : OShapeFlatTB CAP 0 df.leftSB df.rightSB df.mvs ada adb gap
@@ -74,7 +74,7 @@ glyph-block Letter-Latin-O : begin
 	create-glyph 'cyrl/broadOn' 0x47B : glyph-proc
 		define df : include : DivFrame [mix 1 para.diversityM 0.5] 3
 		include : df.markSet.e
-		local gap : Math.max df.mvs : 0.25 * (df.rightSB - df.leftSB)
+		local gap : Math.max (0.25 * (df.rightSB - df.leftSB)) : HSwToV (rBroadOn * Math.SQRT2)
 		local ada : ArchDepthA * df.div
 		local adb : ArchDepthB * df.div
 		include : OShapeFlatTB XH 0 df.leftSB df.rightSB df.mvs ada adb gap
@@ -166,7 +166,8 @@ glyph-block Letter-Latin-O : begin
 	create-glyph 'romanThousandCD' 0x2180 : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.capital
-		local gap : Math.max df.mvs : 0.25 * (df.rightSB - df.leftSB)
+		local dist : df.rightSB - df.leftSB
+		local gap : Math.max (dist / 4) : HSwToV df.mvs
 		local ada : ArchDepthA * df.div
 		local adb : ArchDepthB * df.div
 		include : OShapeFlatTB CAP 0 df.leftSB df.rightSB df.mvs ada adb gap
@@ -176,28 +177,33 @@ glyph-block Letter-Latin-O : begin
 	create-glyph 'romanTenThousand' 0x2182 : glyph-proc
 		local df : include : DivFrame para.diversityM 5
 		include : df.markSet.capital
-		local gap : Math.max df.mvs : 0.25 * (df.rightSB - df.leftSB)
+		local dist : df.rightSB - df.leftSB
+		local gap : Math.max (dist / 4) : HSwToV df.mvs
+		local gapInner : Math.max (dist / 8) : HSwToV df.mvs
 		local ada : ArchDepthA * df.div
 		local adb : ArchDepthB * df.div
-		local innerDist : df.rightSB - df.leftSB - [HSwToV : 5 * df.mvs]
+		local innerDist : dist - [HSwToV : 5 * df.mvs]
 		local arcXL1 : df.leftSB + innerDist * (1 / 4) + [HSwToV : 1 * df.mvs]
 		local arcXR1 : df.leftSB + innerDist * (3 / 4) + [HSwToV : 4 * df.mvs]
 		local heightGap : Math.min (df.mvs + (CAP - df.mvs * 4) / 5) (innerDist / 4 + df.mvs)
-		local heightInner1 : CAP - 2 * heightGap
-		local smInner1  : clamp (df.mvs * 1.5) (0.499 * heightInner1) (ArchDepth * heightInner1 / CAP)
-		local adaInner1 : [ArchDepthAOf smInner1 : arcXR1 - arcXL1 + df.leftSB * 2] * df.div
-		local adbInner1 : [ArchDepthBOf smInner1 : arcXR1 - arcXL1 + df.leftSB * 2] * df.div
+		local heightInner : CAP - 2 * heightGap
+		local smInner  : clamp (df.mvs * 1.5) (0.499 * heightInner) (ArchDepth * heightInner / CAP)
+		local adaInner : [ArchDepthAOf smInner : arcXR1 - arcXL1 + df.leftSB * 2] * df.div
+		local adbInner : [ArchDepthBOf smInner : arcXR1 - arcXL1 + df.leftSB * 2] * df.div
 		include : OShapeFlatTB CAP 0 df.leftSB df.rightSB df.mvs ada adb gap
-		include : OShapeFlatTB (CAP - heightGap) (0 + heightGap) arcXL1 arcXR1 df.mvs adaInner1 adbInner1 (gap / 2)
+		include : OShapeFlatTB (CAP - heightGap) (0 + heightGap) arcXL1 arcXR1 df.mvs adaInner adbInner gapInner
 		include : VBar.m df.middle (df.mvs / 2) (CAP - df.mvs / 2) df.mvs
 
 	create-glyph 'romanHundredThousand' 0x2188 : glyph-proc
 		local df : include : DivFrame para.diversityM 7
 		include : df.markSet.capital
-		local gap : Math.max df.mvs : 0.25 * (df.rightSB - df.leftSB)
+		local dist : df.rightSB - df.leftSB
+		local gap : Math.max (dist / 4) : HSwToV df.mvs
+		local gapInner1 : Math.max (dist / 6) : HSwToV df.mvs
+		local gapInner2 : Math.max (dist / 12) : HSwToV df.mvs
 		local ada : ArchDepthA * df.div
 		local adb : ArchDepthB * df.div
-		local innerDist : df.rightSB - df.leftSB - [HSwToV : 7 * df.mvs]
+		local innerDist : dist - [HSwToV : 7 * df.mvs]
 		local arcXL1 : df.leftSB + innerDist * (1 / 6) + [HSwToV : 1 * df.mvs]
 		local arcXR1 : df.leftSB + innerDist * (5 / 6) + [HSwToV : 6 * df.mvs]
 		local arcXL2 : df.leftSB + innerDist * (2 / 6) + [HSwToV : 2 * df.mvs]
@@ -212,8 +218,8 @@ glyph-block Letter-Latin-O : begin
 		local adaInner2 : [ArchDepthAOf smInner2 : arcXR2 - arcXL2 + df.leftSB * 2] * df.div
 		local adbInner2 : [ArchDepthBOf smInner2 : arcXR2 - arcXL2 + df.leftSB * 2] * df.div
 		include : OShapeFlatTB CAP 0 df.leftSB df.rightSB df.mvs ada adb gap
-		include : OShapeFlatTB (CAP - heightGap) (0 + heightGap) arcXL1 arcXR1 df.mvs adaInner1 adbInner1 (gap * (2 / 3))
-		include : OShapeFlatTB (CAP - 2 * heightGap) (0 + 2 * heightGap) arcXL2 arcXR2 df.mvs adaInner2 adbInner2 (gap * (1 / 3))
+		include : OShapeFlatTB (CAP - heightGap) (0 + heightGap) arcXL1 arcXR1 df.mvs adaInner1 adbInner1 gapInner1
+		include : OShapeFlatTB (CAP - 2 * heightGap) (0 + 2 * heightGap) arcXL2 arcXR2 df.mvs adaInner2 adbInner2 gapInner2
 		include : VBar.m df.middle (df.mvs / 2) (CAP - df.mvs / 2) df.mvs
 
 	create-glyph 'oupperhalf' 0x1D16 : glyph-proc
@@ -259,7 +265,7 @@ glyph-block Letter-Latin-O : begin
 	CreateAccentedComposition 'oDieresis' 0xF6 'o' 'dieresisAbove'
 
 	create-glyph 'numeroRightHalf' : glyph-proc
-		include : OShape XH [Math.max (Stroke * 1.5) (CAP * 0.1)] SB RightSB Stroke ArchDepthA ArchDepthB
+		include : OShape XH [Math.max (CAP * 0.1) (Stroke * 1.5)] SB RightSB Stroke ArchDepthA ArchDepthB
 		include : HBar.b SB RightSB 0
 
 	CreateAccentedComposition 'oSbRsbUnderlineBelow' null 'o' 'sbRsbUnderlineBelow'

--- a/packages/font-glyphs/src/letter/latin/o.ptl
+++ b/packages/font-glyphs/src/letter/latin/o.ptl
@@ -64,14 +64,20 @@ glyph-block Letter-Latin-O : begin
 	create-glyph 'cyrl/BroadOn' 0x47A : glyph-proc
 		define df : include : DivFrame [mix 1 para.diversityM 0.5] 3
 		include : df.markSet.capital
-		include : OShape CAP 0 df.leftSB df.rightSB df.mvs ArchDepthA ArchDepthB
+		local gap : Math.max df.mvs : 0.25 * (df.rightSB - df.leftSB)
+		local ada : ArchDepthA * df.div
+		local adb : ArchDepthB * df.div
+		include : OShapeFlatTB CAP 0 df.leftSB df.rightSB df.mvs ada adb gap
 		include : DotAt df.middle (df.mvs / 2 + O) rBroadOn
 		include : DotAt df.middle (CAP - df.mvs / 2 - O) rBroadOn
 
 	create-glyph 'cyrl/broadOn' 0x47B : glyph-proc
 		define df : include : DivFrame [mix 1 para.diversityM 0.5] 3
 		include : df.markSet.e
-		include : OShape XH 0 df.leftSB df.rightSB df.mvs nothing nothing
+		local gap : Math.max df.mvs : 0.25 * (df.rightSB - df.leftSB)
+		local ada : ArchDepthA * df.div
+		local adb : ArchDepthB * df.div
+		include : OShapeFlatTB XH 0 df.leftSB df.rightSB df.mvs ada adb gap
 		include : DotAt df.middle (df.mvs / 2 + O) rBroadOn
 		include : DotAt df.middle (XH - df.mvs / 2 - O) rBroadOn
 
@@ -160,30 +166,37 @@ glyph-block Letter-Latin-O : begin
 	create-glyph 'romanThousandCD' 0x2180 : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.capital
-		include : OShape CAP 0 df.leftSB df.rightSB df.mvs ArchDepthA ArchDepthB
+		local gap : Math.max df.mvs : 0.25 * (df.rightSB - df.leftSB)
+		local ada : ArchDepthA * df.div
+		local adb : ArchDepthB * df.div
+		include : OShapeFlatTB CAP 0 df.leftSB df.rightSB df.mvs ada adb gap
 		include : VBar.m df.middle (df.mvs / 2) (CAP - df.mvs / 2) df.mvs
 		set-base-anchor 'trailing' Middle 0
 
 	create-glyph 'romanTenThousand' 0x2182 : glyph-proc
 		local df : include : DivFrame para.diversityM 5
 		include : df.markSet.capital
-
+		local gap : Math.max df.mvs : 0.25 * (df.rightSB - df.leftSB)
+		local ada : ArchDepthA * df.div
+		local adb : ArchDepthB * df.div
 		local innerDist : df.rightSB - df.leftSB - [HSwToV : 5 * df.mvs]
 		local arcXL1 : df.leftSB + innerDist * (1 / 4) + [HSwToV : 1 * df.mvs]
 		local arcXR1 : df.leftSB + innerDist * (3 / 4) + [HSwToV : 4 * df.mvs]
 		local heightGap : Math.min (df.mvs + (CAP - df.mvs * 4) / 5) (innerDist / 4 + df.mvs)
 		local heightInner1 : CAP - 2 * heightGap
 		local smInner1  : clamp (df.mvs * 1.5) (0.499 * heightInner1) (ArchDepth * heightInner1 / CAP)
-		local adaInner1 : ArchDepthAOf smInner1 (arcXR1 - arcXL1 + df.leftSB * 2)
-		local adbInner1 : ArchDepthBOf smInner1 (arcXR1 - arcXL1 + df.leftSB * 2)
-		include : OShape CAP 0 df.leftSB df.rightSB df.mvs ArchDepthA ArchDepthB
-		include : OShape (CAP - heightGap) (0 + heightGap) arcXL1 arcXR1 df.mvs adaInner1 adbInner1
+		local adaInner1 : [ArchDepthAOf smInner1 : arcXR1 - arcXL1 + df.leftSB * 2] * df.div
+		local adbInner1 : [ArchDepthBOf smInner1 : arcXR1 - arcXL1 + df.leftSB * 2] * df.div
+		include : OShapeFlatTB CAP 0 df.leftSB df.rightSB df.mvs ada adb gap
+		include : OShapeFlatTB (CAP - heightGap) (0 + heightGap) arcXL1 arcXR1 df.mvs adaInner1 adbInner1 (gap / 2)
 		include : VBar.m df.middle (df.mvs / 2) (CAP - df.mvs / 2) df.mvs
 
 	create-glyph 'romanHundredThousand' 0x2188 : glyph-proc
 		local df : include : DivFrame para.diversityM 7
 		include : df.markSet.capital
-
+		local gap : Math.max df.mvs : 0.25 * (df.rightSB - df.leftSB)
+		local ada : ArchDepthA * df.div
+		local adb : ArchDepthB * df.div
 		local innerDist : df.rightSB - df.leftSB - [HSwToV : 7 * df.mvs]
 		local arcXL1 : df.leftSB + innerDist * (1 / 6) + [HSwToV : 1 * df.mvs]
 		local arcXR1 : df.leftSB + innerDist * (5 / 6) + [HSwToV : 6 * df.mvs]
@@ -193,14 +206,14 @@ glyph-block Letter-Latin-O : begin
 		local heightInner1 : CAP - 2 * heightGap
 		local heightInner2 : CAP - 4 * heightGap
 		local smInner1  : clamp (df.mvs * 1.5) (0.499 * heightInner1) (ArchDepth * heightInner1 / CAP)
-		local adaInner1 : ArchDepthAOf smInner1 (arcXR1 - arcXL1 + df.leftSB * 2)
-		local adbInner1 : ArchDepthBOf smInner1 (arcXR1 - arcXL1 + df.leftSB * 2)
+		local adaInner1 : [ArchDepthAOf smInner1 : arcXR1 - arcXL1 + df.leftSB * 2] * df.div
+		local adbInner1 : [ArchDepthBOf smInner1 : arcXR1 - arcXL1 + df.leftSB * 2] * df.div
 		local smInner2  : clamp (df.mvs * 1.5) (0.499 * heightInner2) (ArchDepth * heightInner2 / CAP)
-		local adaInner2 : ArchDepthAOf smInner2 (arcXR2 - arcXL2 + df.leftSB * 2)
-		local adbInner2 : ArchDepthBOf smInner2 (arcXR2 - arcXL2 + df.leftSB * 2)
-		include : OShape CAP 0 df.leftSB df.rightSB df.mvs ArchDepthA ArchDepthB
-		include : OShape (CAP - heightGap) (0 + heightGap) arcXL1 arcXR1 df.mvs adaInner1 adbInner1
-		include : OShape (CAP - 2 * heightGap) (0 + 2 * heightGap) arcXL2 arcXR2 df.mvs adaInner2 adbInner2
+		local adaInner2 : [ArchDepthAOf smInner2 : arcXR2 - arcXL2 + df.leftSB * 2] * df.div
+		local adbInner2 : [ArchDepthBOf smInner2 : arcXR2 - arcXL2 + df.leftSB * 2] * df.div
+		include : OShapeFlatTB CAP 0 df.leftSB df.rightSB df.mvs ada adb gap
+		include : OShapeFlatTB (CAP - heightGap) (0 + heightGap) arcXL1 arcXR1 df.mvs adaInner1 adbInner1 (gap * (2 / 3))
+		include : OShapeFlatTB (CAP - 2 * heightGap) (0 + 2 * heightGap) arcXL2 arcXR2 df.mvs adaInner2 adbInner2 (gap * (1 / 3))
 		include : VBar.m df.middle (df.mvs / 2) (CAP - df.mvs / 2) df.mvs
 
 	create-glyph 'oupperhalf' 0x1D16 : glyph-proc


### PR DESCRIPTION
Using `OShapeFlatTB` to better approximate a literal C/D ligature.
Also do the same for Cyrillic Broad On as the dots are supposed to separate the left/right hemispheres in a similar manner.
```
OѺoᴏѻ
₵Dↀↂↈ
```
Monospace thin before:
![image](https://github.com/user-attachments/assets/3eca66b5-6f5f-45f4-81a3-c53bbdf209e0)
Monospace thin after:
![image](https://github.com/user-attachments/assets/2fb268a0-8c08-42bc-99af-2ef87057b599)
Monospace regular before:
![image](https://github.com/user-attachments/assets/57ef652b-50e9-4a25-9712-4975b78c1d04)
Monospace regular after:
![image](https://github.com/user-attachments/assets/f73b17a3-f2e2-476d-914c-2721bdfcbbe0)
Monospace heavy before:
![image](https://github.com/user-attachments/assets/d8e3ae2a-0207-4e25-8de1-6a6081c5806c)
Monospace heavy after:
![image](https://github.com/user-attachments/assets/398d41ef-43ca-44f2-9276-0d4f88135069)

Monospace thin extended before:
![image](https://github.com/user-attachments/assets/998b9ac9-64e8-46a8-a59c-d4249902b203)
Monospace thin extended after:
![image](https://github.com/user-attachments/assets/6b58587c-e0d0-466b-b271-e690af1a7cf7)
Monospace regular extended before:
![image](https://github.com/user-attachments/assets/1cb5fecd-8115-4fc3-b3b4-9e20c10a27f5)
Monospace regular extended after:
![image](https://github.com/user-attachments/assets/7b64eafd-fe26-40a2-82d7-1d35cf59971a)
Monospace heavy extended before:
![image](https://github.com/user-attachments/assets/b2cc5881-a4df-4edb-a893-7225ea10e722)
Monospace heavy extended after:
![image](https://github.com/user-attachments/assets/44da74e9-8869-42db-a54f-15ee803604bb)


Aile thin before:
![image](https://github.com/user-attachments/assets/f262db4e-22d4-436e-8792-f1d4704b403d)
Aile thin after:
![image](https://github.com/user-attachments/assets/2b9e638a-e201-429e-b043-f850b0fc762b)
Aile regular before:
![image](https://github.com/user-attachments/assets/ec17f608-4a03-4ddd-92df-9b1db5955b78)
Aile regular after:
![image](https://github.com/user-attachments/assets/7492fa85-17ce-46e9-9406-41539e6bcc5b)
Aile heavy before:
![image](https://github.com/user-attachments/assets/59a869e2-910f-434b-83b1-b147548af82c)
Aile heavy after:
![image](https://github.com/user-attachments/assets/8e9169f5-065a-4caf-95a2-bbf3125aaef4)
