### PR TITLE
Fix #2540 (+ code substitutions)

### DIFF
--- a/packages/font-glyphs/src/common/shapes.ptl
+++ b/packages/font-glyphs/src/common/shapes.ptl
@@ -545,7 +545,7 @@ glyph-block CommonShapes : begin
 		define [impl args] : begin
 			local doAdj : not args.compact
 
-			local skew : HVContrast * (args.swAfter - args.swBefore) / (2 * args.sw)
+			local skew : [HSwToV : args.swAfter - args.swBefore] / (2 * args.sw)
 			local heading : object
 				x : [boolePn args.rtl] * ([boolePn args.lhs] * skew + [boole doAdj] * TanSlope)
 				y : [boolePn args.lhs] * [boolePn args.atBot] * 1

--- a/packages/font-glyphs/src/letter-like/cursive.ptl
+++ b/packages/font-glyphs/src/letter-like/cursive.ptl
@@ -23,7 +23,7 @@ glyph-block LetterLike-Cursive-Shared : begin
 		public [x pX _pSX _deltaX] : begin
 			local pSX : fallback _pSX 0
 			local deltaX : fallback _deltaX 0
-			return : [mix this.box.left this.box.right pX] + pSX * HVContrast * this.sw + deltaX
+			return : [mix this.box.left this.box.right pX] + pSX * [HSwToV this.sw] + deltaX
 
 		public [y pY _pSY _deltaY] : begin
 			local pSY : fallback _pSY 0
@@ -45,7 +45,7 @@ glyph-block LetterLike-Cursive : begin
 	create-glyph 'ell' 0x2113 : glyph-proc
 		include : MarkSet.b
 
-		local loopSize : Width * 0.25 + HalfStroke * HVContrast
+		local loopSize : Width * 0.25 + [HSwToV HalfStroke]
 		local l : Middle - loopSize
 		local r : Middle + loopSize
 

--- a/packages/font-glyphs/src/letter/cyrillic/omega.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/omega.ptl
@@ -15,10 +15,10 @@ glyph-block Letter-Cyrillic-Omega : begin
 		local mfine : fine * CThin
 
 		local minHookDepth : Math.min (0.625 * (df.middle - df.leftSB - [HSwToV fine])) ((1 / 3) * (df.rightSB - df.leftSB))
-		local xMidBarLeft    : df.middle - fine / 2 * HVContrast
-		local xMidBarRight   : df.middle + fine / 2 * HVContrast
-		local xMidBarCoLeft  : df.middle - (mfine - fine / 2) * HVContrast
-		local xMidBarCoRight : df.middle + (mfine - fine / 2) * HVContrast
+		local xMidBarLeft    : df.middle - [HSwToV : fine / 2]
+		local xMidBarRight   : df.middle + [HSwToV : fine / 2]
+		local xMidBarCoLeft  : df.middle - [HSwToV : mfine - fine / 2]
+		local xMidBarCoRight : df.middle + [HSwToV : mfine - fine / 2]
 		local y3 : top * p1
 		local y4 : top * p2
 

--- a/packages/font-glyphs/src/letter/greek/lower-omega.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-omega.ptl
@@ -23,15 +23,15 @@ glyph-block Letter-Greek-Lower-Omega : begin
 			g4 x0 y0
 			g4 x1 (top / 2)
 			arch.lhs 0 (sw -- fine) (swAfter -- mfine)
-			flat (df.middle + (mfine - fine / 2) * HVContrast) y3 [widths.heading mfine 0 Upward]
-			curl (df.middle + (mfine - fine / 2) * HVContrast) y4 [heading Upward]
+			flat (df.middle + [HSwToV : mfine - fine / 2]) y3 [widths.heading mfine 0 Upward]
+			curl (df.middle + [HSwToV : mfine - fine / 2]) y4 [heading Upward]
 		include : dispiro
 			widths.rhs fine
 			g4 (df.width - x0) y0
 			g4 (df.width - x1) (top / 2)
 			arch.rhs 0 (sw -- fine) (swAfter -- mfine)
-			flat (df.middle - (mfine - fine / 2) * HVContrast) y3 [widths.heading 0 mfine Upward]
-			curl (df.middle - (mfine - fine / 2) * HVContrast) y4 [heading Upward]
+			flat (df.middle - [HSwToV : mfine - fine / 2]) y3 [widths.heading 0 mfine Upward]
+			curl (df.middle - [HSwToV : mfine - fine / 2]) y4 [heading Upward]
 
 	create-glyph 'grek/omega' 0x3C9 : glyph-proc
 		local df : include : DivFrame para.diversityM 3
@@ -60,15 +60,15 @@ glyph-block Letter-Greek-Lower-Omega : begin
 		local y4 : XH * 0.65
 		include : dispiro
 			widths.rhs mfine
-			flat (df.middle + (mfine - fine / 2) * HVContrast) y4 [heading Downward]
-			curl (df.middle + (mfine - fine / 2) * HVContrast) y3 [heading Downward]
+			flat (df.middle + [HSwToV : mfine - fine / 2]) y4 [heading Downward]
+			curl (df.middle + [HSwToV : mfine - fine / 2]) y3 [heading Downward]
 			arch.rhs 0 (sw -- fine) (swBefore -- mfine)
 			g4 x1 y1
 			arch.rhs y0 (sw -- fine)
 			g4 (df.width - x1) y1
 			arch.rhs 0 (sw -- fine) (swAfter -- mfine)
-			flat (df.middle - (mfine - fine / 2) * HVContrast) y3 [widths.heading 0 mfine Upward]
-			curl (df.middle - (mfine - fine / 2) * HVContrast) y4 [heading Upward]
+			flat (df.middle - [HSwToV : mfine - fine / 2]) y3 [widths.heading 0 mfine Upward]
+			curl (df.middle - [HSwToV : mfine - fine / 2]) y4 [heading Upward]
 
 	create-glyph 'latn/Omega' 0xA7B6 : glyph-proc
 		local df : include : DivFrame para.diversityM 3

--- a/packages/font-glyphs/src/letter/latin-ext/archaic-m.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/archaic-m.ptl
@@ -19,8 +19,8 @@ glyph-block Letter-Latin-Archaic-M : begin
 
 	define [ArchaicMShape df top bottom] : glyph-proc
 		local sw df.mvs
-		local cl : df.leftSB  + 0.5 * HVContrast * sw
-		local cr : df.rightSB - 0.5 * HVContrast * sw
+		local cl : df.leftSB  + [HSwToV : 0.5 * sw]
+		local cr : df.rightSB - [HSwToV : 0.5 * sw]
 		local kt 0.2
 		local ko 0.5
 

--- a/packages/font-glyphs/src/letter/latin-ext/upper-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/upper-ae-oe.ptl
@@ -203,7 +203,7 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 	define [OEShape top df slabKind] : glyph-proc
 		define eBarPos DesignParameters.upperEBarPos
 		define sw : Math.min df.mvs : AdviceStroke2 3 3 top df.div
-		define eleft : df.middle - sw * [if SLAB (1 / 3) (1 / 4)] * HVContrast
+		define eleft : df.middle - [HSwToV : sw * [if SLAB (1 / 3) (1 / 4)]]
 		define swVJut : Math.min sw ((df.rightSB - eleft - [HSwToV sw]) * (4 / 5))
 
 		local xMidRight : df.rightSB - sw / 4

--- a/packages/font-glyphs/src/letter/latin-ext/yogh.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/yogh.ptl
@@ -38,7 +38,7 @@ glyph-block Letter-Latin-Yogh : begin
 			archv
 			g4 RightSB [YSmoothMidR pyt pyb]
 			alsoThruThem {{0.25 [StrokeWidthBlend 0.63 0.66]} {0.5 [StrokeWidthBlend 0.84 0.85]}} important
-			g4 (SB + 0.1 * HVContrast * Stroke) (bot + O)
+			g4 (SB + [HSwToV : 0.1 * Stroke]) (bot + O)
 
 	define [YoghShape slab top bot] : glyph-proc
 		include : UpperHalfT dispiro slab 0 top bot

--- a/packages/font-glyphs/src/letter/latin/lower-f.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-f.ptl
@@ -13,7 +13,7 @@ glyph-block Letter-Latin-Lower-F : begin
 	glyph-block-import Letter-Shared-Shapes : LetterBarOverlay PalatalHook
 
 	define [SetPalatalHookPos barLeft] : glyph-proc
-		set-base-anchor 'palatalHookPos' (barLeft + (Stroke + [Math.max VJutStroke (Width / 12)]) * HVContrast) 0
+		set-base-anchor 'palatalHookPos' (barLeft + [HSwToV : Stroke + [Math.max VJutStroke (Width / 12)]]) 0
 
 	glyph-block-export fbar
 	define fbar : XH * DesignParameters.fBarPosToXH + Stroke * DesignParameters.fbarStrokeAdj

--- a/packages/font-glyphs/src/letter/latin/lower-il.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-il.ptl
@@ -65,7 +65,7 @@ glyph-block Letter-Latin-Lower-I : begin
 			local shift : TailedDotlessIShift df
 			local left : xMiddle - [HSwToV : 0.5 * df.mvs]
 			local right : mix df.leftSB df.rightSB (1.1 - shift)
-			local rightTerm : Math.max right (left + HVContrast * (df.mvs + 1.1 * fine)) (left + HVContrast * df.mvs + HookX)
+			local rightTerm : Math.max right (left + [HSwToV : df.mvs + 1.1 * fine]) (left + [HSwToV df.mvs] + HookX)
 			local middle : mix left right (0.55 * df.div)
 			local hookDepth : Math.max (df.mvs * 0.9) (Hook * [StrokeWidthBlend 0.85 1] * df.div)
 			include : dispiro
@@ -144,7 +144,7 @@ glyph-block Letter-Latin-Lower-I : begin
 			g.gizmo.unapply g.baseAnchors.trailing
 			g.gizmo.unapply g.baseAnchors.overlay
 		local posX : if g.baseAnchors.trailing
-			attach.x + HVContrast * (0.5 * VJutStroke)
+			attach.x + [HSwToV : 0.5 * VJutStroke]
 			attach.x + [HSwToV HalfStroke] + [PalatalHook.adviceGap Stroke]
 		local maskY : if g.baseAnchors.palatalHookMask
 			begin [g.gizmo.unapply g.baseAnchors.palatalHookMask].y

--- a/packages/font-glyphs/src/letter/latin/lower-r.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-r.ptl
@@ -331,7 +331,7 @@ glyph-block Letter-Latin-Lower-R : begin
 			archv
 			straight.down.end (xBar - [HSwToV fine]) (XH * 0.53 + (SmallArchDepth - SmallArchDepthA)) [widths.heading fine 0 Downward]
 		include : BBBarRight xBar 0 XH
-		set-base-anchor 'overlay' (xBar - HVContrast * (BBD + BBS * 2) * 0.25) (XH * 0.5)
+		set-base-anchor 'overlay' (xBar - [HSwToV : BBD + BBS * 2] * 0.25) (XH * 0.5)
 
 	create-glyph 'mathbb/r' 0x1D563 : glyph-proc
 		include : dfR.markSet.e

--- a/packages/font-glyphs/src/letter/latin/upper-b.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-b.ptl
@@ -260,7 +260,7 @@ glyph-block Letter-Latin-Upper-B : begin
 			archv
 			g4   (RightSB - OX)  [YSmoothMidR 0 (yMiddle + Stroke) ada adb] [widths.rhs]
 			arch.rhs 0 (swAfter -- ShoulderFine)
-			g4.up.end (SB + HVContrast * (Stroke - ShoulderFine)) adb [widths.rhs ShoulderFine]
+			g4.up.end (SB + [HSwToV : Stroke - ShoulderFine]) adb [widths.rhs ShoulderFine]
 
 	alias 'grek/beta.cursive'  null  'cyrl/ve.cursiveTall'
 	select-variant 'grek/beta' 0x3B2

--- a/packages/font-glyphs/src/letter/latin/upper-q.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-q.ptl
@@ -76,7 +76,7 @@ glyph-block Letter-Latin-Upper-Q : begin
 			MaskLeft xLB
 
 	# Tails
-	define [QStaraightTail df] : begin
+	define [QStraightTail df] : begin
 		local shift : StrokeWidthBlend 0 0.25
 		return : dispiro
 			widths.rhs
@@ -85,7 +85,7 @@ glyph-block Letter-Latin-Upper-Q : begin
 
 	define [QCurlyTail df] : begin
 		local shift : StrokeWidthBlend 0.5 0.6
-		local startx : df.middle + (Stroke * shift) * HVContrast
+		local startx : df.middle + [HSwToV : Stroke * shift]
 		return : dispiro
 			widths.rhs
 			flat startx HalfStroke [heading Downward]
@@ -149,7 +149,7 @@ glyph-block Letter-Latin-Upper-Q : begin
 
 	define QInnerVertSw : Math.min [AdviceStroke 3.5] ((RightSB - SB - [HSwToV : 2 * Stroke]) / (2 * HVContrast))
 	define QConfig : object
-		straight            { QStdBody                Stroke             QStaraightTail     'capDesc' 'p' }
+		straight            { QStdBody                Stroke             QStraightTail      'capDesc' 'p' }
 		curlyTailed         { QStdBody                Stroke             QCurlyTail         'capDesc' 'p' }
 		crossingCurlyTailed { QStdBody                QInnerVertSw       QCrossingCurlyTail 'capDesc' 'p' }
 		crossing            { QStdBody               [AdviceStroke 4]    QCrossing          'capital' 'e' }

--- a/packages/font-glyphs/src/letter/latin/w.ptl
+++ b/packages/font-glyphs/src/letter/latin/w.ptl
@@ -312,10 +312,10 @@ glyph-block Letter-Latin-W : begin
 			flat x1 top [heading Downward]
 			curl x1 (fine + rInY) [heading Downward]
 			arcvh 16
-			g4 [Math.min ([mix (x1 + [HSwToV fine]) (df.middle - [HSwToV : 0.5 * fine]) 0.5] - (fine - mfine) * HVContrast) (x1 + [HSwToV fine] + rInY)] O [heading {.x (TanSlope + (0.5 * (fine - mfine) / fine)) .y 1}]
+			g4 [Math.min ([mix (x1 + [HSwToV fine]) (df.middle - [HSwToV : 0.5 * fine]) 0.5] - [HSwToV : fine - mfine]) (x1 + [HSwToV fine] + rInY)] O [heading {.x (TanSlope + (0.5 * (fine - mfine) / fine)) .y 1}]
 			archv 16
-			flat (df.middle + (mfine - fine / 2) * HVContrast) y3 [widths.heading mfine 0 Upward]
-			curl (df.middle + (mfine - fine / 2) * HVContrast) y4 [heading Upward]
+			flat (df.middle + [HSwToV : mfine - fine / 2]) y3 [widths.heading mfine 0 Upward]
+			curl (df.middle + [HSwToV : mfine - fine / 2]) y4 [heading Upward]
 
 		if fHookTop
 		: then : begin
@@ -325,16 +325,16 @@ glyph-block Letter-Latin-W : begin
 				flat (df.width - x1) (top - TailY - 0.5 * fine - O) [heading Downward]
 				curl (df.width - x1) y3           [heading Downward]
 				arch.rhs 0 (sw -- fine) (swAfter -- mfine)
-				flat (df.middle - (mfine - fine / 2) * HVContrast) y3 [widths.heading 0 mfine Upward]
-				curl (df.middle - (mfine - fine / 2) * HVContrast) y4 [heading Upward]
+				flat (df.middle - [HSwToV : mfine - fine / 2]) y3 [widths.heading 0 mfine Upward]
+				curl (df.middle - [HSwToV : mfine - fine / 2]) y4 [heading Upward]
 		: else : begin
 			include : dispiro
 				widths.rhs fine
 				g4 (df.width - x0) y0
 				g4 (df.width - x1 - OX) (top / 2)
 				arch.rhs 0 (sw -- fine) (swAfter -- mfine)
-				flat (df.middle - (mfine - fine / 2) * HVContrast) y3 [widths.heading 0 mfine Upward]
-				curl (df.middle - (mfine - fine / 2) * HVContrast) y4 [heading Upward]
+				flat (df.middle - [HSwToV : mfine - fine / 2]) y3 [widths.heading 0 mfine Upward]
+				curl (df.middle - [HSwToV : mfine - fine / 2]) y4 [heading Upward]
 
 		local sf : SerifFrame top 0 x1 df.rightSB
 		include : match slabType
@@ -353,7 +353,7 @@ glyph-block Letter-Latin-W : begin
 			straightDoubleV                    { WShapeImpl   WHooktopShape   FORM-DOUBLE-V   }
 			straightFlatTop                    { WShapeImpl   WHooktopShape   FORM-FLAT-TOP   }
 			straightVerticalSides              { WVertSides   WVSHookTopShape FORM-STRAIGHT   }
-			roundedVerticalSides               { WRounded     WHookTopRounded FORM-CURLY      } 
+			roundedVerticalSides               { WRounded     WHookTopRounded FORM-CURLY      }
 			curly                              { WShapeImpl   WHooktopShape   FORM-CURLY      }
 			cursive                            { WCursiveImpl WHookTopCursive FORM-CURLY      }
 			cyrlCapialOmega                    { WShapeImpl   WHooktopShape   FORM-CYRL-OMEGA }

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -270,7 +270,7 @@ glyph-block Letter-Shared-Shapes : begin
 				[ada SmallArchDepthA] [adb SmallArchDepthB]
 				[ystart (top - ada - TINY)]
 			] : begin
-			local xstart : left + (sw - fine) * HVContrast
+			local xstart : left + [HSwToV : sw - fine]
 			return : list
 				flat xstart ystart [widths.rhs fine]
 				curl xstart (top - ada)
@@ -281,7 +281,7 @@ glyph-block Letter-Shared-Shapes : begin
 				[ada SmallArchDepthA] [adb SmallArchDepthB]
 				[yend (bot + ada + TINY)]
 			] : begin
-			local xend : left + (sw - fine) * HVContrast
+			local xend : left + [HSwToV : sw - fine]
 			return : list
 				arch.rhs bot (sw -- sw) (swAfter -- fine)
 				flat xend (bot + adb) [widths.rhs fine]
@@ -293,14 +293,14 @@ glyph-block Letter-Shared-Shapes : begin
 			] : begin
 			return : dispiro
 				widths.lhs fine
-				flat (left + (sw - fine) * HVContrast) (top - ada - TINY)
-				curl (left + (sw - fine) * HVContrast) (0 + adb)
+				flat (left + [HSwToV : sw - fine]) (top - ada - TINY)
+				curl (left + [HSwToV : sw - fine]) (0 + adb)
 				arch.lhs 0 (sw -- sw) (swBefore -- fine)
 				flat (right - OX) (0 + ada)
 				curl (right - OX) (top - adb)
 				arch.lhs top (sw -- sw) (swAfter -- fine)
-				flat (left + (sw - fine) * HVContrast) (top - ada) [widths.lhs fine]
-				curl (left + (sw - fine) * HVContrast) (top - ada - TINY)
+				flat (left + [HSwToV : sw - fine]) (top - ada) [widths.lhs fine]
+				curl (left + [HSwToV : sw - fine]) (top - ada - TINY)
 
 		export : define [toothless] : with-params [
 				[top XH] [left SB] [right RightSB] [rise SHook] [sw Stroke] [fine ShoulderFine]
@@ -314,8 +314,8 @@ glyph-block Letter-Shared-Shapes : begin
 				flat (right - OX) (0 + ada)
 				curl (right - OX) (top - adb)
 				arch.lhs top (sw -- sw) (swAfter -- fine)
-				flat (left + (sw - fine) * HVContrast) (top - ada) [widths.lhs fine]
-				curl (left + (sw - fine) * HVContrast) (top - ada - TINY) [widths.lhs fine]
+				flat (left + [HSwToV : sw - fine]) (top - ada) [widths.lhs fine]
+				curl (left + [HSwToV : sw - fine]) (top - ada - TINY) [widths.lhs fine]
 
 		export : define [rounded] : with-params [
 				[top XH] [left SB] [right RightSB] [yTerminal CAP] [sw Stroke] [fine ShoulderFine]
@@ -328,16 +328,16 @@ glyph-block Letter-Shared-Shapes : begin
 				flat (right - OX) (0 + ada)
 				curl (right - OX) (top - adb)
 				arch.lhs top (sw -- sw) (swAfter -- fine)
-				flat (left + (sw - fine) * HVContrast) (top - ada + TINY) [widths.lhs fine]
-				curl (left + (sw - fine) * HVContrast) (top - ada) [widths.lhs fine]
+				flat (left + [HSwToV : sw - fine]) (top - ada + TINY) [widths.lhs fine]
+				curl (left + [HSwToV : sw - fine]) (top - ada) [widths.lhs fine]
 
 		export : define [toothlessTop] : with-params [
 				[top XH] [left SB] [right RightSB] [rise SHook] [sw Stroke] [fine ShoulderFine]
 				[mBlend Math.SQRT1_2] [ada SmallArchDepthA] [adb SmallArchDepthB]
 			] : begin
 			return : dispiro
-				flat (left + (sw - fine) * HVContrast) (top - ada - TINY) [widths.lhs fine]
-				curl (left + (sw - fine) * HVContrast) (0 + adb) [widths.lhs fine]
+				flat (left + [HSwToV : sw - fine]) (top - ada - TINY) [widths.lhs fine]
+				curl (left + [HSwToV : sw - fine]) (0 + adb) [widths.lhs fine]
 				arch.lhs 0 (sw -- sw) (swBefore -- fine)
 				flat (right - OX) (0 + ada)
 				curl (right - OX) (top - adb)
@@ -351,8 +351,8 @@ glyph-block Letter-Shared-Shapes : begin
 				[fine ShoulderFine] [ada SmallArchDepthA] [adb SmallArchDepthB]
 			] : begin
 			return : dispiro
-				flat (left + (sw - fine) * HVContrast) (top - ada - TINY) [widths.lhs fine]
-				curl (left + (sw - fine) * HVContrast) (0 + adb) [widths.lhs fine]
+				flat (left + [HSwToV : sw - fine]) (top - ada - TINY) [widths.lhs fine]
+				curl (left + [HSwToV : sw - fine]) (0 + adb) [widths.lhs fine]
 				arch.lhs 0 (sw -- sw) (swBefore -- fine)
 				flat (right - OX) (0 + ada)
 				curl (right - OX) (top - adb)
@@ -368,7 +368,7 @@ glyph-block Letter-Shared-Shapes : begin
 				[ada SmallArchDepthA] [adb SmallArchDepthB]
 				[ystart (top - ada - TINY)]
 			] : begin
-			local xstart : right - (sw - fine) * HVContrast
+			local xstart : right - [HSwToV : sw - fine]
 			return : list
 				flat xstart ystart [widths.lhs fine]
 				curl xstart (top - adb)
@@ -379,7 +379,7 @@ glyph-block Letter-Shared-Shapes : begin
 				[ada SmallArchDepthA] [adb SmallArchDepthB]
 				[yend (bot + ada + TINY)]
 			] : begin
-			local xend : right - (sw - fine) * HVContrast
+			local xend : right - [HSwToV : sw - fine]
 			return : list
 				arch.lhs bot (sw -- sw) (swAfter -- fine)
 				flat xend (bot + ada) [widths.lhs fine]
@@ -477,7 +477,7 @@ glyph-block Letter-Shared-Shapes : begin
 			local fine : barSw * [mix CThinB (ShoulderFine / Stroke) 0.5]
 			return : list
 				g4.up.start
-					sx - (barSw - fine) * HVContrast
+					sx - [HSwToV : barSw - fine]
 					cy - [ArcStartSerifDepth hook]
 					widths.lhs.heading fine Upward
 				arch.lhs cy (sw -- sw) (swBefore -- fine)
@@ -487,7 +487,7 @@ glyph-block Letter-Shared-Shapes : begin
 			local fine : barSw * [mix CThinB (ShoulderFine / Stroke) 0.5]
 			return : list
 				g4.up.start
-					sx + (barSw - fine) * HVContrast
+					sx + [HSwToV : barSw - fine]
 					cy - [ArcStartSerifDepth hook]
 					widths.rhs.heading fine Upward
 				arch.rhs cy (sw -- sw) (swBefore -- fine)
@@ -500,7 +500,7 @@ glyph-block Letter-Shared-Shapes : begin
 			return : list
 				arch.rhs cy (sw -- sw) (swAfter -- fine)
 				g4.up.end
-					ex + (barSw - fine) * HVContrast
+					ex + [HSwToV : barSw - fine]
 					cy + [ArcStartSerifDepth hook]
 					widths.rhs.heading fine Upward
 
@@ -510,7 +510,7 @@ glyph-block Letter-Shared-Shapes : begin
 			return : list
 				arch.lhs cy (sw -- sw) (swAfter -- fine)
 				g4.up.end
-					ex - (barSw - fine) * HVContrast
+					ex - [HSwToV : barSw - fine]
 					cy + [ArcStartSerifDepth hook]
 					widths.lhs.heading fine Upward
 
@@ -823,7 +823,7 @@ glyph-block Letter-Shared-Shapes : begin
 
 		define [Descenders Impl] : namespace
 			export : define Sw ArcStartSerifWidth
-			export : define [adviceGap refSw] : HVContrast * [Sw refSw] + [Math.max (Width / 16) [AdviceStroke 12]]
+			export : define [adviceGap refSw] : [HSwToV : Sw refSw] + [Math.max (Width / 16) [AdviceStroke 12]]
 
 			export : define [m] : with-params [x y xLink [yAttach y] [yOverflow 0] [refSw Stroke] [maskOut null]] : begin
 				local sw : Sw refSw

--- a/packages/font-glyphs/src/number/0.ptl
+++ b/packages/font-glyphs/src/number/0.ptl
@@ -11,7 +11,7 @@ glyph-block Digits-Zero : begin
 	glyph-block-import Digits-Shared : OnumHeight OnumMarks CodeLnum CodeOnum
 
 	define CircleInnerWidth : RightSB - SB - [HSwToV : 2 * Stroke]
-	define SplitSlashGap : [HSwToV Stroke] + [clamp (CircleInnerWidth / 5) (CircleInnerWidth / 3) ([AdviceStroke 5] * HVContrast)]
+	define SplitSlashGap : [HSwToV Stroke] + [clamp (CircleInnerWidth / 5) (CircleInnerWidth / 3) [HSwToV : AdviceStroke 5]]
 	define CutoutVerticalStrokeWidth : Math.max (0.2 * CircleInnerWidth) : Math.min (0.4 * CircleInnerWidth) [AdviceStroke 3]
 	define [CutoutStrokeWidth top] : Math.max (0.1 * top) : Math.min (0.125 * top) (0.5 * CircleInnerWidth) [AdviceStroke 3]
 

--- a/packages/font-glyphs/src/number/1.ptl
+++ b/packages/font-glyphs/src/number/1.ptl
@@ -18,7 +18,7 @@ glyph-block Digits-One : begin
 			include : VBar.m (Middle + balance) 0 top
 			include : dispiro
 				flat (Middle - [HSwToV HalfStroke] + balance) top [widths.lhs topSW]
-				curl (Middle - Stroke / 8 * HVContrast - HookX * 1.25 + balance) (top - Stroke / 8 - Hook * pTopSerif * (top / CAP))
+				curl (Middle - [HSwToV : Stroke / 8] - HookX * 1.25 + balance) (top - Stroke / 8 - Hook * pTopSerif * (top / CAP))
 
 		export : define [FlatSerifed top balance pTopSerif] : glyph-proc
 			define topSW : AdviceStroke 3.5
@@ -69,7 +69,7 @@ glyph-block Digits-One : begin
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarCenter
 	create-glyph 'mathbb/one' 0x1D7D9 : glyph-proc
 		define barCenter : Middle + OneBalance / 2
-		define xSerifTerminal : barCenter - BBD / 8 * HVContrast - HookX * 1.25
+		define xSerifTerminal : barCenter - [HSwToV : BBD / 8] - HookX * 1.25
 		define ySerifTerminal : CAP - BBD / 8 - Hook * 0.75
 		include : MarkSet.capital
 		include : intersection

--- a/packages/font-glyphs/src/number/6.ptl
+++ b/packages/font-glyphs/src/number/6.ptl
@@ -22,7 +22,7 @@ glyph-block Digits-Six : begin
 			arch.rhs 0
 			g4.up.mid (SB + OX) ymiddlea
 			quadControls 0 0.85
-			g4 ([mix SB RightSB 0.85] - 0.25 * Stroke * HVContrast) (charTop - O) [widths.rhs]
+			g4 ([mix SB RightSB 0.85] - [HSwToV : 0.25 * Stroke]) (charTop - O) [widths.rhs]
 
 	glyph-block-export ClosedContourSixShape
 	define [ClosedContourSixShape top] : glyph-proc
@@ -47,7 +47,7 @@ glyph-block Digits-Six : begin
 
 		local xMockBarStart   0
 		local yMockBarStart : ymiddlea + sw * 0.3
-		local xTerminal0 : [mix SB RightSB 0.6] - 0.5 * sw * HVContrast
+		local xTerminal0 : [mix SB RightSB 0.6] - [HSwToV : 0.5 * sw]
 		local kDiagBbd : DiagCorDs (charTop - yMockBarStart) (xTerminal0 - xMockBarStart) bbd
 		local xTerminal : xTerminal0 + (kDiagBbd * bbd / 2)
 		local pStraightBarStart : 0.75 - (sw / charTop)

--- a/packages/font-glyphs/src/symbol/math/geometry.ptl
+++ b/packages/font-glyphs/src/symbol/math/geometry.ptl
@@ -163,9 +163,9 @@ glyph-block Symbol-Math-Geometry : begin
 			straight.right.end right top
 
 	do 'Zigzags'
-		create-glyph 'zigzag' 0x299A : VZigzag Middle ParenBot ParenTop (radiusBox / 4) 9 1 GeometryStroke
-		create-glyph 'wigglyFenceLeft'  0x29D8 : VZigzag Middle ParenBot ParenTop (radiusBox / 4) 10 0 GeometryStroke
-		create-glyph 'wigglyFenceRight' 0x29D9 : VZigzag Middle ParenBot ParenTop (radiusBox / 4) 10 1 GeometryStroke
+		create-glyph 'zigzag' 0x299A : VZigzag Middle ParenBot ParenTop (radiusBox / 4) 9 0 GeometryStroke
+		create-glyph 'wigglyFenceLeft'  0x29D8 : VZigzag Middle ParenBot ParenTop (radiusBox / 4) 10 1 GeometryStroke
+		create-glyph 'wigglyFenceRight' 0x29D9 : VZigzag Middle ParenBot ParenTop (radiusBox / 4) 10 0 GeometryStroke
 
 		define space : (rightBox - leftBox - [HSwToV GeometryStroke] * 2) / 3
 		create-glyph 'doubleWigglyFenceLeft' 0x29DA : glyph-proc

--- a/packages/font-glyphs/src/symbol/math/logicals.ptl
+++ b/packages/font-glyphs/src/symbol/math/logicals.ptl
@@ -81,7 +81,7 @@ glyph-block Symbol-Math-Logicals : begin
 		include : HBar.m m r SymbolMid OperatorStroke
 		include : VBar.l l top bot vs
 		include : VBar.m     m top bot vs
-		include : VBar.m     ([mix l m (1/2)] + vs / 4 * HVContrast) top bot vs
+		include : VBar.m     ([mix l m (1/2)] + [HSwToV : 0.25 * vs]) top bot vs
 
 	create-glyph 'doubleForces' 0x22AB : glyph-proc
 		local l : mix Middle SB 1

--- a/packages/font-glyphs/src/symbol/punctuation/ampersand.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/ampersand.ptl
@@ -49,7 +49,7 @@ glyph-block Symbol-Punctuation-Ampersand : begin
 			g4.left.mid xClosedAmpersandBottom O [widths.rhs.heading sw ClosedBottomSlope]
 
 	define [ClosedAmpersandLeadMask2 sw swTip] : begin
-		define [object x1 x2 y1 y2 k1] : ClosedAmpersandLeadDim sw swTip ((sw - swTip) * HVContrast)
+		define [object x1 x2 y1 y2 k1] : ClosedAmpersandLeadDim sw swTip [HSwToV : sw - swTip]
 		return : intersection [MaskBelow y2] : spiro-outline
 			flat [mix x1 x2 4]  [mix y1 y2 4]  [widths.rhs swTip]
 			curl [mix x1 x2 k1] [mix y1 y2 k1]

--- a/packages/font-glyphs/src/symbol/punctuation/at.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/at.ptl
@@ -120,12 +120,12 @@ glyph-block Symbol-Punctuation-At : begin
 		local shrink 0.6
 
 		include : dispiro
-			straight.up.start (m1 - (sw * (1 - shrink) * HVContrast)) (otop - adb) [widths.heading (sw * shrink) 0 Upward]
+			straight.up.start (m1 - [HSwToV : sw * (1 - shrink)]) (otop - adb) [widths.heading (sw * shrink) 0 Upward]
 			arch.lhs otop (sw -- sw) (swBefore -- (sw * shrink))
 			flat SB (otop - ada)
 			curl SB (obot + adb)
 			arch.lhs obot (sw -- sw) (swAfter -- (sw * shrink))
-			straight.up.end (m1 - (sw * (1 - shrink) * HVContrast)) (obot + ada) [widths.heading (sw * shrink) 0 Upward]
+			straight.up.end (m1 - [HSwToV : sw * (1 - shrink)]) (obot + ada) [widths.heading (sw * shrink) 0 Upward]
 
 		include : dispiro
 			widths.lhs sw

--- a/packages/font-glyphs/src/symbol/punctuation/small.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/small.ptl
@@ -265,7 +265,7 @@ glyph-block Symbol-Punctuation-Small : begin
 		create-glyph "dottedCross.\(suffix)" : glyph-proc
 			include : HBar.m [mix 0 SB 0.5] [mix Width RightSB 0.5] (XH / 2) OperatorStroke
 			include : VBar.m Middle 0 XH OperatorStroke
-			local radius : 0.5 * [AdviceStroke 3] * HVContrast
+			local radius : HSwToV : 0.5 * [AdviceStroke 3]
 			include : DrawAt (SB + radius)      (XH * 0.75) (kDotRadius * radius - overshoot)
 			include : DrawAt (SB + radius)      (XH * 0.25) (kDotRadius * radius - overshoot)
 			include : DrawAt (RightSB - radius) (XH * 0.75) (kDotRadius * radius - overshoot)

--- a/packages/font-kits/src/spiro-kit.mjs
+++ b/packages/font-kits/src/spiro-kit.mjs
@@ -230,7 +230,7 @@ export function SetupBuilders(bindings) {
 
 	widths.heading = function (l, r, d) {
 		if (!isFinite(l)) throw new TypeError("NaN detected for left width");
-		if (!isFinite(r)) throw new TypeError("NaN detected for left width");
+		if (!isFinite(r)) throw new TypeError("NaN detected for right width");
 		if (!isFinite(d.x) || !isFinite(d.y))
 			throw new TypeError("NaN detected for heading directions");
 		return new AfWidthsHeading(l, r, d);


### PR DESCRIPTION
Turns out I flipped all the zigzag symbols in #2540 and didn't notice.

FairfaxHD: ![image](https://github.com/user-attachments/assets/141fc9bc-2065-4e9e-9127-5dad904859ce)
This PR: ![image](https://github.com/user-attachments/assets/b32a42f1-e381-4352-9aa7-d117d3e172c8)

Everything other than `geometry.ptl` are replacements of `HVContrast` to use `HSwToV`. All the instances of `HVContrast` left are either ones that don't seem to be applied to strokes directly, or ones that I'm not sure if replacing is appropriate.