### PR TITLE
Cleanup of loosely related O-derived characters.

### DIFF
--- a/changes/31.9.0.md
+++ b/changes/31.9.0.md
@@ -1,6 +1,7 @@
 * Add IJ-acute ligatures (#2483).
 * Allowed customizing menu WWS value to name map (#2488).
 * Optimize glyphs for `rounded-serifless` and `rounded-serifed` variants for Capital Eszett (`ẞ`).
+* Optimize glyph for Capital OE (`U+0152`) under Quasi-Proportional.
 * Optimize glyphs for closed epsilon shapes (`U+025E`, `U+029A`).
 * Optimize glyphs for cursive variants for Greek Lower Beta (`β`) and Cyrillic Lower Ve (`в`).
 * Optimize glyphs for Cyrillic Capital/Lower Broad On (`U+047A`, `U+047B`).

--- a/packages/font-glyphs/src/letter/greek/phi.ptl
+++ b/packages/font-glyphs/src/letter/greek/phi.ptl
@@ -13,7 +13,7 @@ glyph-block Letter-Greek-Phi : begin
 	glyph-block-import Letter-Latin-Lower-AE-OE : SubDfAndShift
 
 	define [VarPhiRing fFlatTB df y2 y3] : glyph-proc
-		local gap : Math.max df.mvs : 0.25 * (df.rightSB - df.leftSB)
+		local gap : Math.max (0.25 * (df.rightSB - df.leftSB)) : HSwToV df.mvs
 		include : VBar.m df.middle y2 y3 df.mvs
 		include : if fFlatTB
 			OShapeFlatTB y3 y2 df.leftSB df.rightSB df.mvs (ArchDepthA * df.div) (ArchDepthB * df.div) gap
@@ -130,7 +130,7 @@ glyph-block Letter-Greek-Phi : begin
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.capital
 
-		local vJut : Math.max (LongJut - 0.5 * Stroke) : if SLAB (1.25 * Stroke - O) 0
+		local vJut : Math.max (LongJut - 0.5 * Stroke) : if SLAB (1.5 * Stroke) 0
 
 		local top : CAP + vJut
 		local bot : 0 - vJut

--- a/packages/font-glyphs/src/letter/latin-ext/upper-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/upper-ae-oe.ptl
@@ -121,7 +121,7 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 		match slabKind
 			([Just SLAB-E-ALL] || [Just SLAB-E-CAPPED]) : begin
 				include : VSerif.dr df.rightSB top jutTop swVJut
-				include : VSerif.ur df.rightSB 0 jutBot swVJut
+				include : VSerif.ur df.rightSB 0   jutBot swVJut
 		match slabKind
 			[Just SLAB-E-CAPPED] : begin
 				local fine : swVJut * [AdviceStroke 3.5] / Stroke
@@ -210,26 +210,39 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 		local yBar : top * eBarPos
 		local { jutTop jutBot jutMid } : EFVJutLength top eBarPos sw
 
+		local ada : df.archDepthA ArchDepth sw
+		local adb : df.archDepthB ArchDepth sw
+
 		# O half
-		include : dispiro
-			widths.lhs sw 0
-			straight.left.start eleft top [heading Leftward]
-			archv
-			flat  df.leftSB (top - ArchDepthA)
-			curl  df.leftSB (ArchDepthB)
-			arcvh
-			straight.right.end eleft 0 [heading Rightward]
+		if (top > ada + adb) : then : begin
+			include : dispiro
+				widths.lhs sw 0
+				straight.left.start eleft top [heading Leftward]
+				archv
+				flat  df.leftSB (top - ada)
+				curl  df.leftSB (0   + adb)
+				arcvh
+				straight.right.end eleft 0 [heading Rightward]
+		: else : begin
+			local yMidLeft : top * (adb / (ada + adb))
+			include : dispiro
+				widths.lhs sw 0
+				straight.left.start eleft top [heading Leftward]
+				archv
+				g4 df.leftSB yMidLeft
+				arcvh
+				straight.right.end eleft 0 [heading Rightward]
 
 		# E half
 		include : VBar.l eleft 0 top sw
 		include : HBar.t (eleft - O) df.rightSB top sw
 		include : HBar.m (eleft - O) xMidRight yBar sw
-		include : HBar.b (eleft - O) df.rightSB 0 sw
+		include : HBar.b (eleft - O) df.rightSB 0   sw
 
 		match slabKind
 			([Just SLAB-E-ALL] || [Just SLAB-E-CAPPED]) : begin
 				include : VSerif.dr df.rightSB top jutTop swVJut
-				include : VSerif.ur df.rightSB 0 jutBot swVJut
+				include : VSerif.ur df.rightSB 0   jutBot swVJut
 		match slabKind
 			[Just SLAB-E-CAPPED] : begin
 				local fine : swVJut * [AdviceStroke 3.5] / Stroke

--- a/packages/font-glyphs/src/letter/latin/o.ptl
+++ b/packages/font-glyphs/src/letter/latin/o.ptl
@@ -64,9 +64,12 @@ glyph-block Letter-Latin-O : begin
 	create-glyph 'cyrl/BroadOn' 0x47A : glyph-proc
 		define df : include : DivFrame [mix 1 para.diversityM 0.5] 3
 		include : df.markSet.capital
-		local gap : Math.max (0.25 * (df.rightSB - df.leftSB)) : HSwToV (rBroadOn * Math.SQRT2)
-		local ada : ArchDepthA * df.div
-		local adb : ArchDepthB * df.div
+		local dist : df.rightSB - df.leftSB
+		local gap : Math.min
+			Math.max (0.25 * dist) [HSwToV : Math.SQRT2 * rBroadOn]
+			Math.max (dist - [HSwToV : 3 * df.mvs]) [HSwToV df.mvs]
+		local ada : df.archDepthA ArchDepth df.mvs
+		local adb : df.archDepthB ArchDepth df.mvs
 		include : OShapeFlatTB CAP 0 df.leftSB df.rightSB df.mvs ada adb gap
 		include : DotAt df.middle (df.mvs / 2 + O) rBroadOn
 		include : DotAt df.middle (CAP - df.mvs / 2 - O) rBroadOn
@@ -74,9 +77,12 @@ glyph-block Letter-Latin-O : begin
 	create-glyph 'cyrl/broadOn' 0x47B : glyph-proc
 		define df : include : DivFrame [mix 1 para.diversityM 0.5] 3
 		include : df.markSet.e
-		local gap : Math.max (0.25 * (df.rightSB - df.leftSB)) : HSwToV (rBroadOn * Math.SQRT2)
-		local ada : ArchDepthA * df.div
-		local adb : ArchDepthB * df.div
+		local dist : df.rightSB - df.leftSB
+		local gap : Math.min
+			Math.max (0.25 * dist) [HSwToV : Math.SQRT2 * rBroadOn]
+			Math.max (dist - [HSwToV : 3 * df.mvs]) [HSwToV df.mvs]
+		local ada : df.archDepthA SmallArchDepth df.mvs
+		local adb : df.archDepthB SmallArchDepth df.mvs
 		include : OShapeFlatTB XH 0 df.leftSB df.rightSB df.mvs ada adb gap
 		include : DotAt df.middle (df.mvs / 2 + O) rBroadOn
 		include : DotAt df.middle (XH - df.mvs / 2 - O) rBroadOn
@@ -183,15 +189,15 @@ glyph-block Letter-Latin-O : begin
 		local ada : ArchDepthA * df.div
 		local adb : ArchDepthB * df.div
 		local innerDist : dist - [HSwToV : 5 * df.mvs]
-		local arcXL1 : df.leftSB + innerDist * (1 / 4) + [HSwToV : 1 * df.mvs]
-		local arcXR1 : df.leftSB + innerDist * (3 / 4) + [HSwToV : 4 * df.mvs]
+		local arcXL : df.leftSB + innerDist * (1 / 4) + [HSwToV : 1 * df.mvs]
+		local arcXR : df.leftSB + innerDist * (3 / 4) + [HSwToV : 4 * df.mvs]
 		local heightGap : Math.min (df.mvs + (CAP - df.mvs * 4) / 5) (innerDist / 4 + df.mvs)
 		local heightInner : CAP - 2 * heightGap
 		local smInner  : clamp (df.mvs * 1.5) (0.499 * heightInner) (ArchDepth * heightInner / CAP)
-		local adaInner : [ArchDepthAOf smInner : arcXR1 - arcXL1 + df.leftSB * 2] * df.div
-		local adbInner : [ArchDepthBOf smInner : arcXR1 - arcXL1 + df.leftSB * 2] * df.div
+		local adaInner : [ArchDepthAOf smInner : arcXR - arcXL + df.leftSB * 2] * df.div
+		local adbInner : [ArchDepthBOf smInner : arcXR - arcXL + df.leftSB * 2] * df.div
 		include : OShapeFlatTB CAP 0 df.leftSB df.rightSB df.mvs ada adb gap
-		include : OShapeFlatTB (CAP - heightGap) (0 + heightGap) arcXL1 arcXR1 df.mvs adaInner adbInner gapInner
+		include : OShapeFlatTB (CAP - heightGap) (0 + heightGap) arcXL arcXR df.mvs adaInner adbInner gapInner
 		include : VBar.m df.middle (df.mvs / 2) (CAP - df.mvs / 2) df.mvs
 
 	create-glyph 'romanHundredThousand' 0x2188 : glyph-proc


### PR DESCRIPTION
Changes to characters affected by #2541 are invisible under any default configurations, but I felt like I should account for hypothetical edge cases in case something goes wrong in extremely narrow/wide builds.

Otherwise, the main characters changed are `Œ`/`ɶ` under quasi-proportional:
Monospace for reference (effectively unchanged):
thin:
![image](https://github.com/user-attachments/assets/4622c0b6-ba3c-4497-bb2a-bd2e406e3855)
regular:
![image](https://github.com/user-attachments/assets/ad41a7ac-ad1b-420f-adeb-1f6e0602f51a)
heavy:
![image](https://github.com/user-attachments/assets/3db68169-e51f-4d91-a6f8-5fe15372758e)

Aile thin before:
![image](https://github.com/user-attachments/assets/896e1997-0e16-4209-8311-68317dfc9646)
Aile thin after:
![image](https://github.com/user-attachments/assets/d71b384b-59f4-46aa-b287-5f658f7fcbb0)
Aile regular before:
![image](https://github.com/user-attachments/assets/ed5d05a0-753f-470e-8a71-1631150d5b6e)
Aile regular after:
![image](https://github.com/user-attachments/assets/f8e1b70e-195a-4c11-8307-0f75e13f8ece)
Aile heavy before:
![image](https://github.com/user-attachments/assets/f7e56307-8be3-48ff-a66f-269c87fc3868)
Aile heavy after:
![image](https://github.com/user-attachments/assets/1536498e-a8bd-426f-a7c4-ddad8ad901a9)

Also FWIW I also did a minor tweak to Bulgarian Capital Ef's vJut under heavy, and I think I'm finally happy with it:
`Фф𞁂`
![image](https://github.com/user-attachments/assets/a68f1f39-0c26-4281-a39a-3bffea747dba)

