### PR TITLE
Fix rounding errors caused by glyph cross references (#2545)

### DIFF
--- a/changes/31.9.0.md
+++ b/changes/31.9.0.md
@@ -9,6 +9,7 @@
 * Optimize glyph for Cyrillic Lower Dzze (`U+A689`) under italics.
 * Optimize glyphs for Volapük Ae/Oe/Ue (`U+A79A`..`U+A79F`).
 * Optimize glyph for Latin Lower Dezh Digraph with Palatal Hook (`U+1DF12`).
+* Fix misalignments of square brackets under certain size caused by rounding errors (#2545).
 * Add characters:
   - WAVY LINE (`U+2307`).
   - SYMMETRY (`U+232F`).

--- a/packages/font-glyphs/src/meta/aesthetics.ptl
+++ b/packages/font-glyphs/src/meta/aesthetics.ptl
@@ -9,17 +9,18 @@ export : define [calculateMetrics para] : begin
 	define HalfUPM : UPM / 2
 
 	# Key metrics
-	define Width : Math.round para.width
-	define SB para.sb
-	define CAP para.cap
-	define XH para.xHeight
-	define Ascender para.ascender
-	define Descender : fallback para.descender (XH - Ascender)
-	define Contrast : fallback para.contrast 1
+	define Width     : Math.round para.width
+	define SB        : Math.round para.sb
+	define CAP       : Math.round para.cap
+	define XH        : Math.round para.xHeight
+	define Ascender  : Math.round para.ascender
+	define Descender : Math.round : fallback para.descender (XH - Ascender)
+
 	# Key metrics for symbols
-	define SymbolMid para.symbolMid
-	define ParenTop : SymbolMid + para.parenSize / 2
-	define ParenBot : SymbolMid - para.parenSize / 2
+	define SymbolMid : Math.round para.symbolMid
+	define halfParenSize : Math.ceil (para.parenSize / 2)
+	define ParenTop : SymbolMid + halfParenSize
+	define ParenBot : SymbolMid - halfParenSize
 
 	define OperTop : SymbolMid + para.operSize * (Width - SB * 2)
 	define OperBot : SymbolMid - para.operSize * (Width - SB * 2)
@@ -32,6 +33,7 @@ export : define [calculateMetrics para] : begin
 	define BgOpTop : SymbolMid + para.bgopSize * (Width - SB * 2)
 	define BgOpBot : SymbolMid - para.bgopSize * (Width - SB * 2)
 
+	define Contrast  : fallback para.contrast 1
 
 	# Transform constructors
 	define [Italify angle shift] : begin

--- a/packages/font-glyphs/src/symbol/punctuation/brackets.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/brackets.ptl
@@ -162,11 +162,12 @@ glyph-block Symbol-Punctuation-Brackets : begin
 
 		export : define [Mask] : Rect MosaicTop MosaicBottom (-Width) (2 * Width)
 
-		export : define [Shape top bottom barLeft ext] : glyph-proc
+		export : define [Shape top bottom barLeft ext] : begin
 			local hDim : HDim barLeft ext
-			include : HBar.b hDim.l hDim.r bottom
-			include : HBar.t hDim.l hDim.r top
-			include : VBar.l hDim.l bottom top
+			return : union
+				HBar.b hDim.l hDim.r bottom
+				HBar.t hDim.l hDim.r top
+				VBar.l hDim.l bottom top
 
 	do "Bracket Glyphs"
 		create-glyph 'bracketLeft' '[' : Bracket.Shape ParenTop ParenBot

--- a/packages/font/src/cleanup/glyphs.mjs
+++ b/packages/font/src/cleanup/glyphs.mjs
@@ -1,4 +1,5 @@
 import * as Geom from "@iosevka/geometry";
+import { Transform } from "@iosevka/geometry/transform";
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -11,12 +12,16 @@ export function finalizeGlyphs(cache, para, glyphStore) {
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 function regulateGlyphStore(cache, para, skew, glyphStore) {
-	for (const g of glyphStore.glyphs()) {
-		if (!g.geometry.toReferences()) g.geometry = g.geometry.toIndependent();
-	}
+	const simplifiedResultMap = new Map();
 	for (const g of glyphStore.glyphs()) {
 		if (!(g.geometry.measureComplexity() & Geom.CPLX_NON_EMPTY)) continue;
-		if (!g.geometry.toReferences()) flattenSimpleGlyph(cache, para, skew, g);
+		if (!g.geometry.toReferences()) {
+			simplifiedResultMap.set(g, flattenSimpleGlyph(cache, para, skew, g));
+		}
+	}
+	for (const [g, sr] of simplifiedResultMap) {
+		g.gizmo = Transform.Id();
+		g.geometry = new Geom.ContourSetGeometry(sr);
 	}
 }
 
@@ -24,15 +29,13 @@ function flattenSimpleGlyph(cache, para, skew, g) {
 	try {
 		if (!g.gizmo) throw new TypeError("No gizmo");
 		const gSimplified = Geom.SimplifyGeometry.wrapWithGizmo(g.geometry, g.gizmo);
-		const cs = gSimplified.toContours({ cache });
-		g.clearGeometry();
-		g.includeContours(cs);
+		return gSimplified.toContours({ cache });
 	} catch (e) {
 		console.error("Detected broken geometry when processing", g._m_identifier);
 		console.error(e);
 		console.error(
 			`${para.naming.family} ${para.naming.weight} ${para.naming.width} ${para.naming.slope}`,
 		);
-		g.clearGeometry();
+		return [];
 	}
 }

--- a/packages/font/src/cleanup/glyphs.mjs
+++ b/packages/font/src/cleanup/glyphs.mjs
@@ -1,5 +1,4 @@
 import * as Geom from "@iosevka/geometry";
-import { Transform } from "@iosevka/geometry/transform";
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -12,6 +11,9 @@ export function finalizeGlyphs(cache, para, glyphStore) {
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 function regulateGlyphStore(cache, para, skew, glyphStore) {
+	for (const g of glyphStore.glyphs()) {
+		if (!g.geometry.toReferences()) g.geometry = g.geometry.toIndependent();
+	}
 	for (const g of glyphStore.glyphs()) {
 		if (!(g.geometry.measureComplexity() & Geom.CPLX_NON_EMPTY)) continue;
 		if (!g.geometry.toReferences()) flattenSimpleGlyph(cache, para, skew, g);
@@ -27,6 +29,7 @@ function flattenSimpleGlyph(cache, para, skew, g) {
 		g.includeContours(cs);
 	} catch (e) {
 		console.error("Detected broken geometry when processing", g._m_identifier);
+		console.error(e);
 		console.error(
 			`${para.naming.family} ${para.naming.weight} ${para.naming.width} ${para.naming.slope}`,
 		);

--- a/packages/geometry-cache/src/index.mjs
+++ b/packages/geometry-cache/src/index.mjs
@@ -5,7 +5,7 @@ import zlib from "zlib";
 import * as CurveUtil from "@iosevka/geometry/curve-util";
 import { encode, decode } from "@msgpack/msgpack";
 
-const Edition = 46;
+const Edition = 50;
 const MAX_AGE = 16;
 class GfEntry {
 	constructor(age, value) {

--- a/packages/geometry/src/index.mjs
+++ b/packages/geometry/src/index.mjs
@@ -22,9 +22,6 @@ export class GeometryBase {
 	toReferences() {
 		throw new Error("Unimplemented");
 	}
-	toIndependent() {
-		throw new Error("Unimplemented");
-	}
 	getDependencies() {
 		throw new Error("Unimplemented");
 	}
@@ -52,9 +49,6 @@ export class ContourSetGeometry extends GeometryBase {
 	}
 	toReferences() {
 		return null;
-	}
-	toIndependent() {
-		return this;
 	}
 	getDependencies() {
 		return null;
@@ -111,9 +105,6 @@ export class CachedGeometry extends GeometryBase {
 class SimpleGeometry extends CachedGeometry {
 	toReferences() {
 		return null;
-	}
-	toIndependent() {
-		return this;
 	}
 	getDependencies() {
 		return null;
@@ -294,15 +285,7 @@ export class ReferenceGeometry extends GeometryBase {
 		this.m_y = y || 0;
 	}
 
-	toIndependent() {
-		// Do unlinking *recursively*
-		return TransformedGeometry.create(
-			Transform.Translate(this.m_x, this.m_y),
-			this.m_glyph.geometry.toIndependent(),
-		);
-	}
-	unwrapSimple() {
-		// Do unlinking *for only one level*
+	unwrap() {
 		return TransformedGeometry.create(
 			Transform.Translate(this.m_x, this.m_y),
 			this.m_glyph.geometry,
@@ -310,7 +293,7 @@ export class ReferenceGeometry extends GeometryBase {
 	}
 
 	toContours(ctx) {
-		return this.unwrapSimple().toContours(ctx);
+		return this.unwrap().toContours(ctx);
 	}
 	toReferences() {
 		if (this.m_glyph.geometry.measureComplexity() & CPLX_NON_EMPTY) {
@@ -324,13 +307,13 @@ export class ReferenceGeometry extends GeometryBase {
 		return [this.m_glyph];
 	}
 	filterTag(fn) {
-		return this.unwrapSimple().filterTag(fn);
+		return this.unwrap().filterTag(fn);
 	}
 	measureComplexity() {
 		return this.m_glyph.geometry.measureComplexity();
 	}
 	hash(h) {
-		this.unwrapSimple().hash(h);
+		this.unwrap().hash(h);
 	}
 }
 
@@ -345,9 +328,6 @@ export class TaggedGeometry extends GeometryBase {
 	}
 	toReferences() {
 		return this.m_geom.toReferences();
-	}
-	toIndependent() {
-		return new TaggedGeometry(this.m_geom.toIndependent(), this.m_tag);
 	}
 	getDependencies() {
 		return this.m_geom.getDependencies();
@@ -403,9 +383,6 @@ export class TransformedGeometry extends GeometryBase {
 			result.push({ glyph, x: x + this.m_transform.tx, y: y + this.m_transform.ty });
 		return result;
 	}
-	toIndependent() {
-		return TransformedGeometry.create(this.m_transform, this.m_geom.toIndependent());
-	}
 	getDependencies() {
 		return this.m_geom.getDependencies();
 	}
@@ -439,9 +416,6 @@ export class RadicalGeometry extends GeometryBase {
 	}
 	toReferences() {
 		return null;
-	}
-	toIndependent() {
-		return new RadicalGeometry(this.m_geom.toIndependent());
 	}
 	getDependencies() {
 		return this.m_geom.getDependencies();
@@ -493,9 +467,6 @@ export class CombineGeometry extends GeometryBase {
 			}
 		}
 		return results;
-	}
-	toIndependent() {
-		return new CombineGeometry(this.m_parts.map(x => x.toIndependent()));
 	}
 	getDependencies() {
 		let results = [];
@@ -578,12 +549,6 @@ export class BooleanGeometry extends CachedGeometry {
 	toReferences() {
 		return null;
 	}
-	toIndependent() {
-		return new BooleanGeometry(
-			this.m_operator,
-			this.m_operands.map(x => x.toIndependent()),
-		);
-	}
 	getDependencies() {
 		let results = [];
 		for (const part of this.m_operands) {
@@ -657,15 +622,6 @@ export class StrokeGeometry extends CachedGeometry {
 	}
 	toReferences() {
 		return null;
-	}
-	toIndependent() {
-		return new StrokeGeometry(
-			this.m_geom.toIndependent(),
-			this.m_gizmo,
-			this.m_radius,
-			this.m_contrast,
-			this.m_fInside,
-		);
 	}
 	getDependencies() {
 		return this.m_geom.getDependencies();
@@ -742,9 +698,6 @@ export class RemoveHolesGeometry extends CachedGeometry {
 	toReferences() {
 		return null;
 	}
-	toIndependent() {
-		return new RemoveHolesGeometry(this.m_geom.toIndependent(), this.m_gizmo);
-	}
 	getDependencies() {
 		return this.m_geom.getDependencies();
 	}
@@ -791,9 +744,6 @@ export class SimplifyGeometry extends CachedGeometry {
 	}
 	toReferences() {
 		return null;
-	}
-	toIndependent() {
-		return new SimplifyGeometry(this.m_geom.toIndependent());
 	}
 	getDependencies() {
 		return this.m_geom.getDependencies();


### PR DESCRIPTION
This change fixes #2545, which is caused by rounding error, which is then caused by glyph level dependencies when flattening the geometry.

`ReferenceGeometry` holds a *glyph* reference, so when simplifying the geometry, we cannot modify the geometry data glyph by glyph (a later processed glyph may depend on some other glyph before it, causing this bug).