### PR TITLE
Optimize glyphs for `round-top` variants for `A` part of Capital AE under Quasi-Proportional.

### DIFF
--- a/changes/31.9.1.md
+++ b/changes/31.9.1.md
@@ -1,0 +1,1 @@
+* Optimize glyphs for `round-top-serifless` and `round-top-base-serifed` variants for `A` part (`cv11`) of Capital AE (`U+00C6`) under Quasi-Proportional.

--- a/packages/font-glyphs/src/letter/latin-ext/upper-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/upper-ae-oe.ptl
@@ -73,11 +73,16 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 				corner eleft 0
 
 	define [AEAHalfRoundTop df top eleft sw] : glyph-proc
+		define ada : df.archDepthA ArchDepth sw
+		define adb : df.archDepthB ArchDepth sw
+
+		local yMidDepth : if (top > ada + adb) ada (top * (ada / (ada + adb)))
+
 		include : HBar.t df.leftSB eleft (XH * 0.75 / CAP * top) sw
 		include : dispiro
 			widths.rhs sw
 			flat df.leftSB 0 [heading Upward]
-			curl pre@ (post@ <-> ArchDepthA)
+			curl pre@ (post@ <-> yMidDepth)
 			arcvh
 			straight.right.end eleft top [heading Rightward]
 
@@ -206,12 +211,12 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 		define eleft : df.middle - [HSwToV : sw * [if SLAB (1 / 3) (1 / 4)]]
 		define swVJut : Math.min sw ((df.rightSB - eleft - [HSwToV sw]) * (4 / 5))
 
+		define ada : df.archDepthA ArchDepth sw
+		define adb : df.archDepthB ArchDepth sw
+
 		local xMidRight : df.rightSB - sw / 4
 		local yBar : top * eBarPos
 		local { jutTop jutBot jutMid } : EFVJutLength top eBarPos sw
-
-		local ada : df.archDepthA ArchDepth sw
-		local adb : df.archDepthB ArchDepth sw
 
 		# O half
 		if (top > ada + adb) : then : begin


### PR DESCRIPTION
I had this ready on Saturday but I decided to wait until I knew whether you were going to release 31.9.0 this weekend, to avoid conflicts.

`ÆŒᴁɶ`
Monospace for reference (effectively unchanged):
Thin:
![image](https://github.com/user-attachments/assets/b5dbf557-c42e-47b1-abe8-0a7db18a1273)
Regular:
![image](https://github.com/user-attachments/assets/853e4851-910a-4556-9e7d-724144e8a6a7)
Heavy:
![image](https://github.com/user-attachments/assets/d0e976a1-66e1-404e-9ea7-2c2871ec704b)

Compared to Quasi-Proportional:
Aile thin before:
![image](https://github.com/user-attachments/assets/f867ebf7-63a9-4aac-8ea7-8d87bd004a12)
Aile thin after:
![image](https://github.com/user-attachments/assets/ce049236-ce25-4bfe-9ef5-33401b860cfd)
Aile regular before:
![image](https://github.com/user-attachments/assets/9aaabe33-fa3a-449e-b176-fa4215b385c1)
Aile regular after:
![image](https://github.com/user-attachments/assets/cfb9b93e-2134-43a1-8636-a24b4c074d35)
Aile heavy before:
![image](https://github.com/user-attachments/assets/44729b7b-ed4a-4c1b-be05-d4bf2fc9eedc)
Aile heavy after:
![image](https://github.com/user-attachments/assets/0a5afc9c-b6e7-47cc-99e1-65c05c2e19e8)
