### PR TITLE
Optimize auto-serif behavior of four characters.

### DIFF
--- a/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
@@ -516,8 +516,8 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 				include : Base df XH Slabs SHook SmallArchDepthA SmallArchDepthB
 
 
-	select-variant 'AeVolapuk' 0xA79A (follow -- 'a/single')
-	select-variant 'aeVolapuk' 0xA79B (follow -- 'a/single')
+	select-variant 'AeVolapuk' 0xA79A (follow -- [conditional-follow SLAB 'a/single/autoSerifed/slab' 'a/single/autoSerifed/sans'])
+	select-variant 'aeVolapuk' 0xA79B (follow -- [conditional-follow SLAB 'a/single/autoSerifed/slab' 'a/single/autoSerifed/sans'])
 	select-variant 'UeVolapuk' 0xA79E (follow -- 'u')
 	select-variant 'ueVolapuk' 0xA79F (follow -- 'u')
 

--- a/packages/font-glyphs/src/letter/greek/upper-gamma.ptl
+++ b/packages/font-glyphs/src/letter/greek/upper-gamma.ptl
@@ -43,7 +43,7 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 		bottomSerifed   { SLAB-BOTTOM false }
 		serifed         { SLAB-ALL    true  }
 
-	foreach { suffix { slabType doSM } } [Object.entries GammaConfig] : do
+	foreach { suffix { slabType doST } } [Object.entries GammaConfig] : do
 		create-glyph "grek/Gamma.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : GammaShape CAP 0 slabType
@@ -51,11 +51,10 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 		create-glyph "grek/Digamma.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : GammaShape CAP 0 slabType
-
 			local yBar : CAP * DesignParameters.upperEBarPos
-			include : HBar.m GammaBarLeft (RightSB - [xMidBarShrink doSM]) yBar
-			if doSM : include : tagged 'serifRM'
-				VSerif.dr (RightSB - [xMidBarShrink doSM]) (yBar + HalfStroke) [mix Stroke VJut 0.5]
+			include : HBar.m GammaBarLeft (RightSB - [xMidBarShrink doST]) yBar
+			if doST : include : tagged 'serifRM'
+				VSerif.dr (RightSB - [xMidBarShrink doST]) (yBar + HalfStroke) [mix Stroke VJut 0.5]
 
 		create-glyph "cyrl/GheDescender.\(suffix)" : glyph-proc
 			include [refer-glyph "grek/Gamma.\(suffix)"] AS_BASE ALSO_METRICS
@@ -140,18 +139,15 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 	select-variant 'cyrl/ge' 0x491
 	select-variant 'cyrl/gheMidHook' 0x495 (follow -- 'cyrl/ghe.upright')
 
-	create-glyph "grek/digamma.serifless" : glyph-proc
+	select-variant 'grek/Digamma' 0x3DC (follow -- 'grek/Gamma')
+
+	create-glyph 'grek/digamma' 0x3DD : glyph-proc
 		include : MarkSet.p
 		include : GammaShape XH Descender SLAB-NONE
-		include : HBar.m GammaBarLeft (RightSB - [xMidBarShrink SLAB]) [mix 0 XH DesignParameters.upperEBarPos]
-
-	create-glyph "grek/digamma.topRightSerifed" : glyph-proc
-		include [refer-glyph "grek/digamma.serifless"] AS_BASE ALSO_METRICS
-		include : tagged 'serifRM'
-			VSerif.dr (RightSB - [xMidBarShrink SLAB]) ([mix 0 XH DesignParameters.upperEBarPos] + HalfStroke) [mix Stroke VJut 0.5]
-
-	select-variant 'grek/Digamma' 0x3DC
-	select-variant 'grek/digamma' 0x3DD
+		local yBar : mix 0 XH DesignParameters.upperEBarPos
+		include : HBar.m GammaBarLeft (RightSB - [xMidBarShrink SLAB]) yBar
+		if SLAB : include : tagged 'serifRM'
+			VSerif.dr (RightSB - [xMidBarShrink SLAB]) (yBar + HalfStroke) [mix Stroke VJut 0.5]
 
 	define [GhaynOverlayBar top] : LetterBarOverlay.l GammaBarLeft (top * (1 - OverlayPos))
 

--- a/packages/font-glyphs/src/letter/latin/lower-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-g.ptl
@@ -207,7 +207,7 @@ glyph-block Letter-Latin-Lower-G : begin
 	link-reduced-variant 'g/sansSerif' 'g' MathSansSerif
 	CreateTurnedLetter 'turng' 0x1D77 'g' HalfAdvance [mix Descender XH 0.5]
 	select-variant "gBar" 0x1E5 (follow -- 'g')
-	select-variant 'g/single' null (shapeFrom -- 'g')
+	select-variant 'g/single' null (shapeFrom -- 'g') (follow -- [conditional-follow SLAB 'g/single/autoSerifed/slab' 'g/single/autoSerifed/sans'])
 
 	select-variant 'g/hookTopBase' null (shapeFrom -- 'g')
 

--- a/packages/font-glyphs/src/letter/latin/upper-h.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-h.ptl
@@ -25,6 +25,7 @@ glyph-block Letter-Latin-Upper-H : begin
 	define SLAB-ALL                    4
 	define SLAB-ALL-BGR                5
 	define SLAB-TAILED-CYRILLIC-BGR    6
+	define SLAB-SMALL-HETA             7
 
 	define [HSerifs slabType t b l r sw] : begin
 		local sf : SerifFrame t b l r (swRef -- [fallback sw Stroke])
@@ -36,6 +37,7 @@ glyph-block Letter-Latin-Upper-H : begin
 			[Just SLAB-ALL] : composite-proc sf.lt.full sf.rt.full sf.lb.full sf.rb.full
 			[Just SLAB-ALL-BGR] : composite-proc sf.lt.outer sf.rt.inner sf.lb.full sf.rb.full
 			[Just SLAB-TAILED-CYRILLIC-BGR] : composite-proc sf.lt.outer sf.rt.inner sf.lb.full
+			[Just SLAB-SMALL-HETA] : NeedSlab SLAB : begin sf.lt.outer
 
 	define [HShape l r top _sw] : glyph-proc
 		local sw : fallback _sw Stroke
@@ -45,7 +47,22 @@ glyph-block Letter-Latin-Upper-H : begin
 
 	define [HTurned l r top _sw] : glyph-proc
 		local sw : fallback _sw Stroke
+		include : LeaningAnchor.Below.VBar.r r
 		include : tagged 'strokeL' : VBar.l l (top * HBarPos - sw / 2) top sw
+		include : tagged 'strokeR' : VBar.r r 0 top sw
+		include : HBar.m (l - O) (r + O) (top * HBarPos) sw
+
+	define [HLeftHalf l r top _sw] : glyph-proc
+		local sw : fallback _sw Stroke
+		include : LeaningAnchor.Above.VBar.l l
+		include : LeaningAnchor.Below.VBar.l l
+		include : tagged 'strokeL' : VBar.l l 0 top sw
+		include : HBar.m (l - O) (r + O) (top * HBarPos) sw
+
+	define [HRightHalf l r top _sw] : glyph-proc
+		local sw : fallback _sw Stroke
+		include : LeaningAnchor.Above.VBar.r r
+		include : LeaningAnchor.Below.VBar.r r
 		include : tagged 'strokeR' : VBar.r r 0 top sw
 		include : HBar.m (l - O) (r + O) (top * HBarPos) sw
 
@@ -94,22 +111,22 @@ glyph-block Letter-Latin-Upper-H : begin
 			Math.min OverlayStroke (0.625 * (yt - yb))
 
 	define HConfig : object
-		serifless                        { HShape       HTurned SLAB-NONE                  }
-		tailedSerifless                  { TailedHShape HTurned SLAB-NONE                  }
-		topLeftSerifed                   { HShape       HTurned SLAB-TOP-LEFT              }
-		tailedTopLeftSerifed             { TailedHShape HTurned SLAB-TOP-LEFT              }
-		topLeftBottomRightSerifed        { HShape       HTurned SLAB-TOP-LEFT-BOTTOM-RIGHT }
-		serifed                          { HShape       HTurned SLAB-ALL                   }
-		tailedSerifed                    { TailedHShape HTurned SLAB-TAILED-CYRILLIC       }
-		serifedExceptBottomRight         { HShape       HTurned SLAB-TAILED-CYRILLIC       }
-		serifedBGR                       { HShape       HTurned SLAB-ALL-BGR               }
-		tailedSerifedBGR                 { TailedHShape HTurned SLAB-TAILED-CYRILLIC-BGR   }
+		serifless                        { HShape       HTurned HLeftHalf HRightHalf SLAB-NONE                  }
+		tailedSerifless                  { TailedHShape HTurned HLeftHalf HRightHalf SLAB-NONE                  }
+		topLeftSerifed                   { HShape       HTurned HLeftHalf HRightHalf SLAB-TOP-LEFT              }
+		tailedTopLeftSerifed             { TailedHShape HTurned HLeftHalf HRightHalf SLAB-TOP-LEFT              }
+		topLeftBottomRightSerifed        { HShape       HTurned HLeftHalf HRightHalf SLAB-TOP-LEFT-BOTTOM-RIGHT }
+		serifed                          { HShape       HTurned HLeftHalf HRightHalf SLAB-ALL                   }
+		tailedSerifed                    { TailedHShape HTurned HLeftHalf HRightHalf SLAB-TAILED-CYRILLIC       }
+		serifedExceptBottomRight         { HShape       HTurned HLeftHalf HRightHalf SLAB-TAILED-CYRILLIC       }
+		serifedBGR                       { HShape       HTurned HLeftHalf HRightHalf SLAB-ALL-BGR               }
+		tailedSerifedBGR                 { TailedHShape HTurned HLeftHalf HRightHalf SLAB-TAILED-CYRILLIC-BGR   }
 
 	define EnGheGheConfig : object
 		serifless       false
 		topRightSerifed true
 
-	foreach { suffix { Body TurnedBody slabType } } [Object.entries HConfig] : do
+	foreach { suffix { Body TurnedBody LeftHalfBody RightHalfBody slabType } } [Object.entries HConfig] : do
 		create-glyph "H.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : Body SB RightSB CAP
@@ -121,7 +138,6 @@ glyph-block Letter-Latin-Upper-H : begin
 
 		create-glyph "HTurned.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : LeaningAnchor.Below.VBar.r RightSB
 			include : TurnedBody SB RightSB CAP
 			include : HSerifs slabType CAP 0 SB RightSB
 			eject-contour 'serifLB'
@@ -133,40 +149,28 @@ glyph-block Letter-Latin-Upper-H : begin
 
 		create-glyph "leftHalfH.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : LeaningAnchor.Above.VBar.l SB
-			include : LeaningAnchor.Below.VBar.l SB
-			include : Body SB RightSB CAP
-			eject-contour 'strokeR'
+			include : LeftHalfBody SB RightSB CAP
 			include : HSerifs slabType CAP 0 SB RightSB
 			eject-contour 'serifRT'
 			eject-contour 'serifRB'
 
 		create-glyph "rightHalfH.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : LeaningAnchor.Above.VBar.r RightSB
-			include : LeaningAnchor.Below.VBar.r RightSB
-			include : Body SB RightSB CAP
-			eject-contour 'strokeL'
+			include : RightHalfBody SB RightSB CAP
 			include : HSerifs slabType CAP 0 SB RightSB
 			eject-contour 'serifLT'
 			eject-contour 'serifLB'
 
 		create-glyph "leftHalfSmcpH.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			include : LeaningAnchor.Above.VBar.l SB
-			include : LeaningAnchor.Below.VBar.l SB
-			include : Body SB RightSB XH
-			eject-contour 'strokeR'
+			include : LeftHalfBody SB RightSB XH
 			include : HSerifs slabType XH 0 SB RightSB
 			eject-contour 'serifRT'
 			eject-contour 'serifRB'
 
 		create-glyph "rightHalfSmcpH.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			include : LeaningAnchor.Above.VBar.r RightSB
-			include : LeaningAnchor.Below.VBar.r RightSB
-			include : Body SB RightSB XH
-			eject-contour 'strokeL'
+			include : RightHalfBody SB RightSB XH
 			include : HSerifs slabType XH 0 SB RightSB
 			eject-contour 'serifLT'
 			eject-contour 'serifLB'
@@ -236,7 +240,6 @@ glyph-block Letter-Latin-Upper-H : begin
 			include : HSerifs slabType XH 0 df.leftSB xm df.mvs
 			include : MidHook.m df XH
 
-
 	select-variant 'H' 'H'
 	link-reduced-variant 'H/sansSerif' 'H' MathSansSerif
 	select-variant 'H/descBase' (shapeFrom -- 'H')
@@ -247,7 +250,6 @@ glyph-block Letter-Latin-Upper-H : begin
 	select-variant 'cyrl/En/descBase' (shapeFrom -- 'H')
 	select-variant 'leftHalfH' 0x2C75
 	select-variant 'rightHalfH' 0xA7F5
-	select-variant 'grek/Heta' 0x370 (shapeFrom -- 'leftHalfH')
 
 	select-variant 'smcpH' 0x29C (follow -- 'H')
 	select-variant 'leftHalfSmcpH' 0x2C76 (follow -- 'leftHalfH')
@@ -255,7 +257,13 @@ glyph-block Letter-Latin-Upper-H : begin
 	select-variant 'cyrl/en' 0x43D (shapeFrom -- 'smcpH')
 	select-variant 'cyrl/en/descBase' (shapeFrom -- 'smcpH')
 	select-variant 'cyrl/en.BGR' (shapeFrom -- 'smcpH')
-	select-variant 'grek/heta' 0x371 (shapeFrom -- 'leftHalfSmcpH')
+
+	alias 'grek/Heta' 0x370 'leftHalfH'
+
+	create-glyph 'grek/heta' 0x371 : glyph-proc
+		include : MarkSet.e
+		include : LeftHalfBody SB RightSB XH
+		include : HSerifs SLAB-SMALL-HETA XH 0 SB RightSB
 
 	derive-composites 'HDescender' 0x2C67 'H/descBase' [CyrDescender.rSideJut RightSB 0]
 
@@ -279,18 +287,6 @@ glyph-block Letter-Latin-Upper-H : begin
 
 	select-variant 'cyrl/NjeKomi' 0x050A
 	select-variant 'cyrl/njeKomi' 0x050B
-
-	create-glyph 'mathbb/H' 0x210D : glyph-proc
-		include : MarkSet.capital
-		include : VBar.l  SB 0 CAP BBS
-		include : VBar.r RightSB 0 CAP BBS
-		include : VBar.l  (SB + BBD) 0 CAP BBS
-		include : VBar.r (RightSB - BBD) 0 CAP BBS
-		include : HBar.m (SB + BBD) (RightSB - BBD)  (CAP * HBarPos) BBS
-		include : HBar.t SB (SB + BBD) CAP BBS
-		include : HBar.t (RightSB - BBD) RightSB CAP BBS
-		include : HBar.b SB (SB + BBD) 0 BBS
-		include : HBar.b (RightSB - BBD) RightSB 0 BBS
 
 	derive-glyphs 'HCedilla' 0x1E28 'H' : lambda [src gr] : glyph-proc
 		local shift : Width + SB - Middle + [HSwToV HalfStroke]
@@ -317,12 +313,24 @@ glyph-block Letter-Latin-Upper-H : begin
 	derive-glyphs 'cyrl/EnHook' 0x4C7 'cyrl/En/descBase' DProcCapitalHeng
 	derive-glyphs 'cyrl/enHook' 0x4C8 'cyrl/en/descBase' DProcSmallHeng
 
-	derive-glyphs 'cyrl/EnLHook' 0x528 'cyrl/En' : lambda [src srl] : glyph-proc
+	derive-glyphs 'cyrl/EnHookLeft' 0x528 'cyrl/En' : lambda [src srl] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
 		eject-contour 'serifLB'
 		include : PalatalHook.lExt SB 0
 
-	derive-glyphs 'cyrl/enLHook' 0x529 'cyrl/en' : lambda [src srl] : glyph-proc
+	derive-glyphs 'cyrl/enHookLeft' 0x529 'cyrl/en' : lambda [src srl] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
 		eject-contour 'serifLB'
 		include : PalatalHook.lExt SB 0
+
+	create-glyph 'mathbb/H' 0x210D : glyph-proc
+		include : MarkSet.capital
+		include : VBar.l  SB 0 CAP BBS
+		include : VBar.r RightSB 0 CAP BBS
+		include : VBar.l  (SB + BBD) 0 CAP BBS
+		include : VBar.r (RightSB - BBD) 0 CAP BBS
+		include : HBar.m (SB + BBD) (RightSB - BBD)  (CAP * HBarPos) BBS
+		include : HBar.t SB (SB + BBD) CAP BBS
+		include : HBar.t (RightSB - BBD) RightSB CAP BBS
+		include : HBar.b SB (SB + BBD) 0 BBS
+		include : HBar.b (RightSB - BBD) RightSB 0 BBS

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -967,8 +967,6 @@ selector."H/sansSerif" = "serifless"
 selector."H/descBase" = "serifless"
 selector.leftHalfH = "serifless"
 selector.rightHalfH = "serifless"
-selector."grek/Heta" = "serifless"
-selector."grek/heta" = "serifless"
 selector.Hwair = "serifless"
 selector.HHookTop = "serifless"
 
@@ -980,8 +978,6 @@ selector."H/sansSerif" = "serifless"
 selector."H/descBase" = "topLeftSerifed"
 selector.leftHalfH = "topLeftSerifed"
 selector.rightHalfH = "serifless"
-selector."grek/Heta" = "topLeftSerifed"
-selector."grek/heta" = "topLeftSerifed"
 selector.Hwair = "topLeftSerifed"
 selector.HHookTop = "serifless"
 
@@ -993,8 +989,6 @@ selector."H/sansSerif" = "serifless"
 selector."H/descBase" = "topLeftSerifed"
 selector.leftHalfH = "topLeftSerifed"
 selector.rightHalfH = "topLeftBottomRightSerifed"
-selector."grek/Heta" = "topLeftSerifed"
-selector."grek/heta" = "topLeftSerifed"
 selector.Hwair = "topLeftSerifed"
 selector.HHookTop = "topLeftBottomRightSerifed"
 
@@ -1006,8 +1000,6 @@ selector."H/sansSerif" = "serifless"
 selector."H/descBase" = "serifed"
 selector.leftHalfH = "serifed"
 selector.rightHalfH = "serifed"
-selector."grek/Heta" = "serifed"
-selector."grek/heta" = "topLeftSerifed"
 selector.Hwair = "serifedExceptBottomRight"
 selector.HHookTop = "serifed"
 
@@ -2145,8 +2137,9 @@ selectorAffix."ae/a" = "doubleStorey"
 selectorAffix."a/sansSerif" = "doubleStorey"
 selectorAffix."a/rtailBase" = "doubleStorey"
 selectorAffix."a/turnABase" = "doubleStorey"
-selectorAffix."a/single"    = "singleStorey"
-selectorAffix.scripta       = "singleStorey"
+selectorAffix."a/single/autoSerifed/slab" = "singleStorey"
+selectorAffix."a/single/autoSerifed/sans" = "singleStorey"
+selectorAffix.scripta = "singleStorey"
 
 [prime.a.variants-buildup.stages.storey.single-storey]
 rank = 2
@@ -2157,8 +2150,9 @@ selectorAffix."ae/a" = "doubleStorey"
 selectorAffix."a/sansSerif" = "singleStorey"
 selectorAffix."a/rtailBase" = "singleStorey"
 selectorAffix."a/turnABase" = "doubleStorey"
-selectorAffix."a/single"    = "singleStorey"
-selectorAffix.scripta       = "singleStorey"
+selectorAffix."a/single/autoSerifed/slab" = "singleStorey"
+selectorAffix."a/single/autoSerifed/sans" = "singleStorey"
+selectorAffix.scripta = "singleStorey"
 
 [prime.a.variants-buildup.stages.double-storey-hook."*"]
 next = "bar"
@@ -2172,8 +2166,9 @@ selectorAffix."ae/a" = ""
 selectorAffix."a/sansSerif" = ""
 selectorAffix."a/rtailBase" = ""
 selectorAffix."a/turnABase" = ""
-selectorAffix."a/single"    = ""
-selectorAffix.scripta       = ""
+selectorAffix."a/single/autoSerifed/slab" = ""
+selectorAffix."a/single/autoSerifed/sans" = ""
+selectorAffix.scripta = ""
 
 [prime.a.variants-buildup.stages.double-storey-hook.hook-serifed]
 rank = 2
@@ -2184,8 +2179,9 @@ selectorAffix."ae/a" = "hookInwardSerifed"
 selectorAffix."a/sansSerif" = ""
 selectorAffix."a/rtailBase" = "hookInwardSerifed"
 selectorAffix."a/turnABase" = "hookInwardSerifed"
-selectorAffix."a/single"    = ""
-selectorAffix.scripta       = ""
+selectorAffix."a/single/autoSerifed/slab" = ""
+selectorAffix."a/single/autoSerifed/sans" = ""
+selectorAffix.scripta = ""
 
 [prime.a.variants-buildup.stages.ear."*"]
 next = "bar"
@@ -2198,8 +2194,9 @@ selectorAffix."ae/a" = ""
 selectorAffix."a/sansSerif" = ""
 selectorAffix."a/rtailBase" = ""
 selectorAffix."a/turnABase" = ""
-selectorAffix."a/single"    = ""
-selectorAffix.scripta       = ""
+selectorAffix."a/single/autoSerifed/slab" = ""
+selectorAffix."a/single/autoSerifed/sans" = ""
+selectorAffix.scripta = ""
 
 [prime.a.variants-buildup.stages.ear.earless-corner]
 rank = 2
@@ -2209,8 +2206,9 @@ selectorAffix."ae/a" = ""
 selectorAffix."a/sansSerif" = "earlessCorner"
 selectorAffix."a/rtailBase" = "earlessCorner"
 selectorAffix."a/turnABase" = ""
-selectorAffix."a/single"    = "earlessCorner"
-selectorAffix.scripta       = ""
+selectorAffix."a/single/autoSerifed/slab" = "earlessCorner"
+selectorAffix."a/single/autoSerifed/sans" = "earlessCorner"
+selectorAffix.scripta = ""
 
 [prime.a.variants-buildup.stages.ear.earless-rounded]
 rank = 3
@@ -2220,8 +2218,9 @@ selectorAffix."ae/a" = ""
 selectorAffix."a/sansSerif" = "earlessRounded"
 selectorAffix."a/rtailBase" = "earlessRounded"
 selectorAffix."a/turnABase" = ""
-selectorAffix."a/single"    = "earlessRounded"
-selectorAffix.scripta       = ""
+selectorAffix."a/single/autoSerifed/slab" = "earlessRounded"
+selectorAffix."a/single/autoSerifed/sans" = "earlessRounded"
+selectorAffix.scripta = ""
 
 [prime.a.variants-buildup.stages.bar.serifless]
 rank = 1
@@ -2232,8 +2231,9 @@ selectorAffix."ae/a" = "serifless"
 selectorAffix."a/sansSerif" = "serifless"
 selectorAffix."a/rtailBase" = "serifless"
 selectorAffix."a/turnABase" = "serifless"
-selectorAffix."a/single"    = "serifless"
-selectorAffix.scripta       = "serifless"
+selectorAffix."a/single/autoSerifed/slab" = "serifless"
+selectorAffix."a/single/autoSerifed/sans" = "serifless"
+selectorAffix.scripta = "serifless"
 
 [prime.a.variants-buildup.stages.bar.serifed]
 rank = 2
@@ -2243,8 +2243,9 @@ selectorAffix."ae/a" = "serifless"
 selectorAffix."a/sansSerif" = "serifless"
 selectorAffix."a/rtailBase" = "serifless"
 selectorAffix."a/turnABase" = "serifed"
-selectorAffix."a/single"    = { if = [{ storey = "double-storey" }], then = "doubleSerifed", else = "serifed" }
-selectorAffix.scripta       = "serifed"
+selectorAffix."a/single/autoSerifed/slab" = { if = [{ storey = "double-storey" }], then = "doubleSerifed", else = "serifed" }
+selectorAffix."a/single/autoSerifed/sans" = "serifed"
+selectorAffix.scripta = "serifed"
 
 [prime.a.variants-buildup.stages.bar.double-serifed]
 rank = 3
@@ -2255,8 +2256,9 @@ selectorAffix."ae/a" = "serifless"
 selectorAffix."a/sansSerif" = "serifless"
 selectorAffix."a/rtailBase" = "topSerifed"
 selectorAffix."a/turnABase" = "serifed"
-selectorAffix."a/single"    = "doubleSerifed"
-selectorAffix.scripta       = "serifed"
+selectorAffix."a/single/autoSerifed/slab" = "doubleSerifed"
+selectorAffix."a/single/autoSerifed/sans" = "doubleSerifed"
+selectorAffix.scripta = "serifed"
 
 [prime.a.variants-buildup.stages.bar.tailed]
 rank = 4
@@ -2266,8 +2268,9 @@ selectorAffix."ae/a" = "serifless"
 selectorAffix."a/sansSerif" = "tailed"
 selectorAffix."a/rtailBase" = "serifless"
 selectorAffix."a/turnABase" = "tailed"
-selectorAffix."a/single"    = "tailed"
-selectorAffix.scripta       = "tailed"
+selectorAffix."a/single/autoSerifed/slab" = "tailed"
+selectorAffix."a/single/autoSerifed/sans" = "tailed"
+selectorAffix.scripta = "tailed"
 
 [prime.a.variants-buildup.stages.bar.tailed-serifed]
 rank = 5
@@ -2278,8 +2281,9 @@ selectorAffix."ae/a" = "serifless"
 selectorAffix."a/sansSerif" = "tailed"
 selectorAffix."a/rtailBase" = "topSerifed"
 selectorAffix."a/turnABase" = "tailed"
-selectorAffix."a/single"    = "tailedSerifed"
-selectorAffix.scripta       = "tailed"
+selectorAffix."a/single/autoSerifed/slab" = "tailedSerifed"
+selectorAffix."a/single/autoSerifed/sans" = "tailedSerifed"
+selectorAffix.scripta = "tailed"
 
 [prime.a.variants-buildup.stages.bar.toothless-corner]
 rank = 6
@@ -2290,8 +2294,9 @@ selectorAffix."ae/a" = "serifless"
 selectorAffix."a/sansSerif" = "toothlessCorner"
 selectorAffix."a/rtailBase" = "serifless"
 selectorAffix."a/turnABase" = "toothlessCorner"
-selectorAffix."a/single"    = "serifless"
-selectorAffix.scripta       = "serifless"
+selectorAffix."a/single/autoSerifed/slab" = "serifless"
+selectorAffix."a/single/autoSerifed/sans" = "serifless"
+selectorAffix.scripta = "serifless"
 
 [prime.a.variants-buildup.stages.bar.toothless-rounded]
 rank = 7
@@ -2302,8 +2307,9 @@ selectorAffix."ae/a" = "serifless"
 selectorAffix."a/sansSerif" = "toothlessRounded"
 selectorAffix."a/rtailBase" = "serifless"
 selectorAffix."a/turnABase" = "toothlessRounded"
-selectorAffix."a/single"    = "serifless"
-selectorAffix.scripta       = "serifless"
+selectorAffix."a/single/autoSerifed/slab" = "serifless"
+selectorAffix."a/single/autoSerifed/sans" = "serifless"
+selectorAffix.scripta = "serifless"
 
 
 
@@ -2748,7 +2754,8 @@ selectorAffix."g/sansSerif" = ""
 selectorAffix."g/hookTopBase" = ""
 selectorAffix."gScript" = ""
 selectorAffix."gScriptCrossedTail" = ""
-selectorAffix."g/single" = ""
+selectorAffix."g/single/autoSerifed/slab" = ""
+selectorAffix."g/single/autoSerifed/sans" = ""
 
 [prime.g.variants-buildup.stages.openness."*"]
 next = "END"
@@ -2761,7 +2768,8 @@ selectorAffix."g/sansSerif" = "doubleStorey"
 selectorAffix."g/hookTopBase" = "singleStoreySerifless"
 selectorAffix."gScript" = "singleStoreyScriptCut"
 selectorAffix."gScriptCrossedTail" = "singleStoreyScriptCut"
-selectorAffix."g/single" = "singleStorey"
+selectorAffix."g/single/autoSerifed/slab" = "singleStoreySerifed"
+selectorAffix."g/single/autoSerifed/sans" = "singleStoreySerifless"
 
 [prime.g.variants-buildup.stages.openness.open]
 rank = 1
@@ -2771,7 +2779,8 @@ selectorAffix."g/sansSerif" = "openDoubleStorey"
 selectorAffix."g/hookTopBase" = "singleStoreySerifless"
 selectorAffix."gScript" = "singleStoreyScriptCut"
 selectorAffix."gScriptCrossedTail" = "singleStoreyScriptCut"
-selectorAffix."g/single" = "singleStorey"
+selectorAffix."g/single/autoSerifed/slab" = "singleStoreySerifed"
+selectorAffix."g/single/autoSerifed/sans" = "singleStoreySerifless"
 
 [prime.g.variants-buildup.stages.storey.single-storey]
 next = "hook"
@@ -2782,7 +2791,8 @@ selectorAffix."g/sansSerif" = "singleStorey"
 selectorAffix."g/hookTopBase" = "singleStorey"
 selectorAffix."gScript" = "singleStorey"
 selectorAffix."gScriptCrossedTail" = "singleStorey"
-selectorAffix."g/single" = "singleStorey"
+selectorAffix."g/single/autoSerifed/slab" = "singleStorey"
+selectorAffix."g/single/autoSerifed/sans" = "singleStorey"
 
 [prime.g.variants-buildup.stages.hook."*"]
 next = "ear"
@@ -2795,7 +2805,8 @@ selectorAffix."g/sansSerif" = ""
 selectorAffix."g/hookTopBase" = ""
 selectorAffix."gScript" = ""
 selectorAffix."gScriptCrossedTail" = ""
-selectorAffix."g/single" = ""
+selectorAffix."g/single/autoSerifed/slab" = ""
+selectorAffix."g/single/autoSerifed/sans" = ""
 
 [prime.g.variants-buildup.stages.hook.flat-hook]
 rank = 2
@@ -2805,7 +2816,8 @@ selectorAffix."g/sansSerif" = "flatHook"
 selectorAffix."g/hookTopBase" = "flatHook"
 selectorAffix."gScript" = "flatHook"
 selectorAffix."gScriptCrossedTail" = ""
-selectorAffix."g/single" = "flatHook"
+selectorAffix."g/single/autoSerifed/slab" = "flatHook"
+selectorAffix."g/single/autoSerifed/sans" = "flatHook"
 
 [prime.g.variants-buildup.stages.ear.serifless]
 rank = 1
@@ -2814,7 +2826,8 @@ selectorAffix."g/sansSerif" = "serifless"
 selectorAffix."g/hookTopBase" = "serifless"
 selectorAffix."gScript" = "scriptCut"
 selectorAffix."gScriptCrossedTail" = "scriptCut"
-selectorAffix."g/single" = "serifless"
+selectorAffix."g/single/autoSerifed/slab" = "serifless"
+selectorAffix."g/single/autoSerifed/sans" = "serifless"
 
 [prime.g.variants-buildup.stages.ear.serifed]
 rank = 2
@@ -2824,7 +2837,8 @@ selectorAffix."g/sansSerif" = "serifless"
 selectorAffix."g/hookTopBase" = "serifless"
 selectorAffix."gScript" = "scriptCut"
 selectorAffix."gScriptCrossedTail" = "scriptCut"
-selectorAffix."g/single" = "serifed"
+selectorAffix."g/single/autoSerifed/slab" = "serifed"
+selectorAffix."g/single/autoSerifed/sans" = "serifed"
 
 [prime.g.variants-buildup.stages.ear.earless-corner]
 rank = 3
@@ -2834,7 +2848,8 @@ selectorAffix."g/sansSerif" = "earlessCorner"
 selectorAffix."g/hookTopBase" = "earlessCornerHTB"
 selectorAffix."gScript" = "scriptCut"
 selectorAffix."gScriptCrossedTail" = "scriptCut"
-selectorAffix."g/single" = "earlessCorner"
+selectorAffix."g/single/autoSerifed/slab" = "earlessCorner"
+selectorAffix."g/single/autoSerifed/sans" = "earlessCorner"
 
 [prime.g.variants-buildup.stages.ear.earless-rounded]
 rank = 4
@@ -2844,7 +2859,8 @@ selectorAffix."g/sansSerif" = "earlessRounded"
 selectorAffix."g/hookTopBase" = "serifless"
 selectorAffix."gScript" = "scriptCut"
 selectorAffix."gScriptCrossedTail" = "scriptCut"
-selectorAffix."g/single" = "earlessRounded"
+selectorAffix."g/single/autoSerifed/slab" = "earlessRounded"
+selectorAffix."g/single/autoSerifed/sans" = "earlessRounded"
 
 
 
@@ -5538,8 +5554,6 @@ rank = 1
 description = "Greek capital Gamma (`Γ`) without serifs"
 selector."grek/Gamma" = "serifless"
 selector."grek/Gamma/sansSerif" = "serifless"
-selector."grek/Digamma" = "serifless"
-selector."grek/digamma" = "serifless"
 selector."cyrl/Ghe" = "serifless"
 selector."cyrl/ghe.upright" = "serifless"
 selector."cyrl/Ge" = "serifless"
@@ -5552,8 +5566,6 @@ rank = 2
 description = "Greek capital Gamma (`Γ`) with serifs at top right"
 selector."grek/Gamma" = "topRightSerifed"
 selector."grek/Gamma/sansSerif" = "serifless"
-selector."grek/Digamma" = "topRightSerifed"
-selector."grek/digamma" = "topRightSerifed"
 selector."cyrl/Ghe" = "topRightSerifed"
 selector."cyrl/ghe.upright" = "topRightSerifed"
 selector."cyrl/Ge" = "serifless"
@@ -5566,8 +5578,6 @@ rank = 3
 description = "Greek capital Gamma (`Γ`) with bottom serif"
 selector."grek/Gamma" = "bottomSerifed"
 selector."grek/Gamma/sansSerif" = "serifless"
-selector."grek/Digamma" = "bottomSerifed"
-selector."grek/digamma" = "serifless"
 selector."cyrl/Ghe" = "bottomSerifed"
 selector."cyrl/ghe.upright" = "serifless"
 selector."cyrl/Ge" = "bottomSerifed"
@@ -5580,8 +5590,6 @@ rank = 4
 description = "Greek capital Gamma (`Γ`) with motion serifs at top and bottom"
 selector."grek/Gamma" = "serifed"
 selector."grek/Gamma/sansSerif" = "serifless"
-selector."grek/Digamma" = "serifed"
-selector."grek/digamma" = "topRightSerifed"
 selector."cyrl/Ghe" = "serifed"
 selector."cyrl/ghe.upright" = "serifed"
 selector."cyrl/Ge" = "serifed"


### PR DESCRIPTION
Originally this was just going to be for returning auto-serifed behavior to Greek Lower Digamma/Heta to save a handful of glyphs, but I extended the scope to improve variant selection for forced-single-storey `a` and `g` to facilitate #2552 so that one of its single-storey `g`-derived characters doesn't show duplicate variants once its auto-serifed variants are exposed in the specimen.

Showing all `a` variants as an example:
sans before:
![image](https://github.com/user-attachments/assets/fcb74c7d-47f6-4ea3-8656-91ca31a04308)
sans after  (in particular look at `cv36`-`02`/`07`):
![image](https://github.com/user-attachments/assets/d1c57b2a-2686-4522-952a-38b60adcb2a3)
slab before:
![image](https://github.com/user-attachments/assets/a1e16369-d9ae-4c81-a992-9d29d5acd788)
slab after (effectively unchanged):
![image](https://github.com/user-attachments/assets/42443b43-e76f-47ca-a137-c840eafdcffe)

To show `g` variants in the same way would not show an obvious difference except for in the variant atlas in the release build, so I'll spare you the images for bandwidth reasons.