### PR TITLE
Cleanup of #2553 .

### DIFF
--- a/packages/font-glyphs/src/letter/latin/lower-a.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-a.ptl
@@ -275,10 +275,11 @@ glyph-block Letter-Latin-Lower-A : begin
 	derive-composites 'aRetroflexHook' 0x1D8F 'a/rtailBase'
 		RetroflexHook.rSideJut RightSB 0 (yOverflow -- Stroke)
 
-	select-variant 'scripta' 0x0251
-	select-variant 'largescripta' 0x2C6D (follow -- 'scripta')
-	select-variant 'invscripta' 0xAB64 (follow -- 'scripta')
-	derive-composites 'alphaRetroflexHook' 0x1D90 'scripta.singleStoreySerifless'
+	select-variant 'scripta'      0x251  (follow -- [conditional-follow SLAB 'scripta/autoSerifed/slab' 'scripta/autoSerifed/sans'])
+	select-variant 'largescripta' 0x2C6D (follow -- [conditional-follow SLAB 'scripta/autoSerifed/slab' 'scripta/autoSerifed/sans'])
+	select-variant 'invscripta'   0xAB64 (follow -- [conditional-follow SLAB 'scripta/autoSerifed/slab' 'scripta/autoSerifed/sans'])
+
+	derive-composites 'scriptaRetroflexHook' 0x1D90 'scripta.singleStoreySerifless'
 		RetroflexHook.rSideJut RightSB 0 (yOverflow -- Stroke)
 
 	CreateTurnedLetter 'turnscripta' 0x252 'scripta' HalfAdvance (XH / 2)

--- a/packages/font-glyphs/src/letter/latin/lower-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-g.ptl
@@ -207,7 +207,6 @@ glyph-block Letter-Latin-Lower-G : begin
 	link-reduced-variant 'g/sansSerif' 'g' MathSansSerif
 	CreateTurnedLetter 'turng' 0x1D77 'g' HalfAdvance [mix Descender XH 0.5]
 	select-variant "gBar" 0x1E5 (follow -- 'g')
-	select-variant 'g/single' null (shapeFrom -- 'g') (follow -- [conditional-follow SLAB 'g/single/autoSerifed/slab' 'g/single/autoSerifed/sans'])
 
 	select-variant 'g/hookTopBase' null (shapeFrom -- 'g')
 
@@ -216,8 +215,8 @@ glyph-block Letter-Latin-Lower-G : begin
 	select-variant 'gScriptPalatalHook' 0x1D83 (follow -- 'gScript')
 	select-variant 'gScriptCrossedTail' 0xAB36
 
-	alias 'cyrl/de.BGR' null 'g/single'
-	alias 'cyrl/de.SRB' null 'g/single'
+	select-variant 'cyrl/de.BGR' (shapeFrom -- 'g') (follow -- [conditional-follow SLAB 'g/single/autoSerifed/slab' 'g/single/autoSerifed/sans'])
+	alias 'cyrl/de.SRB' null 'cyrl/de.BGR'
 
 	derive-glyphs 'gHookTop' 0x260 "g/hookTopBase" : function [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2139,7 +2139,8 @@ selectorAffix."a/rtailBase" = "doubleStorey"
 selectorAffix."a/turnABase" = "doubleStorey"
 selectorAffix."a/single/autoSerifed/slab" = "singleStorey"
 selectorAffix."a/single/autoSerifed/sans" = "singleStorey"
-selectorAffix.scripta = "singleStorey"
+selectorAffix."scripta/autoSerifed/slab" = "singleStorey"
+selectorAffix."scripta/autoSerifed/sans" = "singleStorey"
 
 [prime.a.variants-buildup.stages.storey.single-storey]
 rank = 2
@@ -2152,7 +2153,8 @@ selectorAffix."a/rtailBase" = "singleStorey"
 selectorAffix."a/turnABase" = "doubleStorey"
 selectorAffix."a/single/autoSerifed/slab" = "singleStorey"
 selectorAffix."a/single/autoSerifed/sans" = "singleStorey"
-selectorAffix.scripta = "singleStorey"
+selectorAffix."scripta/autoSerifed/slab" = "singleStorey"
+selectorAffix."scripta/autoSerifed/sans" = "singleStorey"
 
 [prime.a.variants-buildup.stages.double-storey-hook."*"]
 next = "bar"
@@ -2168,7 +2170,8 @@ selectorAffix."a/rtailBase" = ""
 selectorAffix."a/turnABase" = ""
 selectorAffix."a/single/autoSerifed/slab" = ""
 selectorAffix."a/single/autoSerifed/sans" = ""
-selectorAffix.scripta = ""
+selectorAffix."scripta/autoSerifed/slab" = ""
+selectorAffix."scripta/autoSerifed/sans" = ""
 
 [prime.a.variants-buildup.stages.double-storey-hook.hook-serifed]
 rank = 2
@@ -2181,7 +2184,8 @@ selectorAffix."a/rtailBase" = "hookInwardSerifed"
 selectorAffix."a/turnABase" = "hookInwardSerifed"
 selectorAffix."a/single/autoSerifed/slab" = ""
 selectorAffix."a/single/autoSerifed/sans" = ""
-selectorAffix.scripta = ""
+selectorAffix."scripta/autoSerifed/slab" = ""
+selectorAffix."scripta/autoSerifed/sans" = ""
 
 [prime.a.variants-buildup.stages.ear."*"]
 next = "bar"
@@ -2196,7 +2200,8 @@ selectorAffix."a/rtailBase" = ""
 selectorAffix."a/turnABase" = ""
 selectorAffix."a/single/autoSerifed/slab" = ""
 selectorAffix."a/single/autoSerifed/sans" = ""
-selectorAffix.scripta = ""
+selectorAffix."scripta/autoSerifed/slab" = ""
+selectorAffix."scripta/autoSerifed/sans" = ""
 
 [prime.a.variants-buildup.stages.ear.earless-corner]
 rank = 2
@@ -2208,7 +2213,8 @@ selectorAffix."a/rtailBase" = "earlessCorner"
 selectorAffix."a/turnABase" = ""
 selectorAffix."a/single/autoSerifed/slab" = "earlessCorner"
 selectorAffix."a/single/autoSerifed/sans" = "earlessCorner"
-selectorAffix.scripta = ""
+selectorAffix."scripta/autoSerifed/slab" = ""
+selectorAffix."scripta/autoSerifed/sans" = ""
 
 [prime.a.variants-buildup.stages.ear.earless-rounded]
 rank = 3
@@ -2220,7 +2226,8 @@ selectorAffix."a/rtailBase" = "earlessRounded"
 selectorAffix."a/turnABase" = ""
 selectorAffix."a/single/autoSerifed/slab" = "earlessRounded"
 selectorAffix."a/single/autoSerifed/sans" = "earlessRounded"
-selectorAffix.scripta = ""
+selectorAffix."scripta/autoSerifed/slab" = ""
+selectorAffix."scripta/autoSerifed/sans" = ""
 
 [prime.a.variants-buildup.stages.bar.serifless]
 rank = 1
@@ -2233,7 +2240,8 @@ selectorAffix."a/rtailBase" = "serifless"
 selectorAffix."a/turnABase" = "serifless"
 selectorAffix."a/single/autoSerifed/slab" = "serifless"
 selectorAffix."a/single/autoSerifed/sans" = "serifless"
-selectorAffix.scripta = "serifless"
+selectorAffix."scripta/autoSerifed/slab" = "serifless"
+selectorAffix."scripta/autoSerifed/sans" = "serifless"
 
 [prime.a.variants-buildup.stages.bar.serifed]
 rank = 2
@@ -2245,7 +2253,8 @@ selectorAffix."a/rtailBase" = "serifless"
 selectorAffix."a/turnABase" = "serifed"
 selectorAffix."a/single/autoSerifed/slab" = { if = [{ storey = "double-storey" }], then = "doubleSerifed", else = "serifed" }
 selectorAffix."a/single/autoSerifed/sans" = "serifed"
-selectorAffix.scripta = "serifed"
+selectorAffix."scripta/autoSerifed/slab" = "serifed"
+selectorAffix."scripta/autoSerifed/sans" = "serifed"
 
 [prime.a.variants-buildup.stages.bar.double-serifed]
 rank = 3
@@ -2258,7 +2267,8 @@ selectorAffix."a/rtailBase" = "topSerifed"
 selectorAffix."a/turnABase" = "serifed"
 selectorAffix."a/single/autoSerifed/slab" = "doubleSerifed"
 selectorAffix."a/single/autoSerifed/sans" = "doubleSerifed"
-selectorAffix.scripta = "serifed"
+selectorAffix."scripta/autoSerifed/slab" = "serifed"
+selectorAffix."scripta/autoSerifed/sans" = "serifed"
 
 [prime.a.variants-buildup.stages.bar.tailed]
 rank = 4
@@ -2268,9 +2278,10 @@ selectorAffix."ae/a" = "serifless"
 selectorAffix."a/sansSerif" = "tailed"
 selectorAffix."a/rtailBase" = "serifless"
 selectorAffix."a/turnABase" = "tailed"
-selectorAffix."a/single/autoSerifed/slab" = "tailed"
+selectorAffix."a/single/autoSerifed/slab" = { if = [{ storey = "double-storey" }], then = "tailedSerifed", else = "tailed" }
 selectorAffix."a/single/autoSerifed/sans" = "tailed"
-selectorAffix.scripta = "tailed"
+selectorAffix."scripta/autoSerifed/slab" = "tailed"
+selectorAffix."scripta/autoSerifed/sans" = "tailed"
 
 [prime.a.variants-buildup.stages.bar.tailed-serifed]
 rank = 5
@@ -2283,7 +2294,8 @@ selectorAffix."a/rtailBase" = "topSerifed"
 selectorAffix."a/turnABase" = "tailed"
 selectorAffix."a/single/autoSerifed/slab" = "tailedSerifed"
 selectorAffix."a/single/autoSerifed/sans" = "tailedSerifed"
-selectorAffix.scripta = "tailed"
+selectorAffix."scripta/autoSerifed/slab" = "tailed"
+selectorAffix."scripta/autoSerifed/sans" = "tailed"
 
 [prime.a.variants-buildup.stages.bar.toothless-corner]
 rank = 6
@@ -2294,9 +2306,10 @@ selectorAffix."ae/a" = "serifless"
 selectorAffix."a/sansSerif" = "toothlessCorner"
 selectorAffix."a/rtailBase" = "serifless"
 selectorAffix."a/turnABase" = "toothlessCorner"
-selectorAffix."a/single/autoSerifed/slab" = "serifless"
+selectorAffix."a/single/autoSerifed/slab" = "doubleSerifed"
 selectorAffix."a/single/autoSerifed/sans" = "serifless"
-selectorAffix.scripta = "serifless"
+selectorAffix."scripta/autoSerifed/slab" = "serifed"
+selectorAffix."scripta/autoSerifed/sans" = "serifless"
 
 [prime.a.variants-buildup.stages.bar.toothless-rounded]
 rank = 7
@@ -2307,9 +2320,10 @@ selectorAffix."ae/a" = "serifless"
 selectorAffix."a/sansSerif" = "toothlessRounded"
 selectorAffix."a/rtailBase" = "serifless"
 selectorAffix."a/turnABase" = "toothlessRounded"
-selectorAffix."a/single/autoSerifed/slab" = "serifless"
+selectorAffix."a/single/autoSerifed/slab" = "doubleSerifed"
 selectorAffix."a/single/autoSerifed/sans" = "serifless"
-selectorAffix.scripta = "serifless"
+selectorAffix."scripta/autoSerifed/slab" = "serifed"
+selectorAffix."scripta/autoSerifed/sans" = "serifless"
 
 
 


### PR DESCRIPTION
Focusing on optimizing serifs under _slab_ this time, for forced-single-storey `a`-derived characters under tailed/toothless double-storey variants.
Also save a few glyphs surrounding single-storey `g` while I still can.
`aæ𝖺ᶏɐꞛɑꭤ`
All `a` variants:
sans (effectively unchanged from #2553 ):
![image](https://github.com/user-attachments/assets/cbea0b94-5fbf-4c96-b662-487cb17cc87b)
slab before:
![image](https://github.com/user-attachments/assets/13d5e364-cda7-4533-a595-ac878c0a20d5)
slab after:
![image](https://github.com/user-attachments/assets/2bc2d19a-22a2-43e1-927d-bcf3a58201bd)
