### PR TITLE
Optimize serifed `semi-chancery` variants for `x`.

### DIFF
--- a/changes/31.9.2.md
+++ b/changes/31.9.2.md
@@ -4,3 +4,4 @@
   - LONG RIGHT TACK (`U+27DD`).
   - LONG LEFT TACK (`U+27DE`).
   - UP ARROW THROUGH CIRCLE (`U+29BD`).
+* Optimize `semi-chancery-straight-serifed` and `semi-chancery-curly-serifed` variants for `x` (`cv58`).

--- a/packages/font-glyphs/src/letter/latin/x.ptl
+++ b/packages/font-glyphs/src/letter/latin/x.ptl
@@ -63,31 +63,22 @@ glyph-block Letter-Latin-X : begin
 
 		local fine : [AdviceStroke 3] * (sw / Stroke)
 
-		local leftXExt  : leftX  - SideJut
-		local rightXExt : rightX + SideJut
+		local leftXExt  : leftX  - [if fSlab SideJut 0]
+		local rightXExt : rightX + [if fSlab SideJut 0]
 
 		return : dispiro
 			if fHalf
 				flat [mix leftX rightX 0.5] [mix leftY rightY 0.5] [widths.center fine]
-				if fSlab
-					list
-						flat leftXExt (leftY - sign * sw / 2) [widths.center.heading sw Rightward]
-						curl (leftX + TINY) (leftY - sign * sw / 2) [widths.center.heading sw Rightward]
-						alsoThruThem {{blendK1X blendK1Y} {blendK2X blendK2Y}}
-						flat [mix leftX rightX pStraightX] [mix leftY rightY pStraightY] [widths.center : mix sw fine 0.5]
-						corner [mix leftX rightX 0.5] [mix leftY rightY 0.5] [widths.center fine]
-					list
-						straight.right.start leftX  (leftY - sign * sw / 2) [widths.center sw]
-						alsoThruThem {{blendK1X blendK1Y} {blendK2X blendK2Y}}
-						flat [mix leftX rightX pStraightX] [mix leftY rightY pStraightY] [widths.center : mix sw fine 0.5]
-						corner [mix leftX rightX 0.5] [mix leftY rightY 0.5] [widths.center fine]
+				list
+					flat leftXExt (leftY - sign * sw / 2) [widths.center.heading sw Rightward]
+					curl (leftX + TINY) (leftY - sign * sw / 2) [widths.center.heading sw Rightward]
+					alsoThruThem {{blendK1X blendK1Y} {blendK2X blendK2Y}}
+					flat [mix leftX rightX pStraightX] [mix leftY rightY pStraightY] [widths.center : mix sw fine 0.5]
+					corner [mix leftX rightX 0.5] [mix leftY rightY 0.5] [widths.center fine]
 			curl [mix leftX rightX (1 - pStraightX)] [mix leftY rightY (1 - pStraightY)] [widths.center : mix sw fine 0.5]
 			alsoThruThem {{(1 - blendK2X) (1 - blendK2Y)} {(1 - blendK1X) (1 - blendK1Y)}}
-			if fSlab
-				list
-					flat (rightX - TINY) (rightY + sign * sw / 2) [widths.center.heading sw Rightward]
-					curl rightXExt (rightY + sign * sw / 2) [widths.center.heading sw Rightward]
-				straight.right.end   rightX (rightY + sign * sw / 2) [widths.center sw]
+			flat (rightX - TINY) (rightY + sign * sw / 2) [widths.center.heading sw Rightward]
+			curl rightXExt (rightY + sign * sw / 2) [widths.center.heading sw Rightward]
 
 	glyph-block-export XCursiveHalfShape
 	define [XCursiveHalfShape] : with-params [

--- a/packages/font-glyphs/src/letter/latin/x.ptl
+++ b/packages/font-glyphs/src/letter/latin/x.ptl
@@ -51,7 +51,7 @@ glyph-block Letter-Latin-X : begin
 		include : HalfXStrand stb slab xLeft yLeft xMid yMid turn pStraight tension _sw (-0.001)
 		include : HalfXStrand stb slab xRight yRight xMid yMid turn pStraight tension _sw (-0.001)
 
-	define [XChanceryStrand sign leftX leftY rightX rightY fHalf _sw] : begin
+	define [XChanceryStrand sign fSlab _leftX leftY _rightX rightY fHalf _sw] : begin
 		local sw : fallback _sw Stroke
 		local blendK1X : StrokeWidthBlend 0.58 0.65
 		local blendK1Y   0.2
@@ -62,6 +62,9 @@ glyph-block Letter-Latin-X : begin
 		local pStraightY : StrokeWidthBlend 0.2 0.25
 
 		local fine : [AdviceStroke 3] * (sw / Stroke)
+
+		local leftX  : _leftX  - [if fSlab SideJut 0]
+		local rightX : _rightX + [if fSlab SideJut 0]
 
 		return : dispiro
 			if fHalf
@@ -142,7 +145,7 @@ glyph-block Letter-Latin-X : begin
 			include : match stroke1
 				[Just STROKE-STRAIGHT] : XStrand true  fSlab df.leftSB bot df.rightSB top turn 0.4 tension sw
 				[Just STROKE-CURLY]    : XStrand false fSlab df.leftSB bot df.rightSB top turn 0.4 tension sw
-				[Just STROKE-CHANCERY] : XChanceryStrand (-1) df.leftSB bot df.rightSB top false sw
+				[Just STROKE-CHANCERY] : XChanceryStrand (-1) fSlab df.leftSB bot df.rightSB top false sw
 				([Just STROKE-CURSIVE] || [Just STROKE-CURSIVE-FLAT]) : composite-proc
 					XCursiveHalfShape top bot df.middle df.rightSB
 						swCoEnd -- swCursiveCoEnd
@@ -154,7 +157,7 @@ glyph-block Letter-Latin-X : begin
 			include : match stroke2
 				[Just STROKE-STRAIGHT] : XStrand true  fSlab df.leftSB top df.rightSB bot turn 0.4 tension sw
 				[Just STROKE-CURLY]    : XStrand false fSlab df.leftSB top df.rightSB bot turn 0.4 tension sw
-				[Just STROKE-CHANCERY] : XChanceryStrand (+1) df.leftSB top df.rightSB bot false sw
+				[Just STROKE-CHANCERY] : XChanceryStrand (+1) fSlab df.leftSB top df.rightSB bot false sw
 				[Just STROKE-CURSIVE]  : XCursiveHalfShape top bot df.middle df.rightSB
 					swCoEnd -- swCursiveCoEnd
 					swEnd -- swCursiveEnd
@@ -168,12 +171,12 @@ glyph-block Letter-Latin-X : begin
 			include : match stroke1
 				[Just STROKE-STRAIGHT] : HalfXStrand true  fSlab df.rightSB top df.middle midy turn 0.4 tension sw
 				[Just STROKE-CURLY]    : HalfXStrand false fSlab df.rightSB top df.middle midy turn 0.4 tension sw
-				[Just STROKE-CHANCERY] : XChanceryStrand (-1) df.leftSB bot df.rightSB top true sw
+				[Just STROKE-CHANCERY] : XChanceryStrand (-1) fSlab df.leftSB bot df.rightSB top true sw
 				__ : glyph-proc
 			include : match stroke2
 				[Just STROKE-STRAIGHT] : HalfXStrand true  fSlab df.rightSB bot df.middle midy turn 0.4 tension sw
 				[Just STROKE-CURLY]    : HalfXStrand false fSlab df.rightSB bot df.middle midy turn 0.4 tension sw
-				[Just STROKE-CHANCERY] : XChanceryStrand (+1) df.leftSB top df.rightSB bot true sw
+				[Just STROKE-CHANCERY] : XChanceryStrand (+1) fSlab df.leftSB top df.rightSB bot true sw
 				[Just STROKE-CURSIVE]  : XCursiveHalfShape top bot df.middle df.rightSB
 					swCoEnd -- swCursiveCoEnd
 					swEnd -- swCursiveEnd
@@ -196,7 +199,7 @@ glyph-block Letter-Latin-X : begin
 		cursive                         { STROKE-CURSIVE  STROKE-CURSIVE  null                     false }
 		semiChanceryStraightSerifless   { STROKE-STRAIGHT STROKE-CHANCERY null                     false }
 		semiChanceryCurlySerifless      { STROKE-CURLY    STROKE-CHANCERY null                     false }
-		chancery                        { STROKE-CHANCERY STROKE-CHANCERY null                     false }
+		chancery                        { STROKE-CHANCERY STROKE-CHANCERY null                     SLAB  }
 		straightSerifed                 { STROKE-STRAIGHT STROKE-STRAIGHT XSerifs.Full             true  }
 		curlySerifed                    { STROKE-CURLY    STROKE-CURLY    XSerifs.Full             true  }
 		semiChanceryStraightSerifed     { STROKE-STRAIGHT STROKE-CHANCERY XSerifs.SemiChancery     true  }

--- a/packages/font-glyphs/src/letter/latin/x.ptl
+++ b/packages/font-glyphs/src/letter/latin/x.ptl
@@ -51,7 +51,7 @@ glyph-block Letter-Latin-X : begin
 		include : HalfXStrand stb slab xLeft yLeft xMid yMid turn pStraight tension _sw (-0.001)
 		include : HalfXStrand stb slab xRight yRight xMid yMid turn pStraight tension _sw (-0.001)
 
-	define [XChanceryStrand sign fSlab _leftX leftY _rightX rightY fHalf _sw] : begin
+	define [XChanceryStrand sign fSlab leftX leftY rightX rightY fHalf _sw] : begin
 		local sw : fallback _sw Stroke
 		local blendK1X : StrokeWidthBlend 0.58 0.65
 		local blendK1Y   0.2
@@ -63,20 +63,28 @@ glyph-block Letter-Latin-X : begin
 
 		local fine : [AdviceStroke 3] * (sw / Stroke)
 
-		local leftX  : _leftX  - [if fSlab SideJut 0]
-		local rightX : _rightX + [if fSlab SideJut 0]
+		local leftXExt  : leftX  - SideJut
+		local rightXExt : rightX + SideJut
 
 		return : dispiro
 			if fHalf
 				flat [mix leftX rightX 0.5] [mix leftY rightY 0.5] [widths.center fine]
 				list
-					straight.right.start leftX  (leftY - sign * sw / 2) [widths.center sw]
+					if fSlab
+						begin
+							flat (leftX + TINY) (leftY - sign * sw / 2) [widths.center sw]
+							curl leftXExt (leftY - sign * sw / 2) [widths.center sw]
+						straight.right.start leftX  (leftY - sign * sw / 2) [widths.center sw]
 					alsoThruThem {{blendK1X blendK1Y} {blendK2X blendK2Y}}
 					flat [mix leftX rightX pStraightX] [mix leftY rightY pStraightY] [widths.center : mix sw fine 0.5]
 					corner [mix leftX rightX 0.5] [mix leftY rightY 0.5] [widths.center fine]
 			curl [mix leftX rightX (1 - pStraightX)] [mix leftY rightY (1 - pStraightY)] [widths.center : mix sw fine 0.5]
 			alsoThruThem {{(1 - blendK2X) (1 - blendK2Y)} {(1 - blendK1X) (1 - blendK1Y)}}
-			straight.right.end   rightX (rightY + sign * sw / 2) [widths.center sw]
+			if fSlab
+				begin
+					flat (rightX - TINY) (rightY + sign * sw / 2) [widths.center sw]
+					curl rightXExt (rightY + sign * sw / 2) [widths.center sw]
+				straight.right.end   rightX (rightY + sign * sw / 2) [widths.center sw]
 
 	glyph-block-export XCursiveHalfShape
 	define [XCursiveHalfShape] : with-params [
@@ -199,7 +207,7 @@ glyph-block Letter-Latin-X : begin
 		cursive                         { STROKE-CURSIVE  STROKE-CURSIVE  null                     false }
 		semiChanceryStraightSerifless   { STROKE-STRAIGHT STROKE-CHANCERY null                     false }
 		semiChanceryCurlySerifless      { STROKE-CURLY    STROKE-CHANCERY null                     false }
-		chancery                        { STROKE-CHANCERY STROKE-CHANCERY null                     SLAB  }
+		chancery                        { STROKE-CHANCERY STROKE-CHANCERY null                     false }
 		straightSerifed                 { STROKE-STRAIGHT STROKE-STRAIGHT XSerifs.Full             true  }
 		curlySerifed                    { STROKE-CURLY    STROKE-CURLY    XSerifs.Full             true  }
 		semiChanceryStraightSerifed     { STROKE-STRAIGHT STROKE-CHANCERY XSerifs.SemiChancery     true  }

--- a/packages/font-glyphs/src/letter/latin/x.ptl
+++ b/packages/font-glyphs/src/letter/latin/x.ptl
@@ -69,21 +69,24 @@ glyph-block Letter-Latin-X : begin
 		return : dispiro
 			if fHalf
 				flat [mix leftX rightX 0.5] [mix leftY rightY 0.5] [widths.center fine]
-				list
-					if fSlab
-						begin
-							flat (leftX + TINY) (leftY - sign * sw / 2) [widths.center sw]
-							curl leftXExt (leftY - sign * sw / 2) [widths.center sw]
+				if fSlab
+					list
+						flat leftXExt (leftY - sign * sw / 2) [widths.center.heading sw Rightward]
+						curl (leftX + TINY) (leftY - sign * sw / 2) [widths.center.heading sw Rightward]
+						alsoThruThem {{blendK1X blendK1Y} {blendK2X blendK2Y}}
+						flat [mix leftX rightX pStraightX] [mix leftY rightY pStraightY] [widths.center : mix sw fine 0.5]
+						corner [mix leftX rightX 0.5] [mix leftY rightY 0.5] [widths.center fine]
+					list
 						straight.right.start leftX  (leftY - sign * sw / 2) [widths.center sw]
-					alsoThruThem {{blendK1X blendK1Y} {blendK2X blendK2Y}}
-					flat [mix leftX rightX pStraightX] [mix leftY rightY pStraightY] [widths.center : mix sw fine 0.5]
-					corner [mix leftX rightX 0.5] [mix leftY rightY 0.5] [widths.center fine]
+						alsoThruThem {{blendK1X blendK1Y} {blendK2X blendK2Y}}
+						flat [mix leftX rightX pStraightX] [mix leftY rightY pStraightY] [widths.center : mix sw fine 0.5]
+						corner [mix leftX rightX 0.5] [mix leftY rightY 0.5] [widths.center fine]
 			curl [mix leftX rightX (1 - pStraightX)] [mix leftY rightY (1 - pStraightY)] [widths.center : mix sw fine 0.5]
 			alsoThruThem {{(1 - blendK2X) (1 - blendK2Y)} {(1 - blendK1X) (1 - blendK1Y)}}
 			if fSlab
-				begin
-					flat (rightX - TINY) (rightY + sign * sw / 2) [widths.center sw]
-					curl rightXExt (rightY + sign * sw / 2) [widths.center sw]
+				list
+					flat (rightX - TINY) (rightY + sign * sw / 2) [widths.center.heading sw Rightward]
+					curl rightXExt (rightY + sign * sw / 2) [widths.center.heading sw Rightward]
 				straight.right.end   rightX (rightY + sign * sw / 2) [widths.center sw]
 
 	glyph-block-export XCursiveHalfShape


### PR DESCRIPTION
Inspired by code for `Ƙ` where it corrects for the ending x-coordinate of the hooked spur when the other leg is serifed.
`x𝗑хҳԕԗ`
Before:
![image](https://github.com/user-attachments/assets/3eb604b7-bb17-4381-a74a-163f93d4149a)
After:
![image](https://github.com/user-attachments/assets/5fe274cb-54b5-423f-92fe-6f83be5c7cc9)
