### PR TITLE
Add ccmp substitutions for `Ǳ`/`ǲ`/`ǳ` with combining caron, for `Ǆ`/`ǅ`/`ǆ`.

### DIFF
--- a/packages/font-glyphs/src/auto-build/composite.ptl
+++ b/packages/font-glyphs/src/auto-build/composite.ptl
@@ -2,7 +2,7 @@
 $$include '../meta/macros.ptl'
 
 import [mix linreg clamp fallback] from "@iosevka/util"
-import [getGrMesh AnyCvOrCherryPicking CvDecompose Joining hashCv IsCompositeOrLigature NLDAcuteVariant] from "@iosevka/glyph/relation"
+import [getGrMesh AnyCvOrCherryPicking CvDecompose Joining hashCv IsCompositeOrLigature NLDAcuteVariant HBSCaronVariant] from "@iosevka/glyph/relation"
 import [hashGeometry] from "@iosevka/geometry"
 import [Transform] from "@iosevka/geometry/transform"
 extern Map
@@ -836,7 +836,7 @@ glyph-block AutoBuild-Enclosure : begin
 			list 0x2789  {'one/sansSerif.lnum' 'zero.lnum'} WideWidth1
 			list 0x1F16D {'C' 'C'} WideWidth2
 			list 0x1F12D {'C' 'D'} WideWidth1
-			list 0x1F12E {'W' 'z'} WideWidth1
+			list 0x1F12E {'W' 'smcpZ'} WideWidth1
 		foreach [j : range 10 till 20] : compositions.push : list (0x2460 + j - 1) [digitGlyphNames j] WideWidth1
 		foreach [j : range 21 till 35] : compositions.push : list (0x3251 + j - 21) [digitGlyphNames j] WideWidth1
 		foreach [j : range 36 till 50] : compositions.push : list (0x32B1 + j - 36) [digitGlyphNames j] WideWidth1
@@ -1445,7 +1445,7 @@ glyph-block Autobuild-Ligatures : begin
 		list 0xEF11 { 'IAcute' 'JAcute' }
 		list 0xEF12 { 'iAcute' 'jAcute' }
 
-	# Link Gr for acuted variants
+	# Link Gr for acute variants
 	NLDAcuteVariant.set [glyphStore.queryByUnicodeEnsured 0x132] [glyphStore.queryNameByUnicodeEnsured 0xEF11]
 	NLDAcuteVariant.set [glyphStore.queryByUnicodeEnsured 0x133] [glyphStore.queryNameByUnicodeEnsured 0xEF12]
 
@@ -1470,6 +1470,11 @@ glyph-block Autobuild-Ligatures : begin
 		list 0x20AF { 'D' 'grek/rho' }
 		list 0x2116 { 'N' 'numeroRightHalf' }
 		list 0x1F190 { 'D' 'J' } WideWidth1
+
+	# Link Gr for caron variants
+	HBSCaronVariant.set [glyphStore.queryByUnicodeEnsured 0x1F1] [glyphStore.queryNameByUnicodeEnsured 0x1C4]
+	HBSCaronVariant.set [glyphStore.queryByUnicodeEnsured 0x1F2] [glyphStore.queryNameByUnicodeEnsured 0x1C5]
+	HBSCaronVariant.set [glyphStore.queryByUnicodeEnsured 0x1F3] [glyphStore.queryNameByUnicodeEnsured 0x1C6]
 
 	createLigatures 'romanNumerals1' 1 1 1 1 0 : list
 		list 0x2160 { 'I' }

--- a/packages/font-glyphs/src/auto-build/recursive-build.ptl
+++ b/packages/font-glyphs/src/auto-build/recursive-build.ptl
@@ -16,7 +16,7 @@ glyph-block Recursive-Build : begin
 
 	define [MiniatureParaT] : with-params [pp crowd scale [sbscale (Width / UPM)] [mono false] [mono2 false] [forceUpright false]] : begin
 		local forkedPara : Object.assign {.} pp
-		forkedPara.stroke = [AdviceStroke crowd : Math.pow [clamp 0 1 (HalfUPM / Width)] 0.5] / scale
+		forkedPara.stroke = [AdviceStroke crowd : Math.sqrt : clamp 0 1 (HalfUPM / Width)] / scale
 		forkedPara.dotSize = pp.dotSize * forkedPara.stroke / pp.stroke
 		forkedPara.periodSize = pp.periodSize * forkedPara.stroke / pp.stroke
 		forkedPara.sb = SB * sbscale

--- a/packages/font-otl/src/gsub-ccmp.ptl
+++ b/packages/font-otl/src/gsub-ccmp.ptl
@@ -1,7 +1,7 @@
 $$include './meta/macros.ptl'
 
 import [UkMapToLookup UkLigatureToLookup] from "./table-util.mjs"
-import [Dotless TieMark TieGlyph OgonekTrY IsSuperscript IsSubscript LeaningMark LeaningMarkSpacer NLDAcuteVariant] from "@iosevka/glyph/relation"
+import [Dotless TieMark TieGlyph OgonekTrY IsSuperscript IsSubscript LeaningMark LeaningMarkSpacer NLDAcuteVariant HBSCaronVariant] from "@iosevka/glyph/relation"
 import as UnicodeKnowledge from "@iosevka/font-glyphs/unicode-knowledge"
 
 extern Map
@@ -127,6 +127,17 @@ export : define [buildCCMP gsub glyphStore markGlyphs] : begin
 			local nldVariant : NLDAcuteVariant.get g
 			if nldVariant : substitutions.push
 				object [from : list gn 'acuteAbove'] [to nldVariant]
+
+		export-lookup : gsub.createLookup : object
+			.type 'gsub_ligature'
+			.substitutions substitutions
+
+	Ccmp-Group "DZ-Caron composites" : begin
+		local substitutions {}
+		foreach { gn g } [glyphStore.namedEntries] : begin
+			local hbsVariant : HBSCaronVariant.get g
+			if hbsVariant : substitutions.push
+				object [from : list gn 'caronAbove'] [to hbsVariant]
 
 		export-lookup : gsub.createLookup : object
 			.type 'gsub_ligature'

--- a/packages/glyph/src/relation.mjs
+++ b/packages/glyph/src/relation.mjs
@@ -24,6 +24,7 @@ export const TieMark = LinkedGlyphProp("TieMark");
 export const LeaningMark = LinkedGlyphProp("LeaningMark");
 export const LeaningMarkSpacer = LinkedGlyphProp("LeaningMarkSpacer");
 export const NLDAcuteVariant = LinkedGlyphProp("NLDAcuteVariant");
+export const HBSCaronVariant = LinkedGlyphProp("HBSCaronVariant");
 
 export const LocalizedForm = {
 	SRB: {


### PR DESCRIPTION
This is already how it works under Quasi-Proporitional as a side effect of ligatures being expanded out. This makes it consistent under Monospace.

HBS is the inclusive ISO code for _all_ Serbo-Croatian languages/dialects, each of which may or may not have their own respective ISO code as well (e.g. Serbian, Bosnian, Montenegrin, etc.).

`Ĳ́ ĳ́ Ǳ̌ ǲ̌ ǳ̌`
![image](https://github.com/user-attachments/assets/aabd5dec-51ff-4085-8513-d5d9d0f444a7)

It should be noted that some other fonts also do this:
Microsoft Sans Serif:
![image](https://github.com/user-attachments/assets/c83fabbf-3988-4c45-b52f-518665ae861c)

