### PR TITLE
Make Dotless J with Stroke and Hook serifed under slab.

### DIFF
--- a/changes/32.0.0.md
+++ b/changes/32.0.0.md
@@ -9,3 +9,4 @@
   - ARMENIAN SMALL LETTER TURNED AYB (`U+0560`) ... ARMENIAN HYPHEN (`U+058A`).
   - ARMENIAN DRAM SIGN (`U+058F`).
 * Optimize `semi-chancery-straight-serifed` and `semi-chancery-curly-serifed` variants for `x` (`cv58`).
+* Make Dotless J with Stroke and Hook (`U+0284`) have a serif under slab.

--- a/packages/font-glyphs/src/letter/armenian/aliases.ptl
+++ b/packages/font-glyphs/src/letter/armenian/aliases.ptl
@@ -13,10 +13,10 @@ glyph-block Letter-Armenian-Aliases : begin
 	alias 'armn/aybTurned' 0x560 'm'
 	alias 'armn/ayb' 0x561 'turnm'
 	alias 'armn/ho' 0x570 'h'
-	alias 'armn/yi' 0x575 [if SLAB 'dotlessj.flatHookSerifed' 'dotlessj.flatHookSerifless']
+	alias 'armn/yi' 0x575 'dotlessj.flatHook'
 	alias 'armn/vo' 0x578 'n'
 	alias 'armn/peh' 0x57A 'turnmLeg'
 	alias 'armn/seh' 0x57D 'u'
 	alias 'armn/co' 0x581 'cyrl/de.BGR'
 	alias 'armn/oh' 0x585 'o'
-	alias 'armn/yiBar' 0x588 [if SLAB 'dotlessjBar.flatHookSerifed' 'dotlessjBar.flatHookSerifless']
+	alias 'armn/yiBar' 0x588 'dotlessjBar.flatHook'

--- a/packages/font-glyphs/src/letter/latin/lower-j.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-j.ptl
@@ -35,14 +35,16 @@ glyph-block Letter-Latin-Lower-J : begin
 		set-base-anchor 'overlay' barCenter (top / 2)
 
 	define XMiddle : namespace
-		export : define [Straight df] : begin df.middle
-		export : define [Hooky df] : df.middle + [IBalance2 df]
-		export : define [Regular df] : df.middle + JBalance
+		export : define [StraightSerifless df] : begin df.middle
+		export : define [StraightSerifed df] : df.middle + [IBalance2 df]
+		export : define [BentHook df] : df.middle + JBalance
 		export : define [FlatHookSerifless df] : df.middle + 0.25 * JBalance * df.div * [mix 1 df.div 2]
 		export : define [FlatHookSerifed df] : df.middle + JBalance * df.div
+		export : define [StraightAutoSerifed df] : if SLAB [StraightSerifless df] [StraightSerifed df]
+		export : define [FlatHookAutoSerifed df] : if SLAB [FlatHookSerifed df] [FlatHookSerifless df]
 
 	define Body : namespace
-		export : define [Regular df top xMiddle] : glyph-proc
+		export : define [BentHook df top xMiddle] : glyph-proc
 			local hookx : Math.min (xMiddle - (Width * 0.5) - [HSwToV HalfStroke] + OXHook) (xMiddle - 1.5 * [HSwToV Stroke] + OXHook)
 			set-base-anchor "below" [mix hookx xMiddle 0.5] Descender
 			include : dispiro
@@ -74,28 +76,48 @@ glyph-block Letter-Latin-Lower-J : begin
 			set-base-anchor "trailing" (xMiddle - [HSwToV HalfStroke]) Descender
 
 	define Serifs : namespace
+		export : define [None df top xMiddle] : no-shape
 		export : define [Long df top xMiddle] : HSerif.lt xMiddle top (LongJut * df.div)
+		export : define [Auto df top xMiddle] : if SLAB [Long df top xMiddle] [no-shape]
 
 	define Marks : namespace
+		export : define [Serifless df top xMiddle] : glyph-proc
+			set-base-anchor 'above'   xMiddle  top
+			set-base-anchor 'overlay' xMiddle (top / 2)
+
 		export : define [Serifed df top xMiddle] : glyph-proc
 			include : Serifless df top xMiddle
 			include : LeaningAnchor.Above.At [mix df.middle xMiddle (7/8)]
 
-		export : define [Serifless df top xMiddle] : glyph-proc
-			set-base-anchor 'above' xMiddle top
-			set-base-anchor 'overlay' xMiddle (top / 2)
+		export : define [AutoSerifed df top xMiddle] : glyph-proc
+			include : if SLAB
+				Serifed   df top xMiddle
+				Serifless df top xMiddle
+
+	define Div : namespace
+		export : define BentHook          1
+		export : define StraightSerifless para.diversityII
+		export : define StraightSerifed   para.diversityI
+		export : define FlatHookSerifless para.diversityII
+		export : define FlatHookSerifed   para.diversityI
+		export : define StraightAutoSerifed : if SLAB para.diversityI para.diversityII
+		export : define FlatHookAutoSerifed : if SLAB para.diversityI para.diversityII
 
 	define JConfig : object
-		'serifless'               { "Regular"         null         XMiddle.Regular            Marks.Serifless  1                }
-		'serifed'                 { "Regular"         Serifs.Long  XMiddle.Regular            Marks.Serifed    1                }
-		'straightLine'            { "Straight"        null         XMiddle.Straight           Marks.Serifless  para.diversityII }
-		'hooky'                   { "Straight"        Serifs.Long  XMiddle.Hooky              Marks.Serifed    para.diversityI  }
-		'flatHookSerifless'       { "FlatHook"        null         XMiddle.FlatHookSerifless  Marks.Serifless  para.diversityII }
-		'flatHookSerifed'         { "FlatHook"        Serifs.Long  XMiddle.FlatHookSerifed    Marks.Serifed    para.diversityI  }
-		'diagonalTailedSerifless' { "DiagonalTailed"  null         XMiddle.FlatHookSerifless  Marks.Serifless  para.diversityII }
-		'diagonalTailedSerifed'   { "DiagonalTailed"  Serifs.Long  XMiddle.FlatHookSerifed    Marks.Serifed    para.diversityI  }
+		'bentHook'                { "BentHook"        Serifs.Auto  XMiddle.BentHook            Marks.AutoSerifed Div.BentHook            }
+		'bentHookSerifless'       { "BentHook"        Serifs.None  XMiddle.BentHook            Marks.Serifless   Div.BentHook            }
+		'bentHookSerifed'         { "BentHook"        Serifs.Long  XMiddle.BentHook            Marks.Serifed     Div.BentHook            }
+		'straight'                { "Straight"        Serifs.Auto  XMiddle.StraightAutoSerifed Marks.AutoSerifed Div.StraightAutoSerifed }
+		'straightSerifless'       { "Straight"        Serifs.None  XMiddle.StraightSerifless   Marks.Serifless   Div.StraightSerifless   }
+		'straightSerifed'         { "Straight"        Serifs.Long  XMiddle.StraightSerifed     Marks.Serifed     Div.StraightSerifed     }
+		'flatHook'                { "FlatHook"        Serifs.Auto  XMiddle.FlatHookAutoSerifed Marks.AutoSerifed Div.FlatHookAutoSerifed }
+		'flatHookSerifless'       { "FlatHook"        Serifs.None  XMiddle.FlatHookSerifless   Marks.Serifless   Div.FlatHookSerifless   }
+		'flatHookSerifed'         { "FlatHook"        Serifs.Long  XMiddle.FlatHookSerifed     Marks.Serifed     Div.FlatHookSerifed     }
+		'diagonalTailed'          { "DiagonalTailed"  Serifs.Auto  XMiddle.FlatHookAutoSerifed Marks.AutoSerifed Div.FlatHookAutoSerifed }
+		'diagonalTailedSerifless' { "DiagonalTailed"  Serifs.None  XMiddle.FlatHookSerifless   Marks.Serifless   Div.FlatHookSerifless   }
+		'diagonalTailedSerifed'   { "DiagonalTailed"  Serifs.Long  XMiddle.FlatHookSerifed     Marks.Serifed     Div.FlatHookSerifed     }
 
-	foreach {suffix { shapeId Serif xMiddleT Marks div } } [Object.entries JConfig] : do
+	foreach { suffix { shapeId Serif xMiddleT Marks div } } [Object.entries JConfig] : do
 		local df : DivFrame div
 		local xMiddle : xMiddleT df
 
@@ -103,7 +125,7 @@ glyph-block Letter-Latin-Lower-J : begin
 			set-width df.width
 			include : df.markSet.p
 			include : Body.(shapeId) df XH xMiddle
-			if Serif : include : tagged 'serifLT' : Serif df XH xMiddle
+			include : tagged 'serifLT' : Serif df XH xMiddle
 			include : Marks df XH xMiddle
 
 		create-glyph "dotlessjBar.\(suffix)" : glyph-proc
@@ -122,7 +144,7 @@ glyph-block Letter-Latin-Lower-J : begin
 	link-reduced-variant 'j/sansSerif' 'j' MathSansSerif
 
 	select-variant 'dotlessjBar'        0x25F (follow -- 'dotlessj')
-	select-variant 'dotlessjBarHookTop' 0x284 (follow -- 'dotlessj/sansSerif')
+	select-variant 'dotlessjBarHookTop' 0x284 (follow -- 'dotlessjHookTop')
 	CreateAccentedComposition 'jBar'    0x249 'dotlessjBar' 'tittleAbove'
 
 	alias 'grek/yot' 0x3F3 'j'

--- a/packages/font-glyphs/src/letter/latin/lower-j.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-j.ptl
@@ -40,7 +40,7 @@ glyph-block Letter-Latin-Lower-J : begin
 		export : define [BentHook df] : df.middle + JBalance
 		export : define [FlatHookSerifless df] : df.middle + 0.25 * JBalance * df.div * [mix 1 df.div 2]
 		export : define [FlatHookSerifed df] : df.middle + JBalance * df.div
-		export : define [StraightAutoSerifed df] : if SLAB [StraightSerifless df] [StraightSerifed df]
+		export : define [StraightAutoSerifed df] : if SLAB [StraightSerifed df] [StraightSerifless df]
 		export : define [FlatHookAutoSerifed df] : if SLAB [FlatHookSerifed df] [FlatHookSerifless df]
 
 	define Body : namespace

--- a/packages/font-glyphs/src/letter/latin/upper-j.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-j.ptl
@@ -13,7 +13,7 @@ glyph-block Letter-Latin-Upper-J : begin
 	glyph-block-import Letter-Blackboard : BBS BBD
 	glyph-block-import Letter-Latin-Lower-J : FlatHookDotlessJShape
 
-	define [JFullHookBase df dfHook top] : glyph-proc
+	define [JBentHookBase df dfHook top] : glyph-proc
 		set-width df.width
 		include : df.markSet.[if (top > XH) 'capital' 'e']
 
@@ -51,7 +51,7 @@ glyph-block Letter-Latin-Upper-J : begin
 			flat (df.rightSB - JBalance2 - [Math.min (0.625 * (df.rightSB - df.leftSB)) (1.375 * hd.x)]) 0 [widths.rhs Stroke]
 			curl df.leftSB 0
 
-	define [JDescendingBase df dfHook top] : glyph-proc
+	define [JDescendingBentHookBase df dfHook top] : glyph-proc
 		set-width df.width
 		include : df.markSet.[if (top > XH) 'capDesc' 'p']
 
@@ -69,8 +69,8 @@ glyph-block Letter-Latin-Upper-J : begin
 			hookend Descender
 			g4 hookx (Descender + JHook)
 
-	set JFullHookBase.WithCurlyTail   : function [df top] : JCurlyTailBaseT df (df.rightSB - [HSwToV HalfStroke] - JBalance2) (df.leftSB)                    top 0         'capital'
-	set JDescendingBase.WithCurlyTail : function [df top] : JCurlyTailBaseT df (df.middle + JBalance) (df.middle + JBalance - LongJut - [HSwToV HalfStroke]) top Descender 'capDesc'
+	set JBentHookBase.WithCurlyTail   : function [df top] : JCurlyTailBaseT df (df.rightSB - [HSwToV HalfStroke] - JBalance2) (df.leftSB)                    top 0         'capital'
+	set JDescendingBentHookBase.WithCurlyTail : function [df top] : JCurlyTailBaseT df (df.middle + JBalance) (df.middle + JBalance - LongJut - [HSwToV HalfStroke]) top Descender 'capDesc'
 	define [JCurlyTailBaseT df xc xCo top bottom markClass] : glyph-proc
 		set-width df.width
 		include : df.markSet.(markClass)
@@ -112,9 +112,9 @@ glyph-block Letter-Latin-Upper-J : begin
 
 	define JConfig : SuffixCfg.weave
 		object # height and hook
-			""                          { JFullHookBase                  [DivFrame 1]                [DivFrame 1]               }
+			bentHook                    { JBentHookBase                  [DivFrame 1]                [DivFrame 1]               }
 			flatHook                    { JFlatHookBase                  [DivFrame 1]                [DivFrame 1]               }
-			descending                  { JDescendingBase                [DivFrame 1]                [DivFrame 1]               }
+			descendingBentHook          { JDescendingBentHookBase        [DivFrame 1]                [DivFrame 1]               }
 			descendingFlatHookSerifless { JDescendingFlatHookBase        [DivFrame para.diversityI]  [DivFrame para.diversityI] }
 			descendingFlatHookSerifed   { JDescendingFlatHookSerifedBase [DivFrame para.diversityI]  [DivFrame para.diversityI] }
 		function [body] : if (body == 'descendingFlatHookSerifless' || body == 'descendingFlatHookSerifed') {."" null} : object

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1059,13 +1059,13 @@ selectorAffix.JCurlyTail = "descending"
 [prime.capital-j.variants-buildup.stages.hook."*"]
 next = "serifs"
 
-[prime.capital-j.variants-buildup.stages.hook.standard]
+[prime.capital-j.variants-buildup.stages.hook.bent-hook]
 rank = 1
 keyAffix = ""
-selectorAffix.J = ""
-selectorAffix."J/noDescend" = ""
-selectorAffix."J/sansSerif" = ""
-selectorAffix.JCurlyTail = ""
+selectorAffix.J = "bentHook"
+selectorAffix."J/noDescend" = "bentHook"
+selectorAffix."J/sansSerif" = "bentHook"
+selectorAffix.JCurlyTail = "bentHook"
 
 [prime.capital-j.variants-buildup.stages.hook.flat-hook]
 rank = 2
@@ -1073,7 +1073,7 @@ descriptionAffix = "flat hook"
 selectorAffix.J = "flatHook"
 selectorAffix."J/noDescend" = "flatHook"
 selectorAffix."J/sansSerif" = "flatHook"
-selectorAffix.JCurlyTail = ""
+selectorAffix.JCurlyTail = "bentHook"
 
 [prime.capital-j.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -3082,29 +3082,33 @@ tagKind = "letter"
 [prime.j.variants.serifless]
 rank = 1
 description = "`j` without serif"
-selector.dotlessj = "serifless"
-selector."dotlessj/sansSerif" = "serifless"
+selector.dotlessj = "bentHookSerifless"
+selector."dotlessj/sansSerif" = "bentHookSerifless"
+selector.dotlessjHookTop = "bentHook"
 selector.dotlessjCurlyTail = "serifless"
 
 [prime.j.variants.serifed]
 rank = 2
 description = "`j` with top serif"
-selector.dotlessj = "serifed"
-selector."dotlessj/sansSerif" = "serifless"
+selector.dotlessj = "bentHookSerifed"
+selector."dotlessj/sansSerif" = "bentHookSerifless"
+selector.dotlessjHookTop = "bentHook"
 selector.dotlessjCurlyTail = "serifed"
 
 [prime.j.variants.straight-line]
 rank = 3
 description = "`j` like a straight line"
-selector.dotlessj = "straightLine"
-selector."dotlessj/sansSerif" = "straightLine"
+selector.dotlessj = "straightSerifless"
+selector."dotlessj/sansSerif" = "straightSerifless"
+selector.dotlessjHookTop = "straight"
 selector.dotlessjCurlyTail = "serifless"
 
 [prime.j.variants.hooky]
 rank = 4
 description = "`j` like a straight line with top serif"
-selector.dotlessj = "hooky"
-selector."dotlessj/sansSerif" = "straightLine"
+selector.dotlessj = "straightSerifed"
+selector."dotlessj/sansSerif" = "straightSerifless"
+selector.dotlessjHookTop = "straight"
 selector.dotlessjCurlyTail = "serifed"
 
 [prime.j.variants.flat-hook-serifless]
@@ -3112,6 +3116,7 @@ rank = 5
 description = "`j` with flat terminal hook"
 selector.dotlessj = "flatHookSerifless"
 selector."dotlessj/sansSerif" = "flatHookSerifless"
+selector.dotlessjHookTop = "flatHook"
 selector.dotlessjCurlyTail = "serifless"
 
 [prime.j.variants.flat-hook-serifed]
@@ -3119,6 +3124,7 @@ rank = 6
 description = "`j` with flat terminal hook and top serif"
 selector.dotlessj = "flatHookSerifed"
 selector."dotlessj/sansSerif" = "flatHookSerifless"
+selector.dotlessjHookTop = "flatHook"
 selector.dotlessjCurlyTail = "serifed"
 
 [prime.j.variants.diagonal-tailed-serifless]
@@ -3126,6 +3132,7 @@ rank = 7
 description = "`j` with diagonal tail"
 selector.dotlessj = "diagonalTailedSerifless"
 selector."dotlessj/sansSerif" = "diagonalTailedSerifless"
+selector.dotlessjHookTop = "diagonalTailed"
 selector.dotlessjCurlyTail = "serifless"
 
 [prime.j.variants.diagonal-tailed-serifed]
@@ -3133,6 +3140,7 @@ rank = 8
 description = "`j` with top serif and diagonal tail"
 selector.dotlessj = "diagonalTailedSerifed"
 selector."dotlessj/sansSerif" = "diagonalTailedSerifless"
+selector.dotlessjHookTop = "diagonalTailed"
 selector.dotlessjCurlyTail = "serifed"
 
 


### PR DESCRIPTION
Some internal variant names were changed, but the final variant name keys that are actually visible to the configurator are unchanged.
Also use this opportunity to cleanup two lines in `armenian/aliases.ptl`.
`jʄ𝗃`
Sans:
![image](https://github.com/user-attachments/assets/7be544e3-c58d-4ef6-b9c0-6748f22c3d92)
Slab:
![image](https://github.com/user-attachments/assets/7d1b8b72-1619-4966-8a0b-992119d6e3cf)
Compared to DejaVu Mono:
![image](https://github.com/user-attachments/assets/ec3078b0-db03-4902-89d2-dd948c366cf8)
Aile:
![image](https://github.com/user-attachments/assets/22e308ef-c093-43a6-b776-f6260a1d7f3d)
Etoile:
![image](https://github.com/user-attachments/assets/aa9d0383-27b4-4b77-bd8e-43422b427284)
Compared to DejaVu Serif:
![image](https://github.com/user-attachments/assets/17250c7e-ab4a-482d-85d4-fa8e2f9730f6)
