### PR TITLE
Case sensitive typo-bug

### DIFF
--- a/tools/misc/src/make-webfont-css.mjs
+++ b/tools/misc/src/make-webfont-css.mjs
@@ -17,7 +17,7 @@ export default function (output, family, hs, formats, unhinted) {
 		if (!WebfontFormatMap.get(ext)) throw new TypeError("Invalid webfont file format " + ext);
 	}
 	for (const term of hs) {
-		const dirSuffix = unhinted ? "-unhinted" : "";
+		const dirSuffix = unhinted ? "-Unhinted" : "";
 		const src = formats
 			.map(
 				ext =>


### PR DESCRIPTION
.css generated path for unhinted fonts were `Iosevka*/*-unhinted/` when actual folders were `Iosevka*/*-Unhinted`

Took me an hour to figure out why my fonts were hidden :/