### PR TITLE
Complete Armenian letters block

### DIFF
--- a/changes/32.0.0.md
+++ b/changes/32.0.0.md
@@ -1,3 +1,5 @@
+* Add Armenian letters:
+  - ARMENIAN CAPITAL LETTER AYB (`U+0531`) ... ARMENIAN DRAM SIGN (`U+058F`).
 * Add characters:
   - LEFT AND RIGHT DOUBLE TURNSTILE (`U+27DA`).
   - LEFT AND RIGHT TACK (`U+27DB`).
@@ -6,10 +8,5 @@
   - UP ARROW THROUGH CIRCLE (`U+29BD`).
   - UPPER LEFT QUADRANT STANDING KNIGHT (`U+1CCD2`) ... LOWER RIGHT QUADRANT STANDING KNIGHT (`U+1CCD5`).
   - HORIZONTAL ZIGZAG LINE (`U+1CEB0`).
-* Add Armenian letters:
-  - ARMENIAN CAPITAL LETTER AYB (`U+0531`) ... ARMENIAN CAPITAL LETTER FEH (`U+0556`).
-  - ARMENIAN MODIFIER LETTER LEFT HALF RING (`U+0559`) ... ARMENIAN APOSTROPHE (`U+055A`).
-  - ARMENIAN SMALL LETTER TURNED AYB (`U+0560`) ... ARMENIAN HYPHEN (`U+058A`).
-  - RIGHT-FACING ARMENIAN ETERNITY SIGN (`U+058D`) ... ARMENIAN DRAM SIGN (`U+058F`).
 * Optimize `semi-chancery-straight-serifed` and `semi-chancery-curly-serifed` variants for `x` (`cv58`).
 * Make Dotless J with Stroke and Hook (`U+0284`) have a serif under slab.

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -1290,6 +1290,8 @@ glyph-block Mark-Above : begin
 	derive-composites 'graveAbove/viCenter' null 'graveAbove' [VNSecondaryMark 0.875 0 1.75 0.5]
 	derive-composites 'hookAbove/viCenter'  null 'hookAbove'  [VNSecondaryMark 0.875 0 1.75 0.5]
 
+	# Combining brackets
+
 	create-glyph 'leftParenAbove' 0x1AC1 : glyph-proc
 		set-width 0
 		set-mark-anchor 'aboveBraceL' markMiddle aboveMarkMid (markMiddle - markExtend) aboveMarkMid
@@ -1382,3 +1384,11 @@ glyph-block Mark-Above : begin
 		include : refer-glyph 'rightBrackAbove'
 		# No need to setup anchors -- ccmp will help us
 
+	create-glyph 'armn/abbreviationMark' 0x55F : glyph-proc
+		set-width 0
+		include : StdAnchors.wide
+
+		local leftEnd  : markMiddle - markExtend * 1.5
+		local rightEnd : markMiddle + markExtend * 1.5
+		include : VBar.m leftEnd aboveMarkBot aboveMarkTop (markFine * 2)
+		include : HBar.b leftEnd rightEnd aboveMarkBot (markFine * 2)

--- a/packages/font-glyphs/src/meta/unicode-knowledge.ptl
+++ b/packages/font-glyphs/src/meta/unicode-knowledge.ptl
@@ -221,6 +221,11 @@ export : define decompOverrides : object
 	0x1DF0C { 'eshCurlyTail'   'dblBarOver' }
 	0x1DF1A { 'iRetroflexHook' 'barOver' }
 
+	# Aliasing of Armenian marks
+	0x559   { 'modifierLetterLeftHalfRing' }
+	0x55A   { 'modifierLetterRightHalfRing' }
+	0x55B   { 'prime' }
+	0x55D   { 'revprime' }
 
 # List of canonical and non-canonical combinations but applicable for ccmp feature
 export : define ccmpCombinations : list

--- a/packages/font-glyphs/src/symbol/geometric/stars.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/stars.ptl
@@ -178,7 +178,7 @@ glyph-block Symbol-Other-Stars : begin
 	glyph-block-import Common-Derivatives
 
 	define [EternitySymbol sign] : glyph-proc
-		define sw : AdviceStroke 6
+		define sw : AdviceStroke 6.5
 		define radius : (RightSB - Middle) / 2
 
 		foreach [j : range 0 8] : do

--- a/packages/font-glyphs/src/symbol/punctuation/quotes-and-primes.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/quotes-and-primes.ptl
@@ -2,6 +2,7 @@
 $$include '../../meta/macros.ptl'
 
 import [mix linreg clamp fallback] from "@iosevka/util"
+import [Box] from "@iosevka/geometry/box"
 import [DependentSelector] from "@iosevka/glyph/relation"
 
 glyph-module
@@ -64,9 +65,6 @@ glyph-block Symbol-Punctuation-Quotes-And-Primes : begin
 	alias 'mdfApostrophe'       0x2BC 'closeSingleQuote'
 	alias 'mdfRevComma'         0x2BD 'revSingleQuote'
 	alias 'mdfDoubleApostrophe' 0x2EE 'closeDoubleQuote'
-
-	alias 'armn/turnComma'  0x559 'openSingleQuote'
-	alias 'armn/apostrophe' 0x55A 'closeSingleQuote'
 
 	# Primes
 	create-glyph 'prime' 0x2032 : glyph-proc
@@ -244,3 +242,31 @@ glyph-block Symbol-Punctuation-Quotes-And-Primes : begin
 
 	derive-composites 'hypodiastole' 0x2E12 'modifierLetterRightHalfRing'
 		ApparentTranslate 0 ([mix [mix [mix PeriodSize commaLow 0.5] yCurlyQuotes 0.5] quoteBottom (-1)] - quoteTop)
+
+	# Armenian exclamatory
+	create-glyph 'armn/exclam' 0x55C : glyph-proc
+		local df : include : DivFrame para.diversityF
+		local height : quoteTop - quoteBottom
+		local xLeft  : df.middle - height / 2.5
+		local xRight : df.middle + height / 2.5
+		local sw : AdviceStroke 3
+		include : dispiro
+			g4.up.start xLeft  quoteBottom [widths.rhs.heading sw Upward]
+			g2 [pre@mix@post 0.5] [pre@mix@post 0.5] [widths.center sw]
+			g4.up.end   xRight quoteTop    [widths.lhs.heading sw Upward]
+
+	create-glyph "armn/questionMark" 0x055E : glyph-proc
+		local df : include : DivFrame para.diversityF
+
+		local height : quoteTop - quoteBottom
+		local xLeft  : df.middle - height / 2
+		local xRight : df.middle + height / 2
+		local sw : AdviceStroke 4
+
+		local frame : new Box quoteTop [mix quoteBottom quoteTop 0.2] xLeft xRight
+		include : dispiro
+			g4.up.start frame.left frame.bot [widths.rhs sw]
+			arch.rhs frame.top 0.55
+			g4.down.mid frame.right ([frame.yp 0.55] - 0.5 * sw) [widths.rhs sw]
+			arcvh
+			g4.left.end [frame.xp 0.6] frame.bot [heading Leftward]


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/e3757db5-bc13-432e-9ddd-cdf8c4158e9a)


U+0559 and U+055A are changed to half rings for matching Armenian style better (consider add variants in the future?).
U+055F implemented as a mark.