### PR TITLE
Optimize jut length of Armenian bars under slab.

### DIFF
--- a/packages/font-glyphs/src/letter/armenian/eh-liun-hiun.ptl
+++ b/packages/font-glyphs/src/letter/armenian/eh-liun-hiun.ptl
@@ -49,7 +49,7 @@ glyph-block Letter-Armenian-Eh-Liun-Hiun : begin
 				include : composite-proc sf.lt.full sf.lb.outer
 
 		create-glyph 'armn/liun' 0x56C : glyph-proc
-			local df : include : DivFrame para.diversityII
+			local df : include : DivFrame : if SLAB para.diversityI para.diversityII
 			include : df.markSet.p
 			local xMiddle : df.middle - [IBalance2 df]
 			include : VBar.m xMiddle Descender XH df.mvs

--- a/packages/font-glyphs/src/letter/armenian/hook-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/hook-group.ptl
@@ -23,7 +23,7 @@ glyph-block Letter-Armenian-Hook-Group : begin
 			local df : include : DivFrame 1
 			include : df.markSet.capital
 			include : LeftHook df CAP df.mvs SLAB 0
-			include : [ArmHBar.right df 1].mid
+			include : [ArmHBar.right df 1 SLAB].mid
 
 	do "Ech"
 		create-glyph 'armn/Ech' 0x535 : glyph-proc

--- a/packages/font-glyphs/src/letter/armenian/keh.ptl
+++ b/packages/font-glyphs/src/letter/armenian/keh.ptl
@@ -8,8 +8,7 @@ glyph-module
 glyph-block Letter-Armenian-Keh : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : OBarRight OBarLeft
-	glyph-block-import Letter-Shared-Shapes : SerifFrame
+	glyph-block-import Letter-Shared-Shapes : OBarLeft SerifFrame
 
 	# Common Params
 	define barPos : XH / 2

--- a/packages/font-glyphs/src/letter/armenian/lower-dza-cheh.ptl
+++ b/packages/font-glyphs/src/letter/armenian/lower-dza-cheh.ptl
@@ -8,8 +8,12 @@ glyph-module
 glyph-block Letter-Armenian-Lower-Dza-Cheh : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : OBarRight OBarLeft
-	glyph-block-import Letter-Shared-Shapes : SerifFrame
+	glyph-block-import Letter-Shared-Shapes : OBarRight SerifFrame
+
+	# Common Params
+	define barPos : XH / 2
+	define highBarPos XH
+	define jut Jut
 
 	do "Dz'a"
 		create-glyph 'armn/dza' 0x571 : glyph-proc
@@ -17,7 +21,6 @@ glyph-block Letter-Armenian-Lower-Dza-Cheh : begin
 			include : df.markSet.b
 			local x1 : mix df.leftSB df.rightSB 0.25
 			local x2 : mix df.leftSB df.rightSB 0.75
-			local xOffset : 0.5 * [HSwToV df.mvs]
 			local y2 : Math.min [mix Ascender XH 0.5] (XH + 0.5 * SmallArchDepthA)
 			include : dispiro
 				widths.center df.mvs
@@ -26,27 +29,26 @@ glyph-block Letter-Armenian-Lower-Dza-Cheh : begin
 				flat df.middle y2
 				curl x2 y2 [heading Rightward]
 
-			local stemFine : df.mvs * (ShoulderFine / Stroke)
+			local stemFine : ShoulderFine * (df.mvs / Stroke)
+			define [knots] : list
+				straight.left.start x2 (y2 + 0.5 * df.mvs)
+				archv
+				flat df.leftSB (XH - SmallArchDepthA)
+				curl df.leftSB (0 + SmallArchDepthB) [heading Downward]
 			include : dispiro
 				widths.lhs df.mvs
-				curl x2 (y2 + 0.5 * df.mvs)
-				archv.superness 1.5
-				straight.down.end df.leftSB (XH - SmallArchDepthA)
-				curl df.leftSB (0 + SmallArchDepthB)
+				knots
 				OBarRight.arcEnd 0 df.leftSB df.rightSB df.mvs stemFine SmallArchDepthA SmallArchDepthB
 			include : intersection
 				spiro-outline
-					curl x2 (y2 + 0.5 * df.mvs)
-					archv.superness 1.5
-					# curl df.middle XH
-					straight.down.end df.leftSB (XH - SmallArchDepthA)
+					knots
 					corner df.leftSB 0
 					corner VERY-FAR 0
 					corner VERY-FAR Ascender
 				dispiro
 					widths.rhs df.mvs
 					flat df.leftSB XH
-					curl df.middle XH
+					curl df.middle XH [heading Rightward]
 					archv
 					flat df.rightSB (XH - SmallArchDepthB)
 					curl df.rightSB 0 [heading Downward]
@@ -59,21 +61,21 @@ glyph-block Letter-Armenian-Lower-Dza-Cheh : begin
 			local df : include : DivFrame 1
 			include : df.markSet.b
 			local x1 : mix df.leftSB df.rightSB 0.75
-			local stemFine : df.mvs * (ShoulderFine / Stroke)
+			local stemFine : ShoulderFine * (df.mvs / Stroke)
 			include : dispiro
 				widths.lhs df.mvs
-				flat df.rightSB Ascender
-				curl x1 Ascender
+				flat x1 Ascender
+				curl df.middle Ascender [heading Leftward]
 				archv
-				flat df.leftSB (XH - SmallArchDepthA)
-				curl df.leftSB (0 + SmallArchDepthB)
+				flat df.leftSB (Ascender - SmallArchDepthA)
+				curl df.leftSB (0 + SmallArchDepthB) [heading Downward]
 				OBarRight.arcEnd 0 df.leftSB df.rightSB df.mvs stemFine SmallArchDepthA SmallArchDepthB
 			include : dispiro
 				widths.rhs df.mvs
-				flat df.leftSB XH
-				curl df.middle XH
+				flat (df.leftSB - jut + [HSwToV : 0.5 * df.mvs]) highBarPos
+				curl df.middle highBarPos [heading Rightward]
 				archv
-				flat df.rightSB (XH - SmallArchDepthB)
+				flat df.rightSB (highBarPos - SmallArchDepthB)
 				curl df.rightSB 0 [heading Downward]
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df Ascender 0

--- a/packages/font-glyphs/src/letter/armenian/lower-q-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/lower-q-group.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Letter-Armenian-Lower-Q-Group : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : SerifFrame OBarRight
+	glyph-block-import Letter-Shared-Shapes : OBarRight SerifFrame
 	glyph-block-import Letter-Armenian-Shared-Shapes : ArmHBar
 
 	do "Gim"
@@ -17,7 +17,7 @@ glyph-block Letter-Armenian-Lower-Q-Group : begin
 			include : df.markSet.p
 			include : OBarRight.shape (top -- XH)
 			include : VBar.r df.rightSB Descender XH
-			include : [ArmHBar.right df 0].base
+			include : [ArmHBar.right df 0 SLAB].base
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH Descender
 				include sf.rb.fullSide
@@ -30,7 +30,7 @@ glyph-block Letter-Armenian-Lower-Q-Group : begin
 			include : df.markSet.p
 			include : OBarRight.shape (top -- XH)
 			include : VBar.r df.rightSB Descender XH
-			include : [ArmHBar.right df 0].desc
+			include : [ArmHBar.right df 0 SLAB].desc
 			if (SLAB && [not para.isItalic]) : begin
 				local sf : SerifFrame.fromDf df XH Descender
 				include sf.rt.outer

--- a/packages/font-glyphs/src/letter/armenian/lower-u-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/lower-u-group.ptl
@@ -8,8 +8,7 @@ glyph-module
 glyph-block Letter-Armenian-Lower-U-Group : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : nShoulder nShoulderKnots 
-	glyph-block-import Letter-Shared-Shapes : SerifFrame
+	glyph-block-import Letter-Shared-Shapes : nShoulder nShoulderKnots SerifFrame
 	glyph-block-import Letter-Armenian-Shared-Shapes : ArmHBar TwoNeck
 	glyph-block-import Letter-Latin-U : USerifs
 	glyph-block-import Letter-Latin-Lower-M : SmallMArches
@@ -74,7 +73,7 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 				top -- XH
 				bottom -- Descender
 				stroke -- df.mvs
-			include : [ArmHBar.right df 0].base
+			include : [ArmHBar.right df 0 SLAB].base
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH 0
 				local sf2 : SerifFrame.fromDf df XH Descender
@@ -209,7 +208,7 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 				top -- XH
 				bottom -- Descender
 				stroke -- df.mvs
-			include : [ArmHBar.right df 0].desc
+			include : [ArmHBar.right df 0 SLAB].desc
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH 0
 				include sf.lt.outer
@@ -227,7 +226,7 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 				stroke -- df.mvs
 			include : FlipAround df.middle 0
 			include : VBar.r df.rightSB 0 Ascender df.mvs
-			include : [ArmHBar.right df 0].top
+			include : [ArmHBar.right df 0 SLAB].top
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH 0
 				local sf2 : SerifFrame.fromDf df Ascender 0
@@ -304,13 +303,13 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 					include : composite-proc sf.lb.outer
 
 			# Alternate straight 'n' form
-			# include :	nShoulder
+			# include : nShoulder
 			# 	left -- (df.leftSB + [HSwToV df.mvs])
 			# 	right -- df.rightSB
 			# 	top -- XH
 			# 	bottom -- 0
 			# 	stroke -- df.mvs
-			# include : [ArmHBar.right df 0].base
+			# include : [ArmHBar.right df 0 SLAB].base
 			# if SLAB : begin
 			# 	local sf : SerifFrame.fromDf df XH 0
 			# 	include sf.lt.outer
@@ -347,7 +346,7 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 				stroke -- df.mvs
 			include : FlipAround df.middle 0
 			include : VBar.r df.rightSB Descender Ascender df.mvs
-			include : [ArmHBar.right df 1].desc
+			include : [ArmHBar.right df 0 SLAB].desc
 
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH 0

--- a/packages/font-glyphs/src/letter/armenian/upper-gim-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/upper-gim-group.ptl
@@ -9,7 +9,6 @@ glyph-block Letter-Armenian-Upper-Gim-Group : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Shapes : SerifFrame
-	glyph-block-import Letter-Armenian-Shared-Shapes : ArmHBar
 
 	# Common Params
 	define barPos : XH / 2
@@ -30,7 +29,7 @@ glyph-block Letter-Armenian-Upper-Gim-Group : begin
 				curl df.leftSB (barPosB + ArchDepthB)
 				arcvh
 				flat df.middle barPosB
-				curl (df.rightSB + jut - [HSwToV : 0.5 * df.mvs]) barPosB
+				curl (df.rightSB + jut * [if SLAB 1.5 1] - [HSwToV : 0.5 * df.mvs]) barPosB
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df CAP 0
 				include sf.rb.full
@@ -47,8 +46,7 @@ glyph-block Letter-Armenian-Upper-Gim-Group : begin
 				curl (df.leftSB + OX) (highBarPos - ArchDepthA)
 				arcvh
 				flat df.middle highBarPos
-				curl df.rightSB highBarPos
-			include : [ArmHBar.right df 1].high
+				curl (df.rightSB + jut * [if SLAB 1.5 1] - [HSwToV : 0.5 * df.mvs]) highBarPos
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df CAP 0
 				include sf.rt.full
@@ -65,8 +63,7 @@ glyph-block Letter-Armenian-Upper-Gim-Group : begin
 				curl (df.leftSB + OX) (highBarPos - SmallArchDepthA)
 				arcvh
 				flat df.middle highBarPos
-				curl df.rightSB highBarPos
-			include : [ArmHBar.right df 0].high
+				curl (df.rightSB + jut * [if SLAB 1.5 1] - [HSwToV : 0.5 * df.mvs]) highBarPos
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df Ascender 0
 				include sf.rt.inner

--- a/packages/font-glyphs/src/letter/armenian/upper-u-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/upper-u-group.ptl
@@ -46,7 +46,7 @@ glyph-block Letter-Armenian-Upper-U-Group : begin
 			include : df.markSet.capital
 			include : UShape df CAP 1 df.mvs
 			include : FlipAround Middle (CAP / 2)
-			include : [ArmHBar.right df 1].mid
+			include : [ArmHBar.right df 1 SLAB].mid
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df CAP 0
 				include : composite-proc sf.lb.full sf.rb.full

--- a/packages/font-glyphs/src/symbol/punctuation/dashes.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/dashes.ptl
@@ -33,7 +33,7 @@ glyph-block Symbol-Punctuation-Dashes : begin
 		foreach { suffix { yBar } } [Object.entries UnderScoreConfig] : do
 			create-glyph "underscore.\(suffix)" : HBar.b SB RightSB yBar
 			create-glyph "doubleUnderscore.\(suffix)" : composite-proc
-				HBar.b SB RightSB yBar
+				HBar.b SB RightSB  yBar
 				HBar.b SB RightSB (yBar - openBoxGap)
 			create-glyph "openBox.\(suffix)" : composite-proc
 				HBar.b SB RightSB yBar
@@ -55,8 +55,8 @@ glyph-block Symbol-Punctuation-Dashes : begin
 		local df : include : DivFrame para.diversityF
 		include : dispiro
 			widths.center
-			g4 df.leftSB SymbolMid [heading Rightward]
-			g4 df.middle (0.95 * SymbolMid)
+			g4 df.leftSB  SymbolMid [heading Rightward]
+			g4 df.middle (SymbolMid + 2 * O)
 			g4 df.rightSB SymbolMid [heading Rightward]
 
 	alias 'softhyphen' 0xAD  'hyphen'
@@ -67,7 +67,7 @@ glyph-block Symbol-Punctuation-Dashes : begin
 	create-glyph 'figureDash' 0x2012 : HBar.m SB RightSB SymbolMid
 	create-glyph 'overline' 0x203E : HBar.t SB RightSB CAP
 	create-glyph 'mdfUnaspirated' 0x2ED : composite-proc
-		HBar.t SB RightSB CAP
+		HBar.t SB RightSB  CAP
 		HBar.t SB RightSB (CAP - openBoxGap)
 
 	create-glyph 'enDash' 0x2013 : glyph-proc


### PR DESCRIPTION
Also optimize arcs for glyphs of `ձ` and `ճ`.

`ձ` in particular appeared to be pulling the arc in opposite directions and so it looked rather jagged and messy.
I also went ahead and made the knots of the arc of `ձ` into a separate list declaration such as to not have to copy and paste the code for the mask.

I didn't touch `ծ` but I will note that it could stand to be improved in the future for some of the same reasons, in regard to its jagged arc shape.

```
 ԱԲԳԴԵԶԷԸԹԺԻԼԽԾԿ
ՀՁՂՃՄՅՆՇՈՉՊՋՌՍՎՏ
ՐՑՒՓՔՕՖ  ՙ՚՛՜՝՞◌՟
ՠաբգդեզէըթժիլխծկ
հձղճմյնշոչպջռսվտ
րցւփքօֆևֈ։֊  ֍֎֏
```

Sans Thin Upright:
![image](https://github.com/user-attachments/assets/8e9b759a-f218-4567-86e9-450e38de9b99)
Sans Regular Upright:
![image](https://github.com/user-attachments/assets/051760d1-411d-475d-8437-e4c4c86a1624)
Sans Heavy Upright:
![image](https://github.com/user-attachments/assets/9a3c0565-f2df-4c5e-922e-865a589a9380)
Sans Thin Italic:
![image](https://github.com/user-attachments/assets/0457f85e-f8a0-4f9b-adce-00573df0fc0b)
Sans Regular Italic:
![image](https://github.com/user-attachments/assets/622c5da9-3ecf-443f-8c89-da8ef4220e05)
Sans Heavy Italic:
![image](https://github.com/user-attachments/assets/9587f3a5-98a6-4d51-9d4e-d548b4a1b031)
Slab Thin Upright:
![image](https://github.com/user-attachments/assets/a2ebaa66-526c-4ffe-ade0-13d5a92da153)
Slab Regular Upright:
![image](https://github.com/user-attachments/assets/8b047947-6e80-4af7-b918-671200bba8cb)
Slab Heavy Upright:
![image](https://github.com/user-attachments/assets/695301a5-ddba-4ceb-acd4-5e60c8388a8f)
Slab Thin Italic:
![image](https://github.com/user-attachments/assets/aad27e04-d23a-4c31-bc13-cfba5752b655)
Slab Regular Italic:
![image](https://github.com/user-attachments/assets/113c711a-cad9-4d69-9d8b-4f2373567f4e)
Slab Heavy Italic:
![image](https://github.com/user-attachments/assets/5ddf1b87-5d96-4195-9772-96742e5adffc)
Aile Thin Upright:
![image](https://github.com/user-attachments/assets/899184f9-d5ed-427d-8af1-bc301456cd03)
Aile Regular Upright:
![image](https://github.com/user-attachments/assets/f4989e47-b396-4096-b91b-8c1b19301af9)
Aile Heavy Upright:
![image](https://github.com/user-attachments/assets/b2541b2d-b38d-460c-a959-1d4b0eb4dd97)
Aile Thin Italic:
![image](https://github.com/user-attachments/assets/61a90404-1d45-4d99-bd64-e30d9e13f4c2)
Aile Regular Italic:
![image](https://github.com/user-attachments/assets/c80fb18d-4947-4f63-a83d-da05638cd5b1)
Aile Heavy Italic:
![image](https://github.com/user-attachments/assets/4749edbc-aa55-4ee7-a340-e590905d8ae6)
Etoile Thin Upright:
![image](https://github.com/user-attachments/assets/c7385a4d-4fdf-4c21-8b84-368a885d8f22)
Etoile Regular Upright:
![image](https://github.com/user-attachments/assets/dca8e0bf-ba85-4b2b-af14-00c49ec11829)
Etoile Heavy Upright:
![image](https://github.com/user-attachments/assets/7fd80051-0c33-43e9-817e-9159ce09248c)
Etoile Thin Italic:
![image](https://github.com/user-attachments/assets/f1cfeed6-8430-49f9-9037-d41a7c188f1f)
Etoile Regular Italic:
![image](https://github.com/user-attachments/assets/cb2d3ad7-145f-4c2d-af79-c535b91a7df7)
Etoile Heavy Italic:
![image](https://github.com/user-attachments/assets/64001e46-03c4-4e60-be0b-d20b56d552ca)
