### PR TITLE
Optimize glyphs for `Ի`/`Կ`/`Վ` (Armenian).

### DIFF
--- a/changes/32.0.2.md
+++ b/changes/32.0.2.md
@@ -1,2 +1,5 @@
+* Optimize glyphs for Armenian Capital Ini (`U+053B`), Ken (`U+053F`), and Vew (`U+054E`).
+* Remove bottom-right serif from Armenian Capital Now (`U+0546`).
+* Remove top-right serif from Armenian Lower Ben (`U+0562`).
 * Make serif of Armenian Lower Yi (`U+0575`) consistent with Armenian Lower Liwn (`U+056C`).
 * Make hook of Armenian Lower Co (`U+0581`) consistent with Armenian Lower Yi (`U+0575`).

--- a/packages/font-glyphs/src/letter/armenian/hook-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/hook-group.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Letter-Armenian-Hook-Group : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : SerifFrame
+	glyph-block-import Letter-Shared-Shapes : SerifFrame DToothlessRise
 	glyph-block-import Letter-Armenian-Shared-Shapes : ArmHBar LeftHook RightHook
 
 	do "Ben"
@@ -47,7 +47,11 @@ glyph-block Letter-Armenian-Hook-Group : begin
 		create-glyph 'armn/Ini' 0x53B : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.capital
-			include : RightHook df XH df.mvs
+			include : dispiro
+				widths.lhs df.mvs
+				g4 df.rightSB (XH - Hook) [heading Upward]
+				arch.lhs.centerAt.rtl.t df.middle XH (sw -- df.mvs)
+				g4 (df.leftSB + 1 / 16) (XH - DToothlessRise) [heading Leftward]
 			include : VBar.l df.leftSB 0 CAP
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df CAP 0
@@ -62,9 +66,8 @@ glyph-block Letter-Armenian-Hook-Group : begin
 				widths.lhs df.mvs
 				flat df.leftSB CAP [heading Downward]
 				curl df.leftSB (midy + ArchDepthB)
-				arch.lhs midy (sw -- df.mvs)
-				flat df.rightSB (midy + ArchDepthA)
-				curl df.rightSB XH [heading Upward]
+				arch.lhs.centerAt.ltr.b df.middle midy (sw -- df.mvs)
+				g4 (df.rightSB - 1 / 16) (midy + DToothlessRise) [heading Rightward]
 			include : VBar.r df.rightSB 0 XH
 
 			if SLAB : begin
@@ -83,7 +86,7 @@ glyph-block Letter-Armenian-Hook-Group : begin
 		create-glyph 'armn/Nu' 0x546 : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.capital
-			include : LeftHook df CAP df.mvs SLAB SLAB
+			include : LeftHook df CAP df.mvs SLAB 0
 			include : FlipAround df.middle (CAP / 2)
 			include : [ArmHBar.left df 1 SLAB].top
 
@@ -105,9 +108,8 @@ glyph-block Letter-Armenian-Hook-Group : begin
 				widths.lhs df.mvs
 				flat df.leftSB XH [heading Downward]
 				curl df.leftSB (midy + ArchDepthB)
-				arch.lhs midy (sw -- df.mvs)
-				flat df.rightSB (midy + ArchDepthA)
-				curl df.rightSB XH [heading Upward]
+				arch.lhs.centerAt.ltr.b df.middle midy (sw -- df.mvs)
+				g4 (df.rightSB - 1 / 16) (midy + DToothlessRise) [heading Rightward]
 			include : VBar.r df.rightSB 0 CAP df.mvs
 			include : [ArmHBar.right df 1 SLAB].base
 

--- a/packages/font-glyphs/src/letter/armenian/lower-u-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/lower-u-group.ptl
@@ -58,9 +58,6 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH Descender
 				include : composite-proc sf.lt.outer sf.lb.fullSide
-				if [not para.isItalic] : begin
-					local sf2 : SerifFrame.fromDf df XH (XH / 2)
-					include sf2.rb.full
 
 	do "Da"
 		create-glyph 'armn/da' 0x564 : glyph-proc

--- a/packages/font-glyphs/src/letter/armenian/to.ptl
+++ b/packages/font-glyphs/src/letter/armenian/to.ptl
@@ -43,7 +43,7 @@ glyph-block Letter-Armenian-To : begin
 			local fine : df.adviceStroke2 6 3 XH
 			include : df.markSet.p
 			include : VBar.l df.leftSB Descender XH df.mvs
-			local barPosT : XH / 2 + df.mvs / 2
+			local barPosT : barPos + df.mvs / 2
 			include : dispiro
 				nShoulderKnots
 					left -- (df.leftSB + [HSwToV df.mvs])

--- a/packages/font-glyphs/src/letter/latin/lower-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-g.ptl
@@ -162,15 +162,15 @@ glyph-block Letter-Latin-Lower-G : begin
 			local df : include : DivFrame 1
 			include : df.markSet.p
 			set-base-anchor 'overlay' Middle (XH / 2)
-			set-base-anchor 'strike' Middle (XH / 2)
-			include : bodyShape df XH
+			set-base-anchor 'strike'  Middle (XH / 2)
+			include : bodyShape df  XH
 			include : hookShape df (XH - hookStart)
 
 		create-glyph "GScript.\(suffix)" : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.capDesc
 			set-base-anchor 'overlay' Middle (CAP / 2)
-			include : bodyShape df CAP
+			include : bodyShape df  CAP
 			include : hookShape df (CAP - hookStart)
 
 		create-glyph "gScriptPalatalHook.\(suffix)" : glyph-proc
@@ -178,7 +178,7 @@ glyph-block Letter-Latin-Lower-G : begin
 			include : df.markSet.p
 			set-base-anchor 'overlay' Middle (XH / 2)
 			local dfSub : DivFrame (0.75 * para.diversityM) 2
-			include : bodyShape dfSub XH
+			include : bodyShape dfSub  XH
 			include : hookShape dfSub (XH - hookStart)
 			include : PalatalHook.r
 				x -- df.rightSB
@@ -213,8 +213,8 @@ glyph-block Letter-Latin-Lower-G : begin
 		include : MarkSet.p
 		set-base-anchor 'overlay' Middle (XH / 2)
 		define df : DivFrame 1
-		include : SingleStorey.ScriptCutBody df XH
-		include : SingleStorey.CrossedHook df (XH - HalfStroke)
+		include : SingleStorey.ScriptCutBody df  XH
+		include : SingleStorey.CrossedHook   df (XH - HalfStroke)
 
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarRight
 	create-glyph 'mathbb/g' 0x1D558 : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/lower-j.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-j.ptl
@@ -87,11 +87,6 @@ glyph-block Letter-Latin-Lower-J : begin
 			include : Serifless df top xMiddle
 			include : LeaningAnchor.Above.At [mix df.middle xMiddle (7/8)]
 
-		export : define [AutoSerifed df top xMiddle] : glyph-proc
-			include : if SLAB
-				Serifed   df top xMiddle
-				Serifless df top xMiddle
-
 	define Div : namespace
 		export : define BentHook          1
 		export : define StraightSerifless para.diversityII


### PR DESCRIPTION
Code taken from Cyrillic Che (`Ч`) for a less crowded intersection.
Also remove hook serifs from `Ն` and `բ` under slab, as not all fonts put serifs there, and it looks rather crowded under heavy, and not to mention that they were also the only hooked letters where we had bothered to put serifs on their hooks.

```
 ԱԲԳԴԵԶԷԸԹԺԻԼԽԾԿ
ՀՁՂՃՄՅՆՇՈՉՊՋՌՍՎՏ
ՐՑՒՓՔՕՖ  ՙ՚՛՜՝՞◌՟
ՠաբգդեզէըթժիլխծկ
հձղճմյնշոչպջռսվտ
րցւփքօֆևֈ։֊  ֍֎֏
```

Sans Thin Upright:
![image](https://github.com/user-attachments/assets/9b01d8db-8fb5-4ccb-9dd8-071c86b2f939)
Sans Regular Upright:
![image](https://github.com/user-attachments/assets/c4dc2907-d1aa-47bf-976c-5e1f9edd9b23)
Sans Heavy Upright:
![image](https://github.com/user-attachments/assets/8d2780ea-6b72-44ac-ac0b-c10e76d35b6f)
Sans Thin Italic:
![image](https://github.com/user-attachments/assets/ddd63e7b-1df6-4440-a0b1-10112da6a066)
Sans Regular Italic:
![image](https://github.com/user-attachments/assets/cb7b6de3-4d52-40e5-9787-c07baba4906d)
Sans Heavy Italic:
![image](https://github.com/user-attachments/assets/2b3528f9-3888-49c4-a3d1-8e756b5f9466)
Slab Thin Upright:
![image](https://github.com/user-attachments/assets/a8b3f70d-3d3c-4fc3-ab3c-719b305fd976)
Slab Regular Upright:
![image](https://github.com/user-attachments/assets/7aeb0ff7-762d-4397-958b-8ff42d12f9dc)
Slab Heavy Upright:
![image](https://github.com/user-attachments/assets/0c562a1c-ecd5-4dab-973d-9f65239443a5)
Slab Thin Italic:
![image](https://github.com/user-attachments/assets/7fe9cbbc-22cc-450c-98ef-d5b768eabc6b)
Slab Regular Italic:
![image](https://github.com/user-attachments/assets/92402f71-e591-4bbc-a671-d773080864bb)
Slab Heavy Italic:
![image](https://github.com/user-attachments/assets/a4e8497e-ce6b-4e7c-8338-71e6cc5fc878)
Aile Thin Upright:
![image](https://github.com/user-attachments/assets/61fd6ac1-0170-4f57-9b00-ea4da4af80b8)
Aile Regular Upright:
![image](https://github.com/user-attachments/assets/a6c185e3-2f9f-4dd1-8b70-e74d75092027)
Aile Heavy Upright:
![image](https://github.com/user-attachments/assets/eaf68695-5335-46a7-aec0-76562f2d713b)
Aile Thin Italic:
![image](https://github.com/user-attachments/assets/f1c51489-85b6-4cc6-9251-855b5da05395)
Aile Regular Italic:
![image](https://github.com/user-attachments/assets/102118c9-6bb0-4709-a740-a19351b9d8ef)
Aile Heavy Italic:
![image](https://github.com/user-attachments/assets/53dec952-049e-4ea7-9b0b-14c2981e6521)
Etoile Thin Upright:
![image](https://github.com/user-attachments/assets/6989e64c-d4d6-4645-be8c-5d563b3975fa)
Etoile Regular Upright:
![image](https://github.com/user-attachments/assets/c7d7a3a6-c584-4201-85d3-adda20db2ef1)
Etoile Heavy Upright:
![image](https://github.com/user-attachments/assets/ca04b63c-71ed-4f51-bdbe-0f64a3534b4f)
Etoile Thin Italic:
![image](https://github.com/user-attachments/assets/a7339a00-5168-4fa3-b9ee-e20bcabfaaee)
Etoile Regular Italic:
![image](https://github.com/user-attachments/assets/bf18c48c-dfb9-42d3-a618-4d5ee9e6610d)
Etoile Heavy Italic:
![image](https://github.com/user-attachments/assets/07ec046f-8188-488e-a349-2ce67d26806b)
