### PR TITLE
Refactor of the u and che's bowl shape function

### DIFF
--- a/packages/font-glyphs/src/letter/armenian/lower-u-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/lower-u-group.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Letter-Armenian-Lower-U-Group : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : nShoulder nShoulderKnots SerifFrame
+	glyph-block-import Letter-Shared-Shapes : nShoulder uBowl SerifFrame
 	glyph-block-import Letter-Armenian-Shared-Shapes : ArmHBar TwoNeck
 	glyph-block-import Letter-Latin-U : USerifs
 	glyph-block-import Letter-Latin-Lower-M : SmallMArches
@@ -48,7 +48,7 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			local df : include : DivFrame 1
 			include : df.markSet.p
 			include : VBar.l df.leftSB Descender XH df.mvs
-			include : nShoulder
+			include : nShoulder.shape
 				left -- (df.leftSB + [HSwToV df.mvs])
 				right -- df.rightSB
 				top -- XH
@@ -67,7 +67,7 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			local df : include : DivFrame 1
 			include : df.markSet.p
 			include : VBar.l df.leftSB 0 XH df.mvs
-			include : nShoulder
+			include : nShoulder.shape
 				left -- (df.leftSB + [HSwToV df.mvs])
 				right -- df.rightSB
 				top -- XH
@@ -86,13 +86,12 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 		create-glyph 'armn/ech' 0x565 : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.b
-			include : nShoulder
-				top -- 0
-				bottom -- (-Ascender)
-				left -- (df.leftSB + [HSwToV df.mvs])
-				right -- df.rightSB
+			include : uBowl.shape
+				top -- Ascender
+				bottom -- 0
+				left -- df.leftSB
+				right -- (df.rightSB - [HSwToV df.mvs])
 				stroke -- df.mvs
-			include : FlipAround df.middle 0
 			include : VBar.r df.rightSB 0 [mix 0 XH 0.6] df.mvs
 			include : [ArmHBar.normal df 0].high
 			if SLAB : include : USerifs.Toothed df Ascender df.mvs
@@ -103,7 +102,7 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			local df : include : DivFrame 1
 			include : df.markSet.b
 			include : VBar.l df.leftSB Descender XH df.mvs
-			include : nShoulder
+			include : nShoulder.shape
 				left -- (df.leftSB + [HSwToV df.mvs])
 				right -- df.rightSB
 				top -- XH
@@ -121,7 +120,7 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			local df : include : DivFrame 1
 			include : df.markSet.bp
 			include : VBar.l df.leftSB Descender Ascender df.mvs
-			include : nShoulder
+			include : nShoulder.shape
 				left -- (df.leftSB + [HSwToV df.mvs])
 				right -- df.rightSB
 				top -- XH
@@ -137,14 +136,13 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 		create-glyph 'armn/xeh' 0x56D : glyph-proc
 			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.bp
-			include : nShoulder
-				top -- XH
-				bottom -- (XH / 2)
-				left -- (df.leftSB + [HSwToV df.mvs])
-				right -- (df.middle + [HSwToV : df.mvs / 2])
+			include : uBowl.shape
+				top -- (XH / 2)
+				bottom -- 0
+				left -- (df.middle - [HSwToV : df.mvs / 2])
+				right -- (df.rightSB - [HSwToV df.mvs])
 				stroke -- df.mvs
-			include : FlipAround df.middle (XH / 2)
-			include : nShoulder
+			include : nShoulder.shape
 				top -- XH
 				bottom -- (XH / 2)
 				left -- (df.leftSB + [HSwToV df.mvs])
@@ -164,13 +162,12 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 		create-glyph 'armn/ken' 0x56F : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.bp
-			include : nShoulder
-				top -- 0
-				bottom -- (-Ascender)
-				left -- (df.leftSB + [HSwToV df.mvs])
-				right -- df.rightSB
+			include : uBowl.shape
+				top -- Ascender
+				bottom -- 0
+				left -- df.leftSB
+				right -- (df.rightSB - [HSwToV df.mvs])
 				stroke -- df.mvs
-			include : FlipAround df.middle 0
 			include : VBar.r df.rightSB Descender XH df.mvs
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df Ascender 0
@@ -185,7 +182,7 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			local df : include : DivFrame 1
 			include : df.markSet.b
 			include : VBar.l df.leftSB 0 Ascender df.mvs
-			include : nShoulder
+			include : nShoulder.shape
 				left -- (df.leftSB + [HSwToV df.mvs])
 				right -- df.rightSB
 				top -- XH
@@ -202,7 +199,7 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			local df : include : DivFrame 1
 			include : df.markSet.p
 			include : VBar.l df.leftSB 0 XH df.mvs
-			include : nShoulder
+			include : nShoulder.shape
 				left -- (df.leftSB + [HSwToV df.mvs])
 				right -- df.rightSB
 				top -- XH
@@ -218,13 +215,12 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 		create-glyph 'armn/men' 0x574 : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.b
-			include : nShoulder
-				top -- 0
-				bottom -- (-XH)
-				left -- (df.leftSB + [HSwToV df.mvs])
-				right -- df.rightSB
+			include : uBowl.shape
+				top -- XH
+				bottom -- 0
+				left -- df.leftSB
+				right -- (df.rightSB - [HSwToV df.mvs])
 				stroke -- df.mvs
-			include : FlipAround df.middle 0
 			include : VBar.r df.rightSB 0 Ascender df.mvs
 			include : [ArmHBar.right df 0 SLAB].top
 			if SLAB : begin
@@ -236,13 +232,12 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 		create-glyph 'armn/nu' 0x576 : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.b
-			include : nShoulder
-				top -- 0
-				bottom -- (-Ascender)
-				left -- (df.leftSB + [HSwToV df.mvs])
-				right -- df.rightSB
+			include : uBowl.shape
+				top -- Ascender
+				bottom -- 0
+				left -- df.leftSB
+				right -- (df.rightSB - [HSwToV df.mvs])
 				stroke -- df.mvs
-			include : FlipAround df.middle 0
 			include : VBar.r df.rightSB 0 XH df.mvs
 			include : [ArmHBar.left df 0 SLAB].top
 			if SLAB : begin
@@ -255,7 +250,7 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			local df : include : DivFrame 1
 			include : df.markSet.e
 			include : VBar.l df.leftSB 0 XH df.mvs
-			include : nShoulder
+			include : nShoulder.shape
 				left -- (df.leftSB + [HSwToV df.mvs])
 				right -- df.rightSB
 				top -- XH
@@ -286,7 +281,7 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			include : df.markSet.e
 			include : VBar.l df.leftSB 0 XH df.mvs
 
-			# Combination of nShoulderKnots and the straight 2 shape
+			# Combination of nShoulder.knots and the straight 2 shape
 			local fine : df.mvs * (ShoulderFine / Stroke)
 			local left : Math.max (df.rightSB - [HSwToV df.mvs] - jut) df.middle
 			include : dispiro
@@ -303,7 +298,7 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 					include : composite-proc sf.lb.outer
 
 			# Alternate straight 'n' form
-			# include : nShoulder
+			# include : nShoulder.shape
 			# 	left -- (df.leftSB + [HSwToV df.mvs])
 			# 	right -- df.rightSB
 			# 	top -- XH
@@ -320,13 +315,12 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 		create-glyph 'armn/seh' 0x57D : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.e
-			include : nShoulder
-				top -- 0
-				bottom -- (-XH)
-				left -- (df.leftSB + [HSwToV df.mvs])
-				right -- df.rightSB
+			include : uBowl.shape
+				top -- XH
+				bottom -- 0
+				left -- df.leftSB
+				right -- (df.rightSB - [HSwToV df.mvs])
 				stroke -- df.mvs
-			include : FlipAround df.middle 0
 			include : VBar.r df.rightSB 0 XH df.mvs
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH 0
@@ -338,13 +332,12 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 		create-glyph 'armn/vew' 0x57E : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.bp
-			include : nShoulder
-				top -- 0
-				bottom -- (-XH)
-				left -- (df.leftSB + [HSwToV df.mvs])
-				right -- df.rightSB
+			include : uBowl.shape
+				top -- XH
+				bottom -- 0
+				left -- df.leftSB
+				right -- (df.rightSB - [HSwToV df.mvs])
 				stroke -- df.mvs
-			include : FlipAround df.middle 0
 			include : VBar.r df.rightSB Descender Ascender df.mvs
 			include : [ArmHBar.right df 0 SLAB].desc
 
@@ -357,14 +350,13 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 		create-glyph 'armn/tiun' 0x57F : glyph-proc
 			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.e
-			include : nShoulder
+			include : uBowl.shape
 				top -- XH
 				bottom -- 0
-				left -- (df.middle + [HSwToV : df.mvs / 2])
-				right -- df.rightSB
+				left -- df.leftSB
+				right -- (df.middle - [HSwToV : 0.5 * df.mvs])
 				stroke -- df.mvs
-			include : FlipAround df.middle (XH / 2)
-			include : nShoulder
+			include : nShoulder.shape
 				top -- XH
 				bottom -- 0
 				left -- (df.middle + [HSwToV : df.mvs / 2])
@@ -381,7 +373,7 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 		create-glyph 'armn/reh' 0x580 : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.b
-			include : nShoulder
+			include : nShoulder.shape
 				top -- XH
 				bottom -- 0
 				left -- (df.leftSB + [HSwToV df.mvs])
@@ -398,14 +390,13 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 		create-glyph 'armn/piur' 0x583 : glyph-proc
 			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.bp
-			include : nShoulder
+			include : uBowl.shape
 				top -- XH
 				bottom -- 0
-				left -- (df.middle + [HSwToV : df.mvs / 2])
-				right -- df.rightSB
+				left -- df.leftSB
+				right -- (df.middle - [HSwToV : 0.5 * df.mvs])
 				stroke -- df.mvs
-			include : FlipAround df.middle (XH / 2)
-			include : nShoulder
+			include : nShoulder.shape
 				top -- XH
 				bottom -- 0
 				left -- (df.middle + [HSwToV : df.mvs / 2])
@@ -424,13 +415,12 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 		create-glyph 'armn/ew' 0x587 : glyph-proc
 			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.b
-			include : nShoulder
-				top -- 0
-				bottom -- (-Ascender)
-				left -- (df.middle + [HSwToV : df.mvs / 2])
-				right -- df.rightSB
+			include : uBowl.shape
+				top -- Ascender
+				bottom -- 0
+				left -- df.leftSB
+				right -- (df.middle - [HSwToV : 0.5 * df.mvs])
 				stroke -- df.mvs
-			include : FlipAround df.middle 0
 			include : VBar.m df.middle 0 XH df.mvs
 			include : HBar.b df.middle df.rightSB 0 df.mvs
 			if SLAB : begin

--- a/packages/font-glyphs/src/letter/armenian/to.ptl
+++ b/packages/font-glyphs/src/letter/armenian/to.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Letter-Armenian-To : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : nShoulderKnots SerifFrame
+	glyph-block-import Letter-Shared-Shapes : nShoulder SerifFrame
 	glyph-block-import Letter-Armenian-Shared-Shapes : ArmHBar
 
 	# Common Params
@@ -45,7 +45,7 @@ glyph-block Letter-Armenian-To : begin
 			include : VBar.l df.leftSB Descender XH df.mvs
 			local barPosT : XH / 2 + df.mvs / 2
 			include : dispiro
-				nShoulderKnots
+				nShoulder.knots
 					left -- (df.leftSB + [HSwToV df.mvs])
 					right -- df.rightSB
 					top -- XH

--- a/packages/font-glyphs/src/letter/cyrillic/che.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/che.ptl
@@ -10,7 +10,7 @@ glyph-block Letter-Cyrillic-Che : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared : CreateSelectorVariants DefineSelectorGlyph CreateTurnedLetter
-	glyph-block-import Letter-Shared-Shapes : SerifFrame RightwardTailedBar DToothlessRise
+	glyph-block-import Letter-Shared-Shapes : cheBowl SerifFrame RightwardTailedBar DToothlessRise
 	glyph-block-import Letter-Shared-Shapes : TopHook CyrDescender BottomExtension
 	glyph-block-import Letter-Latin-Lower-M : EarlessCornerDoubleArchSmallMShape
 
@@ -38,12 +38,12 @@ glyph-block Letter-Cyrillic-Che : begin
 			[Just BODY.TAILED] : RightwardTailedBar df.rightSB 0 top (sw -- sw)
 			__                 : VBar.r df.rightSB 0 top sw
 
-		include : dispiro
-			widths.lhs sw
-			flat df.leftSB top [heading Downward]
-			curl df.leftSB (bar - DToothlessRise + ArchDepthB - HalfStroke)
-			arch.lhs.centerAt.ltr.b df.middle (bar - DToothlessRise - HalfStroke)
-			g4 (df.rightSB - 1 / 16) (bar - HalfStroke) [heading Rightward]
+		include : cheBowl.shape
+			left -- df.leftSB
+			right -- df.rightSB
+			top -- top
+			bottom -- (bar - DToothlessRise - 0.5 * sw)
+			sw -- sw
 
 		local sf : SerifFrame.fromDf df top 0
 		include : tagged 'serifLT' : match slabType
@@ -252,7 +252,7 @@ glyph-block Letter-Cyrillic-Che : begin
 			include [refer-glyph "cyrl/Shha.\(suffix)"] AS_BASE ALSO_METRICS
 			eject-contour 'strokeR'
 			eject-contour 'serifRB'
-			include : TopHook.lBarInner SB 0 CAP
+			include : TopHook.toRight.lBarInner SB 0 CAP
 			include : LeaningAnchor.Above.VBar.l SB
 
 	select-variant 'cyrl/Shha' 0x4BA (follow -- 'H')

--- a/packages/font-glyphs/src/letter/cyrillic/tshe.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/tshe.ptl
@@ -20,7 +20,7 @@ glyph-block Letter-Cyrillic-Tshe : begin
 		local xTopBarRightSym : 2 * left + [HSwToV sw] - xTopBarLeft
 		local xTopBarRight : Math.max xTopBarRightSym : mix left RightSB 0.475
 
-		include : nShoulder
+		include : nShoulder.shape
 			left -- (left + [HSwToV sw])
 			right -- right
 			top -- [Math.min XH : if SLAB (CAP - 1.25 * VJut) XH]

--- a/packages/font-glyphs/src/letter/greek/pi.ptl
+++ b/packages/font-glyphs/src/letter/greek/pi.ptl
@@ -9,7 +9,7 @@ glyph-block Letter-Greek-Pi : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarLeft BBBarRight
-	glyph-block-import Letter-Shared-Shapes : RightwardTailedBar SerifFrame nShoulder
+	glyph-block-import Letter-Shared-Shapes : RightwardTailedBar SerifFrame
 	glyph-block-import Letter-Shared-Shapes : CyrDescender MidHook
 
 	glyph-block-export PiShape

--- a/packages/font-glyphs/src/letter/latin-ext/hwair.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/hwair.ptl
@@ -9,8 +9,7 @@ glyph-block Letter-Latin-Hwair : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Adjustment : LeaningAnchor
-	glyph-block-import Letter-Shared-Shapes : nShoulderKnots
-	glyph-block-import Letter-Shared-Shapes : SerifFrame
+	glyph-block-import Letter-Shared-Shapes : nShoulder SerifFrame
 
 	define Variants : object
 		straightSerifless      { false false }
@@ -24,7 +23,7 @@ glyph-block Letter-Latin-Hwair : begin
 			include : LeaningAnchor.Above.VBar.l df.leftSB
 			include : VBar.l df.leftSB 0 Ascender df.mvs
 			include : dispiro
-				nShoulderKnots (df.leftSB + [HSwToV df.mvs]) (df.middle + [HSwToV : 0.5 * df.mvs]) (df.mvs * 0.4) nothing (XH * 0.51) (SmallArchDepthA * 0.6 * df.div) (SmallArchDepthB * 0.6 * df.div) df.mvs
+				nShoulder.knots (df.leftSB + [HSwToV df.mvs]) (df.middle + [HSwToV : 0.5 * df.mvs]) (df.mvs * 0.4) nothing (XH * 0.51) (SmallArchDepthA * 0.6 * df.div) (SmallArchDepthB * 0.6 * df.div) df.mvs
 				flat (df.middle + [HSwToV : 0.5 * df.mvs]) (XH * 0.5) [heading Downward]
 				curl (df.middle + [HSwToV : 0.5 * df.mvs]) (SmallArchDepthB * 0.6 * df.div)
 				arcvh

--- a/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
@@ -10,7 +10,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared : CreateTurnedLetter
-	glyph-block-import Letter-Shared-Shapes : nShoulder OBarLeft
+	glyph-block-import Letter-Shared-Shapes : OBarLeft
 	glyph-block-import Letter-Latin-Lower-M : MEnoughSpaceForFullSerifs dfM
 
 	glyph-block-export SubDfAndShift

--- a/packages/font-glyphs/src/letter/latin-ext/middle-welsh-v.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/middle-welsh-v.ptl
@@ -8,7 +8,6 @@ glyph-module
 glyph-block Letter-Latin-Middle-Welsh-V : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : nShoulderKnots
 
 	define [MiddleWelshVShape top pL pR] : glyph-proc
 		include : dispiro

--- a/packages/font-glyphs/src/letter/latin/c.ptl
+++ b/packages/font-glyphs/src/letter/latin/c.ptl
@@ -121,7 +121,7 @@ glyph-block Letter-Latin-C : begin
 		export : define [revTopSerif] : AutoStartSerifL df sty top hook sw
 		export : define [revBotSerif] : AutoStartSerifLB df styBot bot hook sw
 
-		export : define [hookTop] : TopHook.arcStart df.rightSB top hook (refSw -- sw)
+		export : define [hookTop] : TopHook.toRight.arcStart df.rightSB top hook (refSw -- sw)
 
 		# Used by Cyrillic Koppa
 		export : define [baseTopOnly] : CShapeT dispiro 0 df sty SLAB-NONE top bot ada adb hook sw ob

--- a/packages/font-glyphs/src/letter/latin/k.ptl
+++ b/packages/font-glyphs/src/letter/latin/k.ptl
@@ -324,7 +324,7 @@ glyph-block Letter-Latin-K : begin
 					DiagTail.F 1 xDTEnd 0 dtInnerRadius tailAngle (Hook + swDiagTail / 4) swDiagTail
 				CursiveLoopT spiro-outline (-O) left right stroke top slabLT slabLegs
 
-	define [KHookTopBar xBarLeft] : TopHook.lBarInner
+	define [KHookTopBar xBarLeft] : TopHook.toRight.lBarInner
 		x -- xBarLeft
 		yBot -- 0
 		yTop -- Ascender

--- a/packages/font-glyphs/src/letter/latin/lower-b.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-b.ptl
@@ -71,7 +71,7 @@ glyph-block Letter-Latin-Lower-B : begin
 		if [not doTS] : create-glyph "bHookTop.\(suffix)" : glyph-proc
 			include : MarkSet.b
 			include : Body XH
-			include : TopHook.lBarInner SB (XH / 2) Ascender
+			include : TopHook.toRight.lBarInner SB (XH / 2) Ascender
 			include : Serifs
 			include : LeaningAnchor.Above.VBar.l SB
 

--- a/packages/font-glyphs/src/letter/latin/lower-d.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-d.ptl
@@ -119,7 +119,7 @@ glyph-block Letter-Latin-Lower-D : begin
 			local df : DivFrame 1
 			include : df.markSet.b
 			include : Body df (Ascender - Hook - HalfStroke)
-			include : TopHook.rBarInner df.rightSB (XH / 2) Ascender
+			include : TopHook.toRight.rBarInner df.rightSB (XH / 2) Ascender
 			if bottomSerif : include : bottomSerif df Ascender
 			include : LeaningAnchor.Above.VBar.r df.rightSB
 

--- a/packages/font-glyphs/src/letter/latin/lower-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-g.ptl
@@ -206,7 +206,7 @@ glyph-block Letter-Latin-Lower-G : begin
 	select-variant 'g/hookTopBase' (shapeFrom -- 'g')
 	derive-glyphs 'gHookTop' 0x260 "g/hookTopBase" : function [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
-		include : TopHook.rBarOuter RightSB 0 XH
+		include : TopHook.toRight.rBarOuter RightSB 0 XH
 		include : LeaningAnchor.Above.VBar.r RightSB
 
 	create-glyph 'gScriptCrossedTail' 0xAB36 : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/lower-h.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-h.ptl
@@ -12,7 +12,7 @@ glyph-block Letter-Latin-Lower-H : begin
 	glyph-block-import Mark-Above : aboveMarkMid
 	glyph-block-import Mark-Below : belowMarkMid
 	glyph-block-import Mark-Adjustment : LeaningAnchor
-	glyph-block-import Letter-Shared-Shapes : RightwardTailedBar nShoulder nShoulderMask CyrDescender
+	glyph-block-import Letter-Shared-Shapes : RightwardTailedBar nShoulder CyrDescender
 	glyph-block-import Letter-Shared-Shapes : TopHook PalatalHook EngHook RetroflexHook
 
 	define [SmallHSerifs tailed hookTop] : glyph-proc : begin
@@ -60,7 +60,7 @@ glyph-block Letter-Latin-Lower-H : begin
 			include : MarkSet.b
 			include : LeaningAnchor.Above.VBar.l SB
 			include : VBar.l SB 0 Ascender
-			include : nShoulder
+			include : nShoulder.shape
 				left -- (SB + [HSwToV Stroke])
 				right -- RightSB
 				bottom -- [if fTailed (XH - SmallArchDepthB + O) 0]
@@ -74,8 +74,8 @@ glyph-block Letter-Latin-Lower-H : begin
 		create-glyph "hHookTop.\(suffix)" : glyph-proc
 			include : MarkSet.b
 			include : LeaningAnchor.Above.VBar.l SB
-			include : TopHook.lBarInner SB 0 Ascender
-			include : nShoulder
+			include : TopHook.toRight.lBarInner SB 0 Ascender
+			include : nShoulder.shape
 				left -- (SB + [HSwToV Stroke])
 				right -- RightSB
 				bottom -- [if fTailed (XH - SmallArchDepthB + O) 0]
@@ -87,7 +87,7 @@ glyph-block Letter-Latin-Lower-H : begin
 				include : MarkSet.bp
 				include : LeaningAnchor.Above.VBar.l SB
 				include : VBar.l SB 0 Ascender
-				include : nShoulder
+				include : nShoulder.shape
 					left -- (SB + [HSwToV Stroke])
 					right -- RightSB
 					bottom -- 0
@@ -101,8 +101,8 @@ glyph-block Letter-Latin-Lower-H : begin
 			create-glyph "hengHookTop.\(suffix)" : glyph-proc
 				include : MarkSet.bp
 				include : LeaningAnchor.Above.VBar.l SB
-				include : TopHook.lBarInner SB 0 Ascender
-				include : nShoulder
+				include : TopHook.toRight.lBarInner SB 0 Ascender
+				include : nShoulder.shape
 					left -- (SB + [HSwToV Stroke])
 					right -- RightSB
 					bottom -- 0
@@ -155,14 +155,14 @@ glyph-block Letter-Latin-Lower-H : begin
 		include : BBBarLeft df.leftSB 0 Ascender
 		include : union
 			HBar.b (df.rightSB - bbd) df.rightSB 0 bbs
-			nShoulder
+			nShoulder.shape
 				stroke -- bbs
 				left -- (df.leftSB + bbd + [HSwToV bbs])
 				right -- df.rightSB
 				fine -- ShoulderFine
 			intersection
 				VBar.r (df.rightSB - bbd) 0 XH bbs
-				nShoulderMask
+				nShoulder.mask
 					stroke -- bbs
 					left -- (df.leftSB + bbd + [HSwToV bbs] + 1)
 					right -- (df.rightSB - 1)

--- a/packages/font-glyphs/src/letter/latin/lower-j.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-j.ptl
@@ -130,7 +130,7 @@ glyph-block Letter-Latin-Lower-J : begin
 
 		create-glyph "dotlessjBarHookTop.\(suffix)" : glyph-proc
 			include [refer-glyph "dotlessjBar.\(suffix)"] AS_BASE ALSO_METRICS
-			include : TopHook.mBarOuter xMiddle (XH + O) XH
+			include : TopHook.toRight.mBarOuter xMiddle (XH + O) XH
 
 	select-variant 'dotlessj' 0x237
 

--- a/packages/font-glyphs/src/letter/latin/lower-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-m.ptl
@@ -9,7 +9,7 @@ glyph-block Letter-Latin-Lower-M : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Adjustment : LeaningAnchor
-	glyph-block-import Letter-Shared-Shapes : CurlyTail nShoulder nShoulderMask
+	glyph-block-import Letter-Shared-Shapes : CurlyTail nShoulder
 	glyph-block-import Letter-Shared-Shapes : RightwardTailedBar DToothlessRise DMBlend MidHook
 	glyph-block-import Letter-Shared-Shapes : CyrDescender PalatalHook EngHook UpwardHookShape
 	glyph-block-import Letter-Shared-Shapes : SerifFrame
@@ -455,14 +455,14 @@ glyph-block Letter-Latin-Lower-M : begin
 		include : BBBarLeft df.leftSB 0 XH (bbd -- bbd) (bbs -- bbs)
 		include : union
 			HBar.b (xMid - bbd) xMid 0 bbs
-			nShoulder
+			nShoulder.shape
 				stroke -- bbs
 				left -- (df.leftSB + bbd + [HSwToV bbs])
 				right -- xMid
 				fine -- ShoulderFine
 			intersection
 				VBar.r (xMid - bbd) 0 XH bbs
-				nShoulderMask
+				nShoulder.mask
 					stroke -- bbs
 					left -- (df.leftSB + bbd + [HSwToV bbs] + 1)
 					right -- (xMid - 1)
@@ -470,7 +470,7 @@ glyph-block Letter-Latin-Lower-M : begin
 					fine -- ShoulderFine
 		include : union
 			HBar.b (df.rightSB - bbd) df.rightSB 0 bbs
-			nShoulder
+			nShoulder.shape
 				leftY0 -- 0
 				stroke -- bbs
 				left -- xMid
@@ -478,7 +478,7 @@ glyph-block Letter-Latin-Lower-M : begin
 				fine -- ShoulderFine
 			intersection
 				VBar.r (df.rightSB - bbd) 0 XH bbs
-				nShoulderMask
+				nShoulder.mask
 					stroke -- bbs
 					left -- (xMid + 1)
 					right -- (df.rightSB - 1)

--- a/packages/font-glyphs/src/letter/latin/lower-n.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-n.ptl
@@ -11,7 +11,7 @@ glyph-block Letter-Latin-Lower-N : begin
 	glyph-block-import Mark-Shared-Metrics : markHalfStroke
 	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared : CreateAccentedComposition
-	glyph-block-import Letter-Shared-Shapes : CurlyTail nShoulder nShoulderKnots nShoulderMask
+	glyph-block-import Letter-Shared-Shapes : CurlyTail nShoulder
 	glyph-block-import Letter-Shared-Shapes : RightwardTailedBar DToothlessRise DMBlend MidHook
 	glyph-block-import Letter-Shared-Shapes : CyrDescender PalatalHook RetroflexHook EngHook
 	glyph-block-import Letter-Shared-Shapes : SerifFrame
@@ -48,7 +48,7 @@ glyph-block Letter-Latin-Lower-N : begin
 
 	define [EaredBody top left right yBR sw] : glyph-proc
 		include : VBar.l left 0 top sw
-		include : nShoulder
+		include : nShoulder.shape
 			left -- (left + [HSwToV sw])
 			right -- right
 			top -- top
@@ -336,14 +336,14 @@ glyph-block Letter-Latin-Lower-N : begin
 		local bbd BBD
 		include : BBBarLeft df.leftSB 0 XH
 		include : HBar.b (df.rightSB - bbd) df.rightSB 0 bbs
-		include : nShoulder
+		include : nShoulder.shape
 			stroke -- bbs
 			left -- (df.leftSB + bbd + [HSwToV bbs])
 			right -- df.rightSB
 			fine -- ShoulderFine
 		include : intersection
 			VBar.r (df.rightSB - bbd) 0 XH bbs
-			nShoulderMask
+			nShoulder.mask
 				stroke -- bbs
 				left -- (df.leftSB + bbd + [HSwToV bbs] + 1)
 				right -- (df.rightSB - 1)

--- a/packages/font-glyphs/src/letter/latin/lower-p.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-p.ptl
@@ -142,7 +142,7 @@ glyph-block Letter-Latin-Lower-P : begin
 		include [refer-glyph src] AS_BASE ALSO_METRICS
 		eject-contour 'serifLT'
 		eject-contour 'stemLeft'
-		include : TopHook.lBarOuter SB Descender XH
+		include : TopHook.toRight.lBarOuter SB Descender XH
 		include : LeaningAnchor.Above.VBar.l SB
 
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarLeft

--- a/packages/font-glyphs/src/letter/latin/lower-q.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-q.ptl
@@ -107,7 +107,7 @@ glyph-block Letter-Latin-Lower-Q : begin
 	derive-glyphs 'qHookTop' 0x2A0 "q/hookTopBase" : function [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
 		include : VBar.r RightSB 0 XH
-		include : TopHook.rBarOuter RightSB 0 XH
+		include : TopHook.toRight.rBarOuter RightSB 0 XH
 		include : LeaningAnchor.Above.VBar.r RightSB
 
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarRight

--- a/packages/font-glyphs/src/letter/latin/lower-t.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-t.ptl
@@ -250,7 +250,7 @@ glyph-block Letter-Latin-Lower-T : begin
 
 			include : union
 				difference [Style.Body df sym top 0] [MaskAbove XH]
-				TopHook.mBarInner attach.x XH Ascender
+				TopHook.toRight.mBarInner attach.x XH Ascender
 
 		create-glyph "tLTail.\(suffix)" : glyph-proc
 			set-width df.width
@@ -273,7 +273,7 @@ glyph-block Letter-Latin-Lower-T : begin
 			include : df.markSet.bp
 			include : Style.Retroflex df sym XH Descender
 			local attach : currentGlyph.gizmo.unapply currentGlyph.baseAnchors.hooktopAttach
-			include : TopHook.mBarInner attach.x XH Ascender
+			include : TopHook.toRight.mBarInner attach.x XH Ascender
 
 		create-glyph "tCurlyTail.\(suffix)" : glyph-proc
 			include : MarkSet.b

--- a/packages/font-glyphs/src/letter/latin/lower-y.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-y.ptl
@@ -12,7 +12,7 @@ glyph-block Letter-Latin-Lower-Y : begin
 	glyph-block-import Mark-Above : aboveMarkTop aboveMarkBot aboveMarkMid aboveMarkStack
 	glyph-block-import Mark-Below : belowMarkStack
 	glyph-block-import Letter-Shared : CreateAccentedComposition CreateTurnedLetter
-	glyph-block-import Letter-Shared-Shapes : nShoulder FlatHookDepth SerifFrame BeltOverlay TopHook
+	glyph-block-import Letter-Shared-Shapes : uBowl FlatHookDepth SerifFrame BeltOverlay TopHook
 
 	define SLAB-NONE           { false false false }
 	define SLAB-AUTO           { SLAB  SLAB  false }
@@ -342,14 +342,11 @@ glyph-block Letter-Latin-Lower-Y : begin
 	alias 'latn/lambdaStroke.curlyTailedTurnSerifless' null 'latn/lambdaStrokeFHT.curlyTurnSerifless'
 
 	define Cursive : namespace
-		export : define [Arc top bottom] : new-glyph : glyph-proc
-			include : nShoulder
-				top -- top
-				bottom -- bottom
-				left -- (SB + [HSwToV Stroke])
-				right -- RightSB
-				fine -- ShoulderFine
-			include : FlipAround Middle [mix bottom top 0.5]
+		export : define [Arc top bottom] : uBowl.shape
+			top -- top
+			bottom -- bottom
+			left -- SB
+			right -- (RightSB - [HSwToV Stroke])
 
 		export : define [Hook y0 bottom] : dispiro
 			widths.rhs
@@ -398,7 +395,7 @@ glyph-block Letter-Latin-Lower-Y : begin
 			include : MarkSet.p
 			include : Cursive.Arc XH 0
 			include : hookShape (XH - TailY - HalfStroke) Descender
-			include : TopHook.rBarInner RightSB 0 XH
+			include : TopHook.toRight.rBarInner RightSB 0 XH
 			include : Cursive.Serifs XH slabKind
 			eject-contour 'serifRT'
 

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -12,8 +12,8 @@ glyph-block Letter-Latin-U : begin
 	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared : CreateAccentedComposition
 	glyph-block-import Letter-Shared : SetGrekUpperTonos
-	glyph-block-import Letter-Shared-Shapes : nShoulder RightwardTailedBar DToothlessRise SerifFrame
-	glyph-block-import Letter-Shared-Shapes : CyrDescender CyrTailDescender RetroflexHook VerticalHook
+	glyph-block-import Letter-Shared-Shapes : uBowl RightwardTailedBar DToothlessRise SerifFrame
+	glyph-block-import Letter-Shared-Shapes : CyrDescender CyrTailDescender RetroflexHook VerticalHook TopHook
 
 	glyph-block-export UShape USerifs
 
@@ -39,32 +39,30 @@ glyph-block Letter-Latin-U : begin
 	define [UShapeGroup ada adb] : namespace
 		export : define [Toothed df top sw fHookLeft fShortLeg] : glyph-proc
 			set-base-anchor 'trailing' df.rightSB 0
-			include : nShoulder
-				top -- top
-				bottom -- [if fHookLeft (TailY + HalfStroke) 0]
-				left -- (df.leftSB + [HSwToV sw])
-				right -- df.rightSB
+			include : uBowl.shape
+				top -- (top - [if fHookLeft (TailY + HalfStroke) 0])
+				bottom -- 0
+				left -- df.leftSB
+				right -- (df.rightSB - [HSwToV sw])
 				stroke -- sw
 				fine -- ShoulderFine
 				ada -- ada
 				adb -- adb
-			if fHookLeft : include : RetroflexHook.rExt df.rightSB (TailY + HalfStroke) (sw -- sw)
-			include : FlipAround df.middle (top / 2)
+			if fHookLeft : include : TopHook.toLeft.lBarInner df.leftSB (adb + TINY) top (sw -- sw)
 			include : tagged 'strokeR' : VBar.r df.rightSB 0 [if fShortLeg [mix ada top 0.5] top] sw
 
 		export : define [Tailed df top sw fHookLeft fShortLeg] : glyph-proc
 			set-base-anchor 'trailing' (df.rightSB + SideJut) 0
-			include : nShoulder
-				top -- top
-				bottom -- [if fHookLeft (TailY + HalfStroke) 0]
-				left -- (df.leftSB + [HSwToV sw])
-				right -- df.rightSB
+			include : uBowl.shape
+				top -- (top - [if fHookLeft (TailY + HalfStroke) 0])
+				bottom -- 0
+				left -- df.leftSB
+				right -- (df.rightSB - [HSwToV sw])
 				stroke -- sw
 				fine -- ShoulderFine
 				ada -- ada
 				adb -- adb
-			if fHookLeft : include : RetroflexHook.rExt df.rightSB (TailY + HalfStroke) (sw -- sw)
-			include : FlipAround df.middle (top / 2)
+			if fHookLeft : include : TopHook.toLeft.lBarInner df.leftSB (adb + TINY) top (sw -- sw)
 			include : tagged 'strokeR' : RightwardTailedBar df.rightSB 0 [if fShortLeg [mix ada top 0.5] top] (sw -- sw)
 
 		export : define [ToothlessRounded df top sw fHookLeft fShortLeg] : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/upper-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-g.ptl
@@ -95,7 +95,7 @@ glyph-block Letter-Latin-Upper-G : begin
 		create-glyph "GHookTop.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : GShape shape SLAB-HOOK-TOP crossBarShape CAP ArchDepthA ArchDepthB
-			include : TopHook.arcStart RightSB CAP Hook
+			include : TopHook.toRight.arcStart RightSB CAP Hook
 			include : ExtendAboveBaseAnchors (CAP + Ascender - XH)
 			include : LeaningAnchor.Above.VBar.r RightSB
 		create-glyph "smcpG.\(suffix)" : glyph-proc
@@ -104,7 +104,7 @@ glyph-block Letter-Latin-Upper-G : begin
 		create-glyph "smcpGHookTop.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : GShape shape SLAB-HOOK-TOP crossBarShape XH ArchDepthA ArchDepthB
-			include : TopHook.arcStart RightSB XH Hook
+			include : TopHook.toRight.arcStart RightSB XH Hook
 			include : ExtendAboveBaseAnchors Ascender
 			include : LeaningAnchor.Above.VBar.r RightSB
 

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -230,37 +230,86 @@ glyph-block Letter-Shared-Shapes : begin
 			quadControls ((x1 - mid) / (x2 - mid)) 0 8
 			g4   x2 y2
 
-	glyph-block-export nShoulderKnots
-	define flex-params [nShoulderKnots] : begin
-		local-parameter : left
-		local-parameter : right
-		local-parameter : fine              -- ShoulderFine
-		local-parameter : top               -- XH
-		local-parameter : bottom            -- 0
-		local-parameter : ada               -- SmallArchDepthA
-		local-parameter : adb               -- SmallArchDepthB
-		local-parameter : stroke            -- Stroke
-		local-parameter : fMask             -- false
-		local-parameter : leftY0            -- nothing
+	glyph-block-export nShoulder
+	define nShoulder : namespace
+		export : define flex-params [knots] : begin
+			local-parameter : left
+			local-parameter : right
+			local-parameter : fine              -- ShoulderFine
+			local-parameter : top               -- XH
+			local-parameter : bottom            -- 0
+			local-parameter : ada               -- SmallArchDepthA
+			local-parameter : adb               -- SmallArchDepthB
+			local-parameter : stroke            -- Stroke
+			local-parameter : fMask             -- false
+			local-parameter : leftY0            -- nothing
 
-		return : list
-			flat (left - [HSwToV fine]) [fallback leftY0 (top - ada - 2)] [widths.rhs fine]
-			curl (left - [HSwToV fine]) (top - ada)
-			arch.rhs top (sw -- stroke) (swBefore -- fine)
-			flat right (top - adb) [widths.rhs stroke]
-			[if fMask corner curl] right bottom [widths.rhs.heading stroke Downward]
-			if [not fMask] {} {[corner left bottom]}
+			return : list
+				flat (left - [HSwToV fine]) [fallback leftY0 (top - ada - 2)] [widths.rhs fine]
+				curl (left - [HSwToV fine]) (top - ada)
+				arch.rhs top (sw -- stroke) (swBefore -- fine)
+				flat right (top - adb) [widths.rhs stroke]
+				[if fMask corner curl] right bottom [widths.rhs.heading stroke Downward]
+				if [not fMask] {} {[corner left bottom]}
 
-	glyph-block-export nShoulder nShoulderMask
-	define [nShoulder] : begin
-		local a : Array.prototype.slice.call arguments 0
-		glyph-proc
-			include : dispiro : nShoulderKnots.apply null a
+		export : define [shape] : begin
+			local a : Array.prototype.slice.call arguments 0
+			glyph-proc
+				include : dispiro : knots.apply null a
 
-	define [nShoulderMask] : begin
-		local a : Array.prototype.slice.call arguments 0
-		glyph-proc
-			include : spiro-outline : nShoulderKnots.apply null [a.concat { (fMask -- true) }]
+		export : define [mask] : begin
+			local a : Array.prototype.slice.call arguments 0
+			glyph-proc
+				include : spiro-outline : knots.apply null [a.concat { (fMask -- true) }]
+
+	glyph-block-export uBowl
+	define uBowl : namespace
+		export : define flex-params [knots] : begin
+			local-parameter : left
+			local-parameter : right
+			local-parameter : fine              -- ShoulderFine
+			local-parameter : top               -- XH
+			local-parameter : bottom            -- 0
+			local-parameter : ada               -- SmallArchDepthA
+			local-parameter : adb               -- SmallArchDepthB
+			local-parameter : stroke            -- Stroke
+			local-parameter : fMask             -- false
+			local-parameter : rightY0           -- (bottom + ada + TINY)
+
+			return : list
+				flat (right + [HSwToV fine]) rightY0 [widths.rhs fine]
+				curl (right + [HSwToV fine]) (bottom + ada)
+				arch.rhs bottom (sw -- stroke) (swBefore -- fine)
+				flat left (bottom + adb) [widths.rhs stroke]
+				[if fMask corner curl] left top [widths.rhs.heading stroke Upward]
+				if fMask {[corner right top]} {}
+		export : define [shape] : begin
+			local a : Array.prototype.slice.call arguments 0
+			glyph-proc
+				include : dispiro : knots.apply null a
+		export : define [mask] : begin
+			local a : Array.prototype.slice.call arguments 0
+			glyph-proc
+				include : spiro-outline : knots.apply null [a.concat { (fMask -- true) }]
+
+	glyph-block-export cheBowl
+	define cheBowl : namespace
+		export : define flex-params [shape] : begin
+			local-parameter : left
+			local-parameter : right
+			local-parameter : top
+			local-parameter : bottom
+			local-parameter : adb       -- ArchDepthB
+			local-parameter : sw      	-- Stroke
+
+			define xMid : mix left right 0.5
+			define rise   DToothlessRise
+
+			return : dispiro
+				flat left top [widths.lhs.heading sw Downward]
+				curl left (bottom+ adb)
+				arch.lhs.centerAt.ltr.b (xMid + [HSwToV : 0.2 * sw]) bottom
+				g4 right (bottom + rise + 0.25 * sw)
 
 	glyph-block-export : OBarLeft
 	define OBarLeft : namespace
@@ -913,7 +962,7 @@ glyph-block Letter-Shared-Shapes : begin
 		glyph-block-export MidHook
 		define MidHook : namespace
 			export : define [general] : with-params [left right top [bottom 0] ada adb [sw Stroke] [xDepth (-HookX)]] : composite-proc
-				nShoulder
+				nShoulder.shape
 					left -- left
 					right -- right
 					top -- top
@@ -945,37 +994,48 @@ glyph-block Letter-Shared-Shapes : begin
 		# Upward hook shape
 		glyph-block-export TopHook
 		define TopHook : namespace
-			export : define [lBarOuter] : with-params [x yBot yTop [sw Stroke]] : glyph-proc
-				local fullDepth : (Ascender - XH) - 0.5 * sw - O
-				local yHookStart : yTop + (fullDepth - TailY)
-				include : ExtendAboveBaseAnchors (yTop + (Ascender - XH))
-				include : union
-					VBar.l x yBot yHookStart sw
-					VerticalHook.l x yHookStart TailX (-TailY) (sw -- sw)
+			define [ward sign] : namespace
+				# Reference point at a bar's left edge, hook placed above yTop
+				export : define [lBarOuter] : with-params [x yBot yTop [sw Stroke]] : glyph-proc
+					local fullDepth : (Ascender - XH) - 0.5 * sw - O
+					local yHookStart : yTop + (fullDepth - TailY)
+					include : ExtendAboveBaseAnchors (yTop + (Ascender - XH))
+					include : union
+						VBar.l x yBot yHookStart sw
+						VerticalHook.l x yHookStart (sign * TailX) (-TailY) (sw -- sw)
 
-			export : define [lBarInner] : with-params [x yBot yTop [sw Stroke]] : glyph-proc
-				local yHookStart : yTop - O - TailY - 0.5 * sw
-				include : union
-					VBar.l x yBot yHookStart sw
-					VerticalHook.l x yHookStart TailX (-TailY) (sw -- sw)
+				# Reference point at a bar's left edge, hook placed below yTop
+				export : define [lBarInner] : with-params [x yBot yTop [sw Stroke]] : glyph-proc
+					local yHookStart : yTop - O - TailY - 0.5 * sw
+					include : union
+						VBar.l x yBot yHookStart sw
+						VerticalHook.l x yHookStart (sign * TailX) (-TailY) (sw -- sw)
 
-			export : define [rBarOuter] : with-params [x yBot yTop [sw Stroke]] : begin
-				return : lBarOuter (x - [HSwToV sw]) yBot yTop (sw -- sw)
-			export : define [rBarInner] : with-params [x yBot yTop [sw Stroke]] : begin
-				return : lBarInner (x - [HSwToV sw]) yBot yTop (sw -- sw)
+				# Reference point at a bar's right edge, hook placed above yTop
+				export : define [rBarOuter] : with-params [x yBot yTop [sw Stroke]] : begin
+					return : lBarOuter (x - [HSwToV sw]) yBot yTop (sw -- sw)
+				# Reference point at a bar's right edge, hook placed below yTop
+				export : define [rBarInner] : with-params [x yBot yTop [sw Stroke]] : begin
+					return : lBarInner (x - [HSwToV sw]) yBot yTop (sw -- sw)
 
-			export : define [mBarOuter] : with-params [x yBot yTop [sw Stroke]] : begin
-				return : lBarOuter (x - [HSwToV : 0.5 * sw]) yBot yTop (sw -- sw)
-			export : define [mBarInner] : with-params [x yBot yTop [sw Stroke]] : begin
-				return : lBarInner (x - [HSwToV : 0.5 * sw]) yBot yTop (sw -- sw)
+				# Reference point at a bar's centerline, hook placed above yTop
+				export : define [mBarOuter] : with-params [x yBot yTop [sw Stroke]] : begin
+					return : lBarOuter (x - [HSwToV : 0.5 * sw]) yBot yTop (sw -- sw)
+				# Reference point at a bar's centerline, hook placed below yTop
+				export : define [mBarInner] : with-params [x yBot yTop [sw Stroke]] : begin
+					return : lBarInner (x - [HSwToV : 0.5 * sw]) yBot yTop (sw -- sw)
 
-			export : define [arcStart] : with-params [cx cy hookY [refSw Stroke]] : begin
-				local sw : ArcStartSerifWidth refSw
-				local fullDepth : (Ascender - XH) - 0.5 * sw - O
-				local yHookStart : cy + (fullDepth - TailY)
-				return : union
-					VBar.r cx (cy - hookY + O * 2) yHookStart sw
-					VerticalHook.r cx yHookStart TailX (-TailY) sw
+				# Special case for arc-start shapes
+				export : define [arcStart] : with-params [cx cy hookY [refSw Stroke]] : begin
+					local sw : ArcStartSerifWidth refSw
+					local fullDepth : (Ascender - XH) - 0.5 * sw - O
+					local yHookStart : cy + (fullDepth - TailY)
+					return : union
+						VBar.r cx (cy - hookY + O * 2) yHookStart sw
+						VerticalHook.r cx yHookStart (sign * TailX) (-TailY) sw
+
+			export : define toLeft : ward (-1)
+			export : define toRight : ward (+1)
 
 		# Leftward hook
 		glyph-block-export LeftHook


### PR DESCRIPTION
In this change...

 * Added a new function `[uBowl]` in the shared letter shapes to construct the bowl shape of toothed `u`. No longer need to use `FlipAround`.
 * Added a new function `[cheBowl]` for the bowl shape used in Ч / ч. This will slightly improve its visual in thick weights.