### PR TITLE
Optimize glyphs for `Ի`/`Կ`/`Վ` (Armenian).

### DIFF
--- a/changes/32.0.2.md
+++ b/changes/32.0.2.md
@@ -1,2 +1,5 @@
+* Optimize glyphs for Armenian Capital Ini (`U+053B`), Ken (`U+053F`), and Vew (`U+054E`).
+* Remove bottom-right serif from Armenian Capital Now (`U+0546`).
+* Remove top-right serif from Armenian Lower Ben (`U+0562`).
 * Make serif of Armenian Lower Yi (`U+0575`) consistent with Armenian Lower Liwn (`U+056C`).
 * Make hook of Armenian Lower Co (`U+0581`) consistent with Armenian Lower Yi (`U+0575`).

--- a/packages/font-glyphs/src/letter/armenian/ca.ptl
+++ b/packages/font-glyphs/src/letter/armenian/ca.ptl
@@ -51,6 +51,10 @@ glyph-block Letter-Armenian-Ca : begin
 			local x3 : mix df.leftSB df.rightSB 0.1
 			local x4 : mix df.leftSB df.rightSB 0.6
 
+			local rExt : Math.max df.rightSB : Math.min
+				x4 + [HSwToV : 1.5 * df.mvs] + jut
+				df.rightSB + jut - [HSwToV : 0.5 * df.mvs]
+
 			include : intersection [MaskBelowLine (x1 - xOffset) Ascender (x2 - xOffset) y2 100] : dispiro
 				widths.rhs df.mvs
 				flat (x3 + xOffset) Ascender
@@ -62,4 +66,4 @@ glyph-block Letter-Armenian-Ca : begin
 				curl (df.leftSB + OX) (highBarPos - SmallArchDepthA)
 				arcvh
 				flat df.middle highBarPos
-				curl (df.rightSB + jut - [HSwToV : 0.5 * df.mvs]) highBarPos
+				curl rExt highBarPos

--- a/packages/font-glyphs/src/letter/armenian/hook-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/hook-group.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Letter-Armenian-Hook-Group : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : SerifFrame
+	glyph-block-import Letter-Shared-Shapes : nShoulder uBowl SerifFrame
 	glyph-block-import Letter-Armenian-Shared-Shapes : ArmHBar LeftHook RightHook
 
 	do "Ben"
@@ -47,7 +47,14 @@ glyph-block Letter-Armenian-Hook-Group : begin
 		create-glyph 'armn/Ini' 0x53B : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.capital
-			include : RightHook df XH df.mvs
+			include : nShoulder.shape
+				left -- (df.leftSB + [HSwToV df.mvs])
+				right -- df.rightSB
+				top -- XH
+				bottom -- (XH / 2)
+				ada -- ArchDepthA
+				adb -- ArchDepthB
+				stroke -- df.mvs
 			include : VBar.l df.leftSB 0 CAP
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df CAP 0
@@ -58,13 +65,14 @@ glyph-block Letter-Armenian-Hook-Group : begin
 			local df : include : DivFrame 1
 			include : df.markSet.capital
 			local midy : XH / 2 - df.mvs / 2
-			include : dispiro
-				widths.lhs df.mvs
-				flat df.leftSB CAP [heading Downward]
-				curl df.leftSB (midy + ArchDepthB)
-				arch.lhs midy (sw -- df.mvs)
-				flat df.rightSB (midy + ArchDepthA)
-				curl df.rightSB XH [heading Upward]
+			include : uBowl.shape
+				left -- df.leftSB
+				right -- (df.rightSB - [HSwToV df.mvs])
+				top -- CAP
+				bottom -- midy
+				ada -- ArchDepthA
+				adb -- ArchDepthB
+				stroke -- df.mvs
 			include : VBar.r df.rightSB 0 XH
 
 			if SLAB : begin
@@ -83,7 +91,7 @@ glyph-block Letter-Armenian-Hook-Group : begin
 		create-glyph 'armn/Nu' 0x546 : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.capital
-			include : LeftHook df CAP df.mvs SLAB SLAB
+			include : LeftHook df CAP df.mvs SLAB 0
 			include : FlipAround df.middle (CAP / 2)
 			include : [ArmHBar.left df 1 SLAB].top
 
@@ -101,13 +109,14 @@ glyph-block Letter-Armenian-Hook-Group : begin
 			local df : include : DivFrame 1
 			include : df.markSet.capital
 			local midy : XH / 2 - df.mvs / 2
-			include : dispiro
-				widths.lhs df.mvs
-				flat df.leftSB XH [heading Downward]
-				curl df.leftSB (midy + ArchDepthB)
-				arch.lhs midy (sw -- df.mvs)
-				flat df.rightSB (midy + ArchDepthA)
-				curl df.rightSB XH [heading Upward]
+			include : uBowl.shape
+				left -- df.leftSB
+				right -- (df.rightSB - [HSwToV df.mvs])
+				top -- XH
+				bottom -- midy
+				ada -- ArchDepthA
+				adb -- ArchDepthB
+				stroke -- df.mvs
 			include : VBar.r df.rightSB 0 CAP df.mvs
 			include : [ArmHBar.right df 1 SLAB].base
 

--- a/packages/font-glyphs/src/letter/armenian/lower-u-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/lower-u-group.ptl
@@ -58,9 +58,6 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH Descender
 				include : composite-proc sf.lt.outer sf.lb.fullSide
-				if [not para.isItalic] : begin
-					local sf2 : SerifFrame.fromDf df XH (XH / 2)
-					include sf2.rb.full
 
 	do "Da"
 		create-glyph 'armn/da' 0x564 : glyph-proc

--- a/packages/font-glyphs/src/letter/armenian/to.ptl
+++ b/packages/font-glyphs/src/letter/armenian/to.ptl
@@ -43,7 +43,7 @@ glyph-block Letter-Armenian-To : begin
 			local fine : df.adviceStroke2 6 3 XH
 			include : df.markSet.p
 			include : VBar.l df.leftSB Descender XH df.mvs
-			local barPosT : XH / 2 + df.mvs / 2
+			local barPosT : barPos + df.mvs / 2
 			include : dispiro
 				nShoulder.knots
 					left -- (df.leftSB + [HSwToV df.mvs])

--- a/packages/font-glyphs/src/letter/latin/lower-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-g.ptl
@@ -162,15 +162,15 @@ glyph-block Letter-Latin-Lower-G : begin
 			local df : include : DivFrame 1
 			include : df.markSet.p
 			set-base-anchor 'overlay' Middle (XH / 2)
-			set-base-anchor 'strike' Middle (XH / 2)
-			include : bodyShape df XH
+			set-base-anchor 'strike'  Middle (XH / 2)
+			include : bodyShape df  XH
 			include : hookShape df (XH - hookStart)
 
 		create-glyph "GScript.\(suffix)" : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.capDesc
 			set-base-anchor 'overlay' Middle (CAP / 2)
-			include : bodyShape df CAP
+			include : bodyShape df  CAP
 			include : hookShape df (CAP - hookStart)
 
 		create-glyph "gScriptPalatalHook.\(suffix)" : glyph-proc
@@ -178,7 +178,7 @@ glyph-block Letter-Latin-Lower-G : begin
 			include : df.markSet.p
 			set-base-anchor 'overlay' Middle (XH / 2)
 			local dfSub : DivFrame (0.75 * para.diversityM) 2
-			include : bodyShape dfSub XH
+			include : bodyShape dfSub  XH
 			include : hookShape dfSub (XH - hookStart)
 			include : PalatalHook.r
 				x -- df.rightSB
@@ -213,8 +213,8 @@ glyph-block Letter-Latin-Lower-G : begin
 		include : MarkSet.p
 		set-base-anchor 'overlay' Middle (XH / 2)
 		define df : DivFrame 1
-		include : SingleStorey.ScriptCutBody df XH
-		include : SingleStorey.CrossedHook df (XH - HalfStroke)
+		include : SingleStorey.ScriptCutBody df  XH
+		include : SingleStorey.CrossedHook   df (XH - HalfStroke)
 
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarRight
 	create-glyph 'mathbb/g' 0x1D558 : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/lower-j.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-j.ptl
@@ -87,11 +87,6 @@ glyph-block Letter-Latin-Lower-J : begin
 			include : Serifless df top xMiddle
 			include : LeaningAnchor.Above.At [mix df.middle xMiddle (7/8)]
 
-		export : define [AutoSerifed df top xMiddle] : glyph-proc
-			include : if SLAB
-				Serifed   df top xMiddle
-				Serifless df top xMiddle
-
 	define Div : namespace
 		export : define BentHook          1
 		export : define StraightSerifless para.diversityII

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -10,8 +10,7 @@ glyph-block Letter-Latin-U : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Shared-Metrics : markHalfStroke
 	glyph-block-import Mark-Adjustment : LeaningAnchor
-	glyph-block-import Letter-Shared : CreateAccentedComposition
-	glyph-block-import Letter-Shared : SetGrekUpperTonos
+	glyph-block-import Letter-Shared : CreateAccentedComposition SetGrekUpperTonos
 	glyph-block-import Letter-Shared-Shapes : uBowl RightwardTailedBar DToothlessRise SerifFrame
 	glyph-block-import Letter-Shared-Shapes : CyrDescender CyrTailDescender RetroflexHook VerticalHook TopHook
 
@@ -310,6 +309,7 @@ glyph-block Letter-Latin-U : begin
 	select-variant 'U/withTonos' (follow -- 'U')
 	link-reduced-variant 'U/sansSerif' 'U' MathSansSerif
 	select-variant 'smcpU' 0x1D1C (follow -- 'U')
+
 	select-variant 'u' 'u'
 	link-reduced-variant 'u/sansSerif' 'u' MathSansSerif
 	select-variant 'u/uRTailBase' (shapeFrom -- 'u')

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -242,10 +242,10 @@ glyph-block Letter-Shared-Shapes : begin
 			local-parameter : adb               -- SmallArchDepthB
 			local-parameter : stroke            -- Stroke
 			local-parameter : fMask             -- false
-			local-parameter : leftY0            -- nothing
+			local-parameter : leftY0            -- (top - ada - 2)
 
 			return : list
-				flat (left - [HSwToV fine]) [fallback leftY0 (top - ada - 2)] [widths.rhs fine]
+				flat (left - [HSwToV fine]) leftY0 [widths.rhs fine]
 				curl (left - [HSwToV fine]) (top - ada)
 				arch.rhs top (sw -- stroke) (swBefore -- fine)
 				flat right (top - adb) [widths.rhs stroke]
@@ -300,14 +300,14 @@ glyph-block Letter-Shared-Shapes : begin
 			local-parameter : top
 			local-parameter : bottom
 			local-parameter : adb       -- ArchDepthB
-			local-parameter : sw      	-- Stroke
+			local-parameter : sw        -- Stroke
 
 			define xMid : mix left right 0.5
 			define rise   DToothlessRise
 
 			return : dispiro
 				flat left top [widths.lhs.heading sw Downward]
-				curl left (bottom+ adb)
+				curl left (bottom + adb)
 				arch.lhs.centerAt.ltr.b (xMid + [HSwToV : 0.2 * sw]) bottom
 				g4 right (bottom + rise + 0.25 * sw)
 


### PR DESCRIPTION
Reopening of #2572 , now using `ubowl`.

```
 ԱԲԳԴԵԶԷԸԹԺԻԼԽԾԿ
ՀՁՂՃՄՅՆՇՈՉՊՋՌՍՎՏ
ՐՑՒՓՔՕՖ  ՙ՚՛՜՝՞◌՟
ՠաբգդեզէըթժիլխծկ
հձղճմյնշոչպջռսվտ
րցւփքօֆևֈ։֊  ֍֎֏
```

Sans Thin Upright:
![image](https://github.com/user-attachments/assets/d424b42a-9424-41ac-9eb5-b6156e0fb1dc)
Sans Regular Upright:
![image](https://github.com/user-attachments/assets/b5f7a5c1-e619-4aec-987c-43b014677210)
Sans Heavy Upright:
![image](https://github.com/user-attachments/assets/8196ad1e-5bd5-4def-aafd-56203cafe7c4)
Sans Thin Italic:
![image](https://github.com/user-attachments/assets/1e4e2392-55de-4eb7-b7df-254d3a44ee34)
Sans Regular Italic:
![image](https://github.com/user-attachments/assets/2ef3d974-236b-48d8-9e19-a2df8c5e83f9)
Sans Heavy Italic:
![image](https://github.com/user-attachments/assets/6816b91a-31b5-4aec-9643-0b256c948e8e)
Slab Thin Upright:
![image](https://github.com/user-attachments/assets/2051004f-328b-446f-bbdb-0d50374bbe31)
Slab Regular Upright:
![image](https://github.com/user-attachments/assets/6b6c1768-1392-494c-b676-a3d82aa13c82)
Slab Heavy Upright:
![image](https://github.com/user-attachments/assets/185b648a-1787-42dd-aded-d33f950fcf2e)
Slab Thin Italic:
![image](https://github.com/user-attachments/assets/0a02b7b4-b05e-495a-b9fa-a37d6e92d3b1)
Slab Regular Italic:
![image](https://github.com/user-attachments/assets/fa8dbcf6-b514-42aa-a0d5-7bede5369b97)
Slab Heavy Italic:
![image](https://github.com/user-attachments/assets/301532f0-8c65-4e2b-8819-baa31ede2106)
Aile Thin Upright:
![image](https://github.com/user-attachments/assets/5c3b28fe-015b-4954-a7dc-f36a914c1e50)
Aile Regular Upright:
![image](https://github.com/user-attachments/assets/9a0c551d-c982-45c1-812e-4728aa8af2ca)
Aile Heavy Upright:
![image](https://github.com/user-attachments/assets/6966253e-7f6c-49cf-a2de-ca143d683007)
Aile Thin Italic:
![image](https://github.com/user-attachments/assets/19a21f42-216f-4fb6-97bd-ff216ba62863)
Aile Regular Italic:
![image](https://github.com/user-attachments/assets/b18e667a-805e-4519-adb6-02b795dbe7f6)
Aile Heavy Italic:
![image](https://github.com/user-attachments/assets/8475d745-e7e1-4d94-9baa-dc74cab0beea)
Etoile Thin Upright:
![image](https://github.com/user-attachments/assets/bcec5e60-bc6f-4085-8cb8-d27e15c83922)
Etoile Regular Upright:
![image](https://github.com/user-attachments/assets/1d27764f-4384-46f3-91a5-cbac8f370b64)
Etoile Heavy Upright:
![image](https://github.com/user-attachments/assets/5d165caa-264c-4551-8b12-f4997d1bd0b7)
Etoile Thin Italic:
![image](https://github.com/user-attachments/assets/b42b3f21-5a36-4fd8-83ed-80a7140f24c7)
Etoile Regular Italic:
![image](https://github.com/user-attachments/assets/2be7aa39-0a94-4506-9877-82889fd3e13b)
Etoile Heavy Italic:
![image](https://github.com/user-attachments/assets/f4b9e3be-a655-44b9-a334-55d721aabc29)
