### PR TITLE
Improve consistency of combining parentheses' anchor points for overlines in Serbian localized forms.

### DIFF
--- a/packages/font-glyphs/src/letter/latin/lower-il.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-il.ptl
@@ -136,6 +136,7 @@ glyph-block Letter-Latin-Lower-I : begin
 
 	define Serifs : namespace
 		export : define [Hooky        df top xMiddle] : HSerif.lt xMiddle top (LongJut * df.div)                                         Stroke df.mvs
+		export : define [HookyShort   df top xMiddle] : HSerif.lt xMiddle top [mix Jut (LongJut * df.div) 0.5]                           Stroke df.mvs
 		export : define [Serifed      df top xMiddle] : HSerif.lt xMiddle top ((LongJut * df.div) - (xMiddle - df.middle))               Stroke df.mvs
 		export : define [SerifedShort df top xMiddle] : HSerif.lt xMiddle top [mix Jut ((LongJut * df.div) - (xMiddle - df.middle)) 0.5] Stroke df.mvs
 
@@ -158,6 +159,7 @@ glyph-block Letter-Latin-Lower-I : begin
 		'hooky'                 { Body.Serifless     Serifs.Hooky         Marks.Serifed    XMiddle.Hooky              para.diversityI   0      }
 		'hookyBottom'           { Body.HookyBottom   null                 Marks.Serifless  XMiddle.HookyBottom        para.diversityI   Stroke }
 		'zshaped'               { Body.HookyBottom   Serifs.Hooky         Marks.Serifed    XMiddle.Center             para.diversityI   Stroke }
+		'zshapedAsymmetric'     { Body.HookyBottom   Serifs.HookyShort    Marks.Serifed    XMiddle.Center             para.diversityI   Stroke }
 		'serifed'               { Body.Serifed       Serifs.Serifed       Marks.Serifed    XMiddle.Serifed            para.diversityI   Stroke }
 		'serifedAsymmetric'     { Body.Serifed       Serifs.SerifedShort  Marks.Serifed    XMiddle.Serifed            para.diversityI   Stroke }
 		'tailed'                { Body.Tailed        null                 Marks.Serifless  XMiddle.Tailed             para.diversityI   Stroke }
@@ -339,7 +341,7 @@ glyph-block Letter-Latin-Lower-I : begin
 		CreateTurnedLetter 'turnl' 0xA781 'l' HalfAdvance (XH / 2)
 		select-variant 'l/phoneticLeft' (shapeFrom -- 'l')
 		select-variant 'l/compLigRight' (shapeFrom -- 'l')
-		select-variant 'lDotBase' null (follow -- 'l')
+		select-variant 'lDotBase' (follow -- 'l')
 		select-variant 'lRTail' 0x26D (follow -- 'l/reduced/rtail')
 		select-variant 'llWelsh' 0x1EFB (follow -- 'l')
 		select-variant 'lPalatalHook' 0x1D85 (follow -- 'l')

--- a/packages/font-glyphs/src/letter/latin/lower-il.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-il.ptl
@@ -319,8 +319,8 @@ glyph-block Letter-Latin-Lower-I : begin
 		alias 'cyrl/Iota' 0xA646 'latn/Iota'
 
 		select-variant 'cyrl/ghe.SRB/base' (shapeFrom -- 'dotlessi') (follow -- 'cyrl/ghe.SRB')
-		CreateAccentedComposition      'cyrl/ghe.SRB' null 'cyrl/ghe.SRB/base'   'sbRsbOverlineAbove/diversityI'
-		CreateMultiAccentedComposition 'cyrl/gje.SRB' null 'cyrl/ghe.SRB/base' { 'sbRsbOverlineAbove/diversityI' 'acuteAbove' }
+		CreateAccentedComposition      'cyrl/ghe.SRB' null 'cyrl/ghe.SRB/base'   'cyrl/ghe.SRB/overlineAbove'
+		CreateMultiAccentedComposition 'cyrl/gje.SRB' null 'cyrl/ghe.SRB/base' { 'cyrl/ghe.SRB/overlineAbove' 'acuteAbove' }
 
 		CreateTurnedLetter 'turni' 0x1D09 'i' HalfAdvance (XH / 2)
 		CreateTurnedLetter 'grek/turniota' 0x2129 'latn/iota' HalfAdvance (XH / 2)

--- a/packages/font-glyphs/src/letter/latin/lower-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-m.ptl
@@ -440,8 +440,8 @@ glyph-block Letter-Latin-Lower-M : begin
 	select-variant 'cyrl/shcha/reduced.italic' (shapeFrom -- 'cyrl/shcha.italic') (follow -- 'cyrl/shcha.italic/reduced')
 	alias 'cyrl/shcha/reduced.BGR' null 'cyrl/shcha/reduced.italic'
 
-	derive-composites 'cyrl/te.SRB' null 'cyrl/sha.italic' 'sbRsbOverlineAbove/diversityM'
-	derive-composites 'cyrl/te/reduced.SRB' null 'cyrl/sha/reduced.italic' 'sbRsbOverlineAbove/diversityM'
+	derive-composites 'cyrl/te.SRB' null 'cyrl/sha.italic' 'cyrl/te.SRB/overlineAbove'
+	derive-composites 'cyrl/te/reduced.SRB' null 'cyrl/sha/reduced.italic' 'cyrl/te.SRB/overlineAbove'
 
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarLeft
 	create-glyph 'mathbb/m' 0x1D55E : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -350,7 +350,7 @@ glyph-block Letter-Latin-U : begin
 
 	derive-glyphs 'cyrl/pe.SRB' null 'cyrl/i.italic' : lambda [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
-		include [refer-glyph 'sbRsbOverlineAbove']
+		include [refer-glyph 'cyrl/pe.SRB/overlineAbove']
 
 	derive-glyphs 'cyrl/tetse.italic' null 'cyrl/tse.italic' : lambda [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -491,25 +491,46 @@ glyph-block Mark-Above : begin
 			flat (SB - Width)      aboveMarkMid [widths.center : 2 * markHalfStroke]
 			curl (RightSB - Width) aboveMarkMid
 
-	create-glyph 'sbRsbOverlineAbove/diversityI' : glyph-proc
+	create-glyph 'cyrl/ghe.SRB/overlineAbove' : glyph-proc
 		local df : DivFrame para.diversityI
 		set-width 0
-		include : StdAnchors.impl 'above' 0 (1.5 * df.div)
+		set-mark-anchor 'above' markMiddle XH markMiddle aboveMarkStack
 
 		local leftEnd  : markMiddle - (df.rightSB - df.leftSB) / 2
 		local rightEnd : markMiddle + (df.rightSB - df.leftSB) / 2
+
+		set-base-anchor 'aboveBraceL' leftEnd aboveMarkMid
+		set-base-anchor 'aboveBraceR' rightEnd aboveMarkMid
 
 		include : dispiro
 			flat leftEnd  aboveMarkMid [widths.center : 2 * markHalfStroke]
 			curl rightEnd aboveMarkMid
 
-	create-glyph 'sbRsbOverlineAbove/diversityM' : glyph-proc
-		local df : DivFrame para.diversityM
+	create-glyph 'cyrl/pe.SRB/overlineAbove' : glyph-proc
+		local df : DivFrame 1
 		set-width 0
-		include : StdAnchors.impl 'above' 0 (1.5 * df.div)
+		set-mark-anchor 'above' markMiddle XH markMiddle aboveMarkStack
 
 		local leftEnd  : markMiddle - (df.rightSB - df.leftSB) / 2
 		local rightEnd : markMiddle + (df.rightSB - df.leftSB) / 2
+
+		set-base-anchor 'aboveBraceL' leftEnd aboveMarkMid
+		set-base-anchor 'aboveBraceR' rightEnd aboveMarkMid
+
+		include : dispiro
+			flat leftEnd  aboveMarkMid [widths.center : 2 * markHalfStroke]
+			curl rightEnd aboveMarkMid
+
+	create-glyph 'cyrl/te.SRB/overlineAbove' : glyph-proc
+		local df : DivFrame para.diversityM 3
+		set-width 0
+		set-mark-anchor 'above' markMiddle XH markMiddle aboveMarkStack
+
+		local leftEnd  : markMiddle - (df.rightSB - df.leftSB) / 2
+		local rightEnd : markMiddle + (df.rightSB - df.leftSB) / 2
+
+		set-base-anchor 'aboveBraceL' leftEnd aboveMarkMid
+		set-base-anchor 'aboveBraceR' rightEnd aboveMarkMid
 
 		include : dispiro
 			flat leftEnd  aboveMarkMid [widths.center : 2 * markHalfStroke]

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2999,7 +2999,7 @@ description = "`i` with shorter top serif and full bottom serif"
 selector.dotlessi = "serifedAsymmetric"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "serifed"
-selector."cyrl/ghe.SRB" = "zshaped"
+selector."cyrl/ghe.SRB" = "zshapedAsymmetric"
 
 [prime.i.variants.tailed]
 rank = 7


### PR DESCRIPTION
This also slightly improves the width of the overline itself above `cyrl/te.SRB` in particular under monospace by setting its crowdedness to 3 instead of the default 1.

```
г᪻ п᪻ т᪻ ѓ п́
итигшпшг
```

Monospace SS16 Before:
![image](https://github.com/user-attachments/assets/49066dee-7117-42ce-a0b1-901716ead8d3)
Monospace SS16 After:
![image](https://github.com/user-attachments/assets/60b7e7ee-1770-42c2-bc78-5761b6e518db)
Aile SS16 Before:
![image](https://github.com/user-attachments/assets/50cb781c-3f5e-476a-af12-05b0d0365a64)
Aile SS16 After:
![image](https://github.com/user-attachments/assets/5aaafa8b-3c72-44b3-aa86-ce60349dcdc8)

Also allow Serbian Ghe & Macedonian Gje to respond to `serifed-asymmetric` variants of `i` via the internal-only variant `zshapedAsymmetric`.

All `i` variants under `SRB`:

`i𝗂гѓi𝗂гѓ`

![image](https://github.com/user-attachments/assets/f4c49ddd-0516-4496-8061-0c9f822d6144)
