### PR TITLE
Fix broken arc of `ↇ` under heavy.

### DIFF
--- a/packages/font-glyphs/src/letter/latin/upper-d.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-d.ptl
@@ -34,8 +34,7 @@ glyph-block Letter-Latin-Upper-D : begin
 			[if offset corner flat] (df.leftSB - O) (top - offset) [heading Rightward]
 			curl [arch.adjust-x.top (right - bsmooth)] (top - offset)
 			archv
-			flat (right - OX - offset) (top - adb)
-			curl (right - OX - offset) (0 + ada)
+			flatside.rd (right - OX - offset) 0 top ada adb
 			arcvh
 			flat [arch.adjust-x.bot (right - bsmooth)] offset
 			[if offset corner curl] (df.leftSB - O) offset [heading Leftward]


### PR DESCRIPTION
`Dↁↇ`
Before:
![image](https://github.com/user-attachments/assets/82eeacb4-dcac-47f6-be66-c1388e5d45ef)
After:
![image](https://github.com/user-attachments/assets/ec1b87c9-7261-4809-a8d6-b47f753234e6)
