### PR TITLE
Add `shoulderFine` as an attribute of `DivFrame`.

### DIFF
--- a/packages/font-glyphs/src/common/shapes.ptl
+++ b/packages/font-glyphs/src/common/shapes.ptl
@@ -644,13 +644,13 @@ glyph-block CommonShapes : begin
 		export : define flex-params [lhs] : begin
 			local-parameter : y
 			local-parameter : p
-			local-parameter : sw 		   -- Stroke
+			local-parameter : sw           -- Stroke
 			local-parameter : compact      -- false
-			local-parameter : o 		   -- O
+			local-parameter : o            -- O
 			local-parameter : anglePre     -- nothing
 			local-parameter : anglePost    -- nothing
-			local-parameter : swBefore	   -- sw
-			local-parameter : swAfter	   -- sw
+			local-parameter : swBefore     -- sw
+			local-parameter : swAfter      -- sw
 			local-parameter : mockPre      -- nothing
 			local-parameter : mockPost     -- nothing
 			local-parameter : blendPre     -- [if anglePre nothing [arcvh]]
@@ -662,13 +662,13 @@ glyph-block CommonShapes : begin
 		export : define flex-params [rhs] : begin
 			local-parameter : y
 			local-parameter : p
-			local-parameter : sw 		   -- Stroke
+			local-parameter : sw           -- Stroke
 			local-parameter : compact      -- false
-			local-parameter : o 		   -- O
+			local-parameter : o            -- O
 			local-parameter : anglePre     -- nothing
 			local-parameter : anglePost    -- nothing
-			local-parameter : swBefore	   -- sw
-			local-parameter : swAfter	   -- sw
+			local-parameter : swBefore     -- sw
+			local-parameter : swAfter      -- sw
 			local-parameter : mockPre      -- nothing
 			local-parameter : mockPost     -- nothing
 			local-parameter : blendPre     -- [if anglePre nothing [arcvh]]
@@ -685,12 +685,12 @@ glyph-block CommonShapes : begin
 					define flex-params [f] : begin
 						local-parameter : x
 						local-parameter : y
-						local-parameter : sw 		   -- Stroke
+						local-parameter : sw           -- Stroke
 						local-parameter : compact      -- false
 						local-parameter : knot-ty      -- nothing
-						local-parameter : o 		   -- O
-						local-parameter : swBefore	   -- sw
-						local-parameter : swAfter	   -- sw
+						local-parameter : o            -- O
+						local-parameter : swBefore     -- sw
+						local-parameter : swAfter      -- sw
 						return : impl : object x y sw compact knot-ty o swBefore swAfter
 							lhs : side == lhs
 							rtl : dir == "rtl"

--- a/packages/font-glyphs/src/letter/armenian/keh.ptl
+++ b/packages/font-glyphs/src/letter/armenian/keh.ptl
@@ -42,7 +42,7 @@ glyph-block Letter-Armenian-Keh : begin
 				right -- df.rightSB
 				bot   -- bot
 				sw    -- df.mvs
-				fine  -- (df.mvs * ShoulderFine / Stroke)
+				fine  -- df.shoulderFine
 			include : VBar.l df.leftSB Descender XH df.mvs
 			include : HCrossBar (df.leftSB - jut + [HSwToV : 0.5 * df.mvs]) df.rightSB 0 ostroke
 			if SLAB : begin

--- a/packages/font-glyphs/src/letter/armenian/lower-dza-cheh.ptl
+++ b/packages/font-glyphs/src/letter/armenian/lower-dza-cheh.ptl
@@ -30,7 +30,6 @@ glyph-block Letter-Armenian-Lower-Dza-Cheh : begin
 				curl x2 y2 [heading Rightward]
 
 			local yMid : Math.max (y2 + 0.5 * df.mvs - 1.5 * SmallArchDepthA) (0 + SmallArchDepthB + TINY)
-			local fine : ShoulderFine * (df.mvs / Stroke)
 			define [knots] : list
 				straight.left.start x2 (y2 + 0.5 * df.mvs) [heading Leftward]
 				archv
@@ -39,7 +38,7 @@ glyph-block Letter-Armenian-Lower-Dza-Cheh : begin
 			include : dispiro
 				widths.lhs df.mvs
 				knots
-				OBarRight.arcEnd 0 df.leftSB df.rightSB df.mvs fine SmallArchDepthA SmallArchDepthB
+				OBarRight.arcEnd 0 df.leftSB df.rightSB df.mvs df.shoulderFine SmallArchDepthA SmallArchDepthB
 			include : intersection
 				spiro-outline
 					knots
@@ -62,7 +61,6 @@ glyph-block Letter-Armenian-Lower-Dza-Cheh : begin
 			local df : include : DivFrame 1
 			include : df.markSet.b
 			local x1 : mix df.leftSB df.rightSB 0.75
-			local fine : ShoulderFine * (df.mvs / Stroke)
 			include : dispiro
 				widths.lhs df.mvs
 				flat x1 Ascender
@@ -70,7 +68,7 @@ glyph-block Letter-Armenian-Lower-Dza-Cheh : begin
 				archv
 				flat df.leftSB (Ascender - SmallArchDepthA)
 				curl df.leftSB (0 + SmallArchDepthB) [heading Downward]
-				OBarRight.arcEnd 0 df.leftSB df.rightSB df.mvs fine SmallArchDepthA SmallArchDepthB
+				OBarRight.arcEnd 0 df.leftSB df.rightSB df.mvs df.shoulderFine SmallArchDepthA SmallArchDepthB
 			include : dispiro
 				widths.rhs df.mvs
 				flat (df.leftSB - jut + [HSwToV : 0.5 * df.mvs]) highBarPos

--- a/packages/font-glyphs/src/letter/armenian/upper-dza-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/upper-dza-group.ptl
@@ -32,11 +32,10 @@ glyph-block Letter-Armenian-Upper-Dza : begin
 		create-glyph 'armn/Sha' 0x547 : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.capital
-			local fine : ShoulderFine * (df.mvs / Stroke)
 			include : dispiro
 				widths.rhs df.mvs
 				curl df.leftSB CAP [heading Rightward]
-				flat df.middle ([mix XH CAP 0.5] + df.mvs - fine) [heading Rightward]
+				flat df.middle ([mix XH CAP 0.5] + df.mvs - df.shoulderFine) [heading Rightward]
 				curl df.rightSB (XH + df.mvs) [heading Rightward]
 			include : dispiro
 				widths.rhs df.mvs
@@ -45,21 +44,20 @@ glyph-block Letter-Armenian-Upper-Dza : begin
 				flat df.leftSB ArchDepthB
 				curl df.leftSB ([mix XH CAP 0.5] - ArchDepthA)
 				arcvh
-				g4 df.middle [mix XH CAP 0.5] [widths.rhs fine]
+				g4 df.middle [mix XH CAP 0.5] [widths.rhs df.shoulderFine]
 
 	do "Cha"
 		create-glyph 'armn/Cha' 0x549 : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.capital
-			local fine : ShoulderFine * (df.mvs / Stroke)
 			include : dispiro
 				widths.rhs df.mvs
 				g4 df.leftSB (CAP - Hook)
 				hookstart CAP (sw -- df.mvs)
 				flat df.rightSB (CAP - ArchDepthB)
-				curl df.rightSB ([mix (XH / 2) df.mvs 0.5] - fine + ArchDepthA)
+				curl df.rightSB ([mix (XH / 2) df.mvs 0.5] - df.shoulderFine + ArchDepthA)
 				arcvh
-				g4 df.middle ([mix (XH / 2) df.mvs 0.5] - fine) [widths.rhs fine]
+				g4 df.middle ([mix (XH / 2) df.mvs 0.5] - df.shoulderFine) [widths.rhs df.shoulderFine]
 			include : dispiro
 				widths.rhs df.mvs
 				flat [mix df.leftSB df.rightSB 0.1] (XH / 2) [heading Rightward]

--- a/packages/font-glyphs/src/letter/armenian/upper-za-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/upper-za-group.ptl
@@ -15,49 +15,47 @@ glyph-block Letter-Armenian-Upper-Za-Group : begin
 		create-glyph 'armn/Za' 0x536 : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.capital
-			local fine : ShoulderFine * (df.mvs / Stroke)
-			local fine2 : df.adviceStroke 4
+			local fine : df.adviceStroke 4
 			include : dispiro
 				widths.rhs df.mvs
 				g4 df.leftSB (CAP - Hook)
 				hookstart CAP (sw -- df.mvs)
 				flat df.rightSB (CAP - ArchDepthB)
-				curl df.rightSB (df.mvs - fine + ArchDepthA)
+				curl df.rightSB (df.mvs - df.shoulderFine + ArchDepthA)
 				arcvh
-				g4 df.leftSB (df.mvs - fine) [widths.rhs fine]
-			include : VBar.l df.leftSB 0 VJut fine2
+				g4 df.leftSB (df.mvs - df.shoulderFine) [widths.rhs df.shoulderFine]
+			include : VBar.l df.leftSB 0 VJut fine
 			include : [ArmHBar.normal df].base
 
 	do "Jheh"
 		create-glyph 'armn/Jheh' 0x54B : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.capital
-			local fine : ShoulderFine * (df.mvs / Stroke)
-			local fine2 : df.adviceStroke 4
-			local x1 : df.middle + [HSwToV : [StrokeWidthBlend 0 0.5] * fine2]
+			local fine : df.adviceStroke 4
+			local x1 : df.middle + [HSwToV : [StrokeWidthBlend 0 0.5] * fine]
 			include : dispiro
 				widths.rhs df.mvs
 				straight.up.start df.leftSB (CAP - ArchDepthA)
 				arch.rhs CAP (sw -- df.mvs)
 				flat df.rightSB (CAP - ArchDepthB)
-				curl df.rightSB (df.mvs - fine + ArchDepthA)
+				curl df.rightSB (df.mvs - df.shoulderFine + ArchDepthA)
 				arcvh
-				g4 df.leftSB (df.mvs - fine) [widths.rhs fine]
+				g4 df.leftSB (df.mvs - df.shoulderFine) [widths.rhs df.shoulderFine]
 			include : intersection
 				spiro-outline
 					flat df.rightSB CAP
-					curl df.rightSB (df.mvs - fine + ArchDepthA)
+					curl df.rightSB (df.mvs - df.shoulderFine + ArchDepthA)
 					arcvh
-					corner df.leftSB (df.mvs - fine) [widths.rhs fine]
+					corner df.leftSB (df.mvs - df.shoulderFine) [widths.rhs df.shoulderFine]
 					corner df.leftSB CAP
 				dispiro
 					widths.lhs df.mvs
 					flat df.leftSB (CAP - ArchDepthA)
 					curl df.leftSB (CAP - 1.1 * ArchDepthA)
 					g4 [pre@mix@post 0.5] [pre@mix@post 0.5] [widths.center df.mvs]
-					flat x1 (0.55 * ArchDepthB) [widths.rhs fine2]
-					curl x1 (0.5 * ArchDepthB) [widths.rhs fine2]
+					flat x1 (0.55 * ArchDepthB) [widths.rhs fine]
+					curl x1 (0.5 * ArchDepthB) [widths.rhs fine]
 					arcvh
-					g4 df.leftSB (df.mvs - fine) [widths.rhs fine]
-			include : VBar.l df.leftSB 0 VJut fine2
+					g4 df.leftSB (df.mvs - df.shoulderFine) [widths.rhs df.shoulderFine]
+			include : VBar.l df.leftSB 0 VJut fine
 			include : [ArmHBar.normal df].base

--- a/packages/font-glyphs/src/letter/latin/lower-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-m.ptl
@@ -141,7 +141,7 @@ glyph-block Letter-Latin-Lower-M : begin
 			top       -- top
 			bottom    -- mbot
 			width     -- df.mvs
-			fine      -- (df.mvs * ShoulderFine / Stroke)
+			fine      -- df.shoulderFine
 		include : SmallMShoulderSpiro
 			df        -- df
 			left      -- (mid + [HSwToV : 0.5 * df.mvs])
@@ -149,7 +149,7 @@ glyph-block Letter-Latin-Lower-M : begin
 			top       -- top
 			bottom    -- rbot
 			width     -- df.mvs
-			fine      -- (df.mvs * ShoulderFine / Stroke)
+			fine      -- df.shoulderFine
 		include : tagged 'barL' : VBar.l df.leftSB lbot top df.mvs
 
 	define [SmallMShortLegHeight top df] : (top - df.mvs) * 0.45

--- a/packages/font-glyphs/src/meta/aesthetics.ptl
+++ b/packages/font-glyphs/src/meta/aesthetics.ptl
@@ -430,6 +430,7 @@ export : define [GenDivFrame metrics] : begin
 			set this.leftSB       : metrics.SB * sbMul
 			set this.rightSB      : metrics.Width * div - metrics.SB * sbMul
 			set this.mvs            mvs
+			set this.shoulderFine : metrics.ShoulderFine * (mvs / metrics.Stroke)
 			set this.markSet      : MarksetDiv div sbMul metrics
 
 			# No-overshoot metrics -- used for arch depth calculation


### PR DESCRIPTION
Mainly for code cleanup purposes.
Essentially calculates a custom `ShoulderFine` value based on the ratio between the `DivFrame`'s `mvs` and the default `Stroke`.
As of right now it's implemented by Latin Lower `m` and several Armenian letters.