### PR TITLE
Add new diversity classification `diversityT` between `1` and `diversityM`.

### DIFF
--- a/packages/font-glyphs/src/auto-build/recursive-build.ptl
+++ b/packages/font-glyphs/src/auto-build/recursive-build.ptl
@@ -24,6 +24,7 @@ glyph-block Recursive-Build : begin
 			forkedPara.slopeAngle  = 0
 		if mono : begin
 			forkedPara.diversityM  = 1
+			forkedPara.diversityT  = 1
 		if mono2 : begin
 			forkedPara.diversityF  = 1
 			forkedPara.diversityI  = 1
@@ -48,6 +49,7 @@ glyph-block Recursive-Build : begin
 		forkedPara.jut = Jut * p
 		forkedPara.longjut = LongJut * p
 		forkedPara.diversityM = 1
+		forkedPara.diversityT = 1
 		if fMono : begin
 			forkedPara.diversityF  = 1
 			forkedPara.diversityI  = 1

--- a/packages/font-glyphs/src/auto-build/transformed.ptl
+++ b/packages/font-glyphs/src/auto-build/transformed.ptl
@@ -294,7 +294,9 @@ glyph-block Autobuild-Transformed-Texture : begin
 
 		local forkedPara : Object.assign {.} para
 		if (extL + extR > 0)
-		: then : forkedPara.diversityM = 1 + extL + extR
+		: then : begin
+			forkedPara.diversityM = 1 + extL + extR
+			forkedPara.diversityT = 1 + extL + extR
 		: else : begin
 			forkedPara.diversityF  = 1 + extL + extR
 			forkedPara.diversityI  = 1 + extL + extR

--- a/packages/font-glyphs/src/letter/cyrillic/te-midhook.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/te-midhook.ptl
@@ -8,6 +8,7 @@ glyph-block Letter-Cyrillic-Te-MidHook : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Shapes : MidHook
+	glyph-block-import Letter-Latin-Upper-T : TConfig
 
 	define [Shape df top pArc slabTop slabBot] : glyph-proc
 		local left : [mix df.leftSB df.rightSB 0.3] + OX
@@ -21,9 +22,9 @@ glyph-block Letter-Cyrillic-Te-MidHook : begin
 		include : MidHook.general
 			left   -- (left + [HSwToV df.mvs])
 			right  -- df.rightSB
-			top    -- top * HBarPos + df.mvs / 4
-			ada    -- ArchDepthA * pArc
-			adb    -- ArchDepthB * pArc
+			top    -- (top * HBarPos + df.mvs / 4)
+			ada    -- (ArchDepthA * pArc)
+			adb    -- (ArchDepthB * pArc)
 			sw     -- df.mvs
 
 		if slabTop : begin
@@ -33,21 +34,14 @@ glyph-block Letter-Cyrillic-Te-MidHook : begin
 		if slabBot : begin
 			include : HSerif.mb (left + [HSwToV : 0.5 * df.mvs]) 0 Jut
 
-	define Config : object
-		serifless     { 1                           false false }
-		motionSerifed { [mix 1 para.diversityM 0.5] true  false }
-		serifed       { [mix 1 para.diversityM 0.5] true  true  }
-
-	foreach { suffix { div doST doSB } } [Object.entries Config] : do
-		local df : DivFrame div 3
-
+	foreach { suffix { div doST doSB } } [Object.entries TConfig] : do
 		create-glyph "cyrl/TeMidHook.\(suffix)" : glyph-proc
-			set-width df.width
+			local df : include : DivFrame div
 			include : df.markSet.capDesc
 			include : Shape df CAP 1 doST doSB
 
 		create-glyph "cyrl/teMidHook.upright.\(suffix)" : glyph-proc
-			set-width df.width
+			local df : include : DivFrame div
 			include : df.markSet.p
 			include : Shape df XH [Math.pow HBarPos 0.3] doST doSB
 

--- a/packages/font-glyphs/src/letter/cyrillic/tje.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/tje.ptl
@@ -11,6 +11,7 @@ glyph-block Letter-Cyrillic-Tje : begin
 	glyph-block-import Letter-Shared : CreateDependentComposite
 	glyph-block-import Letter-Shared-Shapes : SerifFrame
 	glyph-block-import Letter-Latin-Upper-F : EFVJutLength
+	glyph-block-import Letter-Latin-Upper-T : TConfig
 	glyph-block-import Letter-Cyrillic-Yeri : YeriConfig YeriBarPos
 
 	define [LeftHalf df top slabTop slabBot] : glyph-proc
@@ -33,40 +34,33 @@ glyph-block Letter-Cyrillic-Tje : begin
 	define [RightHalf Yeri df top] : glyph-proc
 		local { jutTop jutBot jutMid } : EFVJutLength top YeriBarPos df.mvs
 		include : Yeri top
-			left   -- [mix df.leftSB df.rightSB 0.3] + OX
+			left   -- ([mix df.leftSB df.rightSB 0.3] + OX)
 			right  -- df.rightSB
 			stroke -- df.mvs
-			bowl   -- YeriBarPos * top + [Math.min HalfStroke jutMid]
+			bowl   -- (YeriBarPos * top + [Math.min HalfStroke jutMid])
 		eject-contour 'serifYeriLT'
 		eject-contour 'serifYeriLB'
 
-	define Config : object
-		serifless     { false false }
-		motionSerifed { true  false }
-		serifed       { true  true  }
-
-	foreach { suffix { doST doSB } } [Object.entries Config] : do
-		local df : DivFrame [mix 1 para.diversityM 0.5] 3
-
+	foreach { suffix { div doST doSB } } [Object.entries TConfig] : do
 		create-glyph "cyrl/Tje/leftHalf.\(suffix)" : glyph-proc
-			set-width df.width
+			local df : include : DivFrame para.diversityT 3
 			include : df.markSet.capital
 			include : LeftHalf df CAP doST doSB
 
 		create-glyph "cyrl/tje.upright/leftHalf.\(suffix)" : glyph-proc
-			set-width df.width
+			local df : include : DivFrame para.diversityT 3
 			include : df.markSet.e
 			include : LeftHalf df XH doST doSB
 
 	foreach { suffix { Uc Lc } } [Object.entries YeriConfig] : do
 		create-glyph "cyrl/Tje/rightHalf.\(suffix)"  : glyph-proc
-			local df : include : DivFrame [mix 1 para.diversityM 0.5] 3
+			local df : include : DivFrame para.diversityT 3
 			include : df.markSet.capital
 			include : RightHalf Uc df CAP
 			DependentSelector.set currentGlyph : if (suffix === "corner") 'full' 'reduced'
 
 		create-glyph "cyrl/tje.upright/rightHalf.\(suffix)" : glyph-proc
-			local df : include : DivFrame [mix 1 para.diversityM 0.5] 3
+			local df : include : DivFrame para.diversityT 3
 			include : df.markSet.e
 			include : RightHalf Lc df XH
 			DependentSelector.set currentGlyph : if (suffix === "corner") 'full' 'reduced'

--- a/packages/font-glyphs/src/letter/cyrillic/yat.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/yat.ptl
@@ -66,20 +66,20 @@ glyph-block Letter-Cyrillic-Yat : begin
 
 	foreach { suffix { Uc Lc } } [pairs-of YeriConfig] : do
 		create-glyph "cyrl/Yat.\(suffix)" : glyph-proc
-			local df : include : DivFrame [mix 1 para.diversityM 0.5]
+			local df : include : DivFrame para.diversityT
 			include : df.markSet.capital
 			include : YatShape df Uc CAP
 				pBar -- 0.5
 
 		create-glyph "cyrl/yat.upright.\(suffix)" : glyph-proc
-			local df : include : DivFrame [mix 1 para.diversityM 0.5]
+			local df : include : DivFrame para.diversityT
 			include : df.markSet.b
 			include : YatShape df Lc Ascender
 				pBar -- (0.55 * XH / Ascender)
 				fLowerCase -- true
 
 		create-glyph "cyrl/yatTall.\(suffix)" : glyph-proc
-			local df : include : DivFrame [mix 1 para.diversityM 0.5]
+			local df : include : DivFrame para.diversityT
 			include : df.markSet.b
 			include : ExtendAboveBaseAnchors (Ascender + 0.5 * AccentStackOffset)
 			include : YatShape df Lc (Ascender + 0.5 * AccentStackOffset)

--- a/packages/font-glyphs/src/letter/cyrillic/yeri.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/yeri.ptl
@@ -215,7 +215,7 @@ glyph-block Letter-Cyrillic-Yeri : begin
 	define [CyrYeryShape LeftHalf df top fBackYer fTail] : glyph-proc
 		local sw : if fBackYer [AdviceStroke 3.25 df.div] df.mvs
 
-		local jut : Math.min Jut : [Math.sqrt : sw / Stroke] * Jut
+		local jut : [Math.min 1 : Math.sqrt : sw / Stroke] * Jut
 		local xm : mix (df.rightSB - [HSwToV sw]) (df.middle + [HSwToV : 0.5 * sw]) 0.75
 
 		include : if fBackYer
@@ -295,23 +295,23 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			include : Lc (left -- df.leftSB) (right -- df.rightSB) XH
 			include : YeriOverlayBar df XH
 		create-glyph "cyrl/Yer.\(suffix)" : glyph-proc
-			local df : include : DivFrame [mix 1 para.diversityM 0.5]
+			local df : include : DivFrame para.diversityT
 			include : df.markSet.capital
 			include : CyrBackYerShape Uc CAP (left -- df.leftSB) (right -- df.rightSB)
 		create-glyph "cyrl/yer.\(suffix)" : glyph-proc
-			local df : include : DivFrame [mix 1 para.diversityM 0.5]
+			local df : include : DivFrame para.diversityT
 			include : df.markSet.e
 			include : CyrBackYerShape Lc XH (left -- df.leftSB) (right -- df.rightSB)
 		create-glyph "cyrl/yerTall.\(suffix)" : glyph-proc
-			local df : include : DivFrame [mix 1 para.diversityM 0.5]
+			local df : include : DivFrame para.diversityT
 			include : df.markSet.b
 			include : CyrBackYerShape Lc Ascender (left -- df.leftSB) (right -- df.rightSB) (pBar -- YeriBarPos * XH / Ascender)
 		create-glyph "cyrl/YerNeutral.\(suffix)" : glyph-proc
-			local df : include : DivFrame [mix 1 para.diversityM 0.5]
+			local df : include : DivFrame para.diversityT
 			include : df.markSet.capital
 			include : CyrNeutralYerShape Uc CAP (left -- df.leftSB) (right -- df.rightSB)
 		create-glyph "cyrl/yerNeutral.\(suffix)" : glyph-proc
-			local df : include : DivFrame [mix 1 para.diversityM 0.5]
+			local df : include : DivFrame para.diversityT
 			include : df.markSet.e
 			include : CyrNeutralYerShape Lc XH (left -- df.leftSB) (right -- df.rightSB)
 		create-glyph "ZhuangToneSix.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/o.ptl
+++ b/packages/font-glyphs/src/letter/latin/o.ptl
@@ -62,7 +62,7 @@ glyph-block Letter-Latin-O : begin
 
 	define rBroadOn : DotRadius * [StrokeWidthBlend 1.625 1]
 	create-glyph 'cyrl/BroadOn' 0x47A : glyph-proc
-		define df : include : DivFrame [mix 1 para.diversityM 0.5] 3
+		define df : include : DivFrame para.diversityT 3
 		include : df.markSet.capital
 		local dist : df.rightSB - df.leftSB
 		local gap : Math.min
@@ -75,7 +75,7 @@ glyph-block Letter-Latin-O : begin
 		include : DotAt df.middle (CAP - df.mvs / 2 - O) rBroadOn
 
 	create-glyph 'cyrl/broadOn' 0x47B : glyph-proc
-		define df : include : DivFrame [mix 1 para.diversityM 0.5] 3
+		define df : include : DivFrame para.diversityT 3
 		include : df.markSet.e
 		local dist : df.rightSB - df.leftSB
 		local gap : Math.min

--- a/packages/font-glyphs/src/letter/latin/upper-t.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-t.ptl
@@ -73,22 +73,21 @@ glyph-block Letter-Latin-Upper-T : begin
 			include : tagged 'serifMB' : HSerif.lb (xRight - [HSwToV HalfStroke]) 0 MidJutSide
 			include : tagged 'serifRT' : HSerif.rt xRight top SideJut
 
+	glyph-block-export TConfig
 	define TConfig : object
-		serifless     { 1                           false false }
-		motionSerifed { [mix 1 para.diversityM 0.5] true  false }
-		serifed       { [mix 1 para.diversityM 0.5] true  true  }
+		serifless     { 1               false false }
+		motionSerifed { para.diversityT true  false }
+		serifed       { para.diversityT true  true  }
 
 	foreach { suffix { div doST doSB } } [Object.entries TConfig] : do
-		local df : DivFrame div
-
 		create-glyph "T.\(suffix)" : glyph-proc
-			set-width df.width
+			local df : include : DivFrame div
 			include : df.markSet.capital
 			set-base-anchor 'bottomRight' (df.middle + [HSwToV HalfStroke]) 0
 			include : TShape df CAP doST doSB
 
 		create-glyph "cyrl/TeDescender.\(suffix)" : glyph-proc
-			set-width df.width
+			local df : include : DivFrame div
 			include : df.markSet.capital
 			set-base-anchor 'bottomRight' (df.middle + [HSwToV HalfStroke]) 0
 			include : TShape df CAP doST doSB
@@ -98,42 +97,44 @@ glyph-block Letter-Latin-Upper-T : begin
 				jut -- [if doSB MidJutCenter Jut]
 
 		create-glyph "TStroke.\(suffix)" : glyph-proc
+			local df : DivFrame div
 			include [refer-glyph "T.\(suffix)"] AS_BASE ALSO_METRICS
 			include : LetterBarOverlay.m.in df.middle 0 CAP 0.45
 
 		create-glyph "Thookleft.\(suffix)" : glyph-proc
+			local df : DivFrame div
 			include [refer-glyph "T.\(suffix)"] AS_BASE ALSO_METRICS
 			eject-contour 'serifLT'
 			eject-contour 'strokeLT'
 			include : LeftHook (df.leftSB + LeftHook.extension) CAP df.middle
 
 		create-glyph "smcpT.\(suffix)" : glyph-proc
-			set-width df.width
+			local df : include : DivFrame div
 			include : df.markSet.e
 			set-base-anchor 'bottomRight' (df.middle + [HSwToV HalfStroke]) 0
 			include : TShape df XH doST doSB
 
 		create-glyph "cyrl/Twe/upper.\(suffix)" : glyph-proc
-			set-width df.width
+			local df : include : DivFrame div
 			include : df.markSet.capital
 			include : TweUpperShape df CAP doST doSB
 			set-base-anchor 'cvDecompose' (df.width / 2) CAP
 
 		create-glyph "cyrl/twe/upper.\(suffix)" : glyph-proc
-			set-width df.width
+			local df : include : DivFrame div
 			include : df.markSet.e
 			include : TweUpperShape df XH doST doSB
 			set-base-anchor 'cvDecompose' (df.width / 2) XH
 
 		create-glyph "currency/tengeSign.\(suffix)" : glyph-proc
-			set-width df.width
+			local df : include : DivFrame div
 			include : df.markSet.capital
 			local gap : Math.max (CAP * 0.1) [AdviceStroke2 2 6 CAP]
 			include : HBar.t [TLeftX df] [TRightX df] CAP OverlayStroke
 			include : TShape df (CAP - gap - OverlayStroke) doST doSB
 
 		create-glyph "cyrl/teDescender.upright.\(suffix)" : glyph-proc
-			set-width df.width
+			local df : include : DivFrame div
 			include : df.markSet.e
 			include : TShape df XH doST doSB
 			include : CyrDescender.rSideJut
@@ -142,8 +143,9 @@ glyph-block Letter-Latin-Upper-T : begin
 				jut -- [if doSB MidJutCenter Jut]
 
 		create-glyph "TRTailBR.\(suffix)" : glyph-proc
+			local df : DivFrame div
 			include [refer-glyph "T.\(suffix)"] AS_BASE ALSO_METRICS
-			include : MarkSet.capital
+			include : df.markSet.capital
 			include : RetroflexHook.mExt df.middle 0
 
 		create-glyph "cyrl/TjeKomi.\(suffix)" : glyph-proc
@@ -196,7 +198,7 @@ glyph-block Letter-Latin-Upper-T : begin
 	CreateAccentedComposition 'TComma'   0x021A 'T' 'commaBelow'
 
 	create-glyph 'capitalSmcpI' 0xA7AE : glyph-proc
-		local df : include : DivFrame [if SLAB [mix 1 para.diversityM 0.5] 1]
+		local df : include : DivFrame : if SLAB para.diversityT 1
 		include : df.markSet.capital
 		local l : TLeftX df
 		local r : TRightX df
@@ -212,7 +214,7 @@ glyph-block Letter-Latin-Upper-T : begin
 			include : tagged 'serifLB' : VSerif.ul l 0 VJut
 
 	create-glyph 'mathbb/T' 0x1D54B : glyph-proc
-		local df : DivFrame 1
+		local df : include : DivFrame 1
 		include : df.markSet.capital
 		include : HBar.t [TLeftX df] [TRightX df] CAP BBS
 		include : VBar.m (df.middle - BBD / 2) 0 CAP BBS

--- a/params/parameters.toml
+++ b/params/parameters.toml
@@ -79,6 +79,7 @@ onumZeroHeightRatio = 1.145
 
 # Reset diversity
 diversityM  = 1
+diversityT  = 1
 diversityF  = 1
 diversityI  = 1
 diversityII = 1
@@ -127,15 +128,17 @@ forceMonospace = true
 [spacing-quasi-proportional]
 spacing = 3
 isQuasiProportional = true
-diversityM  = 1.3333333333333 # 4/3
+diversityM  = 1.3333333333333 # 8/6
+diversityT  = 1.1666666666666 # 7/6
 diversityF  = 0.8333333333333 # 5/6
-diversityI  = 0.6666666666666 # 2/3
-diversityII = 0.5             # 1/2
+diversityI  = 0.6666666666666 # 4/6
+diversityII = 0.5             # 3/6
 
 [spacing-quasi-proportional-extension-only]
 spacing = 3
 isQuasiProportional = true
-diversityM  = 1.3333333333333 # 4/3
+diversityM  = 1.3333333333333 # 8/6
+diversityT  = 1.1666666666666 # 7/6
 diversityF  = 1.00
 diversityI  = 1.00
 diversityII = 1.00


### PR DESCRIPTION
I felt like enough characters used a diversity of `mix 1 para.diversityM 0.5` to justify its existence.

This allows the ability to separately configure the width of capital serifed `T` from the width of `M` in custom builds.

This also fills in the gap of 1/6-en increments between `1` and `1.3333333333333`.