### PR TITLE
Cleanup/optimization of a few loosely-related Cyrillic letters.

### DIFF
--- a/changes/32.2.0.md
+++ b/changes/32.2.0.md
@@ -15,3 +15,4 @@
   - MODIFIER LETTER SMALL CAPITAL OE (`U+107A3`).
   - MODIFIER LETTER CYRILLIC SMALL EM (`U+1E03B`).
 * Make LATIN SMALL LIGATURE FF (`U+FB00`) ... LATIN SMALL LIGATURE FFL (`U+FB04`) slightly narrower under Quasi-Proportional.
+* Optimize glyphs for Bulgarian Cyrillic Capital/Small Letter Ef (`U+0424`, `U+0444`).

--- a/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
@@ -246,18 +246,20 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 
 		create-glyph "cyrl/Dhe.\(suffix)" : glyph-proc
 			include [refer-glyph "cyrl/Ze.\(suffix)"] AS_BASE ALSO_METRICS
-			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
+			local desc : (-LongJut) + HalfStroke
+			include : ExtendBelowBaseAnchors desc
 			include : let [zeNoO : CyrZe slabTop slabBot CAP 0 (hook -- Hook) (xo -- 0) (yo -- 0)]
 				difference
-					VBar.m [arch.adjust-x.bot Middle] (-LongJut + 0.5 * Stroke) (Stroke + O) [AdviceStroke 3.5]
+					VBar.m [arch.adjust-x.bot Middle] desc (Stroke + O) [AdviceStroke 3.5]
 					zeNoO.ShapeMask
 
 		create-glyph "cyrl/dhe.\(suffix)" : glyph-proc
 			include [refer-glyph "cyrl/ze.\(suffix)"] AS_BASE ALSO_METRICS
-			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
+			local desc : (-LongJut) + HalfStroke
+			include : ExtendBelowBaseAnchors desc
 			include : let [zeNoO : CyrZe slabTop slabBot XH 0 (hook -- SHook) (xo -- 0) (yo -- 0)]
 				difference
-					VBar.m [arch.adjust-x.bot Middle] (-LongJut + 0.5 * Stroke) (Stroke + O) [AdviceStroke 3.5]
+					VBar.m [arch.adjust-x.bot Middle] desc (Stroke + O) [AdviceStroke 3.5]
 					zeNoO.ShapeMask
 
 		create-glyph "cyrl/DzjeKomi.\(suffix)" : glyph-proc
@@ -376,8 +378,8 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 	do "Volapuk AE"
 		glyph-block-import Letter-Latin-Lower-A : SingleStorey
 
-		define [FullBarBody df height bar hook ada adb] : glyph-proc
-			local eps : SmallEpsilon CLOSED-STEM CLOSED-STEM height 0
+		define [FullBarBody df top bar hook ada adb] : glyph-proc
+			local eps : SmallEpsilon CLOSED-STEM CLOSED-STEM top 0
 				blend    -- VolBlend
 				hook     -- hook
 				overflow -- 0
@@ -385,10 +387,10 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 				adb2     -- adb
 			define [object stroke] : eps.Dim
 			include : eps.Shape
-			include : bar df height stroke
+			include : bar df top stroke
 
-		define [EarlessCornerBody df height bar hook ada adb] : glyph-proc
-			local eps : SmallEpsilon SLAB-INWARD CLOSED-STEM height 0
+		define [EarlessCornerBody df top bar hook ada adb] : glyph-proc
+			local eps : SmallEpsilon SLAB-INWARD CLOSED-STEM top 0
 				blend    -- VolBlend
 				hook     -- hook
 				overflow -- 0
@@ -396,10 +398,10 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 				adb2     -- adb
 			define [object stroke] : eps.Dim
 			include : eps.Shape
-			include : bar df (height - DToothlessRise) stroke
+			include : bar df (top - DToothlessRise) stroke
 
-		define [EarlessRoundedBody df height bar hook ada adb] : glyph-proc
-			local eps : SmallEpsilon CLOSED-ROUND CLOSED-STEM height 0
+		define [EarlessRoundedBody df top bar hook ada adb] : glyph-proc
+			local eps : SmallEpsilon CLOSED-ROUND CLOSED-STEM top 0
 				blend    -- VolBlend
 				hook     -- hook
 				overflow -- 0
@@ -407,7 +409,7 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 				adb2     -- adb
 			define [object stroke] : eps.Dim
 			include : eps.Shape
-			include : bar df (height - adb) stroke
+			include : bar df (top - adb) stroke
 
 		define SingleStoreyConfig : object
 			singleStoreySerifless               { FullBarBody        SingleStorey.SeriflessBar     }
@@ -440,9 +442,9 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 		glyph-block-import Letter-Latin-U : USerifs
 		glyph-block-import Letter-Shared-Shapes : RightwardTailedBar
 
-		define [UToothed df height slab hook ada adb] : glyph-proc
+		define [UToothed df top slab hook ada adb] : glyph-proc
 			set-base-anchor 'trailing' df.rightSB 0
-			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-STEM height 0
+			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-STEM top 0
 				blend    -- VolBlend
 				hook     -- hook
 				overflow -- 0
@@ -450,12 +452,12 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 				adb2     -- adb
 			define [object stroke] : eps.Dim
 			include : eps.Shape
-			include : VBar.r df.rightSB 0 height stroke
-			include : slab df height
+			include : VBar.r df.rightSB 0 top stroke
+			include : slab df top
 
-		define [UTailed df height slab hook ada adb] : glyph-proc
+		define [UTailed df top slab hook ada adb] : glyph-proc
 			set-base-anchor 'trailing' (df.rightSB + SideJut) 0
-			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-STEM height 0
+			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-STEM top 0
 				blend    -- VolBlend
 				hook     -- hook
 				overflow -- 0
@@ -463,11 +465,11 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 				adb2     -- adb
 			define [object stroke] : eps.Dim
 			include : eps.Shape
-			include : RightwardTailedBar df.rightSB 0 height stroke
-			include : slab df height
+			include : RightwardTailedBar df.rightSB 0 top stroke
+			include : slab df top
 
-		define [UToothlessRounded df height slab hook ada adb] : glyph-proc
-			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-ROUND height 0
+		define [UToothlessRounded df top slab hook ada adb] : glyph-proc
+			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-ROUND top 0
 				blend    -- VolBlend
 				hook     -- hook
 				overflow -- 0
@@ -475,11 +477,11 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 				adb2     -- adb
 			define [object stroke] : eps.Dim
 			include : eps.Shape
-			include : VBar.r df.rightSB ada height stroke
-			include : slab df height
+			include : VBar.r df.rightSB ada top stroke
+			include : slab df top
 
-		define [UToothlessCorner df height slab hook ada adb] : glyph-proc
-			local eps : SmallEpsilon OPEN-VERTICAL SLAB-INWARD height 0
+		define [UToothlessCorner df top slab hook ada adb] : glyph-proc
+			local eps : SmallEpsilon OPEN-VERTICAL SLAB-INWARD top 0
 				blend    -- VolBlend
 				hook     -- hook
 				overflow -- 0
@@ -487,8 +489,8 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 				adb2     -- adb
 			define [object stroke] : eps.Dim
 			include : eps.Shape
-			include : VBar.r df.rightSB DToothlessRise height stroke
-			include : slab df height stroke
+			include : VBar.r df.rightSB DToothlessRise top stroke
+			include : slab df top stroke
 
 		define SmallUConfig : SuffixCfg.weave
 			object # body

--- a/packages/font-glyphs/src/letter/greek/phi.ptl
+++ b/packages/font-glyphs/src/letter/greek/phi.ptl
@@ -44,9 +44,6 @@ glyph-block Letter-Greek-Phi : begin
 				adb       -- adb
 
 	define [GrekLowerPhiCursiveRing fFlatTB df y2 y3] : glyph-proc
-		local df : include : DivFrame para.diversityM 3
-		include : df.markSet.e
-
 		local l : df.leftSB + OX * 2
 		local r : df.width - l
 		include : dispiro
@@ -121,26 +118,26 @@ glyph-block Letter-Greek-Phi : begin
 	create-glyph 'grek/Phi' 0x3A6 : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.capital
-		include : GrekCapitalPhiImpl 0 df
+		include : GrekCapitalPhiImpl false df
 
 	create-glyph 'cyrl/Ef' 0x424 : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.capital
-		include : GrekCapitalPhiImpl 1 df
+		include : GrekCapitalPhiImpl true df
 
 	create-glyph 'cyrl/Ef.BGR' : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.capital
 
-		local vJut : Math.max (LongJut - 0.5 * Stroke) : if SLAB (1.5 * Stroke) 0
+		local vJut : Math.max (LongJut - HalfStroke) : if SLAB (1.5 * Stroke) 0
 
 		local top : CAP + vJut
-		local bot : 0 - vJut
+		local bot : 0   - vJut
 
 		include : ExtendAboveBaseAnchors top
 		include : ExtendBelowBaseAnchors bot
 
-		include : VarPhiRing 0 df 0 CAP
+		include : VarPhiRing true df 0 CAP
 		include : StraightBar df bot 0 CAP top
 
 		if SLAB : begin
@@ -150,24 +147,24 @@ glyph-block Letter-Greek-Phi : begin
 	create-glyph 'taillessphi' 0x2C77 : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.e
-		include : GrekLowerPhiCursiveRing 0 df 0 XH
+		include : GrekLowerPhiCursiveRing false df 0 XH
 
 	create-glyph 'grek/phi.cursive' : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.p
-		include : GrekLowerPhiCursiveRing 0 df 0 XH
+		include : GrekLowerPhiCursiveRing false df 0 XH
 		include : VBar.m df.middle Descender (0.2 * df.mvs)
 
 	create-glyph 'grek/phi.straight' : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.bp
-		include : VarPhiRing 0 df 0 XH
+		include : VarPhiRing false df 0 XH
 		include : StraightBar df Descender 0 XH Ascender
 
 	create-glyph 'grek/phi.neohellenic' : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.p
-		include : VarPhiRing 0 df 0 XH
+		include : VarPhiRing false df 0 XH
 		include : VBar.m df.middle Descender (0.2 * df.mvs)
 
 	select-variant 'grek/phi' 0x3C6
@@ -183,8 +180,8 @@ glyph-block Letter-Greek-Phi : begin
 
 	define CyrlLowerEfConfig : SuffixCfg.weave
 		object # bowl
-			""                    { VarPhiRing Stroke }
-			splitBowl             { CyrlEfSplitRing [DivFrame para.diversityM 3].mvs }
+			""                    { VarPhiRing      Stroke  }
+			splitBowl             { CyrlEfSplitRing nothing }
 		object # bar
 			serifless             { StraightBar nothing nothing }
 			topSerifed            { StraightBar MtSerif nothing }
@@ -196,17 +193,11 @@ glyph-block Letter-Greek-Phi : begin
 		create-glyph "cyrl/ef.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.bp
-			include : Bowl 1 df 0 XH
-			include : Bar df Descender 0 XH Ascender barSw
-			if sMT : include : sMT df Ascender  barSw
-			if sMB : include : sMB df Descender barSw
-		create-glyph "cyrl/ef.BGR.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.diversityM 3
-			include : df.markSet.bp
-			include : VarPhiRing 0 df 0 XH
-			include : Bar df Descender 0 XH Ascender barSw
-			if sMT : include : sMT df Ascender  barSw
-			if sMB : include : sMB df Descender barSw
+			include : Bowl true df 0 XH
+			local mvs : fallback barSw df.mvs
+			include : Bar df Descender 0 XH Ascender mvs
+			if sMT : include : sMT df Ascender  mvs
+			if sMB : include : sMB df Descender mvs
 
 	select-variant 'cyrl/ef' 0x444
-	select-variant 'cyrl/ef.BGR'
+	select-variant 'cyrl/ef.BGR' (shapeFrom -- 'cyrl/ef')

--- a/packages/font-glyphs/src/letter/latin/c.ptl
+++ b/packages/font-glyphs/src/letter/latin/c.ptl
@@ -37,8 +37,7 @@ glyph-block Letter-Latin-C : begin
 				g4 (df.rightSB - offset) (top - [fallback hook Hook])
 				hookstart (top - offset) (sw -- sw)
 
-		flat (df.leftSB + OX + offset) (top - ada)
-		curl (df.leftSB + OX + offset) (bot + adb)
+		flatside.ld (df.leftSB + offset) bot top ada adb
 
 		match sb
 			[Just SLAB-CLASSICAL] : SerifedArcEnd.LtrLhs (df.rightSB - offset) bot sw [fallback hook Hook] origBar
@@ -64,8 +63,7 @@ glyph-block Letter-Latin-C : begin
 				g4 (df.leftSB + offset) (top - [fallback hook Hook])
 				hookstart (top - offset) (sw -- sw)
 
-		flat (df.rightSB - OX + offset) (top - ada)
-		curl (df.rightSB - OX + offset) (bot + adb)
+		flatside.rd (df.rightSB + offset) bot top ada adb
 
 		match sb
 			[Just SLAB-CLASSICAL] : SerifedArcEnd.RtlRhs (df.leftSB + offset) bot sw [fallback hook Hook]
@@ -107,8 +105,7 @@ glyph-block Letter-Latin-C : begin
 				[Just SLAB-CLASSICAL] : SerifedArcStart.RtlLhs RightSB XH sw Hook
 				[Just SLAB-INWARD] : InwardSlabArcStart.RtlLhs RightSB XH sw Hook
 				__ : list [g4 RightSB (XH - Hook) [widths.lhs sw]] [hookstart XH (sw -- sw)]
-			flat (SB + OX) (XH - SmallArchDepthA)
-			curl (SB + OX) SmallArchDepthB
+			flatside.ld SB 0 XH SmallArchDepthA SmallArchDepthB
 			CurlyTail.n fine 0 RightSB 0 0 (yLoopTop -- XH * 0.45)
 
 	glyph-block-export CLetterForm
@@ -214,13 +211,13 @@ glyph-block Letter-Latin-C : begin
 				include : Translate 0 (SB / 2)
 
 		create-glyph "cyrl/esWide.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.diversityM 3
+			local df : include : DivFrame para.diversityT 3
 			include : df.markSet.e
-			local desc : -LongJut + 0.5 * Stroke
+			local desc : (-LongJut) + HalfStroke
 			include : ExtendBelowBaseAnchors desc
 			local lf : CLetterForm df sty styBot XH desc
-				ada -- [df.archDepthA SmallArchDepth df.mvs]
-				adb -- [df.archDepthB SmallArchDepth df.mvs]
+				ada -- [df.archDepthA SmallArchDepth Stroke]
+				adb -- [df.archDepthB SmallArchDepth Stroke]
 			include : lf.full
 
 		create-glyph "cHookTop.\(suffix)" : glyph-proc
@@ -240,10 +237,12 @@ glyph-block Letter-Latin-C : begin
 		create-glyph "stretchedC.\(suffix)" : glyph-proc
 			include : MarkSet.p
 			local lf : CLetterForm [DivFrame 1] sty styBot XH Descender
+				ada -- SmallArchDepthA
+				adb -- SmallArchDepthB
 			include : lf.full
 
 		define [KoppaShapeT styTop styBot top base] : union
-			VBar.r (Middle + [HSwToV Stroke]) Descender (Stroke / 2)
+			VBar.r (Middle + [HSwToV Stroke]) Descender HalfStroke
 			difference base
 				Rect (top / 2) Descender (Middle + [HSwToV Stroke]) (Width * 4)
 				Rect (XH / 2) [mix Stroke Hook 0.5] Middle (Width * 4)
@@ -357,9 +356,10 @@ glyph-block Letter-Latin-C : begin
 
 	derive-glyphs 'cyrl/The' 0x4AA "cyrl/Es" : function [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
-		include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
+		local desc : (-LongJut) + HalfStroke
+		include : ExtendBelowBaseAnchors desc
 		include : difference
-			VBar.m [arch.adjust-x.bot Middle] (-LongJut + 0.5 * Stroke) (Stroke + O) [AdviceStroke 3.5]
+			VBar.m [arch.adjust-x.bot Middle] desc (Stroke + O) [AdviceStroke 3.5]
 			OShapeOutline.NoOvershoot CAP 0 SB RightSB Stroke ArchDepthA ArchDepthB
 
 	derive-multi-part-glyphs 'cyrl/The.BSH' null { 'cyrl/Es' 'invCommaBelow' } : lambda [srcs gr] : glyph-proc
@@ -373,9 +373,10 @@ glyph-block Letter-Latin-C : begin
 
 	derive-glyphs 'cyrl/the' 0x4AB "cyrl/es" : function [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
-		include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
+		local desc : (-LongJut) + HalfStroke
+		include : ExtendBelowBaseAnchors desc
 		include : difference
-			VBar.m [arch.adjust-x.bot Middle] (-LongJut + 0.5 * Stroke) (Stroke + O) [AdviceStroke 3.5]
+			VBar.m [arch.adjust-x.bot Middle] desc (Stroke + O) [AdviceStroke 3.5]
 			OShapeOutline.NoOvershoot XH 0 SB RightSB Stroke SmallArchDepthA SmallArchDepthB
 
 	derive-multi-part-glyphs 'cyrl/the.BSH' null { 'cyrl/es' 'invCommaBelow' } : lambda [srcs gr] : glyph-proc
@@ -441,12 +442,12 @@ glyph-block Letter-Latin-C : begin
 					curl df.middle [mix bot top 0.5] [widths.center.heading swBarFine Upward]
 
 		define [OutlineMask df] : spiro-outline
-			curl (df.leftSB + 0.5 * Stroke)  (post@ <-> SmallArchDepthA)
-			arch.rhs (sw -- Stroke) (tMask - 0.5 * Stroke)
-			flat (df.rightSB - 0.5 * Stroke) (pre@ <-> SmallArchDepthB)
-			curl pre@                        (post@ <+> SmallArchDepthA)
-			arch.rhs (sw -- Stroke) (bMask + 0.5 * Stroke)
-			flat post@ 					     (pre@ <+> SmallArchDepthB)
+			curl (df.leftSB + HalfStroke)  (post@ <-> SmallArchDepthA)
+			arch.rhs (sw -- Stroke) (tMask - HalfStroke)
+			flat (df.rightSB - HalfStroke) (pre@  <-> SmallArchDepthB)
+			curl pre@                      (post@ <+> SmallArchDepthA)
+			arch.rhs (sw -- Stroke) (bMask + HalfStroke)
+			flat post@                     (pre@  <+> SmallArchDepthB)
 
 		define [InterruptMask df] : begin
 			define gap : Math.max (XH / 8) [AdviceStroke2 6 6 XH]

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -52,8 +52,7 @@ glyph-block Letter-Latin-Lower-E : begin
 			flat (df.rightSB - OX) barBottom [heading Upward]
 			curl (df.rightSB - OX) (top - adb)
 			arch.lhs top (sw -- stroke)
-			flat (df.leftSB + OX) (top - ada)
-			curl (df.leftSB + OX) (0   + adb)
+			flatside.ld df.leftSB 0 top ada adb
 			SmallESerifedTerminalShape df top stroke tailSlab noSwash
 
 		include : SmallETerminalSerif df top stroke tailSlab noSwash
@@ -73,10 +72,9 @@ glyph-block Letter-Latin-Lower-E : begin
 			flat (df.leftSB + OX) barBottom [heading Upward]
 			curl (df.leftSB + OX) (top - ada)
 			arch.rhs top (sw -- stroke)
-			flat (df.rightSB - OX) (top - adb)
-			curl (df.rightSB - OX) (0   + ada)
+			flatside.rd df.rightSB 0 top ada adb
 			hookend 0 (sw -- stroke)
-			g4   (df.leftSB + 0.5 * OX) [HookHeight top stroke true]
+			g4 (df.leftSB + 0.5 * OX) [HookHeight top stroke true]
 
 	glyph-block-export SmallERoundedShape
 	define [SmallERoundedShape] : with-params [
@@ -92,10 +90,9 @@ glyph-block Letter-Latin-Lower-E : begin
 			if para.isItalic [alsoThru.g2 0.5 0.8] [list]
 			[if para.isItalic g4.right.mid curl] [mix xStart df.rightSB 0.475] (barBottom - extraCurliness)
 			archv
-			g4   (df.rightSB - OX) [YSmoothMidR top barBottom]
+			g4 (df.rightSB - OX) [YSmoothMidR top barBottom]
 			arch.lhs top (sw -- stroke)
-			flat (df.leftSB + OX) (top - ada)
-			curl (df.leftSB + OX) (0   + adb)
+			flatside.ld df.leftSB 0 top ada adb
 			SmallESerifedTerminalShape df top stroke tailSlab noSwash
 
 		include : SmallETerminalSerif df top stroke tailSlab noSwash
@@ -117,12 +114,11 @@ glyph-block Letter-Latin-Lower-E : begin
 			if para.isItalic [alsoThru.g2 0.5 0.8] [list]
 			[if para.isItalic g4.left.mid curl] [mix xStart df.leftSB 0.475] (barBottom - extraCurliness)
 			archv
-			g4   (df.leftSB + OX) [YSmoothMidL top barBottom]
+			g4 (df.leftSB + OX) [YSmoothMidL top barBottom]
 			arch.rhs top (sw -- stroke)
-			flat (df.rightSB - OX) (top - adb)
-			curl (df.rightSB - OX) (0   + ada)
+			flatside.rd df.rightSB 0 top ada adb
 			hookend 0 (sw -- stroke)
-			g4   (df.leftSB + 0.5 * OX) [HookHeight top stroke true]
+			g4 (df.leftSB + 0.5 * OX) [HookHeight top stroke true]
 
 	define [AbkCheShape] : with-params [
 		fDesc Body df top [stroke df.mvs] [barpos nothing]
@@ -134,14 +130,15 @@ glyph-block Letter-Latin-Lower-E : begin
 		include : Body dfSub top
 			stroke -- stroke
 			barpos -- barpos
-			ada -- (ada * divSub)
-			adb -- (adb * divSub)
+			ada -- [clamp (stroke * 1.5) (top - adb * divSub - TINY) (ada * divSub)]
+			adb -- [clamp (stroke * 1.5) (top - ada * divSub - TINY) (adb * divSub)]
 			tailSlab -- tailSlab
 		define offset : Width * (df.div - divSub)
 		if fDesc : begin
-			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
+			local desc : (-LongJut) + HalfStroke
+			include : ExtendBelowBaseAnchors desc
 			include : difference
-				VBar.m dfSub.middle (-LongJut + 0.5 * Stroke) (stroke + O) [AdviceStroke 3.5 df.div]
+				VBar.m dfSub.middle desc (stroke + O) [AdviceStroke 3.5 df.div]
 				OShapeOutline.NoOvershoot top 0 dfSub.leftSB dfSub.rightSB stroke
 		include : Translate offset 0
 


### PR DESCRIPTION
Make Bulgarian Cyrillic Ef use `fFlatTB`:
`Фф𞁂`
Etoile Before:
![image](https://github.com/user-attachments/assets/95399115-352d-42e1-b326-72c07a27bbeb)
Etoile After:
![image](https://github.com/user-attachments/assets/6e848508-8528-4f88-b4bb-253e3d04bf77)
Unify width of Cyrillic wide es with broad on:
```
ᲃᲃ
Ѻѻ
```
Etoile Before:
![image](https://github.com/user-attachments/assets/4cdfa599-df70-4511-a41c-f03fc7027631)
Etoile After:
![image](https://github.com/user-attachments/assets/9889765d-aee2-4bcb-b242-0ded1162fb49)

Also some other miscellaneous code cleanup involving some tangentially related letters.