### PR TITLE
Optimize ArchDepth and Hook perameters for Ezh-derived letters.

### DIFF
--- a/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
@@ -241,7 +241,7 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 
 		create-glyph "cyrl/ze.BGR.\(suffix)" : glyph-proc
 			include : MarkSet.p
-			include : let [ze : CyrZe slabTop slabBot XH Descender (hook -- SHook)]
+			include : let [ze : CyrZe slabTop slabBot XH Descender (hook -- Hook)]
 				union [ze.Shape] [ze.AutoStartSerifL] [ze.AutoEndSerifL]
 
 		create-glyph "cyrl/Dhe.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
@@ -10,51 +10,45 @@ glyph-block Letter-Latin-Ezh : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Shapes : CurlyTail SerifedArcEnd PalatalHook RetroflexHook
 
-	define [StdTerminalShape df top bot yMidBar sw] : begin
-		local hookDepth : Hook * (top - bot) / [fallback para.cap0 CAP]
-		local pArc : SmallArchDepthB / (SmallArchDepthA + SmallArchDepthB)
-		list
-			g4 (df.rightSB - OX) [mix yMidBar bot pArc]
-			hookend bot
-			g4 df.leftSB (bot + hookDepth)
+	define [pArc ada adb] : adb / (ada + adb)
 
-	define [HooklessTerminalShape p] : function [df top bot yMidBar sw] : list
+	define [StdTerminalShape df top bot yMidBar sw hook ada adb] : list
+		g4 (df.rightSB - OX) [mix yMidBar bot : pArc ada adb]
+		hookend bot
+		g4 df.leftSB (bot + hook)
+
+	define [HooklessTerminalShape p] : function [df top bot yMidBar sw hook ada adb] : list
 		g4.down.mid  (df.rightSB - OX) [mix yMidBar bot p] [heading Downward]
 
-	define [RetroflexConnectionTerminal df top bot yMidBar sw] : begin
-		local hookDepth : Hook * (top - bot) / [fallback para.cap0 CAP]
-		local pArc : SmallArchDepthB / (SmallArchDepthA + SmallArchDepthB)
-		list
-			g4   (df.rightSB - OX) [mix yMidBar bot pArc]
-			SerifedArcEnd.RtlRhs df.leftSB bot sw hookDepth
+	define [RetroflexConnectionTerminal df top bot yMidBar sw hook ada adb] : list
+		g4 (df.rightSB - OX) [mix yMidBar bot : pArc ada adb]
+		SerifedArcEnd.RtlRhs df.leftSB bot sw hook
 
-	define [CurlyTailTerminalShape df top bot yMidBar sw] : begin
-		local pArc : SmallArchDepthB / (SmallArchDepthA + SmallArchDepthB)
+	define [CurlyTailTerminalShape df top bot yMidBar sw hook ada adb] : begin
 		local fine : df.adviceStroke2 3.5 5 (top - bot)
-
 		return : list
-			g4 (df.rightSB - OX) [mix yMidBar bot pArc]
+			g4 (df.rightSB - OX) [mix yMidBar bot : pArc ada adb]
 			CurlyTail.n fine bot df.leftSB df.width (bot + 0.5 * fine)
-				yLoopTop -- [mix yMidBar bot 0.5] + 0.25 * fine
+				yLoopTop -- ([mix yMidBar bot 0.5] + 0.25 * fine)
 				swBefore -- sw
 
-	define [ConventionalStart df top bot ezhLeft ezhRight yMidBar sw] : glyph-proc
+	define [ConventionalStart df top bot ezhLeft ezhRight yMidBar sw hook] : glyph-proc
 		include : HBar.t df.leftSB ezhRight top sw
 		include : dispiro
-			corner ezhRight (top - sw) [widths.rhs (sw / HVContrast)]
-			corner ezhLeft  yMidBar    [widths.lhs (sw / HVContrast)]
+			corner ezhRight (top - sw) [widths.rhs : sw / HVContrast]
+			corner ezhLeft  yMidBar    [widths.lhs : sw / HVContrast]
 
-	define [CurisveStart df top bot ezhLeft ezhRight yMidBar sw] : glyph-proc
+	define [CurisveStart df top bot ezhLeft ezhRight yMidBar sw hook] : glyph-proc
 		define hookTerminalWidth : [AdviceStroke 3.5] / Stroke * sw
 		define xDiagWidth : 1 * sw
 		define yFootHeight : [Math.max (0.15 * (top - bot)) (sw * 0.625)] + 0.4 * sw
-		define yHookDepth : Hook + sw * 0.25
+		define yHookDepth : hook + sw * 0.25
 		define yHookStraightDepth : Math.min (yHookDepth - sw * 1.1) (yHookDepth / 3 - sw / 4)
 		define xHookDepth : Math.max (0.25 * (df.rightSB - df.leftSB)) (hookTerminalWidth * 1.5)
 		define xMockTailDepth : Math.max (0.375 * (df.rightSB - df.leftSB)) (hookTerminalWidth * 1.375)
 		define kTop 0.625
 		define kBot 0.625
-		define yTailDepth : Hook * 0.5
+		define yTailDepth : hook * 0.5
 
 		include : tagged 'strokeTop' : intersection
 			spiro-outline
@@ -74,8 +68,8 @@ glyph-block Letter-Latin-Ezh : begin
 
 		include : VBar.r ezhRight top (top - yFootHeight) (xDiagWidth / HVContrast)
 		include : dispiro
-			corner ezhRight (top - yFootHeight) [widths.rhs (sw / HVContrast)]
-			corner ezhLeft  yMidBar             [widths.lhs (sw / HVContrast)]
+			corner ezhRight (top - yFootHeight) [widths.rhs : sw / HVContrast]
+			corner ezhLeft  yMidBar             [widths.lhs : sw / HVContrast]
 
 	glyph-block-export EzhShape
 	define flex-params [EzhShape] : glyph-proc
@@ -88,21 +82,24 @@ glyph-block Letter-Latin-Ezh : begin
 		local-parameter : isCursive     -- false
 		local-parameter : isSerifed     -- SLAB
 		local-parameter : sw            -- Stroke
+		local-parameter : hook          -- Hook
+		local-parameter : ada           -- SmallArchDepthA
+		local-parameter : adb           -- SmallArchDepthB
 
-		local yMidBar : [mix bot top [if isCursive 0.5 0.55]] + 0.5 * sw
-		local ezhLeft : mix df.leftSB df.rightSB pLeft
+		local yMidBar : [mix bot top : if isCursive 0.5 0.55] + 0.5 * sw
+		local ezhLeft  : mix df.leftSB df.rightSB pLeft
 		local ezhRight : mix df.leftSB df.rightSB pRight
 
 		include : union
 			if isCursive
-				CurisveStart      df top bot ezhLeft ezhRight yMidBar sw
-				ConventionalStart df top bot ezhLeft ezhRight yMidBar sw
+				CurisveStart      df top bot ezhLeft ezhRight yMidBar sw hook
+				ConventionalStart df top bot ezhLeft ezhRight yMidBar sw hook
 			dispiro
 				widths.rhs sw
 				flat ezhLeft yMidBar [heading Rightward]
 				curl [arch.adjust-x.top df.middle] yMidBar
 				archv
-				terminalShape df top bot yMidBar sw
+				terminalShape df top bot yMidBar sw hook ada adb
 
 		if isSerifed : include : VSerif.dl df.leftSB top VJut (sw / Stroke * VJutStroke)
 
@@ -116,15 +113,30 @@ glyph-block Letter-Latin-Ezh : begin
 	foreach { suffix { isCursive isSerifed } } [pairs-of EzhConfig] : do
 		create-glyph "Ezh.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : EzhShape [DivFrame 1] CAP 0 (isCursive -- isCursive) (isSerifed -- isSerifed)
+			include : EzhShape [DivFrame 1] CAP 0
+				isCursive -- isCursive
+				isSerifed -- isSerifed
+				hook      -- Hook
+				ada       -- ArchDepthA
+				adb       -- ArchDepthB
 
 		create-glyph "smcpEzh.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			include : EzhShape [DivFrame 1] XH 0 (isCursive -- isCursive) (isSerifed -- isSerifed)
+			include : EzhShape [DivFrame 1] XH 0
+				isCursive -- isCursive
+				isSerifed -- isSerifed
+				hook      -- Hook
+				ada       -- ArchDepthA
+				adb       -- ArchDepthB
 
 		create-glyph "ezh.\(suffix)" : glyph-proc
 			include : MarkSet.p
-			include : EzhShape [DivFrame 1] XH Descender (isCursive -- isCursive) (isSerifed -- isSerifed)
+			include : EzhShape [DivFrame 1] XH Descender
+				isCursive -- isCursive
+				isSerifed -- isSerifed
+				hook      -- Hook
+				ada       -- SmallArchDepthA
+				adb       -- SmallArchDepthB
 
 		create-glyph "ezhTail.\(suffix)" : glyph-proc
 			include : MarkSet.p
@@ -132,15 +144,16 @@ glyph-block Letter-Latin-Ezh : begin
 			local [object yMidBar] : include : EzhShape [DivFrame 1] XH b
 				isCursive -- isCursive
 				isSerifed -- isSerifed
+				ada       -- SmallArchDepthA
+				adb       -- SmallArchDepthB
 				terminalShape -- [HooklessTerminalShape 0.5]
-
 			local y : mix yMidBar b 0.5
 			include : dispiro
 				widths.rhs
 				g4.down.mid (RightSB - OX) y [heading Downward]
 				arcvh
 				flat [mix SB RightSB 0.45] b
-				curl [mix SB RightSB 0.4] b
+				curl [mix SB RightSB 0.4]  b
 				archv
 				g4 (SB + [HSwToV Stroke]) [mix (Descender + Stroke) b 0.5]
 				arcvh
@@ -152,6 +165,9 @@ glyph-block Letter-Latin-Ezh : begin
 			include : EzhShape [DivFrame 1] XH Descender
 				isCursive -- isCursive
 				isSerifed -- isSerifed
+				hook      -- Hook
+				ada       -- SmallArchDepthA
+				adb       -- SmallArchDepthB
 				terminalShape -- CurlyTailTerminalShape
 
 		create-glyph "ezhRetroflexHook.\(suffix)" : glyph-proc
@@ -159,39 +175,62 @@ glyph-block Letter-Latin-Ezh : begin
 			include : EzhShape [DivFrame 1] XH 0
 				isCursive -- isCursive
 				isSerifed -- isSerifed
+				hook      -- SHook
+				ada       -- SmallArchDepthA
+				adb       -- SmallArchDepthB
 				terminalShape -- RetroflexConnectionTerminal
-			include : RetroflexHook.l SB 0 (yAttach -- Hook)
+			include : RetroflexHook.l
+				x -- SB
+				y -- 0
+				yAttach -- SHook
 
 		create-glyph "ezhPalatalHook.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 1
 			include : df.markSet.p
 			local dfSub : DivFrame (0.75 * para.diversityM) 2
-			local p : SmallArchDepthB / (SmallArchDepthA + SmallArchDepthB)
+			local ada : dfSub.archDepthA SmallArchDepth dfSub.mvs
+			local adb : dfSub.archDepthB SmallArchDepth dfSub.mvs
 			local [object yMidBar] : include : EzhShape dfSub XH Descender
 				isCursive -- isCursive
 				isSerifed -- isSerifed
 				sw        -- dfSub.mvs
-			local y : [mix yMidBar Descender p] - 0.5 * dfSub.mvs
+				hook      -- Hook
+				ada       -- ada
+				adb       -- adb
+			local y : [mix yMidBar Descender : pArc ada adb] - 0.5 * dfSub.mvs
 			include : PalatalHook.r
-				x -- df.rightSB
-				y -- y
-				xLink -- dfSub.rightSB
-				refSw -- dfSub.mvs
+				x       -- df.rightSB
+				y       -- y
+				xLink   -- dfSub.rightSB
+				refSw   -- dfSub.mvs
 				maskOut -- [intersection [MaskBelow y] [MaskLeft dfSub.rightSB]]
 
 		if [not isSerifed] : begin
-			create-glyph "ezhPalatalHook/phoneticRight.\(suffix)" : glyph-proc
+			create-glyph "ezh/phoneticRight.\(suffix)" : glyph-proc
 				include : MarkSet.p
-				local p : SmallArchDepthB / (SmallArchDepthA + SmallArchDepthB)
-				local [object yMidBar] : include : EzhShape [DivFrame 1] XH Descender
+				include : EzhShape [DivFrame 1] XH Descender
+					pLeft     -- 0.27
 					isCursive -- isCursive
 					isSerifed -- isSerifed
-				local y : [mix yMidBar Descender p] - HalfStroke
+					hook      -- Hook
+					ada       -- SmallArchDepthA
+					adb       -- SmallArchDepthB
+
+			create-glyph "ezhPalatalHook/phoneticRight.\(suffix)" : glyph-proc
+				include : MarkSet.p
+				local [object yMidBar] : include : EzhShape [DivFrame 1] XH Descender
+					pLeft     -- 0.27
+					isCursive -- isCursive
+					isSerifed -- isSerifed
+					hook      -- Hook
+					ada       -- SmallArchDepthA
+					adb       -- SmallArchDepthB
+				local y : [mix yMidBar Descender : pArc SmallArchDepthA SmallArchDepthB] - HalfStroke
 				include : PalatalHook.r
-					x -- [mix SB RightSB (4/3)]
-					y -- y
-					xLink -- RightSB
-					refSw -- [AdviceStroke 3]
+					x       -- [mix SB RightSB (4/3)]
+					y       -- y
+					xLink   -- RightSB
+					refSw   -- [AdviceStroke 3]
 					maskOut -- [intersection [MaskBelow y] [MaskLeft RightSB]]
 
 	select-variant 'Ezh' 0x1B7
@@ -201,16 +240,21 @@ glyph-block Letter-Latin-Ezh : begin
 	select-variant 'ezhCurlyTail' 0x293 (follow -- 'ezh')
 	select-variant 'ezhRetroflexHook' 0x1D9A (follow -- 'ezh')
 	select-variant 'ezhPalatalHook' 0x1DF18 (follow -- 'ezh')
-	select-variant 'ezh/phoneticRight' (shapeFrom -- 'ezh')
+	select-variant 'ezh/phoneticRight'
 	select-variant 'ezhPalatalHook/phoneticRight' (follow -- 'ezh/phoneticRight')
 
 	alias 'cyrl/abk/Dze' 0x4E0 'Ezh'
 	alias 'cyrl/abk/dze' 0x4E1 'ezh'
 
-	# Variants for Ezh doesn't make sense for Lyogh.
+	# Variants for Ezh don't make sense for Lyogh.
 	create-glyph 'lyogh.serifless' : glyph-proc
 		include : MarkSet.bp
-		include : EzhShape [DivFrame 1] XH Descender 0.4
+		include : EzhShape [DivFrame 1] XH Descender
+			pLeft     -- 0.4
+			isSerifed -- false
+			hook      -- Hook
+			ada       -- SmallArchDepthA
+			adb       -- SmallArchDepthB
 		include : VBar.l SB (XH * 0.1) Ascender
 
 	create-glyph 'lyogh.hooky' : glyph-proc
@@ -221,7 +265,13 @@ glyph-block Letter-Latin-Ezh : begin
 
 	create-glyph 'lyoghRTail.serifless' : glyph-proc
 		include : MarkSet.b
-		include : EzhShape [DivFrame 1] XH 0 0.4
+		include : EzhShape [DivFrame 1] XH 0
+			pLeft     -- 0.4
+			isSerifed -- false
+			hook      -- SHook
+			ada       -- SmallArchDepthA
+			adb       -- SmallArchDepthB
+			terminalShape -- RetroflexConnectionTerminal
 		include : VBar.l SB 0 Ascender
 		include : RetroflexHook.lExt SB 0
 
@@ -232,29 +282,29 @@ glyph-block Letter-Latin-Ezh : begin
 	select-variant 'lyoghRTail' 0x1DF05 (follow -- 'lyogh')
 
 
-	# Used by ampersand only
-	# Current reversed Ezh is generated using a auto-build.
+	# Used by ampersand only.
+	# Current reversed Ezh is generated using an auto-build.
 	glyph-block-export RevEzhShape
 	define flex-params [RevEzhShape] : glyph-proc
 		local-parameter : top
 		local-parameter : bot
-		local-parameter : pLeft -- 0.075
-		local-parameter : pRight -- 0.8
-		local-parameter : hookless -- false
-		local-parameter : ada -- SmallArchDepthA
-		local-parameter : adb -- SmallArchDepthB
+		local-parameter : pLeft     -- 0.075
+		local-parameter : pRight    -- 0.8
+		local-parameter : hookless  -- false
+		local-parameter : ada       -- SmallArchDepthA
+		local-parameter : adb       -- SmallArchDepthB
 		local-parameter : diagCoeff -- 1.2
-		local-parameter : pyBar -- 0.6
+		local-parameter : pyBar     -- 0.6
 
 		local cor : HSwToV diagCoeff
 		local yMidBar : RevEzhShape.yMidBar top bot pyBar
 		local ezhRight : mix SB RightSB pRight
-		local ezhLeft : mix SB RightSB pLeft
+		local ezhLeft  : mix SB RightSB pLeft
 
 		include : HBar.t ezhLeft RightSB top
 		include : dispiro
-			corner ezhLeft (top - Stroke) [widths.lhs (Stroke / HVContrast)]
-			corner ezhRight yMidBar       [widths.rhs (Stroke / HVContrast)]
+			corner ezhLeft (top - Stroke) [widths.lhs : Stroke / HVContrast]
+			corner ezhRight yMidBar       [widths.rhs : Stroke / HVContrast]
 
 		include : dispiro
 			widths.lhs


### PR DESCRIPTION
Ideally I would like to show before and after images of three weights each of both widths of monospace, both upright and italic, both sans and slab, and both aile and etoile, but that would be 2×((3×2×2×2)+(3×2))=60 images (and then ×3 again for the three different examples below would make it 120 total) so I'm only showing a subset for bandwidth reasons. However, just bear in mind that I tested _every_ permutation.

Firstly, optimize the mid x point when in a digraph ligature (mind you, `𝼜` and `𝼙` are still not yet added):
```
ts dz tʃ dʒ
ʦ  ʣ  ʧ  ʤ 
tɕ dʑ tᶋ d𝼘
ʨ  ʥ  𝼗  𝼒 
tʂ dʐ tᶘ dᶚ
ꭧ  ꭦ  𝼜  𝼙 
```
Thin Upright:
![image](https://github.com/user-attachments/assets/6fb301f7-327b-4d17-9977-19f9ff40d6c2)
Regular Upright:
![image](https://github.com/user-attachments/assets/9a032213-7085-4508-878d-dc5a2f2193c7)
Heavy Upright:
![image](https://github.com/user-attachments/assets/3e6ef35d-e1bc-44b1-b649-f3bb11eebee7)
Thin Italic:
![image](https://github.com/user-attachments/assets/f5c7352a-7010-4045-848d-b728a0c454ae)
Regular Italic:
![image](https://github.com/user-attachments/assets/4336cc19-d274-4e45-9612-ba7c5192ca9d)
Heavy Italic:
![image](https://github.com/user-attachments/assets/e1bd48b3-332c-4830-b9eb-f20d3932fe00)
Secondly, make capital Ezh use full ArchDepth:
`ƷʒӠӡzᴣᴢЗз`
Thin Upright:
![image](https://github.com/user-attachments/assets/e662b867-3399-47e3-b4e8-2c64ec7385e5)
Regular Upright:
![image](https://github.com/user-attachments/assets/cb537a6c-29e9-4050-b2da-650c740d9cc0)
Heavy Upright:
![image](https://github.com/user-attachments/assets/851e6131-5416-466f-a9cd-297bca81b0a5)
Thin Italic:
![image](https://github.com/user-attachments/assets/0d62b262-84be-4cea-ab72-5b665039c4cf)
Regular Italic:
![image](https://github.com/user-attachments/assets/a0187a3e-c105-4aeb-b1a4-fbcd36173267)
Heavy Italic:
![image](https://github.com/user-attachments/assets/9763d46e-7df0-4508-a0b2-a63d88be405b)
Thirdly, Optimize the ezh terminal for Lezh with retroflex hook:
```
lʃ lʒ
ɬ  ɮ 
lᶘ lᶚ
ꞎ  𝼅 
```
Thin Upright:
![image](https://github.com/user-attachments/assets/5c3a9c1d-6202-46a0-9f8e-bcf50e46a65f)
Regular Upright:
![image](https://github.com/user-attachments/assets/2be79b61-bac3-4abc-b710-e1a46ffefa26)
Heavy Upright:
![image](https://github.com/user-attachments/assets/f35109e2-03a4-4c6c-926f-3a9569d6e46b)
Thin Italic:
![image](https://github.com/user-attachments/assets/7798d7a6-903a-4d9c-980f-bdb78f3e1ede)
Regular Italic:
![image](https://github.com/user-attachments/assets/cf250d44-d07f-4b82-bb6c-3a8bbe2e68f5)
Heavy Italic:
![image](https://github.com/user-attachments/assets/771e2907-ab05-4698-96aa-2af4716473a1)
