### PR TITLE
Add new parameter `LongVJut` as a `VJut`-like counterpart to `LongJut`.

### DIFF
--- a/packages/font-glyphs/src/letter/cyrillic/che.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/che.ptl
@@ -229,10 +229,10 @@ glyph-block Letter-Cyrillic-Che : begin
 	define [CheVBarBarShape top pyBar] : begin
 		local SwCheVBar : Math.min OverlayStroke (0.625 * (RightSB - SB - [HSwToV : 2 * Stroke]) / HVContrast)
 		local yc : top * [fallback pyBar 0.5] + Stroke * 0.1
-		return : VBar.m Middle (yc + LongJut * 0.8) (yc - LongJut * 0.8) SwCheVBar
+		return : VBar.m Middle (yc + LongVJut * 0.8) (yc - LongVJut * 0.8) SwCheVBar
 
-	derive-composites 'cyrl/CheVBar' 0x4B8 'cyrl/Che' [CheVBarBarShape CAP [if SLAB 0.45 0.35]]
-	derive-composites 'cyrl/cheVBar' 0x4B9 'cyrl/che' [CheVBarBarShape XH  [if SLAB 0.45 0.4 ]]
+	derive-composites 'cyrl/CheVBar' 0x4B8 'cyrl/Che' [CheVBarBarShape CAP : if SLAB 0.45 0.35]
+	derive-composites 'cyrl/cheVBar' 0x4B9 'cyrl/che' [CheVBarBarShape XH  : if SLAB 0.45 0.4 ]
 
 	define ShhaConfig : object
 		serifless                 SERIFS.NONE
@@ -245,7 +245,7 @@ glyph-block Letter-Cyrillic-Che : begin
 			include : MarkSet.capital
 			include : LeaningAnchor.Above.VBar.l SB
 			include : CyrCheShape [DivFrame 1] CAP (1 - HBarPos) BODY.STRAIGHT serifs
-				yBarOffset -- [HSwToV : Math.pow Stroke 2] / (RightSB - SB)
+				yBarOffset -- ([HSwToV : Math.pow Stroke 2] / (RightSB - SB))
 			include : FlipAround Middle (CAP / 2)
 
 		create-glyph "cyrl/Hwe.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/letter/cyrillic/de.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/de.ptl
@@ -11,7 +11,7 @@ glyph-block Letter-Cyrillic-De : begin
 	glyph-block-import Letter-Greek-Lower-Epsilon : CyrZe EpsilonConfig
 
 	glyph-block-export BottomExtension
-	local BottomExtension : 0.25 * Stroke - LongJut
+	local BottomExtension : 0.25 * Stroke - LongVJut
 
 	glyph-block-export CyrDeBottom
 	define [CyrDeBottom left right _sw _desc] : glyph-proc
@@ -126,7 +126,7 @@ glyph-block Letter-Cyrillic-De : begin
 				right  -- sr
 				hook   -- hook
 				stroke -- sw
-				xo     -- 0.5 * O
+				xo     -- (0.5 * O)
 				op     -- 0.5
 			return : union [ze.Shape] [ze.AutoEndSerifL]
 

--- a/packages/font-glyphs/src/letter/cyrillic/dzhe.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/dzhe.ptl
@@ -8,19 +8,22 @@ glyph-block Letter-Cyrillic-Dzhe : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Shapes : SerifFrame
+	glyph-block-import Mark-Adjustment : ExtendBelowBaseAnchors
 
 	define [CyrDzheShape top] : glyph-proc
 		include : VBar.l SB 0 top
 		include : HBar.b SB RightSB 0
 		include : VBar.r RightSB 0 top
-		include : VBar.m Middle Descender Stroke
+		local desc : 0.25 * Stroke - LongVJut
+		include : VBar.m Middle desc Stroke
+		include : ExtendBelowBaseAnchors desc
 		if SLAB : let [sf : SerifFrame.fromDf [DivFrame 1] top 0] : begin
 			include : composite-proc sf.lt.full sf.rt.full sf.lb.outer sf.rb.outer
 
 	create-glyph 'cyrl/Dzhe' 0x40F : glyph-proc
-		include : MarkSet.capDesc
+		include : MarkSet.capital
 		include : CyrDzheShape CAP
 
 	create-glyph 'cyrl/dzhe.upright' : glyph-proc
-		include : MarkSet.p
+		include : MarkSet.e
 		include : CyrDzheShape XH

--- a/packages/font-glyphs/src/letter/cyrillic/dzzhe-zhwe.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/dzzhe-zhwe.ptl
@@ -33,14 +33,14 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 		create-glyph "cyrl/Dzzhe/left" : glyph-proc
 			define df : include : DivFrame para.diversityM 3.5
 			include : df.markSet.capital
-			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
+			include : ExtendBelowBaseAnchors (-LongVJut + HalfStroke)
 			set-base-anchor 'cvDecompose' 0 0
 			include : CyrDzzheDeShape df CAP
 
 		create-glyph "cyrl/dzzhe.upright/left" : glyph-proc
 			define df : include : DivFrame para.diversityM 3.5
 			include : df.markSet.e
-			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
+			include : ExtendBelowBaseAnchors (-LongVJut + HalfStroke)
 			set-base-anchor 'cvDecompose' 0 0
 			include : CyrDzzheDeShape df XH
 
@@ -58,7 +58,7 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 				right  -- subDf.rightSB
 				hook   -- hook
 				stroke -- sw
-				xo     -- 0.33 * OX
+				xo     -- (0.33 * OX)
 			include : ze.Shape
 			include : ze.AutoStartSerifL
 			include : ze.AutoEndSerifL
@@ -94,7 +94,7 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 				left   -- subDf.leftSB
 				right  -- subDf.rightSB
 				hook   -- hook
-				stroke -- 0.5 * sw
+				stroke -- (0.5 * sw)
 				xo     -- 0
 				yo     -- 0
 			include : difference [CyrRightZheShape legShape fSlab fMidSlab df top subDf.middle] [zeNoO.ShapeMask]

--- a/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
@@ -246,20 +246,20 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 
 		create-glyph "cyrl/Dhe.\(suffix)" : glyph-proc
 			include [refer-glyph "cyrl/Ze.\(suffix)"] AS_BASE ALSO_METRICS
-			local desc : (-LongJut) + HalfStroke
+			local desc : (-LongVJut) + HalfStroke
 			include : ExtendBelowBaseAnchors desc
 			include : let [zeNoO : CyrZe slabTop slabBot CAP 0 (hook -- Hook) (xo -- 0) (yo -- 0)]
 				difference
-					VBar.m [arch.adjust-x.bot Middle] desc (Stroke + O) [AdviceStroke 3.5]
+					VBar.m [arch.adjust-x.bot Middle] desc (Stroke + O) VJutStroke
 					zeNoO.ShapeMask
 
 		create-glyph "cyrl/dhe.\(suffix)" : glyph-proc
 			include [refer-glyph "cyrl/ze.\(suffix)"] AS_BASE ALSO_METRICS
-			local desc : (-LongJut) + HalfStroke
+			local desc : (-LongVJut) + HalfStroke
 			include : ExtendBelowBaseAnchors desc
 			include : let [zeNoO : CyrZe slabTop slabBot XH 0 (hook -- SHook) (xo -- 0) (yo -- 0)]
 				difference
-					VBar.m [arch.adjust-x.bot Middle] desc (Stroke + O) [AdviceStroke 3.5]
+					VBar.m [arch.adjust-x.bot Middle] desc (Stroke + O) VJutStroke
 					zeNoO.ShapeMask
 
 		create-glyph "cyrl/DzjeKomi.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/letter/greek/phi.ptl
+++ b/packages/font-glyphs/src/letter/greek/phi.ptl
@@ -129,7 +129,7 @@ glyph-block Letter-Greek-Phi : begin
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.capital
 
-		local vJut : Math.max (LongJut - HalfStroke) : if SLAB (1.5 * Stroke) 0
+		local vJut : Math.max (LongVJut - HalfStroke) : if SLAB (1.5 * Stroke) 0
 
 		local top : CAP + vJut
 		local bot : 0   - vJut

--- a/packages/font-glyphs/src/letter/greek/upper-gamma.ptl
+++ b/packages/font-glyphs/src/letter/greek/upper-gamma.ptl
@@ -59,14 +59,14 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 		create-glyph "cyrl/GheDescender.\(suffix)" : glyph-proc
 			include [refer-glyph "grek/Gamma.\(suffix)"] AS_BASE ALSO_METRICS
 			include : CyrDescender.rSideJut
-				x -- GammaBarLeft + [HSwToV Stroke]
+				x -- (GammaBarLeft + [HSwToV Stroke])
 				y -- 0
 				jut -- MidJutSide
 
 		create-glyph "cyrl/GheDHook.\(suffix)" : glyph-proc
 			include [refer-glyph "grek/Gamma.\(suffix)"] AS_BASE ALSO_METRICS
 			include : PalatalHook.rSideJut
-				x -- GammaBarLeft + [HSwToV Stroke]
+				x -- (GammaBarLeft + [HSwToV Stroke])
 				y -- 0
 				jut -- MidJutSide
 
@@ -77,30 +77,30 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 		create-glyph "cyrl/gheDescender.upright.\(suffix)" : glyph-proc
 			include [refer-glyph "cyrl/ghe.upright.\(suffix)"] AS_BASE ALSO_METRICS
 			include : CyrDescender.rSideJut
-				x -- GammaBarLeft + [HSwToV Stroke]
+				x -- (GammaBarLeft + [HSwToV Stroke])
 				y -- 0
 				jut -- MidJutSide
 
 		create-glyph "cyrl/gheDHook.upright.\(suffix)" : glyph-proc
 			include [refer-glyph "cyrl/ghe.upright.\(suffix)"] AS_BASE ALSO_METRICS
 			include : PalatalHook.rSideJut
-				x -- GammaBarLeft + [HSwToV Stroke]
+				x -- (GammaBarLeft + [HSwToV Stroke])
 				y -- 0
 				jut -- MidJutSide
 
 		create-glyph "cyrl/Ge.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : ExtendAboveBaseAnchors (CAP + LongJut - 0.5 * Stroke)
+			include : ExtendAboveBaseAnchors (CAP + LongVJut - HalfStroke)
 			include : GammaShape CAP 0 slabType
 			eject-contour 'serifRT'
-			include : VBar.r (RightSB - OX) CAP (CAP + LongJut - 0.5 * Stroke)
+			include : VBar.r (RightSB - OX) CAP (CAP + LongVJut - HalfStroke)
 
 		create-glyph "cyrl/ge.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			include : ExtendAboveBaseAnchors (XH + LongJut - 0.5 * Stroke)
+			include : ExtendAboveBaseAnchors (XH + LongVJut - HalfStroke)
 			include : GammaShape XH 0 slabType
 			eject-contour 'serifRT'
-			include : VBar.r (RightSB - OX) XH (XH + LongJut - 0.5 * Stroke)
+			include : VBar.r (RightSB - OX) XH (XH + LongVJut - HalfStroke)
 			if para.isItalic : eject-contour 'serifLB'
 
 		create-glyph "cyrl/GheMidHook.\(suffix)" : glyph-proc
@@ -109,7 +109,7 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 			include : MidHook.general
 				left   -- (GammaBarLeft + [HSwToV Stroke])
 				right  -- RightSB
-				top    -- CAP * HBarPos + Stroke / 4
+				top    -- (CAP * HBarPos + Stroke / 4)
 				ada    -- ArchDepthA
 				adb    -- ArchDepthB
 
@@ -119,9 +119,9 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 			include : MidHook.general
 				left   -- (GammaBarLeft + [HSwToV Stroke])
 				right  -- RightSB
-				top    -- XH * HBarPos + Stroke / 4
-				ada    -- ArchDepthA * [Math.pow HBarPos 0.3]
-				adb    -- ArchDepthB * [Math.pow HBarPos 0.3]
+				top    -- (XH * HBarPos + Stroke / 4)
+				ada    -- (ArchDepthA * [Math.pow HBarPos 0.3])
+				adb    -- (ArchDepthB * [Math.pow HBarPos 0.3])
 			if para.isItalic : eject-contour 'serifLB'
 
 	select-variant 'grek/Gamma' 0x393

--- a/packages/font-glyphs/src/letter/greek/upper-lambda-delta.ptl
+++ b/packages/font-glyphs/src/letter/greek/upper-lambda-delta.ptl
@@ -147,6 +147,6 @@ glyph-block Letter-Latin-Upper-Lambda-Delta : begin
 		local xCutLeft SB
 		local xCutRight RightSB
 		include : HBar.b (xCutLeft - descenderOverflow) (xCutRight + descenderOverflow) 0
-		include : VBar.l (xCutLeft - descenderOverflow) (-LongJut + HalfStroke) Stroke
-		include : VBar.r (xCutRight + descenderOverflow) (-LongJut + HalfStroke) Stroke
+		include : VBar.l (xCutLeft - descenderOverflow) (-LongVJut + HalfStroke) Stroke
+		include : VBar.r (xCutRight + descenderOverflow) (-LongVJut + HalfStroke) Stroke
 

--- a/packages/font-glyphs/src/letter/latin/c.ptl
+++ b/packages/font-glyphs/src/letter/latin/c.ptl
@@ -106,7 +106,7 @@ glyph-block Letter-Latin-C : begin
 				[Just SLAB-INWARD] : InwardSlabArcStart.RtlLhs RightSB XH sw Hook
 				__ : list [g4 RightSB (XH - Hook) [widths.lhs sw]] [hookstart XH (sw -- sw)]
 			flatside.ld SB 0 XH SmallArchDepthA SmallArchDepthB
-			CurlyTail.n fine 0 RightSB 0 0 (yLoopTop -- XH * 0.45)
+			CurlyTail.n fine 0 RightSB 0 0 (yLoopTop -- (XH * 0.45))
 
 	glyph-block-export CLetterForm
 	define [CLetterForm] : with-params [df sty styBot top bot [ada ArchDepthA] [adb ArchDepthB] [hook Hook] [sw Stroke] [ob nothing]] : namespace
@@ -205,7 +205,7 @@ glyph-block Letter-Latin-C : begin
 			local top : Width - SB
 			local p : mix 1 (Width / UPM) 0.5
 			include : PointingTo Width XH Width 0 : function [] : glyph-proc
-				local lf : CLetterForm df sty styBot top 0 (hook -- Hook * p)
+				local lf : CLetterForm df sty styBot top 0 (hook -- (Hook * p))
 				include : lf.full
 				include : FlipAround df.middle (top / 2)
 				include : Translate 0 (SB / 2)
@@ -213,7 +213,7 @@ glyph-block Letter-Latin-C : begin
 		create-glyph "cyrl/esWide.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityT 3
 			include : df.markSet.e
-			local desc : (-LongJut) + HalfStroke
+			local desc : (-LongVJut) + HalfStroke
 			include : ExtendBelowBaseAnchors desc
 			local lf : CLetterForm df sty styBot XH desc
 				ada -- [df.archDepthA SmallArchDepth Stroke]
@@ -356,10 +356,10 @@ glyph-block Letter-Latin-C : begin
 
 	derive-glyphs 'cyrl/The' 0x4AA "cyrl/Es" : function [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
-		local desc : (-LongJut) + HalfStroke
+		local desc : (-LongVJut) + HalfStroke
 		include : ExtendBelowBaseAnchors desc
 		include : difference
-			VBar.m [arch.adjust-x.bot Middle] desc (Stroke + O) [AdviceStroke 3.5]
+			VBar.m [arch.adjust-x.bot Middle] desc (Stroke + O) VJutStroke
 			OShapeOutline.NoOvershoot CAP 0 SB RightSB Stroke ArchDepthA ArchDepthB
 
 	derive-multi-part-glyphs 'cyrl/The.BSH' null { 'cyrl/Es' 'invCommaBelow' } : lambda [srcs gr] : glyph-proc
@@ -373,10 +373,10 @@ glyph-block Letter-Latin-C : begin
 
 	derive-glyphs 'cyrl/the' 0x4AB "cyrl/es" : function [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
-		local desc : (-LongJut) + HalfStroke
+		local desc : (-LongVJut) + HalfStroke
 		include : ExtendBelowBaseAnchors desc
 		include : difference
-			VBar.m [arch.adjust-x.bot Middle] desc (Stroke + O) [AdviceStroke 3.5]
+			VBar.m [arch.adjust-x.bot Middle] desc (Stroke + O) VJutStroke
 			OShapeOutline.NoOvershoot XH 0 SB RightSB Stroke SmallArchDepthA SmallArchDepthB
 
 	derive-multi-part-glyphs 'cyrl/the.BSH' null { 'cyrl/es' 'invCommaBelow' } : lambda [srcs gr] : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/k.ptl
+++ b/packages/font-glyphs/src/letter/latin/k.ptl
@@ -26,9 +26,9 @@ glyph-block Letter-Latin-K : begin
 		local kshRight       : right + [KBalanceRight true straightBar]
 		local serifLengthAdj : Ok + [HSwToV stroke]
 		return : shape.rSideJut
-			x -- kshRight - serifLengthAdj
+			x -- (kshRight - serifLengthAdj)
 			y -- 0
-			jut -- Jut + serifLengthAdj
+			jut -- (Jut + serifLengthAdj)
 
 	define [KSlabs mode top left right stroke straightBar] : glyph-proc
 		local Ok             : KO mode true top stroke
@@ -404,7 +404,7 @@ glyph-block Letter-Latin-K : begin
 		create-glyph "KDescender.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : KBaseShape Stroke CAP CyrDescender
-			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
+			include : ExtendBelowBaseAnchors (0 - LongVJut + HalfStroke)
 
 		create-glyph "KStroke.\(suffix)" : glyph-proc
 			include [refer-glyph "K.\(suffix)"] AS_BASE ALSO_METRICS
@@ -432,7 +432,7 @@ glyph-block Letter-Latin-K : begin
 		create-glyph "smcpKDescender.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : KBaseShape Stroke XH CyrDescender
-			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
+			include : ExtendBelowBaseAnchors (-LongVJut + HalfStroke)
 
 		create-glyph "smcpKVBar.\(suffix)" : glyph-proc
 			include : MarkSet.e
@@ -506,7 +506,7 @@ glyph-block Letter-Latin-K : begin
 		create-glyph "kDescender.\(suffix)" : glyph-proc
 			include : MarkSet.b
 			include : kBaseShape CyrDescender
-			include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
+			include : ExtendBelowBaseAnchors (-LongVJut + HalfStroke)
 
 		create-glyph "kPalatalHook.\(suffix)" : glyph-proc
 			include : MarkSet.b

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -135,7 +135,7 @@ glyph-block Letter-Latin-Lower-E : begin
 			tailSlab -- tailSlab
 		define offset : Width * (df.div - divSub)
 		if fDesc : begin
-			local desc : (-LongJut) + HalfStroke
+			local desc : (-LongVJut) + HalfStroke
 			include : ExtendBelowBaseAnchors desc
 			include : difference
 				VBar.m dfSub.middle desc (stroke + O) [AdviceStroke 3.5 df.div]

--- a/packages/font-glyphs/src/letter/latin/o.ptl
+++ b/packages/font-glyphs/src/letter/latin/o.ptl
@@ -193,7 +193,7 @@ glyph-block Letter-Latin-O : begin
 		local arcXR : df.leftSB + innerDist * (3 / 4) + [HSwToV : 4 * df.mvs]
 		local heightGap : Math.min (df.mvs + (CAP - df.mvs * 4) / 5) (innerDist / 4 + df.mvs)
 		local heightInner : CAP - 2 * heightGap
-		local smInner  : clamp (df.mvs * 1.5) (0.499 * heightInner) (ArchDepth * heightInner / CAP)
+		local smInner  : clamp (df.mvs * 1.5) (heightInner / 2 - TINY) (ArchDepth * heightInner / CAP)
 		local adaInner : [ArchDepthAOf smInner : arcXR - arcXL + df.leftSB * 2] * df.div
 		local adbInner : [ArchDepthBOf smInner : arcXR - arcXL + df.leftSB * 2] * df.div
 		include : OShapeFlatTB CAP 0 df.leftSB df.rightSB df.mvs ada adb gap
@@ -217,10 +217,10 @@ glyph-block Letter-Latin-O : begin
 		local heightGap : Math.min (df.mvs + (CAP - df.mvs * 6) / 7) (innerDist / 6 + df.mvs)
 		local heightInner1 : CAP - 2 * heightGap
 		local heightInner2 : CAP - 4 * heightGap
-		local smInner1  : clamp (df.mvs * 1.5) (0.499 * heightInner1) (ArchDepth * heightInner1 / CAP)
+		local smInner1  : clamp (df.mvs * 1.5) (heightInner1 / 2 - TINY) (ArchDepth * heightInner1 / CAP)
 		local adaInner1 : [ArchDepthAOf smInner1 : arcXR1 - arcXL1 + df.leftSB * 2] * df.div
 		local adbInner1 : [ArchDepthBOf smInner1 : arcXR1 - arcXL1 + df.leftSB * 2] * df.div
-		local smInner2  : clamp (df.mvs * 1.5) (0.499 * heightInner2) (ArchDepth * heightInner2 / CAP)
+		local smInner2  : clamp (df.mvs * 1.5) (heightInner2 / 2 - TINY) (ArchDepth * heightInner2 / CAP)
 		local adaInner2 : [ArchDepthAOf smInner2 : arcXR2 - arcXL2 + df.leftSB * 2] * df.div
 		local adbInner2 : [ArchDepthBOf smInner2 : arcXR2 - arcXL2 + df.leftSB * 2] * df.div
 		include : OShapeFlatTB CAP 0 df.leftSB df.rightSB df.mvs ada adb gap
@@ -284,18 +284,18 @@ glyph-block Letter-Latin-O : begin
 	create-glyph 'OPolish' 0xA7C0 : glyph-proc
 		include [refer-glyph 'O'] AS_BASE
 		include : MarkSet.capital
-		include : ExtendAboveBaseAnchors (CAP + LongJut - 0.5 * Stroke)
-		include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
-		include : VBar.m Middle CAP (CAP + LongJut - 0.5 * Stroke)
-		include : VBar.m Middle (-LongJut + 0.5 * Stroke) 0
+		include : ExtendAboveBaseAnchors (CAP + LongVJut - HalfStroke)
+		include : ExtendBelowBaseAnchors (-LongVJut + HalfStroke)
+		include : VBar.m Middle CAP (CAP + LongVJut - HalfStroke)
+		include : VBar.m Middle (-LongVJut + HalfStroke) 0
 
 	create-glyph 'oPolish' 0xA7C1 : glyph-proc
 		include [refer-glyph 'o'] AS_BASE
 		include : MarkSet.e
-		include : ExtendAboveBaseAnchors (XH + LongJut - 0.5 * Stroke)
-		include : ExtendBelowBaseAnchors (-LongJut + 0.5 * Stroke)
-		include : VBar.m Middle XH (XH + LongJut - 0.5 * Stroke)
-		include : VBar.m Middle (-LongJut + 0.5 * Stroke) 0
+		include : ExtendAboveBaseAnchors (XH + LongVJut - HalfStroke)
+		include : ExtendBelowBaseAnchors (-LongVJut + HalfStroke)
+		include : VBar.m Middle XH (XH + LongVJut - HalfStroke)
+		include : VBar.m Middle (-LongVJut + HalfStroke) 0
 
 	derive-composites 'oRetroflexHook' 0x1DF1B 'o' : RetroflexHook.l
 		x -- [mix [arch.adjust-x.bot Middle] SB 0.75]

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -906,10 +906,10 @@ glyph-block Letter-Shared-Shapes : begin
 				local xPos : x - [HSwToV : 0.5 * sw] + sj + sw * TanSlope * (DesignParameters.serifShiftX + 1)
 				return : Impl xPos y xLink y yOverflow sw
 
-		# Descender of cyrillics
+		# Diacritical descender of cyrillics
 		glyph-block-export CyrDescender
 		define CyrDescender : Descenders : function [x y xLink yAttach yOverflow sw] : glyph-proc
-			local extension : 0.25 * Stroke - LongJut
+			local extension : 0.25 * Stroke - LongVJut
 			include : ExtendBelowBaseAnchors (y + extension)
 			include : union
 				xLinkStroke xLink x yAttach sw
@@ -917,7 +917,7 @@ glyph-block Letter-Shared-Shapes : begin
 
 		glyph-block-export CyrTailDescender
 		define CyrTailDescender : Descenders : function [x y xLink yAttach yOverflow sw] : glyph-proc
-			local extension : 0.25 * Stroke - LongJut
+			local extension : 0.25 * Stroke - LongVJut
 			include : ExtendBelowBaseAnchors (y + extension)
 			include : union
 				xLinkStroke xLink x yAttach sw

--- a/packages/font-glyphs/src/meta/aesthetics.ptl
+++ b/packages/font-glyphs/src/meta/aesthetics.ptl
@@ -103,6 +103,7 @@ export : define [calculateMetrics para] : begin
 	define Jut para.jut
 	define LongJut para.longjut
 	define VJut para.vjut
+	define LongVJut : fallback para.longvjut LongJut
 	define MidJutSide   : Math.max Jut : mix [HSwToV : 0.5 * Stroke] LongJut 0.5
 	define MidJutCenter : Math.max Jut : mix [HSwToV : 0.5 * Stroke] LongJut 0.6
 	define AccentStackOffset para.accentStackOffset
@@ -197,11 +198,11 @@ export : define [calculateMetrics para] : begin
 		BgOpBot BgTkTop BgTkBot Italify Upright Scale Translate ApparentTranslate Rotate
 		GlobalTransform TanSlope HVContrast Upward Downward Rightward Leftward O OX OXHook Hook
 		AHook SHook RHook JHook HookX TailX TailY ArchDepth SmallArchDepth Stroke DotSize PeriodSize
-		HBarPos OverlayPos LongJut Jut VJut VJutStroke AccentStackOffset AccentWidth AccentClearance
-		AccentHeight CThin CThinB SLAB IBalance IBalance2 JBalance JBalance2 TBalance TBalance2
-		RBalance RBalance2 FBalance OneBalance WideWidth0 WideWidth1 WideWidth2 WideWidth3 WideWidth4
-		EssUpper EssLower EssQuestion HalfStroke RightSB Middle DotRadius PeriodRadius SideJut
-		ArchDepthA ArchDepthB SmallArchDepthA SmallArchDepthB CorrectionOMidX CorrectionOMidS
+		HBarPos OverlayPos LongJut LongVJut Jut VJut VJutStroke AccentStackOffset AccentWidth
+		AccentClearance AccentHeight CThin CThinB SLAB IBalance IBalance2 JBalance JBalance2 TBalance
+		TBalance2 RBalance RBalance2 FBalance OneBalance WideWidth0 WideWidth1 WideWidth2 WideWidth3
+		WideWidth4 EssUpper EssLower EssQuestion HalfStroke RightSB Middle DotRadius PeriodRadius
+		SideJut ArchDepthA ArchDepthB SmallArchDepthA SmallArchDepthB CorrectionOMidX CorrectionOMidS
 		compositeBaseAnchors AdviceStroke AdviceStroke2 OverlayStroke OperatorStroke GeometryStroke
 		ShoulderFine AdviceGlottalStopArchDepth StrokeWidthBlend ArchDepthAOf ArchDepthBOf
 		SmoothAdjust MidJutSide MidJutCenter YSmoothMidR YSmoothMidL HSwToV NarrowUnicodeT

--- a/packages/font-glyphs/src/meta/macros.ptl
+++ b/packages/font-glyphs/src/meta/macros.ptl
@@ -376,7 +376,7 @@ define-macro glyph-block : syntax-rules
 			PictTop PictBot BgOpTop BgOpBot BgTkTop BgTkBot Italify Upright Scale Translate
 			ApparentTranslate Rotate GlobalTransform TanSlope HVContrast Upward Downward Rightward
 			Leftward O OX OXHook Hook AHook SHook RHook JHook HookX TailX TailY ArchDepth
-			SmallArchDepth Stroke DotSize PeriodSize HBarPos OverlayPos LongJut Jut VJut
+			SmallArchDepth Stroke DotSize PeriodSize HBarPos OverlayPos LongJut LongVJut Jut VJut
 			VJutStroke AccentStackOffset AccentWidth AccentClearance AccentHeight CThin CThinB
 			SLAB IBalance IBalance2 JBalance JBalance2 TBalance TBalance2 RBalance RBalance2
 			FBalance OneBalance WideWidth0 WideWidth1 WideWidth2 WideWidth3 WideWidth4 EssUpper

--- a/params/shape-weight.toml
+++ b/params/shape-weight.toml
@@ -13,6 +13,7 @@ periodSize = 140   # Size of period
 jut = 85           # Length of slab serif
 vjut = 145         # Length of vertical slab serif
 longjut = 175      # Length of long serifs, like that in `i`.
+longvjut = 175     # Length of diacritical descenders in cyrillics.
 
 archDepth = 195       # Vertical arc size in capital letters.
 smallArchDepth = 200  # Vertical arc size in lowercase letters.


### PR DESCRIPTION
At some point when I was experimenting with phonetic ligatures, I noticed that the instances of `LongJut`, when applied to vertical juts, scaled the same as the horizontal applications, so this is an attempt to detach the two usages like how `VJut` is to `Jut`.

Currently, consequently (but still optionally), `LongVJut` does not scale with the _font stretch_ property, which while unlike `LongJut` is closer to the behavior of `VJut`; If this is undesirable, then the additional line in `params/shape-weight.toml` can simply be commented out (Like how `Descender` is implemented) and thus the functionality returns to how it was beforehand via the use of a `fallback` function to `LongJut` in `aesthetics.ptl`.

Otherwise, at least under the default width configuration, it appears as visually unchanged.