### PR TITLE
Add handy macro for ECMAScript Exponentiation operator (`**`) for shorter, simpler code.

### DIFF
--- a/packages/font-glyphs/src/auto-build/composite.ptl
+++ b/packages/font-glyphs/src/auto-build/composite.ptl
@@ -119,7 +119,7 @@ glyph-block AutoBuild-Enclosure : begin
 
 	define circleWidthClasses {{'NWID' Width 0.12} {'WWID' WideWidth0 0.08}}
 	define [AdjustDigitCount digits width] : Math.max 1 (digits * Width / width)
-	define [EnclosureStrokeScale dscale digits width] : dscale / [Math.pow [AdjustDigitCount digits width] 0.66]
+	define [EnclosureStrokeScale dscale digits width] : dscale / ([AdjustDigitCount digits width] ** 0.66)
 
 	define enclosureInnerPartActualWidth : new Map
 
@@ -213,14 +213,14 @@ glyph-block AutoBuild-Enclosure : begin
 
 		return : {}.concat finalPartsFirstHalf finalPartsSecondHalf
 
-	define [CircCrowd digits width] : 2 + 2 * [Math.pow [AdjustDigitCount digits width] (2 / 3)] * [Math.max 1 (HalfUPM / Width)]
-	define [CircScale digits width] : 0.65 / [Math.pow [AdjustDigitCount digits width] 0.5]
+	define [CircCrowd digits width] : 2 + 2 * ([AdjustDigitCount digits width] ** (2 / 3)) * [Math.max 1 (HalfUPM / Width)]
+	define [CircScale digits width] : 0.65  / ([AdjustDigitCount digits width] ** (1 / 2))
 
 	define [CircleDimens digits w m] : begin
 		define width : fallback w Width
 		define dscale :  linreg HalfUPM 0.55 UPM 0.6  width
 		define spatt  : [linreg HalfUPM 0.22 UPM 0.27 width] * (Width / HalfUPM)
-		define sw0 : [EnclosureStrokeScale dscale digits width] * [AdviceStroke [CircCrowd digits width]] / [CircScale digits width]
+		define sw0 : [EnclosureStrokeScale dscale digits width] * [AdviceStroke : CircCrowd digits width] / [CircScale digits width]
 		define sw : Math.max sw0 [fallback m 0]
 		define top : SymbolMid + CAP * dscale / 2 + (CAP * spatt)
 		define bot : SymbolMid - CAP * dscale / 2 - (CAP * spatt)
@@ -426,7 +426,7 @@ glyph-block AutoBuild-Enclosure : begin
 		include : AddEnclosureMarkTwoLine digits : CircleDimens digits ww
 	define [AddEnclosureMarkTwoLine digits dimens] : glyph-proc
 		define [object width dscale mockInnerWidth] dimens
-		set-base-anchor 'enclosureInnerFirstHalf' (0.5 * width - 0.5 * dscale * [Math.min (Width * digits) mockInnerWidth]) 0
+		set-base-anchor 'enclosureInnerFirstHalf'  (0.5 * width - 0.5 * dscale * [Math.min (Width * digits) mockInnerWidth]) 0
 		set-base-anchor 'enclosureInnerSecondHalf' (0.5 * width - 0.5 * dscale * [Math.min (Width * digits) mockInnerWidth]) 0
 
 	define [createPlayingCardGlyphs digits demands]
@@ -627,12 +627,12 @@ glyph-block AutoBuild-Enclosure : begin
 			archDepthB - sw + sw1
 		include : AddEnclosureMark digits : CircleDimens digits ww
 
-	define [BraceCrowd digits width] : 2.75 + [AdjustDigitCount digits width]
-	define [BraceScale digits width] : 0.65 / [Math.pow [AdjustDigitCount digits width] 0.5]
+	define [BraceCrowd digits width] : 2.75 +  [AdjustDigitCount digits width]
+	define [BraceScale digits width] : 0.65 / ([AdjustDigitCount digits width] ** (1 / 2))
 	define [bracedDottedDimens digits width] : begin
 		define dscale : linreg Width 0.55 UPM 0.65 width
 		define pscale : linreg Width 0.6 UPM 0.75 width
-		define sw0 : [EnclosureStrokeScale dscale digits width] * [AdviceStroke [BraceCrowd digits width]] / [BraceScale digits width]
+		define sw0 : [EnclosureStrokeScale dscale digits width] * [AdviceStroke : BraceCrowd digits width] / [BraceScale digits width]
 		define sw : Math.min Stroke sw0
 		define l : Math.max (SB + O * 3) (width / 2 - [Math.max (Width * digits) CAP] / 2)
 		define r : width - l
@@ -730,8 +730,8 @@ glyph-block AutoBuild-Enclosure : begin
 		include : Regizmo
 		include : AddEnclosureMark digits : bracedDottedDimens digits ww
 
-	define [DottedCrowd digits width] : 2 + [AdjustDigitCount digits width]
-	define [DottedScale digits width] : 1 / [Math.pow [AdjustDigitCount digits width] 0.5]
+	define [DottedCrowd digits width] : 2 +  [AdjustDigitCount digits width]
+	define [DottedScale digits width] : 1 / ([AdjustDigitCount digits width] ** (1 / 2))
 	define [createDottedGlyphs digits demands] : begin
 		foreach {suffix ww} [items-of circleWidthClasses] : do
 			define jobs : CollectJobs DECOMPOSABLE NOT-CENTERED ALLOW-PROPORTIONAL ('dotted' + digits) suffix demands
@@ -837,7 +837,7 @@ glyph-block AutoBuild-Enclosure : begin
 			list 0x1F16D {'C' 'C'} WideWidth2
 			list 0x1F12D {'C' 'D'} WideWidth1
 			list 0x1F12E {'W' 'smcpZ'} WideWidth1
-		foreach [j : range 10 till 20] : compositions.push : list (0x2460 + j - 1) [digitGlyphNames j] WideWidth1
+		foreach [j : range 10 till 20] : compositions.push : list (0x2460 + j - 1)  [digitGlyphNames j] WideWidth1
 		foreach [j : range 21 till 35] : compositions.push : list (0x3251 + j - 21) [digitGlyphNames j] WideWidth1
 		foreach [j : range 36 till 50] : compositions.push : list (0x32B1 + j - 36) [digitGlyphNames j] WideWidth1
 		createCircledGlyphs 2 compositions

--- a/packages/font-glyphs/src/auto-build/recursive-build.ptl
+++ b/packages/font-glyphs/src/auto-build/recursive-build.ptl
@@ -75,7 +75,7 @@ glyph-block Recursive-Build-ParaTfm : begin
 	define ForkTfm : namespace
 		define [boldGrade g] : begin
 			local pGrade : (900 - g) / 100
-			return : 900 - 100 * (2 / 25) * pGrade * pGrade
+			return : 900 - 100 * (2 / 25) * (pGrade ** 2)
 
 		export : define [Bold   a]     : begin [set a.shape.weight : boldGrade a.shape.weight]
 		export : define [Italic a]     : begin

--- a/packages/font-glyphs/src/common/shapes.ptl
+++ b/packages/font-glyphs/src/common/shapes.ptl
@@ -371,7 +371,7 @@ glyph-block CommonShapes : begin
 		local superness DesignParameters.superness
 		local r : piecewise
 			(w <= v)   0.5
-			true     : 1 / ([Math.pow (1 - [Math.pow (1 - v / w) superness]) (1 / superness)] + 1)
+			true     : 1 / (((1 - ((1 - v / w) ** superness)) ** (1 / superness)) + 1)
 		if swash : begin
 			local idepth : w - sw
 			local iwidth : u * r - sw
@@ -588,13 +588,13 @@ glyph-block CommonShapes : begin
 			if [not angle] : return 0
 			local s : Math.sin (angle * Math.PI / 180)
 			local sign : if (s < 0) (-1) 1
-			return : sign * [Math.pow [Math.abs s] (2 / superness)]
+			return : sign * ([Math.abs s] ** (2 / superness))
 
 		define [superCos angle superness] : begin
 			if [not angle] : return 1
 			local c : Math.cos (angle * Math.PI / 180)
 			local sign : if (c < 0) (-1) 1
-			return : sign * [Math.pow [Math.abs c] (2 / superness)]
+			return : sign * ([Math.abs c] ** (2 / superness))
 
 		define [mixR w angW v angV u] : begin
 			if (w < v) : return : 1 - [mixR v angV w angW u]
@@ -609,7 +609,7 @@ glyph-block CommonShapes : begin
 				local chrW : radW * [superCos angW super]
 				return : chrW / (chrV + chrW)
 			: else : begin
-				local r : 1 / ([Math.pow (1 - [Math.pow (1 - v / w) super]) (1 / super)] + 1)
+				local r : 1 / (((1 - ((1 - v / w) ** super)) ** (1 / super)) + 1)
 				set r : 0.5 + (r - 0.5) * (v + w) / (u * 2)
 				return r
 

--- a/packages/font-glyphs/src/letter/cyrillic/che.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/che.ptl
@@ -232,7 +232,7 @@ glyph-block Letter-Cyrillic-Che : begin
 		return : VBar.m Middle (yc + LongVJut * 0.8) (yc - LongVJut * 0.8) SwCheVBar
 
 	derive-composites 'cyrl/CheVBar' 0x4B8 'cyrl/Che' [CheVBarBarShape CAP : if SLAB 0.45 0.35]
-	derive-composites 'cyrl/cheVBar' 0x4B9 'cyrl/che' [CheVBarBarShape XH  : if SLAB 0.45 0.4 ]
+	derive-composites 'cyrl/cheVBar' 0x4B9 'cyrl/che' [CheVBarBarShape XH  : if SLAB 0.45 0.40]
 
 	define ShhaConfig : object
 		serifless                 SERIFS.NONE
@@ -245,7 +245,7 @@ glyph-block Letter-Cyrillic-Che : begin
 			include : MarkSet.capital
 			include : LeaningAnchor.Above.VBar.l SB
 			include : CyrCheShape [DivFrame 1] CAP (1 - HBarPos) BODY.STRAIGHT serifs
-				yBarOffset -- ([HSwToV : Math.pow Stroke 2] / (RightSB - SB))
+				yBarOffset -- ([HSwToV : Stroke ** 2] / (RightSB - SB))
 			include : FlipAround Middle (CAP / 2)
 
 		create-glyph "cyrl/Hwe.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/letter/cyrillic/te-midhook.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/te-midhook.ptl
@@ -44,7 +44,7 @@ glyph-block Letter-Cyrillic-Te-MidHook : begin
 		create-glyph "cyrl/teMidHook.upright.\(suffix)" : glyph-proc
 			local df : include : DivFrame div
 			include : df.markSet.p
-			include : Shape df XH [Math.pow HBarPos 0.3] doST doSB
+			include : Shape df XH (HBarPos ** 0.3) doST doSB
 
 	select-variant 'cyrl/TeMidHook' 0xA68A (follow -- 'T')
 	select-variant 'cyrl/teMidHook.upright' (follow -- 'T')

--- a/packages/font-glyphs/src/letter/greek/upper-gamma.ptl
+++ b/packages/font-glyphs/src/letter/greek/upper-gamma.ptl
@@ -120,8 +120,8 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 				left   -- (GammaBarLeft + [HSwToV Stroke])
 				right  -- RightSB
 				top    -- (XH * HBarPos + Stroke / 4)
-				ada    -- (ArchDepthA * [Math.pow HBarPos 0.3])
-				adb    -- (ArchDepthB * [Math.pow HBarPos 0.3])
+				ada    -- (ArchDepthA * (HBarPos ** 0.3))
+				adb    -- (ArchDepthB * (HBarPos ** 0.3))
 			if para.isItalic : eject-contour 'serifLB'
 
 	select-variant 'grek/Gamma' 0x393

--- a/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
@@ -209,7 +209,7 @@ glyph-block Letter-Latin-Ezh : begin
 			create-glyph "ezh/phoneticRight.\(suffix)" : glyph-proc
 				include : MarkSet.p
 				include : EzhShape [DivFrame 1] XH Descender
-					pLeft     -- 0.27
+					pLeft     -- (4/15)
 					isCursive -- isCursive
 					isSerifed -- isSerifed
 					hook      -- Hook
@@ -219,7 +219,7 @@ glyph-block Letter-Latin-Ezh : begin
 			create-glyph "ezhPalatalHook/phoneticRight.\(suffix)" : glyph-proc
 				include : MarkSet.p
 				local [object yMidBar] : include : EzhShape [DivFrame 1] XH Descender
-					pLeft     -- 0.27
+					pLeft     -- (4/15)
 					isCursive -- isCursive
 					isSerifed -- isSerifed
 					hook      -- Hook

--- a/packages/font-glyphs/src/letter/latin/k.ptl
+++ b/packages/font-glyphs/src/letter/latin/k.ptl
@@ -404,7 +404,7 @@ glyph-block Letter-Latin-K : begin
 		create-glyph "KDescender.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : KBaseShape Stroke CAP CyrDescender
-			include : ExtendBelowBaseAnchors (0 - LongVJut + HalfStroke)
+			include : ExtendBelowBaseAnchors (-LongVJut + HalfStroke)
 
 		create-glyph "KStroke.\(suffix)" : glyph-proc
 			include [refer-glyph "K.\(suffix)"] AS_BASE ALSO_METRICS

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -192,7 +192,7 @@ glyph-block Letter-Latin-Lower-E : begin
 						deltaX   : function [rt] 0
 						ry       : function [rt] : 1/24 + rt + (1/2 - rt) * (3/8)
 						deltaY   : function [rt] (-0.25 * [mix fine markStroke rt])
-						modifier : function [rt] : widths.rhs [mix fine markStroke : Math.pow rt 2]
+						modifier : function [rt] : widths.rhs [mix fine markStroke : rt ** 2]
 					g4.down.mid (RightSB - extL) (-0.75 * depth) [widths.rhs.heading markStroke {.x HVContrast .y turnSlope}]
 					arcvh [widths.rhs markStroke]
 					g4 (RightSB + [mix (-extL) extR (11/16)]) (-depth + O) [heading Rightward]

--- a/packages/font-glyphs/src/letter/latin/lower-t.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-t.ptl
@@ -21,7 +21,7 @@ glyph-block Letter-Latin-Lower-T : begin
 	define SYM-PR-BALANCED   3
 
 	define dfNarrowT : DivFrame para.diversityF
-	define [xSmallTBarLeftT df] : df.middle - TBalance * df.div * df.div - [HSwToV HalfStroke]
+	define [xSmallTBarLeftT df] : df.middle - TBalance * (df.div ** 2) - [HSwToV HalfStroke]
 	define [xSmallTCrossRefT df] : [xSmallTBarLeftT df] + df.div * TBalance2 + [HSwToV HalfStroke]
 
 	define yCrossBar     XH

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -37,7 +37,7 @@ glyph-block Letter-Shared : begin
 		derive-multi-part-glyphs dst u { sourceGid 'commaTR' } : function [gns gr] : glyph-proc
 			local { base comma } gns
 			define baseGlyph : query-glyph base
-			define commaOffset : fallback offset : (Width / 2) * [Math.pow (baseGlyph.advanceWidth / Width * 2) (2/3)]
+			define commaOffset : fallback offset : (Width / 2) * ((baseGlyph.advanceWidth / Width * 2) ** (2/3))
 			include : refer-glyph comma
 			include : ApparentTranslate commaOffset 0
 			include [refer-glyph base] AS_BASE ALSO_METRICS
@@ -652,12 +652,12 @@ glyph-block Letter-Shared-Shapes : begin
 				curl (cx + sign * (dxTailStart + dxDepth)) (cy + O + dyTailStart + dyDepth)
 
 		define [superEllipse theta] : list
-			Math.pow [Math.cos theta] (2 / DiagTailSuperness)
-			Math.pow [Math.sin theta] (2 / DiagTailSuperness)
+			[Math.cos theta] ** (2 / DiagTailSuperness)
+			[Math.sin theta] ** (2 / DiagTailSuperness)
 
 		define [superEllipseDerivative theta] : begin
-			local dc : (-2 / DiagTailSuperness) * [Math.sin theta] * [Math.pow [Math.cos theta] (2 / DiagTailSuperness - 1)]
-			local ds : (+2 / DiagTailSuperness) * [Math.cos theta] * [Math.pow [Math.sin theta] (2 / DiagTailSuperness - 1)]
+			local dc : (-2 / DiagTailSuperness) * [Math.sin theta] * ([Math.cos theta] ** (2 / DiagTailSuperness - 1))
+			local ds : (+2 / DiagTailSuperness) * [Math.cos theta] * ([Math.sin theta] ** (2 / DiagTailSuperness - 1))
 			local h : Math.hypot dc ds
 			return : list (dc / h) (ds / h)
 
@@ -848,7 +848,7 @@ glyph-block Letter-Shared-Shapes : begin
 
 		export : define [l] : with-params [x y xDepth yDepth [sw Stroke] [yExtension 0]]
 			m
-				x -- x + [HSwToV : 0.5 * sw]
+				x -- (x + [HSwToV : 0.5 * sw])
 				y -- y
 				xDepth -- xDepth
 				yDepth -- yDepth
@@ -857,7 +857,7 @@ glyph-block Letter-Shared-Shapes : begin
 
 		export : define [r] : with-params [x y xDepth yDepth [sw Stroke] [yExtension 0]]
 			m
-				x -- x - [HSwToV : 0.5 * sw]
+				x -- (x - [HSwToV : 0.5 * sw])
 				y -- y
 				xDepth -- xDepth
 				yDepth -- yDepth
@@ -978,7 +978,7 @@ glyph-block Letter-Shared-Shapes : begin
 				general
 					left   -- xm
 					right  -- df.rightSB
-					top    -- top * 0.625 + df.mvs / 4
+					top    -- (top * 0.625 + df.mvs / 4)
 					ada    -- ArchDepthA
 					adb    -- ArchDepthB
 					sw     -- df.mvs

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -911,7 +911,7 @@ glyph-block Mark-Above : begin
 
 		local top aboveMarkTop
 		local bot aboveMarkBot
-		local exp : Math.sqrt : 1 + [Math.pow ((top - bot) / markExtend) 2]
+		local exp : Math.sqrt : 1 + (((top - bot) / markExtend) ** 2)
 		include : dispiro
 			widths.center : markFine * 2
 			flat (markMiddle + markExtend) top
@@ -967,7 +967,7 @@ glyph-block Mark-Above : begin
 
 		local top aboveMarkTop
 		local bot aboveMarkBot
-		local exp : Math.sqrt : 1 + [Math.pow (3 * markExtend / (top - bot)) 2]
+		local exp : Math.sqrt : 1 + ((3 * markExtend / (top - bot)) ** 2)
 		include : dispiro
 			widths.center : markFine * 2
 			flat (markMiddle - markExtend) bot

--- a/packages/font-glyphs/src/meta/macros.ptl
+++ b/packages/font-glyphs/src/meta/macros.ptl
@@ -11,6 +11,10 @@ define-operator "~>" 880 'right' : syntax-rules
 define-operator prefix "~~~"  : syntax-rules
 	`(~~~ @x) : dirty `[decor@ @x]
 
+### Exponentiation operator
+define-operator "**" 150 "right" : syntax-rules
+    `(@l ** @r) `[Math.pow @l @r]
+
 ### Macro for identity match
 define-macro Just : begin
 	local m : syntax-rules

--- a/packages/font-glyphs/src/space/index.ptl
+++ b/packages/font-glyphs/src/space/index.ptl
@@ -57,7 +57,7 @@ glyph-block Spaces : begin
 	# The following spaces has explicit em-number. They will follow the em-number
 	# in quasiproportional, and identical to SPACE in monospace
 	define [FractionEmSp name code d] : create-glyph name code : glyph-proc
-		local df : include : DivFrame [if (para.diversityII < 1) (2 / d) 1]
+		local df : include : DivFrame : if (para.diversityII < 1) (2 / d) 1
 
 	FractionEmSp 'threePerEmSp' 0x2004 3
 	FractionEmSp 'fourPerEmsp'  0x2005 4

--- a/packages/font-glyphs/src/symbol/arrow.ptl
+++ b/packages/font-glyphs/src/symbol/arrow.ptl
@@ -30,8 +30,8 @@ glyph-block Symbol-Arrow : for-width-kinds WideWidth1
 	define kLongArrowSB : [DivFrame MosaicWidthScalar 4].leftSB / [DivFrame MosaicWidthScalar 2].leftSB
 
 	# Diagonal arrow params
-	define diagPropX : 1 / [Math.pow 2 (1 / 4)]
-	define diagPropY : 1 / [Math.pow 2 (1 / 4)]
+	define diagPropX : 1 / (2 ** (1 / 4))
+	define diagPropY : 1 / (2 ** (1 / 4))
 	define arrowDiagRSB : mix arrowMidX arrowRSB diagPropX
 	define arrowDiagSB  : mix arrowMidX arrowSB  diagPropX
 	define arrowDiagBot : mix arrowMidX arrowBot diagPropY
@@ -701,8 +701,8 @@ glyph-block Symbol-Arrow : for-width-kinds WideWidth1
 				include : ShareAlikeArrow
 
 	do "Bend and Angle arrows"
-		define bendL : mix arrowMidX arrowSB [Math.max (bendArrowHeadSize / (arrowMidX - arrowSB)) : Math.pow 0.6 (2 /  MosaicWidthScalar)]
-		define bendR : mix arrowMidX arrowRSB [Math.max (bendArrowHeadSize / (arrowMidX - arrowSB)) : Math.pow 0.6 (2 /  MosaicWidthScalar)]
+		define bendL : mix arrowMidX arrowSB  : Math.max (bendArrowHeadSize / (arrowMidX - arrowSB)) (0.6 ** (2 / MosaicWidthScalar))
+		define bendR : mix arrowMidX arrowRSB : Math.max (bendArrowHeadSize / (arrowMidX - arrowSB)) (0.6 ** (2 / MosaicWidthScalar))
 		define bendT : SymbolMid + bendArrowHeadSize * 2
 		define bendB : SymbolMid - bendArrowHeadSize * 2
 

--- a/packages/font-glyphs/src/symbol/geometric/corner-shape.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/corner-shape.ptl
@@ -10,8 +10,8 @@ glyph-block Symbol-Geometric-Corner-Shape: begin
 
 	for-width-kinds WideWidth1 : do
 		define ptMaxWidth : MosaicWidth - SB
-		define ptHeight0 : 1.5 * (Width - SB / 2) * [Math.pow (MosaicWidth / MosaicUnitWidth) (1 / 4)]
-		define ptHeight  : ptHeight0 * ptHeight0 / [Math.hypot ptHeight0 : Math.min ptHeight0 ptMaxWidth]
+		define ptHeight0 : 1.5 * (Width - SB / 2) * ((MosaicWidth / MosaicUnitWidth) ** (1 / 4))
+		define ptHeight  : (ptHeight0 ** 2) / [Math.hypot ptHeight0 : Math.min ptHeight0 ptMaxWidth]
 		define ptWidth  : Math.min ptMaxWidth ptHeight
 		define ptMidX : MosaicWidth / 2
 		define ptSB : (MosaicWidth - ptWidth) / 2

--- a/packages/font-glyphs/src/symbol/geometric/shared.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/shared.ptl
@@ -10,8 +10,8 @@ glyph-block Symbol-Geometric-Shared : begin
 	glyph-block-export GeometricDim
 	define [GeometricDim unitWidth fullWidth] : begin
 		define s : fullWidth / unitWidth
-		define sb : 0.625 * SB * s * s * [Math.pow (unitWidth / Width) 2]
-		define tallSize : 0.5 * para.arrowHeight * (unitWidth - sb) * [Math.pow s (1 / 3)]
+		define sb : 0.625 * SB * (s ** 2) * ((unitWidth / Width) ** 2)
+		define tallSize : 0.5 * para.arrowHeight * (unitWidth - sb) * [Math.cbrt s]
 		define size : Math.min (0.5 * fullWidth - sb) tallSize
 		return : object
 			UnitWidth unitWidth
@@ -29,10 +29,10 @@ glyph-block Symbol-Geometric-Shared : begin
 	glyph-block-export UnicodeWeightGrade
 	define [UnicodeWeightGrade n s] : begin
 		define kwPow 1
-		define kkw : 2 / [Math.pow 4 kwPow]
-		define kw : 10 - s - kkw * [Math.pow n kwPow]
+		define kkw : 2 / (4 ** kwPow)
+		define kw : 10 - s - kkw * (n ** kwPow)
 		define [mulPow ss pm] : (1 / 4 + ss / 8) * [StrokeWidthBlend 2 1]
-		define kMul : [Math.pow n : mulPow s] / [Math.pow 4 : mulPow 2]
+		define kMul : (n ** [mulPow s]) / (4 ** [mulPow 2])
 		define kAdj : GeometryStroke / [AdviceStroke 6]
 		return : kMul * kAdj * [AdviceStroke kw]
 

--- a/packages/font-glyphs/src/symbol/mosaic/teletext.ptl
+++ b/packages/font-glyphs/src/symbol/mosaic/teletext.ptl
@@ -63,7 +63,7 @@ glyph-block Symbol-Mosaic-Teletext : begin
 				include : ForceUpright
 				include : BlockMosaicPattern w h pattern
 
-		define [MakeGappedBlockMosaic w h su] : foreach [offset : range 1 [Math.pow 2 (w * h)]] : begin
+		define [MakeGappedBlockMosaic w h su] : foreach [offset : range 1 : 2 ** (w * h)] : begin
 			create-glyph [MangleName : NameUni (su + offset)] [MangleUnicode (su + offset)] : glyph-proc
 				set-width MosaicWidth
 				include : ForceUpright

--- a/packages/font-glyphs/src/symbol/pictograph/checking-marks.ptl
+++ b/packages/font-glyphs/src/symbol/pictograph/checking-marks.ptl
@@ -16,8 +16,8 @@ glyph-block Symbol-Pictograph-Checking-Marks : begin
 		define heavySw  : UnicodeWeightGrade 9    Geom.Scalar
 
 		define ptMaxWidth : MosaicWidth - SB
-		define ptHeight0 : 1.5 * (Width - SB / 2) * [Math.pow (MosaicWidth / MosaicUnitWidth) (1 / 4)]
-		define ptHeight  : ptHeight0 * ptHeight0 / [Math.hypot ptHeight0 : Math.min ptHeight0 ptMaxWidth]
+		define ptHeight0 : 1.5 * (Width - SB / 2) * ((MosaicWidth / MosaicUnitWidth) ** (1 / 4))
+		define ptHeight  : (ptHeight0 ** 2) / [Math.hypot ptHeight0 : Math.min ptHeight0 ptMaxWidth]
 		define ptWidth  : Math.min ptMaxWidth ptHeight
 		define ptMidX : MosaicWidth / 2
 		define ptSB : (MosaicWidth - ptWidth) / 2

--- a/packages/font-glyphs/src/symbol/pictograph/i-ching.ptl
+++ b/packages/font-glyphs/src/symbol/pictograph/i-ching.ptl
@@ -27,7 +27,7 @@ glyph-block Symbol-Pictograph-I-Ching : begin
 		include : HBar.m (Middle - 0.5 * width) (Middle + 0.5 * width) 0 bar
 		include : HBar.m (RightSB - width) RightSB 0 bar
 
-	define [patterns n su] : foreach [offset: range 0 [Math.pow 2 n]] : begin
+	define [patterns n su] : foreach [offset : range 0 : 2 ** n] : begin
 		create-glyph ('iChing/Pattern/' + n + '/' + offset) (su + offset) : glyph-proc
 			local offsetY : (2 / 3) * (OperBot - PictTop) / n
 			local startY : SymbolMid - offsetY * (n - 1) / 2
@@ -35,7 +35,7 @@ glyph-block Symbol-Pictograph-I-Ching : begin
 				include : with-transform [ApparentTranslate 0 (startY + offsetY * bit)]
 					refer-glyph : if [not : maskBit offset bit] 'iChing/barYang' 'iChing/barYin'
 
-	define [hexagramPatterns su order] : foreach [offset: range 0 64] : begin
+	define [hexagramPatterns su order] : foreach [offset : range 0 64] : begin
 		create-glyph ('iChing/Pattern/6/' + offset) (su + offset) : glyph-proc
 			local offsetY : (PictBot - PictTop) / 6
 			local startY : SymbolMid - offsetY * (6 - 1) / 2
@@ -54,11 +54,11 @@ glyph-block Symbol-Pictograph-I-Ching : begin
 					[Just '1'] 'iChing/barYin'
 					__         'iChing/barRen'
 
-	define [stringPatterns su pats] : foreach [offset: range 0 pats.length] : begin
+	define [stringPatterns su pats] : foreach [offset : range 0 pats.length] : begin
 		local pat pats.(offset)
 		create-glyph ('iChing/Pattern/txj/' + pat) (su + offset) : stringPattern pat
 
-	define [ternaryPatterns n su] : foreach [offset: range 0 [Math.pow 3 n]] : begin
+	define [ternaryPatterns n su] : foreach [offset : range 0 : 3 ** n] : begin
 		local pat : [offset.toString 3].padStart n '0'
 		create-glyph ('iChing/Pattern/txj/' + pat) (su + offset) : stringPattern pat
 

--- a/packages/font-glyphs/src/symbol/pictograph/powerline-and-gui.ptl
+++ b/packages/font-glyphs/src/symbol/pictograph/powerline-and-gui.ptl
@@ -105,7 +105,7 @@ glyph-block Symbol-Pictograph-Powerline-And-GUI : begin
 			define scaffold : object
 			set scaffold.top : mix uiFigBot uiFigTop 0.85
 			set scaffold.bot : mix uiFigBot uiFigTop 0.15
-			set scaffold.width   : (Middle - SB) * 2 * [Math.pow (MosaicWidth / Width) 0.3]
+			set scaffold.width   : (Middle - SB) * 2 * ((MosaicWidth / Width) ** 0.3)
 			set scaffold.xMiddle : MosaicWidth / 2
 			set scaffold.xLeft : scaffold.xMiddle - scaffold.width / 2
 			set scaffold.xRight : scaffold.xMiddle + scaffold.width / 2
@@ -231,7 +231,7 @@ glyph-block Symbol-Pictograph-Powerline-And-GUI : begin
 			set scaffold.top : mix uiFigBot uiFigTop 0.85
 			set scaffold.bot : mix uiFigBot uiFigTop 0.15
 			set scaffold.slope 0.6
-			set scaffold.width   : (Middle - SB) * 2 * [Math.pow (MosaicWidth / Width) 0.5]
+			set scaffold.width   : (Middle - SB) * 2 * ((MosaicWidth / Width) ** 0.5)
 			set scaffold.stroke  : AdviceStroke 3.5
 			set scaffold.xMiddle : MosaicWidth / 2
 			set scaffold.xLeft : scaffold.xMiddle - scaffold.width / 2
@@ -292,7 +292,7 @@ glyph-block Symbol-Pictograph-Powerline-And-GUI : begin
 			set scaffold.top   : [mix uiFigBot uiFigTop 0.9] - scaffold.stroke
 			set scaffold.mid   : mix uiFigBot uiFigTop 0.5
 			set scaffold.bot   : [mix uiFigBot uiFigTop 0.1] + scaffold.stroke
-			set scaffold.width : (Middle - SB) * 2 * [Math.pow (MosaicWidth / Width) 0.5]
+			set scaffold.width : (Middle - SB) * 2 * ((MosaicWidth / Width) ** 0.5)
 			set scaffold.left  : (MosaicWidth / 2) - scaffold.width / 2 + scaffold.stroke / 2
 			set scaffold.right : (MosaicWidth / 2) + scaffold.width / 2 - scaffold.stroke / 2
 

--- a/packages/font-glyphs/src/symbol/pictograph/stick-figure.ptl
+++ b/packages/font-glyphs/src/symbol/pictograph/stick-figure.ptl
@@ -61,8 +61,8 @@ glyph-block Symbol-Pictograph-Stick-Figure : begin
 			local innerKnots {}
 			foreach j [range 1 64] : begin
 				local theta : (Math.PI / 2) * (j / 64)
-				local c : Math.pow [Math.cos theta] (2 / DesignParameters.superness)
-				local s : Math.pow [Math.sin theta] (2 / DesignParameters.superness)
+				local c : [Math.cos theta] ** (2 / DesignParameters.superness)
+				local s : [Math.sin theta] ** (2 / DesignParameters.superness)
 
 				local mx : mix box.left   box.right [mix h1 h2 : if mode (1 - c) s      ]
 				local my : mix box.bottom box.top   [mix v1 v2 : if mode s       (1 - c)]
@@ -111,8 +111,8 @@ glyph-block Symbol-Pictograph-Stick-Figure : begin
 			define nKnots 64
 			foreach j [range 1 nKnots] : begin
 				local theta : (Math.PI / 2) * (j / nKnots)
-				local c : Math.pow [Math.cos theta] (2 / DesignParameters.superness)
-				local s : Math.pow [Math.sin theta] (2 / DesignParameters.superness)
+				local c : [Math.cos theta] ** (2 / DesignParameters.superness)
+				local s : [Math.sin theta] ** (2 / DesignParameters.superness)
 
 				local mx : mix box.left   box.right (ho + s * dh1 + c * dh2)
 				local my : mix box.bottom box.top   (vo + s * dv1 + c * dv2)

--- a/packages/font-glyphs/src/symbol/punctuation/percentages.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/percentages.ptl
@@ -13,8 +13,8 @@ glyph-block Symbol-Punctuation-Percentages : begin
 	define WideUnicode   : WideUnicodeT   WideWidth1
 
 	define [PercentBarCor df sw] : begin
-		local a : 1 - [Math.pow ((df.rightSB - df.leftSB - sw) / (CAP - 0)) 2]
-		return : HVContrast / [if (a > 0) [Math.sqrt a] 1]
+		local a : 1 - (((df.rightSB - df.leftSB - sw) / (CAP - 0)) ** 2)
+		return : HVContrast / [if (a <= 0) 1 : Math.sqrt a]
 
 	define [PercentBarShape df sw] : begin
 		local cor : PercentBarCor df sw
@@ -26,7 +26,7 @@ glyph-block Symbol-Punctuation-Percentages : begin
 
 	create-glyph 'percent.dots' : glyph-proc
 		include : PercentBarShape [DivFrame 1] Stroke
-		local dotwidth ([AdviceStroke 4] * 1.5)
+		local dotwidth : [AdviceStroke 4] * 1.5
 		include : VBar.l SB [mix CAP 0 0.3] CAP dotwidth
 		include : VBar.r RightSB 0 [mix 0 CAP 0.3] dotwidth
 
@@ -147,7 +147,7 @@ glyph-block Symbol-Punctuation-Percentages : begin
 		local adb  : ArchDepthB * 0.5 * para.diversityM
 		local sw   : AdviceStroke2 4 5 CAP para.diversityM
 		local fine : AdviceStroke2 5 5 CAP para.diversityM
-		local cor : HVContrast / [Math.sqrt (1 - [Math.pow ((r - l - sw) / (CAP - 0)) 2])]
+		local cor : HVContrast / [Math.sqrt : 1 - (((r - l - sw) / (CAP - 0)) ** 2)]
 		local pTerm : (fine / 2) / [Math.hypot CAP (r - l)]
 		local pFine : 1 / 2 - (Stroke / 2) / [Math.hypot CAP (r - l)]
 

--- a/packages/font-glyphs/src/symbol/punctuation/slashes-and-number-sign.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/slashes-and-number-sign.ptl
@@ -24,7 +24,7 @@ glyph-block Symbol-Punctuation-Slashes-And-Number-Sign : begin
 		local-parameter : b -- ParenBot
 		local-parameter : w -- Stroke
 
-		local cor : (1 / 2) * HVContrast / [Math.sqrt (1 - [Math.pow ((r - l - w) / (t - b)) 2])]
+		local cor : (1 / 2) * HVContrast / [Math.sqrt : 1 - (((r - l - w) / (t - b)) ** 2)]
 		include : spiro-outline
 			corner (r - w * cor) t
 			corner (r + w * cor) t
@@ -66,7 +66,7 @@ glyph-block Symbol-Punctuation-Slashes-And-Number-Sign : begin
 		local-parameter : b -- ParenBot
 		local-parameter : w -- Stroke
 
-		local cor : (1 / 2) * HVContrast / [Math.sqrt (1 - [Math.pow ((r - l - w) / (t - b)) 2])]
+		local cor : (1 / 2) * HVContrast / [Math.sqrt : 1 - (((r - l - w) / (t - b)) ** 2)]
 		include : spiro-outline
 			corner (l - w * cor) t
 			corner (l + w * cor) t


### PR DESCRIPTION
Ref: https://github.com/be5invis/PatEL/issues/3

Nothing is visually changed except for a sub-pixel tuning of `ezh/phoneticRight` that I included while I'm at it.