### PR TITLE
Misc (minor) extended latin/cyrillic character tweaks.

### DIFF
--- a/packages/font-glyphs/src/letter/cyrillic/yat.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/yat.ptl
@@ -30,10 +30,10 @@ glyph-block Letter-Cyrillic-Yat : begin
 
 		local cTop : if SLAB (top - Stroke / 2) top
 
-		local _xCrossbarLeft : mix 0 df.leftSB [if SLAB 0.25 0.375]
+		local _xCrossbarLeft : mix 0 df.leftSB : if SLAB 0.25 0.375
 		local xCrossbarLeft : fallback xCrossbarLeftOverride _xCrossbarLeft
 		local xCrossbarRight : mix _xCrossbarLeft (xYeriLeft + [HSwToV : 0.5 * sw]) 2
-		local yCrossbar : fallback yCrossbarOverride : [mix (top * pBar + sw / 2) cTop [if SLAB 0.625 0.5]] + 0.25 * OverlayStroke
+		local yCrossbar : fallback yCrossbarOverride : [mix (top * pBar + sw / 2) cTop : if SLAB 0.625 0.5] + 0.25 * OverlayStroke
 		include : HBar.t xCrossbarLeft xCrossbarRight yCrossbar OverlayStroke
 
 		if SLAB : begin

--- a/packages/font-glyphs/src/letter/greek/upper-lambda-delta.ptl
+++ b/packages/font-glyphs/src/letter/greek/upper-lambda-delta.ptl
@@ -13,13 +13,13 @@ glyph-block Letter-Latin-Upper-Lambda-Delta : begin
 	glyph-block-import Letter-Latin-Upper-A : AShape ASerifs
 	glyph-block-import Letter-Latin-V : VShapeOutline VShape VHookRightShape
 
-	define SLAB-NONE     0
-	define SLAB-TOP      1
-	define SLAB-LEFT     2
-	define SLAB-RIGHT    4
-	define SLAB-CYRL-BGR 8
+	define SLAB-NONE       0
+	define SLAB-TOP        1
+	define SLAB-LEFT       2
+	define SLAB-RIGHT      4
+	define SLAB-SMALL-CYRL 8
 
-	define LambeaConfig : SuffixCfg.weave
+	define LambdaConfig : SuffixCfg.weave
 		object
 			straight true
 			curly    false
@@ -49,16 +49,16 @@ glyph-block Letter-Latin-Upper-Lambda-Delta : begin
 		local-parameter : hookWidthOuter -- (TailX / 3)
 		local-parameter : hookWidthInner -- (TailX / 3)
 		include : VHookRightShape
-			df -- df
-			fBarStraight -- fBarStraight
-			top -- top
-			sw -- sw
+			df             -- df
+			fBarStraight   -- fBarStraight
+			top            -- top
+			sw             -- sw
 			hookWidthOuter -- hookWidthOuter
 			hookWidthInner -- hookWidthInner
 		include : FlipAround df.middle (top / 2)
 		include : ASerifs df top sw [maskOffBits slabKind SLAB-LEFT]
 
-	foreach { suffix { fStraightBar slabKind } } [Object.entries LambeaConfig] : do
+	foreach { suffix { fStraightBar slabKind } } [Object.entries LambdaConfig] : do
 		create-glyph "grek/Lambda.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : LambdaShape
@@ -82,7 +82,7 @@ glyph-block Letter-Latin-Upper-Lambda-Delta : begin
 			include : LambdaShape
 				df           -- [DivFrame 1]
 				fBarStraight -- fStraightBar
-				slabKind     -- [bitOr slabKind SLAB-CYRL-BGR]
+				slabKind     -- [bitOr slabKind SLAB-SMALL-CYRL]
 				top          -- XH
 				sw           -- Stroke
 
@@ -115,7 +115,7 @@ glyph-block Letter-Latin-Upper-Lambda-Delta : begin
 			include : LambdaHookLeftShape
 				df             -- df
 				fBarStraight   -- fStraightBar
-				slabKind       -- slabKind
+				slabKind       -- [bitOr slabKind SLAB-SMALL-CYRL]
 				top            -- XH
 				sw             -- df.mvs
 				hookWidthInner -- (TailX / 3 - [HSwToV : 0.25 * df.mvs])
@@ -205,10 +205,10 @@ glyph-block Letter-Latin-Upper-Lambda-Delta : begin
 
 	derive-glyphs 'cyrl/De.BGR' null 'grek/Delta' : function [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
-		local descenderOverflow : if SLAB SideJut ((RightSB - SB) * 0.075)
+		local descenderOverflow : if SLAB SideJut : (RightSB - SB) * 0.075
 		local xCutLeft SB
 		local xCutRight RightSB
-		include : HBar.b (xCutLeft - descenderOverflow) (xCutRight + descenderOverflow) 0
-		include : VBar.l (xCutLeft - descenderOverflow) (-LongVJut + HalfStroke) Stroke
+		include : HBar.b (xCutLeft  - descenderOverflow) (xCutRight + descenderOverflow) 0
+		include : VBar.l (xCutLeft  - descenderOverflow) (-LongVJut + HalfStroke) Stroke
 		include : VBar.r (xCutRight + descenderOverflow) (-LongVJut + HalfStroke) Stroke
 

--- a/packages/font-glyphs/src/letter/latin-ext/sakha-yat.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/sakha-yat.ptl
@@ -7,19 +7,20 @@ glyph-module
 glyph-block Letter-Latin-Sakha-Yat : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : SerifFrame
+	glyph-block-import Letter-Latin-Lower-M : MEnoughSpaceForFullSerifs
 	glyph-block-import Letter-Cyrillic-Yeri : YeriConfig
 	glyph-block-import Letter-Cyrillic-Iotified-A : Iotified
 
 	define [SakhaYatShape Yeri df top] : glyph-proc
-		local jut : Math.min Jut : Jut * 0.75 * df.div
 		include : Yeri top
 			left -- (df.middle - [HSwToV : 0.5 * df.mvs])
 			right -- df.rightSB
 			stroke -- df.mvs
-			jut -- jut
+			jut -- [Math.min Jut : Jut * 0.75 * df.div]
 
-		include : Iotified.outer df top (df.middle + [HSwToV : 0.5 * df.mvs]) (top - df.mvs * 0.5)
+		local fEnoughSpaceForFullSerifs : MEnoughSpaceForFullSerifs df
+		if [not fEnoughSpaceForFullSerifs] : eject-contour 'serifYeriLB'
+		include : Iotified.[if fEnoughSpaceForFullSerifs 'full' 'outer'] df top (df.middle + [HSwToV : 0.5 * df.mvs]) (top - df.mvs * 0.5)
 
 	foreach { suffix { Uc Lc } } [Object.entries YeriConfig] : do
 		create-glyph "latn/yatSakha.upright.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/upper-a.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-a.ptl
@@ -16,15 +16,15 @@ glyph-block Letter-Latin-Upper-A : begin
 	glyph-block-import Letter-Shared-Shapes : SerifFrame
 	glyph-block-import Letter-Latin-V : VShapeOutline VShape VCornerHalfWidth
 
-	define BODY-CURLY     0
-	define BODY-STRAIGHT  1
-	define BODY-ROUND-TOP 2
+	define BODY-CURLY      0
+	define BODY-STRAIGHT   1
+	define BODY-ROUND-TOP  2
 
-	define SLAB-NONE     0
-	define SLAB-TOP      1
-	define SLAB-LEFT     2
-	define SLAB-RIGHT    4
-	define SLAB-CYRL-BGR 8
+	define SLAB-NONE       0
+	define SLAB-TOP        1
+	define SLAB-LEFT       2
+	define SLAB-RIGHT      4
+	define SLAB-SMALL-CYRL 8
 
 	glyph-block-export AShape
 	define AShape : namespace
@@ -122,9 +122,9 @@ glyph-block Letter-Latin-Upper-A : begin
 	define [ASerifs df top sw slabKind] : glyph-proc : begin
 		local sf : SerifFrame.fromDf df top 0
 		if [maskBits slabKind SLAB-LEFT] : include
-			if ([maskBits slabKind SLAB-CYRL-BGR] && para.isItalic) sf.lb.outer sf.lb.full
+			if ([maskBits slabKind SLAB-SMALL-CYRL] && para.isItalic) sf.lb.outer sf.lb.full
 		if [maskBits slabKind SLAB-RIGHT] : include
-			if ([maskBits slabKind SLAB-CYRL-BGR] && para.isItalic) sf.rb.outer sf.rb.full
+			if ([maskBits slabKind SLAB-SMALL-CYRL] && para.isItalic) sf.rb.outer sf.rb.full
 		if [maskBits slabKind SLAB-TOP] : include : intersection [MaskLeft df.middle]
 			if [maskBits slabKind : bitOr SLAB-LEFT SLAB-RIGHT]
 			: then : HSerif.lt df.middle top (MidJutSide + [HSwToV : 0.25 * sw]) sf.swSerif

--- a/packages/font-glyphs/src/letter/latin/w.ptl
+++ b/packages/font-glyphs/src/letter/latin/w.ptl
@@ -387,7 +387,7 @@ glyph-block Letter-Latin-W : begin
 			include : implT df XH bodyType slabType
 
 		create-glyph "ww.\(suffix)": glyph-proc
-			local df : include : DivFrame 1 3
+			local df : include : DivFrame [if (Ldiv / para.diversityM < 1) para.diversityF 1] 3
 			include : df.markSet.capital
 
 			local gap : CAP * 0.05


### PR DESCRIPTION
Mostly about serifs for some recently-edited characters.
Latin Yat has its serifs harmonized with Cyrillic Pe, and Cyrillic Lower Yn's serifs respond to italics like Bulgarian Lower El.

```
ꙞНЊПП
ꙟнњпꭠ
```

Slab Upright Before:
![image](https://github.com/user-attachments/assets/e6b1025f-8d77-4d6d-89eb-67b994780c1c)
Slab Upright After:
![image](https://github.com/user-attachments/assets/a0f2add3-2aa1-4bcd-a492-0362c0b454f5)
Slab Italic Before:
![image](https://github.com/user-attachments/assets/bb105c01-93e1-4b13-86c0-c90824cdfb3a)
Slab Italic After:
![image](https://github.com/user-attachments/assets/b7f24439-5ff7-43de-bddf-822a75a8c3f5)
Etoile Upright Before:
![image](https://github.com/user-attachments/assets/932091b3-f9b0-486a-b012-4330ed1cc019)
Etoile Upright After:
![image](https://github.com/user-attachments/assets/01576d1b-fc4f-4ce6-a2f2-ef3577e6c5ee)
Etoile Italic Before:
![image](https://github.com/user-attachments/assets/7b1007ad-d22f-463b-852a-23ce54cae394)
Etoile Italic After:
![image](https://github.com/user-attachments/assets/7aae65fe-f49e-4be2-9199-2f2b085ab50d)
