### PR TITLE
Make Left/Right Half H and Greek Heta slightly narrower under Quasi-Proportional.

### DIFF
--- a/changes/32.3.1.md
+++ b/changes/32.3.1.md
@@ -1,0 +1,7 @@
+* Make certain characters slightly narrower under Quasi-Proportional. Affected characters:
+  - GREEK CAPITAL LETTER HETA (`U+0370`).
+  - GREEK SMALL LETTER HETA (`U+0371`).
+  - LATIN CAPITAL LETTER HALF H (`U+2C75`).
+  - LATIN SMALL LETTER HALF H (`U+2C76`).
+  - LATIN CAPITAL LETTER REVERSED HALF H (`U+A7F5`).
+  - LATIN SMALL LETTER REVERSED HALF H (`U+A7F6`).

--- a/packages/font-glyphs/src/letter/latin/upper-h.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-h.ptl
@@ -108,7 +108,7 @@ glyph-block Letter-Latin-Upper-H : begin
 		local yt : top - [if slabType Stroke 0]
 		return : HOverlayBar [mix SB 0 0.7] [mix RightSB Width 0.7]
 			mix yb yt 0.5
-			Math.min OverlayStroke (0.625 * (yt - yb))
+			Math.min OverlayStroke : 0.625 * (yt - yb)
 
 	define HConfig : object
 		serifless                        { HShape       HTurned HLeftHalf HRightHalf SLAB-NONE                  }
@@ -148,30 +148,34 @@ glyph-block Letter-Latin-Upper-H : begin
 			include : HSerifs slabType XH 0 SB RightSB
 
 		create-glyph "leftHalfH.\(suffix)" : glyph-proc
-			include : MarkSet.capital
-			include : LeftHalfBody SB RightSB CAP
-			include : HSerifs slabType CAP 0 SB RightSB
+			local df : include : DivFrame para.diversityF
+			include : df.markSet.capital
+			include : LeftHalfBody df.leftSB df.rightSB CAP
+			include : HSerifs slabType CAP 0 df.leftSB df.rightSB
 			eject-contour 'serifRT'
 			eject-contour 'serifRB'
 
 		create-glyph "rightHalfH.\(suffix)" : glyph-proc
-			include : MarkSet.capital
-			include : RightHalfBody SB RightSB CAP
-			include : HSerifs slabType CAP 0 SB RightSB
+			local df : include : DivFrame para.diversityF
+			include : df.markSet.capital
+			include : RightHalfBody df.leftSB df.rightSB CAP
+			include : HSerifs slabType CAP 0 df.leftSB df.rightSB
 			eject-contour 'serifLT'
 			eject-contour 'serifLB'
 
 		create-glyph "leftHalfSmcpH.\(suffix)" : glyph-proc
-			include : MarkSet.e
-			include : LeftHalfBody SB RightSB XH
-			include : HSerifs slabType XH 0 SB RightSB
+			local df : include : DivFrame para.diversityF
+			include : df.markSet.e
+			include : LeftHalfBody df.leftSB df.rightSB XH
+			include : HSerifs slabType XH 0 df.leftSB df.rightSB
 			eject-contour 'serifRT'
 			eject-contour 'serifRB'
 
 		create-glyph "rightHalfSmcpH.\(suffix)" : glyph-proc
-			include : MarkSet.e
-			include : RightHalfBody SB RightSB XH
-			include : HSerifs slabType XH 0 SB RightSB
+			local df : include : DivFrame para.diversityF
+			include : df.markSet.e
+			include : RightHalfBody df.leftSB df.rightSB XH
+			include : HSerifs slabType XH 0 df.leftSB df.rightSB
 			eject-contour 'serifLT'
 			eject-contour 'serifLB'
 
@@ -269,9 +273,10 @@ glyph-block Letter-Latin-Upper-H : begin
 	alias 'grek/Heta' 0x370 'leftHalfH'
 
 	create-glyph 'grek/heta' 0x371 : glyph-proc
-		include : MarkSet.e
-		include : LeftHalfBody SB RightSB XH
-		include : HSerifs SLAB-SMALL-HETA XH 0 SB RightSB
+		local df : include : DivFrame para.diversityF
+		include : df.markSet.e
+		include : LeftHalfBody df.leftSB df.rightSB XH
+		include : HSerifs SLAB-SMALL-HETA XH 0 df.leftSB df.rightSB
 
 	derive-composites 'HDescender' 0x2C67 'H/descBase' [CyrDescender.rSideJut RightSB 0]
 
@@ -337,7 +342,7 @@ glyph-block Letter-Latin-Upper-H : begin
 		include : VBar.r RightSB 0 CAP BBS
 		include : VBar.l  (SB + BBD) 0 CAP BBS
 		include : VBar.r (RightSB - BBD) 0 CAP BBS
-		include : HBar.m (SB + BBD) (RightSB - BBD)  (CAP * HBarPos) BBS
+		include : HBar.m (SB + BBD) (RightSB - BBD) (CAP * HBarPos) BBS
 		include : HBar.t SB (SB + BBD) CAP BBS
 		include : HBar.t (RightSB - BBD) RightSB CAP BBS
 		include : HBar.b SB (SB + BBD) 0 BBS


### PR DESCRIPTION
As a "halved" n-width character, it doesn't need to be the same width as full H (i.e. `1`), but it also doesn't need to be literally `diversityII` (i.e. `0.5`) so this instead sets it to `diversityF`, which also happens to make it optically match with the middle bars of capital `E`/`F`.

`Hʜ FⱵꜰⱶ ꟻꟵꟶ ϜͰϝͱ`

Aile Before:
![image](https://github.com/user-attachments/assets/b576c472-bbff-48bc-98f7-1228c696329b)
Aile After:
![image](https://github.com/user-attachments/assets/6f353bf8-c1a6-4f96-bfa0-48dede94e0ff)
Etoile Before:
![image](https://github.com/user-attachments/assets/a6ffb18c-945b-4038-8a7e-9d879ae95cd0)
Etoile After:
![image](https://github.com/user-attachments/assets/6ca5f6aa-4d33-4b15-bca5-0a51d0e9d485)
