### PR TITLE
Add new macro `VSwToH` as an intuitive inverse of `HSwToV`.

### DIFF
--- a/packages/font-glyphs/src/letter/cyrillic/che.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/che.ptl
@@ -231,7 +231,7 @@ glyph-block Letter-Cyrillic-Che : begin
 	CreateSelectorVariants 'cyrl/tche' 0xA693 [Object.keys ItalicConfig] (follow -- 'cyrl/che')
 
 	define [CheVBarBarShape top pyBar] : begin
-		local SwCheVBar : Math.min OverlayStroke (0.625 * (RightSB - SB - [HSwToV : 2 * Stroke]) / HVContrast)
+		local SwCheVBar : Math.min OverlayStroke : VSwToH : 0.625 * (RightSB - SB - [HSwToV : 2 * Stroke])
 		local yc : top * [fallback pyBar 0.5] + Stroke * 0.1
 		return : VBar.m Middle (yc + LongVJut * 0.8) (yc - LongVJut * 0.8) SwCheVBar
 

--- a/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
@@ -35,8 +35,8 @@ glyph-block Letter-Latin-Ezh : begin
 	define [ConventionalStart df top bot ezhLeft ezhRight yMidBar sw hook] : glyph-proc
 		include : HBar.t df.leftSB ezhRight top sw
 		include : dispiro
-			corner ezhRight (top - sw) [widths.rhs : sw / HVContrast]
-			corner ezhLeft  yMidBar    [widths.lhs : sw / HVContrast]
+			corner ezhRight (top - sw) [widths.rhs : VSwToH sw]
+			corner ezhLeft  yMidBar    [widths.lhs : VSwToH sw]
 
 	define [CurisveStart df top bot ezhLeft ezhRight yMidBar sw hook] : glyph-proc
 		define hookTerminalWidth : [AdviceStroke 3.5] / Stroke * sw
@@ -66,10 +66,10 @@ glyph-block Letter-Latin-Ezh : begin
 				flat [mix (df.leftSB + xMockTailDepth) ezhRight kTop] (top - kTop * yTailDepth)
 				curl [mix (df.leftSB + xMockTailDepth) ezhRight 4]    (top - 4    * yTailDepth)
 
-		include : VBar.r ezhRight top (top - yFootHeight) (xDiagWidth / HVContrast)
+		include : VBar.r ezhRight top (top - yFootHeight) [VSwToH xDiagWidth]
 		include : dispiro
-			corner ezhRight (top - yFootHeight) [widths.rhs : sw / HVContrast]
-			corner ezhLeft  yMidBar             [widths.lhs : sw / HVContrast]
+			corner ezhRight (top - yFootHeight) [widths.rhs : VSwToH sw]
+			corner ezhLeft  yMidBar             [widths.lhs : VSwToH sw]
 
 	glyph-block-export EzhShape
 	define flex-params [EzhShape] : glyph-proc
@@ -320,8 +320,8 @@ glyph-block Letter-Latin-Ezh : begin
 
 		include : HBar.t ezhLeft RightSB top
 		include : dispiro
-			corner ezhLeft (top - Stroke) [widths.lhs : Stroke / HVContrast]
-			corner ezhRight yMidBar       [widths.rhs : Stroke / HVContrast]
+			corner ezhLeft (top - Stroke) [widths.lhs : VSwToH Stroke]
+			corner ezhRight yMidBar       [widths.rhs : VSwToH Stroke]
 
 		include : dispiro
 			widths.lhs

--- a/packages/font-glyphs/src/letter/latin/lower-f.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-f.ptl
@@ -55,7 +55,7 @@ glyph-block Letter-Latin-Lower-F : begin
 			DiagTail.L xBarMiddle Descender [DiagTail.StdDepth df Stroke] Stroke
 
 	glyph-block-export StdSmallFBarLeftPos
-	define [StdSmallFBarLeftPos barAtCenter] : [mix SB RightSB : if barAtCenter 0.45 0.35] - Stroke * [if barAtCenter 0.45 0.25] * HVContrast
+	define [StdSmallFBarLeftPos barAtCenter] : [mix SB RightSB : if barAtCenter 0.45 0.35] - [HSwToV : Stroke * [if barAtCenter 0.45 0.25]]
 
 	glyph-block-export StdSmallFBarLeftPos0
 	define [StdSmallFBarLeftPos0] : [mix SB RightSB 0.35] - [HSwToV : 0.25 * Stroke]

--- a/packages/font-glyphs/src/letter/latin/upper-h.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-h.ptl
@@ -84,7 +84,7 @@ glyph-block Letter-Latin-Upper-H : begin
 
 		include : HSerifs slabType top 0 df.leftSB xm sw
 		if vSlab
-			then : include : VSerif.dr xTopBarRightEnd top VJut (df.mvs / HVContrast)
+			then : include : VSerif.dr xTopBarRightEnd top VJut [VSwToH df.mvs]
 			else : eject-contour 'serifRT'
 
 	define [HwairShape df top yend slabType] : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/upper-q.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-q.ptl
@@ -34,13 +34,13 @@ glyph-block Letter-Latin-Upper-Q : begin
 		define fine : AdviceStroke 3.5
 		define xLB0 : mix df.leftSB df.rightSB (1 / 16)
 		define xLB : xLB0 + [HSwToV : 0.6 * fine]
-		define yLB : [mix 0 Descender (1 - 1 / 32)] + O
+		define yLB : [mix 0 Descender (31 / 32)] + O
 		define xMBArc : mix df.rightSB xLB 0.5
 		define yMBArc : [mix ArchDepthA yLB 0.625] + Stroke * (1 / 16)
 		define xRB0 : mix df.rightSB df.width 0.7
 		define xRB : xRB0 - [HSwToV : 0.75 * Stroke]
 		define yRingStart : XH / 12
-		define notchOffset : (-Descender * 0.625) + Stroke * 0.625 + yRingStart / 2
+		define notchOffset : ((-Descender) * 0.625) + Stroke * 0.625 + yRingStart / 2
 		define tailSlope : 0.2 + 0.5 * (1 - fine / Stroke)
 		# Lower part
 		include : difference
@@ -126,9 +126,9 @@ glyph-block Letter-Latin-Upper-Q : begin
 			VBar.m df.middle [mix Descender HalfStroke 1.75] 0 sw
 			VBar.m df.middle 0 TailDepth
 
-	define detachedTailGap : Math.max (-0.25 * Descender) [AdviceStroke 12]
+	define detachedTailGap : Math.max ((-0.25) * Descender) : AdviceStroke 12
 	define yObliqueTailStart : 0 - detachedTailGap - Stroke * 0.875
-	define yObliqueTailEnd : [mix 0 Descender 0.75] - Stroke * 0.5
+	define yObliqueTailEnd : [mix 0 Descender 0.75] - HalfStroke
 	define [xDetachedTailEnd df] : mix df.rightSB df.width 0.75
 	define kBendStartPartLeftLength 0.5
 	define [xBendTailStart df] : mix df.middle df.leftSB kBendStartPartLeftLength
@@ -151,7 +151,7 @@ glyph-block Letter-Latin-Upper-Q : begin
 	glyph-block-export QInnerDiagSw
 	define QInnerDiagSw : AdviceStroke 4
 
-	define QInnerVertSw : Math.min [AdviceStroke 3.5] ((RightSB - SB - [HSwToV : 2 * Stroke]) / (2 * HVContrast))
+	define QInnerVertSw : Math.min VJutStroke : VSwToH : (RightSB - SB) / 2 - [HSwToV Stroke]
 
 	define QConfig : object
 		straight            { QStdBody                Stroke             QStraightTail      'capDesc' 'p' }
@@ -200,7 +200,7 @@ glyph-block Letter-Latin-Upper-Q : begin
 		include : intersection
 			QInner
 			union
-				VBar.l  (SB + BBD) 0 CAP BBS
+				VBar.l (SB + BBD)      0 CAP BBS
 				VBar.r (RightSB - BBD) 0 CAP BBS
 
 		define terminalX : Middle + HookX

--- a/packages/font-glyphs/src/letter/latin/z.ptl
+++ b/packages/font-glyphs/src/letter/latin/z.ptl
@@ -55,8 +55,8 @@ glyph-block Letter-Latin-Z : begin
 		local cor : 1.2 * HVContrast
 		include : tagged 'strokeTop' : HBar.t SB RightSB XH
 		include : dispiro
-			corner SB [if (mode === MODE-ZSWASH) 0 Stroke] [widths.rhs (Stroke / HVContrast)]
-			corner RightSB (XH - Stroke)                   [widths.lhs (Stroke / HVContrast)]
+			corner SB [if (mode === MODE-ZSWASH) 0 Stroke] [widths.rhs : VSwToH Stroke]
+			corner RightSB (XH - Stroke)                   [widths.lhs : VSwToH Stroke]
 		if [DisplayBottomStroke mode] : include : tagged 'strokeBottom' : HBar.b SB RightSB 0
 		set-base-anchor "trailing" RightSB 0
 
@@ -95,11 +95,11 @@ glyph-block Letter-Latin-Z : begin
 				curl RightSB                                  (top - yTailDepth)
 
 		include : dispiro
-			corner RightSB (top - yFootHeight)                 [widths.rhs (Stroke / HVContrast)]
-			corner SB [if (mode == MODE-ZSWASH) 0 yFootHeight] [widths.lhs (Stroke / HVContrast)]
+			corner RightSB (top - yFootHeight)                 [widths.rhs : VSwToH Stroke]
+			corner SB [if (mode == MODE-ZSWASH) 0 yFootHeight] [widths.lhs : VSwToH Stroke]
 
-		include : VBar.r RightSB top (top - yFootHeight) (xDiagWidth / HVContrast)
-		if (mode != MODE-ZSWASH) : include : VBar.l SB 0 yFootHeight (xDiagWidth / HVContrast)
+		include : VBar.r RightSB top (top - yFootHeight) [VSwToH xDiagWidth]
+		if (mode != MODE-ZSWASH) : include : VBar.l SB 0 yFootHeight [VSwToH xDiagWidth]
 
 		include : tagged 'strokeBottom' : match mode
 			[Just MODE-RTAIL] : intersection

--- a/packages/font-glyphs/src/marks/below.ptl
+++ b/packages/font-glyphs/src/marks/below.ptl
@@ -43,16 +43,16 @@ glyph-block Mark-Below : begin
 		set-base-anchor 'belowBraceR' (markMiddle + 0.5 * markExtend) belowMarkMid
 
 	define [CedillaShape ext] : begin
-		local fine : Math.min [AdviceStroke 6] (0.75 * (belowMarkTop - belowMarkBot - markStroke))
-		local cedillaTop (belowMarkTop + 0.875 * fine)
-		local cedillaBot  belowMarkBot
+		local fine : Math.min (0.75 * (belowMarkTop - belowMarkBot - markStroke)) : AdviceStroke 6
+		local cedillaTop : belowMarkTop + 0.875 * fine
+		local cedillaBot   belowMarkBot
 		return : union
 			VBar.m markMiddle ext (cedillaTop - fine) markStroke
 			dispiro
 				flat (markMiddle - [HSwToV : 0.5 * markStroke]) cedillaTop [widths.rhs.heading fine Rightward]
 				curl markMiddle cedillaTop [heading Rightward]
 				archv
-				g4   (markMiddle + markExtend - O) [mix cedillaTop cedillaBot 0.5] [widths.rhs.heading [mix fine markStroke 0.5] {.x HVContrast .y (-0.5 * (markStroke - fine) / markStroke)}]
+				g4   (markMiddle + markExtend - O) [mix cedillaTop cedillaBot 0.5] [widths.rhs.heading [mix fine markStroke 0.5] {.x HVContrast .y ((-0.5) * (markStroke - fine) / markStroke)}]
 				arcvh
 				flat markMiddle cedillaBot [widths.rhs.heading markStroke Leftward]
 				curl (markMiddle - markExtend) cedillaBot [heading Leftward]
@@ -121,7 +121,7 @@ glyph-block Mark-Below : begin
 		include : StdAnchors.mediumWide
 
 		local boxhs : Math.min (markFine * 2) ((belowMarkTop - belowMarkBot) / 3)
-		local boxvs : Math.min (markFine * 2) ((markExtend * 2) / (HVContrast * 3))
+		local boxvs : Math.min (markFine * 2) [VSwToH : markExtend * (2/3)]
 
 		include : VBar.l (markMiddle - markExtend) belowMarkBot belowMarkTop boxvs
 		include : VBar.r (markMiddle + markExtend) belowMarkBot belowMarkTop boxvs

--- a/packages/font-glyphs/src/meta/aesthetics.ptl
+++ b/packages/font-glyphs/src/meta/aesthetics.ptl
@@ -39,13 +39,13 @@ export : define [calculateMetrics para] : begin
 
 	# Transform constructors
 	define [Italify angle shift] : begin
-		local slope [Math.tan ([fallback angle para.slopeAngle] / 180 * Math.PI)]
-		return : new Transform 1 slope 0 1 [fallback shift : -slope * SymbolMid] 0
+		local slope : Math.tan ([fallback angle para.slopeAngle] / 180 * Math.PI)
+		return : new Transform 1 slope 0 1 [fallback shift : (-slope) * SymbolMid] 0
 	define [Upright angle shift] [Italify angle shift :.inverse]
 	define [Scale sx sy] : new Transform sx 0 0 [fallback sy sx] 0 0
 	define [Translate x y] : new Transform 1 0 0 1 x y
 	define [ApparentTranslate x y] : Translate (x + TanSlope * y) y
-	define [Rotate angle] : new Transform [Math.cos angle] (-[Math.sin angle]) [Math.sin angle] [Math.cos angle] 0 0
+	define [Rotate angle] : new Transform [Math.cos angle] [Math.sin (-angle)] [Math.sin angle] [Math.cos angle] 0 0
 
 	define GlobalTransform : Italify para.slopeAngle
 	define TanSlope   GlobalTransform.xy
@@ -53,6 +53,7 @@ export : define [calculateMetrics para] : begin
 	define CosSlope : Math.cos (para.slopeAngle / 180 * Math.PI)
 	define HVContrast : Contrast * CosSlope + SinSlope * TanSlope
 	define [HSwToV sw] : sw * HVContrast
+	define [VSwToH sw] : sw / HVContrast
 
 	# Orient parameters
 	define Upward    : new Point Point.Type.Corner (-HVContrast)  0
@@ -83,7 +84,7 @@ export : define [calculateMetrics para] : begin
 	define [AdviceStrokeInSpace availSpace contrast crowdedness mul] : begin
 		local nonAdjustedFillRate : crowdedness * contrast * para.stroke / availSpace
 		local adjustedFillRate : StrokeWeightControlSigmoid nonAdjustedFillRate
-		local strokeWidthScalar : Math.min 1 (mul * adjustedFillRate / nonAdjustedFillRate)
+		local strokeWidthScalar : Math.min 1 : mul * adjustedFillRate / nonAdjustedFillRate
 		return : para.stroke * strokeWidthScalar
 	define [AdviceStroke crowdedness div mul] : begin
 		local spaceH : Width * [fallback div 1] - SB * 2
@@ -159,8 +160,8 @@ export : define [calculateMetrics para] : begin
 		local delta : (adb - ada) / 2
 		local smOfSma : ada + delta
 		local smOfSmb : adb - delta
-		local yNotAdjusted : mix top bot (smOfSmb / (smOfSma + smOfSmb))
-		return : yNotAdjusted - delta * [Math.min 1 ((top - bot) / (ada + adb))]
+		local yNotAdjusted : mix top bot : smOfSmb / (smOfSma + smOfSmb)
+		return : yNotAdjusted - delta * [Math.min 1 : (top - bot) / (ada + adb)]
 	set YSmoothMidR.cr : function [c r _ada _adb] : YSmoothMidR (c + r) (c - r) _ada _adb
 	define [YSmoothMidL top bot _ada _adb] : begin
 		local ada : fallback _ada ArchDepthA
@@ -168,8 +169,8 @@ export : define [calculateMetrics para] : begin
 		local delta : (adb - ada) / 2
 		local smOfSma : ada + delta
 		local smOfSmb : adb - delta
-		local yNotAdjusted : mix top bot (smOfSma / (smOfSma + smOfSmb))
-		return : yNotAdjusted + delta * [Math.min 1 ((top - bot) / (ada + adb))]
+		local yNotAdjusted : mix top bot : smOfSma / (smOfSma + smOfSmb)
+		return : yNotAdjusted + delta * [Math.min 1 : (top - bot) / (ada + adb)]
 	set YSmoothMidL.cr : function [c r _ada _adb] : YSmoothMidL (c + r) (c - r) _ada _adb
 
 	define ArchDepthA : ArchDepth - TanSlope * SmoothAdjust
@@ -184,7 +185,7 @@ export : define [calculateMetrics para] : begin
 	define OverlayStroke : AdviceStroke 3.75
 	define OperatorStroke : AdviceStroke 2.75
 	define GeometryStroke : AdviceStroke 4
-	define ShoulderFine : Math.min (Stroke * para.shoulderFineMin) [AdviceStroke 24]
+	define ShoulderFine : Math.min (Stroke * para.shoulderFineMin) : AdviceStroke 24
 
 	define [AdviceGlottalStopArchDepth y sign] : begin
 		return : ((y - Stroke) * 0.24 + Stroke * 0.625) + sign * TanSlope * SmoothAdjust
@@ -205,7 +206,7 @@ export : define [calculateMetrics para] : begin
 		SideJut ArchDepthA ArchDepthB SmallArchDepthA SmallArchDepthB CorrectionOMidX CorrectionOMidS
 		compositeBaseAnchors AdviceStroke AdviceStroke2 AdviceStrokeInSpace OverlayStroke OperatorStroke
 		GeometryStroke ShoulderFine AdviceGlottalStopArchDepth StrokeWidthBlend ArchDepthAOf ArchDepthBOf
-		SmoothAdjust MidJutSide MidJutCenter YSmoothMidR YSmoothMidL HSwToV NarrowUnicodeT
+		SmoothAdjust MidJutSide MidJutCenter YSmoothMidR YSmoothMidL HSwToV VSwToH NarrowUnicodeT
 		WideUnicodeT VERY-FAR TINY]
 
 export : define [setFontMetrics para metrics fm] : begin
@@ -237,9 +238,9 @@ export : define [setFontMetrics para metrics fm] : begin
 
 	local slope : Math.tan para.slopeAngle
 	set fm.post.italicAngle       : Math.round (0 - para.slopeAngle)
-	set fm.hhea.caretSlopeRise    : if para.slopeAngle (1000)                    1
-	set fm.hhea.caretSlopeRun     : if para.slopeAngle (-slope * 1000)           0
-	set fm.hhea.caretOffset       : if para.slopeAngle (-slope * para.symbolMid) 0
+	set fm.hhea.caretSlopeRise    : if para.slopeAngle (1000)                      1
+	set fm.hhea.caretSlopeRun     : if para.slopeAngle ((-slope) * 1000)           0
+	set fm.hhea.caretOffset       : if para.slopeAngle ((-slope) * para.symbolMid) 0
 
 	# Fixed metrics
 	set fm.os2.yStrikeoutPosition    para."os2.yStrikeoutPosition"

--- a/packages/font-glyphs/src/meta/macros.ptl
+++ b/packages/font-glyphs/src/meta/macros.ptl
@@ -389,7 +389,7 @@ define-macro glyph-block : syntax-rules
 			AdviceStroke AdviceStroke2 AdviceStrokeInSpace OverlayStroke OperatorStroke GeometryStroke
 			ShoulderFine AdviceGlottalStopArchDepth StrokeWidthBlend ArchDepthAOf ArchDepthBOf
 			SmoothAdjust MidJutSide MidJutCenter compositeBaseAnchors YSmoothMidR YSmoothMidL HSwToV
-			NarrowUnicodeT WideUnicodeT VERY-FAR TINY]
+			VSwToH NarrowUnicodeT WideUnicodeT VERY-FAR TINY]
 
 		define spiroFnImports `[g4 g2 corner flat curl virt close end straight g2c cg2 flatc ccurl
 			widths disable-contrast heading unimportant important alsoThru alsoThruThem bezControls

--- a/packages/font-glyphs/src/symbol/punctuation/percentages.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/percentages.ptl
@@ -14,7 +14,7 @@ glyph-block Symbol-Punctuation-Percentages : begin
 
 	define [PercentBarCor df sw] : begin
 		local a : 1 - (((df.rightSB - df.leftSB - sw) / (CAP - 0)) ** 2)
-		return : HVContrast / [if (a <= 0) 1 : Math.sqrt a]
+		return : HSwToV : 1 / [if (a <= 0) 1 : Math.sqrt a]
 
 	define [PercentBarShape df sw] : begin
 		local cor : PercentBarCor df sw
@@ -53,7 +53,7 @@ glyph-block Symbol-Punctuation-Percentages : begin
 
 	create-glyph 'basepoint.NWID.dots' : glyph-proc
 		define df : include : DivFrame para.diversityM
-		define slopeDf : DivFrame [Math.min (para.diversityM * 0.8) 1]
+		define slopeDf : DivFrame : Math.min 1 : para.diversityM * 0.8
 
 		define refSw : AdviceStroke 5 df.div
 
@@ -147,7 +147,7 @@ glyph-block Symbol-Punctuation-Percentages : begin
 		local adb  : ArchDepthB * 0.5 * para.diversityM
 		local sw   : AdviceStroke2 4 5 CAP para.diversityM
 		local fine : AdviceStroke2 5 5 CAP para.diversityM
-		local cor : HVContrast / [Math.sqrt : 1 - (((r - l - sw) / (CAP - 0)) ** 2)]
+		local cor : HSwToV : 1 / [Math.sqrt : 1 - (((r - l - sw) / (CAP - 0)) ** 2)]
 		local pTerm : (fine / 2) / [Math.hypot CAP (r - l)]
 		local pFine : 1 / 2 - (Stroke / 2) / [Math.hypot CAP (r - l)]
 

--- a/packages/font-glyphs/src/symbol/punctuation/slashes-and-number-sign.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/slashes-and-number-sign.ptl
@@ -24,7 +24,7 @@ glyph-block Symbol-Punctuation-Slashes-And-Number-Sign : begin
 		local-parameter : b -- ParenBot
 		local-parameter : w -- Stroke
 
-		local cor : (1 / 2) * HVContrast / [Math.sqrt : 1 - (((r - l - w) / (t - b)) ** 2)]
+		local cor : HSwToV : 0.5 / [Math.sqrt : 1 - (((r - l - w) / (t - b)) ** 2)]
 		include : spiro-outline
 			corner (r - w * cor) t
 			corner (r + w * cor) t
@@ -40,7 +40,7 @@ glyph-block Symbol-Punctuation-Slashes-And-Number-Sign : begin
 
 	create-glyph 'doubleSlash' 0x2AFD : glyph-proc
 		define w : AdviceStroke 3
-		define b : Math.max w (Width * 0.15)
+		define b : Math.max w : Width * 0.15
 		include : SlashShape (slashDefautLeft - b) (slashDefaultRight - b) nothing nothing w
 		include : SlashShape (slashDefautLeft + b) (slashDefaultRight + b) nothing nothing w
 
@@ -54,7 +54,7 @@ glyph-block Symbol-Punctuation-Slashes-And-Number-Sign : begin
 
 	create-glyph 'slantedParallel' : glyph-proc
 		define w : AdviceStroke 3
-		define b : Math.max w (Width * 0.15)
+		define b : Math.max w : Width * 0.15
 		include : SlashShape (slashDefautLeft - b) (slashDefaultRight - b) TackTop TackBot w
 		include : SlashShape (slashDefautLeft + b) (slashDefaultRight + b) TackTop TackBot w
 
@@ -66,7 +66,7 @@ glyph-block Symbol-Punctuation-Slashes-And-Number-Sign : begin
 		local-parameter : b -- ParenBot
 		local-parameter : w -- Stroke
 
-		local cor : (1 / 2) * HVContrast / [Math.sqrt : 1 - (((r - l - w) / (t - b)) ** 2)]
+		local cor : HSwToV : 0.5 / [Math.sqrt : 1 - (((r - l - w) / (t - b)) ** 2)]
 		include : spiro-outline
 			corner (l - w * cor) t
 			corner (l + w * cor) t


### PR DESCRIPTION
This is occasionally useful.

It basically divides a value by `HVContrast` instead of multiplies; Not to be confused with dividing `HVContrast` by the value, which is actually equivalent to multiplying it by _1 over_ said value.

Normally I tend not to file PR's when someone else already has one open, but I double checked and saw that there are no files in common between the other open one at the moment and this one, so it should be fine.