### PR TITLE
Improve serifs of Bulgarian Cyrillic Lower Zhe.

### DIFF
--- a/changes/32.3.1.md
+++ b/changes/32.3.1.md
@@ -6,6 +6,7 @@
   - LATIN CAPITAL LETTER REVERSED HALF H (`U+A7F5`).
   - LATIN SMALL LETTER REVERSED HALF H (`U+A7F6`).
 * Fix shape of `U+276E` and `U+276E` (#2603).
+* Improve serifs of Bulgarian Cyrillic Lower Zhe (`ж`).
 * Add characters:
   - OPEN CENTRE CROSS (`U+271B`).
   - HEAVY OPEN CENTRE CROSS (`U+271C`).

--- a/packages/font-glyphs/src/letter/cyrillic/zhe.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/zhe.ptl
@@ -25,7 +25,7 @@ glyph-block Letter-Cyrillic-Zhe : begin
 				if (!para.isItalic && fEnoughSpaceForFullSerifs) : begin
 					include : HSerif.mb df.middle bot Jut
 					if (!fBGR) : include : HSerif.mt df.middle midTop Jut
-				if fBGR : include : HSerif.lt (df.middle - [HSwToV : 0.5 * fine]) midTop SideJut fine
+				if fBGR : include : HSerif.lt (df.middle - [HSwToV : 0.5 * fine]) midTop SideJut
 
 		define [LegSerifs fSlab fHalf df bot top] : glyph-proc
 			define fine : ZheSw df

--- a/packages/font-glyphs/src/letter/cyrillic/zhe.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/zhe.ptl
@@ -14,13 +14,18 @@ glyph-block Letter-Cyrillic-Zhe : begin
 		define [ZheSw df]  : AdviceStroke 3.3 df.div
 		define [ZheSw2 df] : AdviceStroke 4.0 df.div
 		define [ZheSw3 df] : AdviceStroke 3.7 df.div
-		define [Overshoot fSlab df] : if fSlab 0 (O * 3 * df.div)
+		define [Overshoot fSlab df] : if fSlab 0 : O * 3 * df.div
 
-		define [CenterBar fSlab df bot midTop] : glyph-proc
-			include : VBar.m df.middle bot midTop [ZheSw df]
-			if (fSlab && !para.isItalic && (df.width > 7 * para.refJut)) : begin
-				include : HSerif.mb df.middle bot    Jut
-				include : HSerif.mt df.middle midTop Jut
+		define [CenterBar fSlab df bot top midTop] : glyph-proc
+			define fine : ZheSw df
+			include : VBar.m df.middle bot midTop fine
+			if fSlab : begin
+				local fBGR : midTop > top
+				local fEnoughSpaceForFullSerifs : df.width > 7 * para.refJut
+				if (!para.isItalic && fEnoughSpaceForFullSerifs) : begin
+					include : HSerif.mb df.middle bot Jut
+					if (!fBGR) : include : HSerif.mt df.middle midTop Jut
+				if fBGR : include : HSerif.lt (df.middle - [HSwToV : 0.5 * fine]) midTop SideJut fine
 
 		define [LegSerifs fSlab fHalf df bot top] : glyph-proc
 			define fine : ZheSw df
@@ -36,7 +41,7 @@ glyph-block Letter-Cyrillic-Zhe : begin
 			define sw : ZheSw df
 			define fineK 0.1
 			return : CyrDescender.rSideJut
-				x       -- df.rightSB - fineK * sw - [Overshoot fSlab df]
+				x       -- (df.rightSB - fineK * sw - [Overshoot fSlab df])
 				y       -- 0
 				refSw   -- sw
 				sideJut -- SideJut
@@ -76,7 +81,7 @@ glyph-block Letter-Cyrillic-Zhe : begin
 		export : define [CurlyLegs fSlab fHalf df bot top] : begin
 			define fine : ZheSw df
 			define fine2 : ZheSw3 df
-			define overshoot : if fSlab 0 (2 * O * df.div)
+			define overshoot : if fSlab 0 : 2 * O * df.div
 
 			define attach1X : df.middle - [HSwToV : 0.5 * fine]
 			define attach1Y : mix bot top : if fSlab 0.325 0.375
@@ -167,12 +172,12 @@ glyph-block Letter-Cyrillic-Zhe : begin
 			return : union fullShape : HBar.m [if fHalf df.middle (midX + 0.5 * fine)] (df.width - (midX + 0.5 * fine)) midY fine
 
 		export : define [Shape Legs fSlab fMidSlab df bot top midTop] : glyph-proc
-			include : CenterBar fMidSlab    df bot midTop
+			include : CenterBar fMidSlab    df bot top midTop
 			include : Legs      fSlab false df bot top
 			include : LegSerifs fSlab false df bot top
 
 		export : define [HalfShape Legs fSlab fMidSlab df bot top midTop] : glyph-proc
-			include : CenterBar fMidSlab   df bot midTop
+			include : CenterBar fMidSlab   df bot top midTop
 			include : Legs      fSlab true df bot top
 			include : LegSerifs fSlab true df bot top
 


### PR DESCRIPTION
This harmonizes the top serif with that of `к`/`ю`/`ф`/etc.; As such, It does not disappear under monospace or italics.

```
Я, пазачът Вальо уж бди,
а скришом хапва кюфтенца зад щайгите.
```
Slab Upright Before:
![image](https://github.com/user-attachments/assets/95e55993-4da2-48e0-aada-3e3f8fd96900)
Slab Upright After:
![image](https://github.com/user-attachments/assets/8a3b3ee5-8e72-456d-b05f-6d7b99d41dc6)
Slab Italic Before:
![image](https://github.com/user-attachments/assets/dfd22fc9-bd04-441b-9d8e-7bb067b57f95)
Slab Italic After:
![image](https://github.com/user-attachments/assets/e0d9e0a5-1cb4-4d75-a8da-4b966ea3b3ec)
Etoile Upright Before:
![image](https://github.com/user-attachments/assets/aba4c90a-1f40-4e46-af51-6c83c351becd)
Etoile Upright After:
![image](https://github.com/user-attachments/assets/4d76b672-64d9-4537-a9dd-1e46d69c7335)
Etoile Italic Before:
![image](https://github.com/user-attachments/assets/f2385e0b-0537-453b-ba4c-3cdaa42c9a0e)
Etoile Italic After:
![image](https://github.com/user-attachments/assets/8c80bce8-987a-42c5-9abc-cb9aad1c84c0)
