### PR TITLE
Improve serifs of two extended Cyrillic letters under italics.

### DIFF
--- a/packages/font-glyphs/src/letter/cyrillic/orthography.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/orthography.ptl
@@ -32,7 +32,6 @@ glyph-block Letter-Cyrillic-Orthography : begin
 	orthographic-italic 'cyrl/peDescender'    0x525
 	orthographic-italic 'cyrl/dzzhe'          0x52B
 	orthographic-italic 'cyrl/dche'           0x52D
-	orthographic-italic 'cyrl/teTall'         0x1C84
 	orthographic-italic 'cyrl/teThreeLeg'     0x1C85
 	orthographic-italic 'cyrl/tje'            0x1C8A
 	orthographic-italic 'cyrl/este'             null

--- a/packages/font-glyphs/src/letter/cyrillic/yat.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/yat.ptl
@@ -12,20 +12,20 @@ glyph-block Letter-Cyrillic-Yat : begin
 	glyph-block-import Letter-Shared : CreateDependentComposite
 	glyph-block-import Letter-Shared-Metrics : BowlXDepth
 	glyph-block-import Letter-Shared-Shapes : LetterBarOverlay
-	glyph-block-import Letter-Cyrillic-Yeri : YeriConfig
+	glyph-block-import Letter-Cyrillic-Yeri : YeriConfig YeriBarPos
 	glyph-block-import Letter-Cyrillic-Iotified-A : Iotified
 
 	define [xBarLeft df] : Math.max (df.rightSB - (RightSB - SB)) : if SLAB
 		Just ([mix df.leftSB df.rightSB 0.35] - [HSwToV : 0.5 * df.mvs])
 		Just  [mix df.leftSB df.rightSB 0.2]
 
-	define [YatShape] : with-params [df Yeri top [pBar 0.5] [fLowerCase false] [sw df.mvs] [xCrossbarLeftOverride nothing] [yCrossbarOverride nothing]] : glyph-proc
+	define [YatShape] : with-params [df Yeri top [pBar YeriBarPos] [fLowerCase false] [fIotifiedBase false] [sw df.mvs] [xCrossbarLeftOverride nothing] [yCrossbarOverride nothing]] : glyph-proc
 		local xYeriLeft : xBarLeft df
 
 		include : Yeri top
-			left -- xYeriLeft
-			right -- (df.rightSB - O * 2)
-			pBar -- pBar
+			left   -- xYeriLeft
+			right  -- (df.rightSB - O * 2)
+			pBar   -- pBar
 			stroke -- sw
 
 		local cTop : if SLAB (top - Stroke / 2) top
@@ -44,25 +44,24 @@ glyph-block Letter-Cyrillic-Yat : begin
 
 			if fLowerCase : begin
 				eject-contour 'serifYeriLT'
-				include : tagged 'serifLT' : HSerif.lt xYeriLeft top SideJut sw
+				include : tagged 'serifLT' : if (fIotifiedBase && para.isItalic) [glyph-proc] [HSerif.lt xYeriLeft top SideJut sw]
 
-	define [IotifiedYatShape] : with-params [df Yeri top [pBar 0.5] [fLowerCase false]] : glyph-proc
-		local gap : 0.25 * (df.width - 2 * df.leftSB - [if SLAB 2.5 4.5] * df.mvs)
-		define divSub : (df.width - gap - df.mvs) / Width
+	define [IotifiedYatShape] : with-params [df Yeri top [pBar YeriBarPos] [fLowerCase false] [sw df.mvs]] : glyph-proc
+		local gap : 0.25 * (df.width - 2 * df.leftSB - [if SLAB 2.5 4.5] * sw)
+		define divSub : (df.width - gap - sw) / Width
 		define dfSub : DivFrame divSub 2
 
 		local shift : Width * (df.div - divSub)
 		include : with-transform [ApparentTranslate shift 0]
 			YatShape dfSub Yeri top
-				pBar -- pBar
-				fLowerCase -- fLowerCase
-				sw -- df.mvs
+				pBar          -- pBar
+				fLowerCase    -- fLowerCase
+				fIotifiedBase -- true
+				sw            -- sw
 				xCrossbarLeftOverride -- (df.leftSB - shift)
 		eject-contour 'serifDL'
 
-		if fLowerCase
-			include : Iotified.ascender df top 0 (fCapital -- false)
-			include : Iotified.full df top 0 (fCapital -- true)
+		include : Iotified.[if fLowerCase 'ascender' 'full'] df top 0 (fCapital -- (!fLowerCase))
 
 	foreach { suffix { Uc Lc } } [pairs-of YeriConfig] : do
 		create-glyph "cyrl/Yat.\(suffix)" : glyph-proc
@@ -75,27 +74,31 @@ glyph-block Letter-Cyrillic-Yat : begin
 			local df : include : DivFrame para.diversityT
 			include : df.markSet.b
 			include : YatShape df Lc Ascender
-				pBar -- (0.55 * XH / Ascender)
+				pBar -- (YeriBarPos * XH / Ascender)
 				fLowerCase -- true
 
 		create-glyph "cyrl/yatTall.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityT
 			include : df.markSet.b
-			include : ExtendAboveBaseAnchors (Ascender + 0.5 * AccentStackOffset)
-			include : YatShape df Lc (Ascender + 0.5 * AccentStackOffset)
-				pBar -- (0.55 * XH / (Ascender + 0.5 * AccentStackOffset))
+			local asc : Ascender + 0.5 * AccentStackOffset
+			include : ExtendAboveBaseAnchors asc
+			include : YatShape df Lc asc
+				pBar -- (YeriBarPos * XH / asc)
 				fLowerCase -- true
 				yCrossbarOverride -- (Ascender - [if SLAB (0.25 * df.mvs) 0])
 
 		create-glyph "cyrl/YatIotified.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.capital
-			include : IotifiedYatShape df Uc CAP (pBar -- 0.5)
+			include : IotifiedYatShape df Uc CAP
+				pBar -- 0.5
 
 		create-glyph "cyrl/yatIotified.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.b
-			include : IotifiedYatShape df Lc Ascender (pBar -- 0.375) (fLowerCase -- true)
+			include : IotifiedYatShape df Lc Ascender
+				pBar -- 0.375
+				fLowerCase -- true
 
 		# Italic Yat
 		create-glyph "cyrl/yat.italic/yeri.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/letter/cyrillic/zhe.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/zhe.ptl
@@ -21,8 +21,7 @@ glyph-block Letter-Cyrillic-Zhe : begin
 			include : VBar.m df.middle bot midTop fine
 			if fSlab : begin
 				local fBGR : midTop > top
-				local fEnoughSpaceForFullSerifs : df.width > 7 * para.refJut
-				if (!para.isItalic && fEnoughSpaceForFullSerifs) : begin
+				if (!para.isItalic && (df.width > 7 * para.refJut)) : begin
 					include : HSerif.mb df.middle bot Jut
 					if (!fBGR) : include : HSerif.mt df.middle midTop Jut
 				if fBGR : include : HSerif.lt (df.middle - [HSwToV : 0.5 * fine]) midTop SideJut
@@ -32,8 +31,8 @@ glyph-block Letter-Cyrillic-Zhe : begin
 			define fineK 0.1
 			if fSlab : begin
 				if (!fHalf) : begin
-					include : HSerif.lt (df.leftSB  + fine * fineK) top SideJut fine
-					include : HSerif.lb (df.leftSB  + fine * fineK) bot SideJut fine
+					include : HSerif.lt (df.leftSB + fine * fineK) top SideJut fine
+					include : HSerif.lb (df.leftSB + fine * fineK) bot SideJut fine
 				include : HSerif.rt (df.rightSB - fine * fineK) top SideJut fine
 				include : HSerif.rb (df.rightSB - fine * fineK) bot SideJut fine
 

--- a/packages/font-glyphs/src/letter/latin/upper-t.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-t.ptl
@@ -15,8 +15,9 @@ glyph-block Letter-Latin-Upper-T : begin
 	glyph-block-import Letter-Shared-Shapes : LetterBarOverlay UpwardHookShape
 	glyph-block-import Letter-Shared-Shapes : CyrDescender SerifFrame FlatHookDepth LeftHook RetroflexHook
 
-	define [TLeftX df]  : df.leftSB  + 0.75 * OX
-	define [TRightX df] : df.rightSB - 0.75 * OX
+	define ox : 0.75 * OX
+	define [TLeftX df]  : df.leftSB  + ox
+	define [TRightX df] : df.rightSB - ox
 	define [TShape df top doTopSerifs doBottomSerifs] : glyph-proc
 		include : tagged 'strokeV' : VBar.m df.middle 0 top
 		local l : TLeftX df
@@ -60,18 +61,24 @@ glyph-block Letter-Latin-Upper-T : begin
 		eject-contour 'strokeV'
 
 	define [CyrlTallTeShape df top doTopSerifs doBottomSerifs] : glyph-proc
-		local xRight : df.width - 1.5 * df.leftSB
-		local xLeft : df.leftSB - 0.75 * OX
+		define doFullSerifs : doTopSerifs && doBottomSerifs && !para.isItalic
 
-		include : HBar.t xLeft xRight top
-		include : VBar.r xRight 0 top
+		local xRight : df.width - 1.5 * df.leftSB
+		local xLeft : df.leftSB - ox
+
+		include : tagged 'strokeLT' : HBar.t xLeft xRight top
+		include : tagged 'strokeV'  : VBar.r xRight 0 top
 
 		if doTopSerifs : begin
 			include : tagged 'serifLT' : VSerif.dl xLeft top VJut
 		if doBottomSerifs : begin
-			include : tagged 'serifMB' : HSerif.rb (xRight - [HSwToV HalfStroke]) 0 Jut
-			include : tagged 'serifMB' : HSerif.lb (xRight - [HSwToV HalfStroke]) 0 MidJutSide
+			include : tagged 'serifMB' : if para.isItalic [HSerif.rb xRight 0 SideJut] : composite-proc
+				HSerif.rb (xRight - [HSwToV HalfStroke]) 0 Jut
+				HSerif.lb (xRight - [HSwToV HalfStroke]) 0 MidJutSide
+		if doFullSerifs : begin
 			include : tagged 'serifRT' : HSerif.rt xRight top SideJut
+
+		include : LeaningAnchor.Below.VBar.r xRight
 
 	glyph-block-export TConfig
 	define TConfig : object
@@ -158,11 +165,10 @@ glyph-block Letter-Latin-Upper-T : begin
 			include : df.markSet.e
 			include : TjeShape df XH doST
 
-		create-glyph "cyrl/teTall.upright.\(suffix)" : glyph-proc
+		create-glyph "cyrl/teTall.\(suffix)" : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.b
 			include : CyrlTallTeShape df Ascender doST doSB
-			include : LeaningAnchor.Below.VBar.r (df.width - 1.5 * df.leftSB)
 
 	select-variant 'T' 'T'
 	link-reduced-variant 'T/sansSerif' 'T' MathSansSerif
@@ -191,8 +197,7 @@ glyph-block Letter-Latin-Upper-T : begin
 
 	select-variant 'currency/tengeSign' 0x20B8 (follow -- 'T')
 
-	select-variant 'cyrl/teTall.upright' (follow -- 'T')
-	select-variant 'cyrl/teTall.italic' (shapeFrom -- 'cyrl/teTall.upright') (follow -- 'T/rtailBase')
+	select-variant 'cyrl/teTall' 0x1C84 (follow -- 'T')
 
 	CreateAccentedComposition 'TCedilla' 0x0162 'T' 'cedillaBelow'
 	CreateAccentedComposition 'TComma'   0x021A 'T' 'commaBelow'

--- a/packages/font-glyphs/src/letter/latin/w.ptl
+++ b/packages/font-glyphs/src/letter/latin/w.ptl
@@ -387,7 +387,7 @@ glyph-block Letter-Latin-W : begin
 			include : implT df XH bodyType slabType
 
 		create-glyph "ww.\(suffix)": glyph-proc
-			local df : include : DivFrame [if (Ldiv / para.diversityM < 1) para.diversityF 1] 3
+			local df : include : DivFrame [if (Ldiv < para.diversityM) para.diversityF 1] 3
 			include : df.markSet.capital
 
 			local gap : CAP * 0.05


### PR DESCRIPTION
Mainly focusing on lower `ᲄ` and `ꙓ` under slab italic.

`ГТᲉᲄЪᲆъᲅꭠꙒѢꙓᲇѣᲊ`
Slab Upright Before:
![image](https://github.com/user-attachments/assets/0f9f026f-2c26-4680-8e40-c6968083f9c5)
Slab Upright After:
![image](https://github.com/user-attachments/assets/d699d66c-f0bd-40b8-a148-b437accabe63)
Slab Italic Before:
![image](https://github.com/user-attachments/assets/71a18793-6def-4d49-a964-6721fc003fd2)
Slab Italic After:
![image](https://github.com/user-attachments/assets/7dd0a08a-2245-4bdf-b0aa-38b982308ca9)
SS02 Slab Upright Before:
![image](https://github.com/user-attachments/assets/34811ef8-05de-4d2c-ac9e-ac3c2050e0ce)
SS02 Slab Upright After:
![image](https://github.com/user-attachments/assets/1831ca5a-f130-4991-b5cd-7235adb10542)
SS02 Slab Italic Before:
![image](https://github.com/user-attachments/assets/1404f385-a34d-42ad-921c-58523b230ce2)
SS02 Slab Italic After:
![image](https://github.com/user-attachments/assets/c1bc91f4-b668-4402-87f8-289a04cdf221)
Etoile Upright Before:
![image](https://github.com/user-attachments/assets/06f29ab6-1909-4eb9-a8fc-a021ac6fc9f2)
Etoile Upright After:
![image](https://github.com/user-attachments/assets/b1b8d167-d4cb-454e-8102-80fa372ba2c8)
Etoile Italic Before:
![image](https://github.com/user-attachments/assets/450e03fe-9b1f-4c20-854e-244d44489d0f)
Etoile Italic After:
![image](https://github.com/user-attachments/assets/d98bef37-ac84-4c60-a84a-c00140cda315)
SS02 Etoile Upright Before:
![image](https://github.com/user-attachments/assets/05549c1c-ed89-4f0d-ac2f-c51af55d7ede)
SS02 Etoile Upright After:
![image](https://github.com/user-attachments/assets/cbd7d655-8bb4-4fa2-ad90-bb0093b569b5)
SS02 Etoile Italic Before:
![image](https://github.com/user-attachments/assets/617047a3-43d8-40ba-905c-8d9d8dda479f)
SS02 Etoile Italic After:
![image](https://github.com/user-attachments/assets/4a93586e-0323-4390-a1ea-eb8249d965ac)
