### PR TITLE
Make Shwa and Reversed Epsilon with Rhotic Hook slightly wider under Quasi-Proportional.

### DIFF
--- a/changes/32.4.0.md
+++ b/changes/32.4.0.md
@@ -1,5 +1,8 @@
 * Add `curved` variant for `¶` (#2045).
 * Add `top-cut` variants for `a`/`g`/`q`.
 * Add `bottom-cut` variants for `b`.
+Make certain characters slightly wider under Quasi-Proportional. Affected characters:
+  - LATIN SMALL LETTER SCHWA WITH HOOK (`U+025A`).
+  - LATIN SMALL LETTER REVERSED OPEN E WITH HOOK (`U+025D`).
 * Add characters:
-	- CURVED STEM PARAGRAPH SIGN ORNAMENT (`U+2761`).
+  - CURVED STEM PARAGRAPH SIGN ORNAMENT (`U+2761`).

--- a/packages/font-glyphs/src/auto-build/composite.ptl
+++ b/packages/font-glyphs/src/auto-build/composite.ptl
@@ -1669,35 +1669,6 @@ glyph-block Autobuild-Pnonetic-Ligatures : begin
 	createPhoneticLigatures ToLetter 'thSlash' 1 2 stdShrink 1 : list
 		list 0x1D7A { 't/phoneticLeft1' 'h' 'wideSlash' } 'b'
 
-glyph-block Autobuild-Rhotic : begin
-	glyph-block-import Mark-Shared-Metrics : markFine
-	glyph-block-import CommonShapes
-	glyph-block-import Common-Derivatives
-	glyph-block-import Recursive-Build : Widen
-	glyph-block-import Letter-Latin-Rhotic : ErTail
-	glyph-block-import Autobuild-Transformed-Shared : extendRelatedGlyphs link-relations
-
-	define [createRhotics groupName yTail _records] : begin
-		local {records relSets targetNameMap} : extendRelatedGlyphs "rhotic_\(groupName)" _records
-		local pendingGlyphs : records.map : [record] => record.1
-		local thinFont : Widen pendingGlyphs 0.85 1
-		foreach {unicode glyphid pri} [items-of records]
-			if [not : query-glyph targetNameMap.(glyphid)]
-				create-glyph (targetNameMap.(glyphid)) unicode : glyph-proc
-					if [not : thinFont.queryByName glyphid] : begin
-						throw : new Error "Cannot find glyph \(glyphid)"
-					include : MarkSet.e
-					include : thinFont.queryByName glyphid
-					include : ErTail (Width * 0.85 - SB - [HSwToV : 1.25 * markFine]) yTail (XH * 0.2)
-
-		link-relations relSets
-		return { targetNameMap records }
-
-	createRhotics 'er' (XH / 2)
-		list { 0x25A 'schwa' }
-	createRhotics 'revLatinEpsilonEr' (XH * [mix 0.65 1 0.5])
-		list { 0x25D 'latn/epsilonRev' }
-
 glyph-block Autobuild-Double-Emotions : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives

--- a/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
@@ -9,13 +9,15 @@ glyph-module
 glyph-block Letter-Greek-Lower-Epsilon : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
+	glyph-block-import Mark-Shared-Metrics : markFine
 	glyph-block-import Mark-Adjustment : ExtendBelowBaseAnchors
 	glyph-block-import Letter-Shared : CreateTurnedLetter
 	glyph-block-import Letter-Shared-Shapes : SerifedArcStart SerifedArcEnd SerifFrame
 	glyph-block-import Letter-Shared-Shapes : InwardSlabArcStart InwardSlabArcEnd
 	glyph-block-import Letter-Shared-Shapes : ArcStartSerif ArcEndSerif
 	glyph-block-import Letter-Shared-Shapes : OBarLeft OBarRight
-	glyph-block-import Letter-Shared-Shapes : DToothlessRise RetroflexHook CyrDescender UpwardHookShape
+	glyph-block-import Letter-Shared-Shapes : DToothlessRise RetroflexHook CyrDescender
+	glyph-block-import Letter-Shared-Shapes : UpwardHookShape RhoticHookShape
 
 	define SLAB-NONE       0
 	define SLAB-CLASSICAL  1
@@ -261,6 +263,20 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 				difference
 					VBar.m [arch.adjust-x.bot Middle] desc (Stroke + O) VJutStroke
 					zeNoO.ShapeMask
+
+		create-glyph "cyrl/zeRhoticHook.\(suffix)" : glyph-proc
+			local df : include : DivFrame para.diversityM 1
+			include : df.markSet.e
+			local divSub : Math.min 1 : 0.85 * para.diversityM
+			local dfSub : DivFrame divSub 2
+			local stroke : AdviceStroke2 2 3 XH divSub
+			local ze : CyrZe slabTop slabBot XH 0
+				left   -- dfSub.leftSB
+				right  -- dfSub.rightSB
+				hook   -- SHook
+				stroke -- stroke
+			include : union [ze.Shape] [ze.AutoStartSerifL] [ze.AutoEndSerifL]
+			include : RhoticHookShape (dfSub.rightSB - [HSwToV : 1.25 * markFine]) df.width (XH * 0.825) (XH * 0.2)
 
 		create-glyph "cyrl/DzjeKomi.\(suffix)" : glyph-proc
 			include : MarkSet.capital
@@ -537,7 +553,6 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 				include : MarkSet.e
 				include : Base df XH Slabs SHook SmallArchDepthA SmallArchDepthB
 
-
 	select-variant 'AeVolapuk' 0xA79A (follow -- [conditional-follow SLAB 'a/singleStorey/autoSerifed/slab' 'a/singleStorey/autoSerifed/sans'])
 	select-variant 'aeVolapuk' 0xA79B (follow -- [conditional-follow SLAB 'a/singleStorey/autoSerifed/slab' 'a/singleStorey/autoSerifed/sans'])
 	select-variant 'UeVolapuk' 0xA79E (follow -- 'u')
@@ -559,6 +574,7 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 
 	alias 'latn/EpsilonRev' 0xA7AB 'cyrl/Ze'
 	alias 'latn/epsilonRev' 0x25C  'cyrl/ze'
+	select-variant 'latn/epsilonRevRhoticHook' 0x25D (shapeFrom -- 'cyrl/zeRhoticHook') (follow -- 'cyrl/ze')
 
 	select-variant 'cyrl/KsiBase' (follow -- 'cyrl/ZeTopSerifOnly')
 	select-variant 'cyrl/ksiBase' (follow -- 'cyrl/zeTopSerifOnly')

--- a/packages/font-glyphs/src/letter/latin-ext/rhotic.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/rhotic.ptl
@@ -8,30 +8,14 @@ glyph-module
 glyph-block Letter-Latin-Rhotic : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Mark-Shared-Metrics : markFine
-
-	glyph-block-export ErTail
-	define [ErTail left y rise w dohook] : glyph-proc
-		local right Width
-		local mid : mix left right 0.5
-		local sw : fallback w [AdviceStroke 5]
-		include : dispiro
-			widths.rhs sw
-			g2 (left - [HSwToV : 0.5 * sw]) (y)
-			g2 (mid - [HSwToV : 0.5 * sw]) (y + rise)
-		include : dispiro
-			widths.center sw
-			flat mid (y + rise) [heading Downward]
-			curl mid (y + [if dohook 0 (rise - 1)]) [heading Downward]
-			if dohook {[hookend (y - rise) (sw -- sw)]} {[arcvh]}
-			g4 (right - [if dohook sw 0]) (y - [if dohook (rise * 0.5) rise]) [if dohook nothing [heading Rightward]]
+	glyph-block-import Letter-Shared-Shapes : RhoticHookShape
 
 	create-glyph 'rhoticHook' 0x2DE : glyph-proc
-		include : ErTail (-[HSwToV Stroke]) (XH / 2) (XH * 0.3) Stroke true
+		include : RhoticHookShape (-[HSwToV Stroke]) Width (XH / 2) (XH * 0.3) Stroke true
 
 	create-glyph 'rhoticHook/sup' : glyph-proc
 		local sw : [AdviceStroke 3.5] / 0.7
-		include : ErTail (-[HSwToV Stroke] - 3 * SB) (XH / 2) (XH * 0.3) sw true
+		include : RhoticHookShape (-[HSwToV Stroke] - 3 * SB) Width (XH / 2) (XH * 0.3) sw true
 		include : Ungizmo
 		include : Translate (-Middle) (-CAP)
 		include : Scale 0.7

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -9,7 +9,7 @@ glyph-block Letter-Latin-Lower-E : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared : CreateSelectorVariants DefineSelectorGlyph CreateTurnedLetter
-	glyph-block-import Letter-Shared-Shapes : FlatHookDepth RetroflexHook
+	glyph-block-import Letter-Shared-Shapes : FlatHookDepth RetroflexHook RhoticHookShape
 	glyph-block-import Letter-Shared-Shapes : SerifedArcEnd InwardSlabArcEnd ArcEndSerif
 	glyph-block-import Mark-Shared-Metrics : markExtend markStroke markStress markFine
 	glyph-block-import Mark-Above : aboveMarkTop aboveMarkBot aboveMarkMid aboveMarkStack
@@ -235,6 +235,19 @@ glyph-block Letter-Latin-Lower-E : begin
 			include [refer-glyph "e.\(suffix)"] AS_BASE ALSO_METRICS
 			include : FlipAround Middle (XH / 2)
 
+		create-glyph "schwaRhoticHook.\(suffix)" : glyph-proc
+			local df : include : DivFrame para.diversityM 1
+			include : df.markSet.e
+			local divSub : Math.min 1 : 0.85 * para.diversityM
+			local dfSub : DivFrame divSub 2
+			local stroke : AdviceStroke2 2 3 XH divSub
+			include : Body dfSub XH
+				stroke -- stroke
+				ada -- [dfSub.archDepthA SmallArchDepth stroke]
+				adb -- [dfSub.archDepthB SmallArchDepth stroke]
+			include : FlipAround dfSub.middle (XH / 2)
+			include : RhoticHookShape (dfSub.rightSB - [HSwToV : 1.25 * markFine]) df.width (XH * 0.5) (XH * 0.2)
+
 		create-glyph "schwaRetroflexHook.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityM 1
 			include : df.markSet.e
@@ -340,6 +353,7 @@ glyph-block Letter-Latin-Lower-E : begin
 
 	select-variant 'Schwa' 0x18F
 	select-variant 'schwa' 0x259
+	select-variant 'schwaRhoticHook' 0x25A (follow -- 'schwa')
 	select-variant 'schwaRetroflexHook' 0x1D95 (follow -- 'schwa')
 
 	select-variant 'eRev' 0x258 (follow -- 'e')

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -160,8 +160,7 @@ glyph-block Letter-Shared-Shapes : begin
 			flat (x + hookTurn)  (high - overshoot) [heading Rightward]
 			curl (x + hookDepth + sw * TanSlope) (high - overshoot)
 
-	glyph-block-export DToothlessRise
-	glyph-block-export DMBlend
+	glyph-block-export DToothlessRise DMBlend
 	define DToothlessRise : Hook * 0.25 + Stroke / 16
 	define DMBlend          0.80
 
@@ -589,7 +588,7 @@ glyph-block Letter-Shared-Shapes : begin
 	glyph-block-export ArcStartSerifDepth
 	define [ArcStartSerifDepth hook] : hook - 0
 
-	define [ArcStartInwardSerifDepth hook stroke] : Math.max hook (DToothlessRise + stroke)
+	define [ArcStartInwardSerifDepth hook stroke] : Math.max hook : DToothlessRise + stroke
 
 	glyph-block-export : ArcStartSerif
 	define ArcStartSerif : namespace
@@ -641,8 +640,8 @@ glyph-block Letter-Shared-Shapes : begin
 			define dxTurn : [HSwToV : 0.5 * sw] + rIn + 0.5 * sign * TanSlope * fine
 			define dxTailStart : dxTurn + sinAngle * (r * [mix 1 HVContrast sinAngle])
 			define dyTailStart : (rIn + fine) - cosAngle * r
-			define dxDepth : (depth - 0.25 * sw) * +dSinAngle
-			define dyDepth : (depth - 0.25 * sw) * -dCosAngle
+			define dxDepth : (depth - 0.25 * sw) * (+dSinAngle)
+			define dyDepth : (depth - 0.25 * sw) * (-dCosAngle)
 			return : list
 				g4.[if (sign > 0) "right" "left"].mid
 					cx + sign * dxTurn
@@ -688,7 +687,7 @@ glyph-block Letter-Shared-Shapes : begin
 	define [JutIn left right jut swRef hSplit] : begin
 		local ink : HSwToV swRef
 		local gap : (right - left - hSplit * ink) / (hSplit - 1)
-		Math.min jut (0.5 * ink + [Math.max (Stroke * TanSlope) (0.375 * gap)])
+		Math.min jut : 0.5 * ink + [Math.max (Stroke * TanSlope) (0.375 * gap)]
 
 	class CSerifFrame
 		public [new top bot left right swRef swSerif div hSplit fForceSymmetric] : begin
@@ -707,7 +706,7 @@ glyph-block Letter-Shared-Shapes : begin
 
 
 			local jutFS   MidJutSide
-			local jut     : mix [HSwToV : 0.5 * swRef] Jut [Math.min 1 : div * 2.25 / hSplit]
+			local jut     : mix [HSwToV : 0.5 * swRef] Jut : Math.min 1 : div * 2.25 / hSplit
 			local sideJut : jut - 0.5 * ink
 
 			local jutIn     : if fForceSymmetric jut : JutIn left right jut swRef hSplit
@@ -823,6 +822,20 @@ glyph-block Letter-Shared-Shapes : begin
 			archv
 			flat right ada
 			curl right yend [heading Upward]
+
+	glyph-block-export RhoticHookShape
+	define [RhoticHookShape] : with-params [left right y rise [sw [AdviceStroke 5]] [doHook false]] : glyph-proc
+		local mid : mix left right 0.5
+		include : dispiro
+			widths.rhs sw
+			g2 (left - [HSwToV : 0.5 * sw]) (y)
+			g2 (mid  - [HSwToV : 0.5 * sw]) (y + rise)
+		include : dispiro
+			widths.center sw
+			flat mid (y + rise) [heading Downward]
+			curl mid (y + [if doHook 0 (rise - 1)]) [heading Downward]
+			if doHook {[hookend (y - rise) (sw -- sw)]} {[arcvh]}
+			g4 (right - [if doHook sw 0]) (y - [if doHook (rise * 0.5) rise]) [if doHook nothing [heading Rightward]]
 
 	# Generic "connected" vertical hooks
 	glyph-block-export VerticalHook
@@ -941,7 +954,7 @@ glyph-block Letter-Shared-Shapes : begin
 						xDepth -- (-TailX)
 						yDepth -- TailY
 						sw -- sw
-						yExtension -- [Math.max 0 (yAttach + yOverflow - y + (fullDepth - TailY))]
+						yExtension -- [Math.max 0 : yAttach + yOverflow - y + (fullDepth - TailY)]
 				if maskOut maskOut [no-shape]
 
 		# Retroflex hooks
@@ -957,7 +970,7 @@ glyph-block Letter-Shared-Shapes : begin
 					xDepth -- TailX
 					yDepth -- TailY
 					sw -- sw
-					yExtension -- [Math.max 0 (yAttach + yOverflow - y + (fullDepth - TailY))]
+					yExtension -- [Math.max 0 : yAttach + yOverflow - y + (fullDepth - TailY)]
 
 		# Cyrillic "Middle Hook" Characters
 		glyph-block-export MidHook
@@ -983,7 +996,7 @@ glyph-block Letter-Shared-Shapes : begin
 					ada    -- ArchDepthA
 					adb    -- ArchDepthB
 					sw     -- df.mvs
-					xDepth -- (-[Math.max [HSwToV df.mvs] : Math.min HookX (0.5 * (df.rightSB - df.leftSB - [HSwToV : 2 * df.mvs]))])
+					xDepth -- (-[Math.max [HSwToV df.mvs] : Math.min HookX : 0.5 * (df.rightSB - df.leftSB) - [HSwToV df.mvs]])
 
 		# Hook for Eng shape
 		glyph-block-export EngHook


### PR DESCRIPTION
`əɚɜɝ`
Aile Thin Upright Before:
![image](https://github.com/user-attachments/assets/18c0cf86-a0b4-47fd-a05d-9cc2b66a7eac)
Aile Thin Upright After:
![image](https://github.com/user-attachments/assets/5c5eccba-bb81-4309-9c5e-abe455fa28dd)
Aile Regular Upright Before:
![image](https://github.com/user-attachments/assets/6b4db782-3edd-4b1a-b3d1-3fdf6dd629c0)
Aile Regular Upright After:
![image](https://github.com/user-attachments/assets/5af09318-ded4-4298-8744-3e777499f3ac)
Aile Heavy Upright Before:
![image](https://github.com/user-attachments/assets/586182c4-6d21-4b72-9f74-1ac968127e6a)
Aile Heavy Upright After:
![image](https://github.com/user-attachments/assets/a50cfb2a-81fc-4d13-a7b1-f590b7950775)
Aile Thin Italic Before:
![image](https://github.com/user-attachments/assets/fc529f00-79a3-4840-a2c7-a840c4e8a26d)
Aile Thin Italic After:
![image](https://github.com/user-attachments/assets/707d4d6e-f89e-4104-883f-2d517e8cbe36)
Aile Regular Italic Before:
![image](https://github.com/user-attachments/assets/618d54cc-f9f5-4597-910b-b18c75dbfbb9)
Aile Regular Italic After:
![image](https://github.com/user-attachments/assets/357b5f9b-c710-409d-8494-6d5b16b3d122)
Aile Heavy Italic Before:
![image](https://github.com/user-attachments/assets/deb6f464-7db9-4275-b79f-e8a799664ad0)
Aile Heavy Italic After:
![image](https://github.com/user-attachments/assets/2d316e68-f39d-4078-8eac-9b00bf3d5dda)
Etoile Thin Upright Before:
![image](https://github.com/user-attachments/assets/f95ea1fd-9240-4c95-ab83-1b8551b5a15c)
Etoile Thin Upright After:
![image](https://github.com/user-attachments/assets/0b0e1281-afee-4f2d-b56e-de4973c8c3c1)
Etoile Regular Upright Before:
![image](https://github.com/user-attachments/assets/b724bbe1-978f-48a4-9ad8-750cee4d0ef5)
Etoile Regular Upright After:
![image](https://github.com/user-attachments/assets/b582dc3f-6cc0-4d8e-9080-a3b888f57c40)
Etoile Heavy Upright Before:
![image](https://github.com/user-attachments/assets/d78994e5-29af-43be-a3fb-263afa83049d)
Etoile Heavy Upright After:
![image](https://github.com/user-attachments/assets/06964ba6-f4a3-41f0-bca9-bf3cc4c41f28)
Etoile Thin Italic Before:
![image](https://github.com/user-attachments/assets/fadc7598-0687-4064-8a1c-483d5bb12bc4)
Etoile Thin Italic After:
![image](https://github.com/user-attachments/assets/0931aa57-abfa-48da-8ff6-ff47e34d4c13)
Etoile Regular Italic Before:
![image](https://github.com/user-attachments/assets/14c02c90-5e33-4ec1-8d35-94812ed93839)
Etoile Regular Italic After:
![image](https://github.com/user-attachments/assets/f9d850bc-9a4e-4d72-8090-f4700c5c582e)
Etoile Heavy Italic Before:
![image](https://github.com/user-attachments/assets/9c331a2f-c7c9-4747-bd11-320cde28f7e7)
Etoile Heavy Italic After:
![image](https://github.com/user-attachments/assets/5e5f63cb-5cab-4e56-bc10-05097532d4db)
