### PR TITLE
Unify length of diacritical descenders of `Ҙ`/`ҙ`/`Ҫ`/`ҫ`/`Ҿ`/`ҿ` with `Ц`/`ц`/`Щ`/`щ`/`Џ`/`џ`.

### DIFF
--- a/packages/font-glyphs/src/letter/cyrillic/dzhe.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/dzhe.ptl
@@ -14,8 +14,8 @@ glyph-block Letter-Cyrillic-Dzhe : begin
 		include : VBar.l SB 0 top
 		include : HBar.b SB RightSB 0
 		include : VBar.r RightSB 0 top
-		local desc : QuarterStroke - LongVJut
-		include : VBar.m Middle desc Stroke
+		local desc : (-LongVJut) + QuarterStroke
+		include : VBar.m Middle desc Stroke VJutStroke
 		include : ExtendBelowBaseAnchors desc
 		if SLAB : let [sf : SerifFrame.fromDf [DivFrame 1] top 0] : begin
 			include : composite-proc sf.lt.full sf.rt.full sf.lb.outer sf.rb.outer

--- a/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-epsilon.ptl
@@ -248,7 +248,7 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 
 		create-glyph "cyrl/Dhe.\(suffix)" : glyph-proc
 			include [refer-glyph "cyrl/Ze.\(suffix)"] AS_BASE ALSO_METRICS
-			local desc : (-LongVJut) + HalfStroke
+			local desc : (-LongVJut) + QuarterStroke
 			include : ExtendBelowBaseAnchors desc
 			include : let [zeNoO : CyrZe slabTop slabBot CAP 0 (hook -- Hook) (xo -- 0) (yo -- 0)]
 				difference
@@ -257,7 +257,7 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 
 		create-glyph "cyrl/dhe.\(suffix)" : glyph-proc
 			include [refer-glyph "cyrl/ze.\(suffix)"] AS_BASE ALSO_METRICS
-			local desc : (-LongVJut) + HalfStroke
+			local desc : (-LongVJut) + QuarterStroke
 			include : ExtendBelowBaseAnchors desc
 			include : let [zeNoO : CyrZe slabTop slabBot XH 0 (hook -- SHook) (xo -- 0) (yo -- 0)]
 				difference

--- a/packages/font-glyphs/src/letter/latin/c.ptl
+++ b/packages/font-glyphs/src/letter/latin/c.ptl
@@ -213,7 +213,7 @@ glyph-block Letter-Latin-C : begin
 		create-glyph "cyrl/esWide.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.diversityT 3
 			include : df.markSet.e
-			local desc : (-LongVJut) + HalfStroke
+			local desc : (-LongVJut) + QuarterStroke
 			include : ExtendBelowBaseAnchors desc
 			local lf : CLetterForm df sty styBot XH desc
 				ada -- [df.archDepthA SmallArchDepth Stroke]
@@ -356,7 +356,7 @@ glyph-block Letter-Latin-C : begin
 
 	derive-glyphs 'cyrl/The' 0x4AA "cyrl/Es" : function [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
-		local desc : (-LongVJut) + HalfStroke
+		local desc : (-LongVJut) + QuarterStroke
 		include : ExtendBelowBaseAnchors desc
 		include : difference
 			VBar.m [arch.adjust-x.bot Middle] desc (Stroke + O) VJutStroke
@@ -373,7 +373,7 @@ glyph-block Letter-Latin-C : begin
 
 	derive-glyphs 'cyrl/the' 0x4AB "cyrl/es" : function [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
-		local desc : (-LongVJut) + HalfStroke
+		local desc : (-LongVJut) + QuarterStroke
 		include : ExtendBelowBaseAnchors desc
 		include : difference
 			VBar.m [arch.adjust-x.bot Middle] desc (Stroke + O) VJutStroke

--- a/packages/font-glyphs/src/letter/latin/k.ptl
+++ b/packages/font-glyphs/src/letter/latin/k.ptl
@@ -26,8 +26,8 @@ glyph-block Letter-Latin-K : begin
 		local kshRight       : right + [KBalanceRight true straightBar]
 		local serifLengthAdj : Ok + [HSwToV stroke]
 		return : shape.rSideJut
-			x -- (kshRight - serifLengthAdj)
-			y -- 0
+			x   -- (kshRight - serifLengthAdj)
+			y   -- 0
 			jut -- (Jut + serifLengthAdj)
 
 	define [KSlabs mode top left right stroke straightBar] : glyph-proc
@@ -46,8 +46,8 @@ glyph-block Letter-Latin-K : begin
 			local kshRightBot : right + [KBalanceRight slabLegs true]
 			local kshRightTop : if fHookTop (kshRightBot - HookX * 0.5 + [HSwToV : 0.5 * stroke]) kshRightBot
 
-			local attach (top * 0.42 - stroke)
-			local attach2 (top * 0.72 + stroke)
+			local attach  : top * 0.42 - stroke
+			local attach2 : top * 0.72 + stroke
 
 			set-base-anchor 'trailing' (kshRightBot - Ok) 0
 
@@ -273,10 +273,10 @@ glyph-block Letter-Latin-K : begin
 			return : sink
 				g4.up.start (dim.arcStartX + offset) dim.arcStartY [widths.rhs.heading dim.arcFine Upward]
 				arch.rhs (top - offset)
-					sw -- dim.arcStroke
+					sw       -- dim.arcStroke
 					swBefore -- dim.arcFine
-					swAfter -- dim.arcStroke
-					p -- dim.pArcTopX
+					swAfter  -- dim.arcStroke
+					p        -- dim.pArcTopX
 
 				g4.down.mid (dim.arcRightX - offset) (dim.arcRightY - 0.5 * dim.arcRightSlope * [HSwToV dim.arcStroke])
 					heading {.y dim.arcRightSlope .x HVContrast}
@@ -310,7 +310,7 @@ glyph-block Letter-Latin-K : begin
 
 			define swDiagTail : AdviceStroke 2 (1 - (dim.kshLeft - SB) / Width)
 			define swDiagTailAdj : swDiagTail / [mix 1 HVContrast 0.375]
-			define xDTGap : 0.10 * (RightSB - SB) - (0.125 + [clamp 0 0.375 (0.5 * (Width / UPM * 2 - 1))]) * swDiagTail
+			define xDTGap : 0.10 * (RightSB - SB) - (0.125 + [clamp 0 0.375 : 0.5 * (Width / UPM * 2 - 1)]) * swDiagTail
 			define xDTStart : dim.arcTerminalX + [HSwToV swDiagTail] + xDTGap
 			define xDTEnd : dim.kshRight - 0.8 * Hook - [HSwToV : 0.25 * swDiagTail] + xDTGap * 0.625
 			define tailAngle : Math.min 85 (50 + [Math.atan2 (0.75 * swDiagTail) Hook] / Math.PI * 180)
@@ -404,7 +404,7 @@ glyph-block Letter-Latin-K : begin
 		create-glyph "KDescender.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : KBaseShape Stroke CAP CyrDescender
-			include : ExtendBelowBaseAnchors ((-LongVJut) + HalfStroke)
+			include : ExtendBelowBaseAnchors ((-LongVJut) + QuarterStroke)
 
 		create-glyph "KStroke.\(suffix)" : glyph-proc
 			include [refer-glyph "K.\(suffix)"] AS_BASE ALSO_METRICS
@@ -432,7 +432,7 @@ glyph-block Letter-Latin-K : begin
 		create-glyph "smcpKDescender.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : KBaseShape Stroke XH CyrDescender
-			include : ExtendBelowBaseAnchors ((-LongVJut) + HalfStroke)
+			include : ExtendBelowBaseAnchors ((-LongVJut) + QuarterStroke)
 
 		create-glyph "smcpKVBar.\(suffix)" : glyph-proc
 			include : MarkSet.e
@@ -508,7 +508,7 @@ glyph-block Letter-Latin-K : begin
 		create-glyph "kDescender.\(suffix)" : glyph-proc
 			include : MarkSet.b
 			include : kBaseShape CyrDescender
-			include : ExtendBelowBaseAnchors (-LongVJut + HalfStroke)
+			include : ExtendBelowBaseAnchors ((-LongVJut) + QuarterStroke)
 
 		create-glyph "kPalatalHook.\(suffix)" : glyph-proc
 			include : MarkSet.b

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -135,10 +135,10 @@ glyph-block Letter-Latin-Lower-E : begin
 			tailSlab -- tailSlab
 		define shift : Width * (df.div - divSub)
 		if fDesc : begin
-			local desc : (-LongVJut) + HalfStroke
+			local desc : (-LongVJut) + QuarterStroke
 			include : ExtendBelowBaseAnchors desc
 			include : difference
-				VBar.m subDf.middle desc (stroke + O) [AdviceStroke 3.5 df.div]
+				VBar.m subDf.middle desc (stroke + O) (VJutStroke * subDf.mvs / Stroke)
 				OShapeOutline.NoOvershoot top 0 subDf.leftSB subDf.rightSB stroke
 		include : Translate shift 0
 


### PR DESCRIPTION
This unifies the lengths of Cyrillic descenders to `(-LongVJut) + QuarterStroke` since the amount subtracted from `LongVJut` was inconsistently `HalfStroke` or `QuarterStroke` before.

Additionally, this also unifies the stroke widths of _middle descenders in particular_ to `VJutStroke`.

`ЦцЩщЏџҘҙҪҫҾҿ`

Monospace Thin Before:
![image](https://github.com/user-attachments/assets/27408bc3-585d-43a9-afdf-acdd00afd529)
Monospace Thin After:
![image](https://github.com/user-attachments/assets/7a2a0672-e44c-45b2-ba80-32a7fa74d71d)
Monospace Regular Before:
![image](https://github.com/user-attachments/assets/6ef01ff0-3e32-4ff3-8bcf-f1be3131bd8c)
Monospace Regular After:
![image](https://github.com/user-attachments/assets/9f2ea77e-2c42-4e64-9b1a-dff369d7ac42)
Monospace Heavy Before:
![image](https://github.com/user-attachments/assets/2f89bd6c-c7c9-42e1-be15-a786821da89b)
Monospace Heavy After:
![image](https://github.com/user-attachments/assets/524933c2-3b47-4925-a4f4-855cba3f7c92)
Quasi-Proportional Thin Before:
![image](https://github.com/user-attachments/assets/88798438-6048-4455-8064-2e4056a376c8)
Quasi-Proportional Thin After:
![image](https://github.com/user-attachments/assets/d7b20a74-d536-4281-b777-826ffd88d9ff)
Quasi-Proportional Regular Before:
![image](https://github.com/user-attachments/assets/df578f7c-164a-4fbb-a7d9-337009fe4225)
Quasi-Proportional Regular After:
![image](https://github.com/user-attachments/assets/d87a87fe-c042-486b-845d-df284c4c0d2e)
Quasi-Proportional Heavy Before:
![image](https://github.com/user-attachments/assets/84a3c60c-98cb-44fa-aa0b-df8b2fb93f9a)
Quasi-Proportional Heavy After:
![image](https://github.com/user-attachments/assets/2dad756b-4e31-41cc-a6a3-2ebe1b9c94fd)
