### PR TITLE
Unify stroke widths of `Ɵ`/`ɵ` with `Ə`/`ə`.

### DIFF
--- a/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
@@ -173,7 +173,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 		glyph-block-import Letter-Latin-C : CLetterForm CConfig
 
 		define [openOShape df sty styBot] : new-glyph : glyph-proc
-			local { subDf } : SubDfAndShift 0 df OX
+			local subDf : df.slice 3 2 OX
 			local ada : subDf.archDepthA SmallArchDepth df.mvs
 			local adb : subDf.archDepthB SmallArchDepth df.mvs
 
@@ -230,7 +230,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 					include : df.markSet.e
 					set-base-anchor 'cvDecompose' 0 0
 
-					local { subDf } : SubDfAndShift 0 df
+					local subDf : df.slice 3 2
 					local bp : RBarPos XH fSlabBot
 
 					include : RevRShape legShape XH
@@ -252,7 +252,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 			create-glyph "cyrl/rha/left.\(suffix)" : glyph-proc
 				local df : include : DivFrame para.diversityM 3
 				include : df.markSet.p
-				local { subDf } : SubDfAndShift 0 df
+				local subDf : df.slice 3 2
 				set-base-anchor 'cvDecompose' 0 0
 
 				include : Body
@@ -377,17 +377,19 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 
 		create-glyph "rightHalfSlashOverlay" : glyph-proc
 			local fine : 0.375 * OverlayStroke
-			local { subDf shift } : SubDfAndShift 1 [DivFrame para.diversityMM 3] OX
+			local df : DivFrame para.diversityMM 3
+			local { subDf shift } : SubDfAndShift 1 df OX
 			include : dispiro
 				flat (shift + subDf.leftSB + OX + fine) [mix XH 0 1.05] [widths.center : 2 * fine]
 				curl (shift + subDf.rightSB - OX - fine) [mix 0 XH 1.05]
 
 		create-glyph "rightHalfBarOverlay" : glyph-proc
-			local { subDf shift } : SubDfAndShift 1 [DivFrame para.diversityMM 3] OX
-			include : HBar.m (shift + subDf.leftSB + OX + 1) (shift + subDf.rightSB - OX - 1) (XH * 0.5) OverlayStroke
+			local df : DivFrame para.diversityMM 3
+			local { subDf shift } : SubDfAndShift 1 df OX
+			include : HBar.m (shift + subDf.leftSB + [HSwToV : 0.5 * df.mvs]) (shift + subDf.rightSB - [HSwToV : 0.5 * df.mvs]) (XH * 0.5) df.mvs
 
 		define [OODots df kHeight fRound kdr] : glyph-proc
-			local { subDf shift } : SubDfAndShift 0 df OX
+			local subDf : df.slice 3 2 OX
 			local space : InnerDot.spaceOfDf subDf
 			local kHeight2 : [Math.sqrt : [InnerDot.spaceOfDf : DivFrame 1] / space] * kHeight
 			local offset : 0.5 * (space + [HSwToV df.mvs])

--- a/packages/font-glyphs/src/letter/latin/o.ptl
+++ b/packages/font-glyphs/src/letter/latin/o.ptl
@@ -138,12 +138,20 @@ glyph-block Letter-Latin-O : begin
 				curl (XH - SB - O - fine) [mix 0 Width 1.05]
 
 	create-glyph 'Obar' 0x19F : glyph-proc
-		include [refer-glyph 'O'] AS_BASE
-		include : HBar.m (SB + OX + 1) (RightSB - OX - 1) (CAP * 0.5) OverlayStroke
+		include : MarkSet.capital
+		local stroke : AdviceStroke2 2 3 CAP
+		include : OShape CAP 0 SB RightSB stroke ArchDepthA ArchDepthB
+		include : intersection
+			OShapeOutline.NoOvershoot CAP 0 SB RightSB stroke ArchDepthA ArchDepthB
+			HBar.m (SB + OX) (RightSB - OX) (CAP * 0.5) stroke
 
 	create-glyph 'obar' 0x275 : glyph-proc
-		include [refer-glyph 'o'] AS_BASE
-		include : HBar.m (SB + OX + 1) (RightSB - OX - 1) (XH * 0.5) OverlayStroke
+		include : MarkSet.e
+		local stroke : AdviceStroke2 2 3 XH
+		include : OShape XH 0 SB RightSB stroke nothing nothing
+		include : intersection
+			OShapeOutline.NoOvershoot XH 0 SB RightSB stroke nothing nothing
+			HBar.m (SB + OX) (RightSB - OX) (XH * 0.5) stroke
 
 	alias 'grek/capSymbolTheta' 0x3F4 'Obar'
 
@@ -158,16 +166,24 @@ glyph-block Letter-Latin-O : begin
 	alias 'bullEye' 0x298 'cyrl/OMonocular'
 
 	create-glyph 'cyrl/OCross' 0xA69A : glyph-proc
-		include [refer-glyph 'O'] AS_BASE
-		local fine ([StrokeWidthBlend 1 0.5] * OverlayStroke)
-		include : HBar.m (SB + OX + 1) (RightSB - OX - 1) (CAP * 0.5) fine
-		include : VBar.m Middle (O + 1) (CAP - O - 1) fine
+		include : MarkSet.capital
+		local stroke : AdviceStroke2 3 3 CAP
+		include : OShape CAP 0 SB RightSB stroke ArchDepthA ArchDepthB
+		include : intersection
+			OShapeOutline.NoOvershoot CAP 0 SB RightSB stroke ArchDepthA ArchDepthB
+			union
+				HBar.m (SB + OX) (RightSB - OX) (CAP * 0.5) stroke
+				VBar.m Middle O (CAP - O) [Math.min stroke : VSwToH : (RightSB - SB) / 2 - [HSwToV stroke]]
 
 	create-glyph 'cyrl/oCross' 0xA69B : glyph-proc
-		include [refer-glyph 'o'] AS_BASE
-		local fine ([StrokeWidthBlend 1 0.5] * OverlayStroke)
-		include : HBar.m (SB + OX + 1) (RightSB - OX - 1) (XH * 0.5) fine
-		include : VBar.m Middle (O + 1) (XH - O - 1) fine
+		include : MarkSet.e
+		local stroke : AdviceStroke2 3 3 XH
+		include : OShape XH 0 SB RightSB stroke nothing nothing
+		include : intersection
+			OShapeOutline.NoOvershoot XH 0 SB RightSB stroke nothing nothing
+			union
+				HBar.m (SB + OX) (RightSB - OX) (XH * 0.5) stroke
+				VBar.m Middle O (XH - O) [Math.min stroke : VSwToH : (RightSB - SB) / 2 - [HSwToV stroke]]
 
 	create-glyph 'romanThousandCD' 0x2180 : glyph-proc
 		local df : include : DivFrame para.diversityMM 3
@@ -233,9 +249,9 @@ glyph-block Letter-Latin-O : begin
 		include : dispiro
 			widths.rhs
 			flat (SB + OX) (XH / 2) [heading Upward]
-			curl (SB + OX) (XH - [Math.min (XH / 2 - TINY) SmallArchDepthA])
+			curl (SB + OX) (XH - [Math.min SmallArchDepthA : XH / 2 - TINY])
 			arch.rhs XH
-			flat (RightSB - OX) (XH - [Math.min (XH / 2 - TINY) SmallArchDepthB])
+			flat (RightSB - OX) (XH - [Math.min SmallArchDepthB : XH / 2 - TINY])
 			curl (RightSB - OX) (XH / 2) [heading Downward]
 
 	create-glyph 'olowerhalf' 0x1D17 : glyph-proc
@@ -243,9 +259,9 @@ glyph-block Letter-Latin-O : begin
 		include : dispiro
 			widths.lhs
 			flat (SB + OX) (XH / 2) [heading Downward]
-			curl (SB + OX) [Math.min (XH / 2 - TINY) SmallArchDepthB]
+			curl (SB + OX) [Math.min SmallArchDepthB : XH / 2 - TINY]
 			arch.lhs 0
-			flat (RightSB - OX) [Math.min (XH / 2 - TINY) SmallArchDepthA]
+			flat (RightSB - OX) [Math.min SmallArchDepthA : XH / 2 - TINY]
 			curl (RightSB - OX) (XH / 2) [heading Upward]
 
 	create-glyph 'oWithLightCentralizationStroke' : glyph-proc
@@ -285,17 +301,17 @@ glyph-block Letter-Latin-O : begin
 		include [refer-glyph 'O'] AS_BASE
 		include : MarkSet.capital
 		include : ExtendAboveBaseAnchors (CAP + LongVJut - HalfStroke)
-		include : ExtendBelowBaseAnchors (-LongVJut + HalfStroke)
+		include : ExtendBelowBaseAnchors (0   - LongVJut + HalfStroke)
 		include : VBar.m Middle CAP (CAP + LongVJut - HalfStroke)
-		include : VBar.m Middle (-LongVJut + HalfStroke) 0
+		include : VBar.m Middle 0   (0   - LongVJut + HalfStroke)
 
 	create-glyph 'oPolish' 0xA7C1 : glyph-proc
 		include [refer-glyph 'o'] AS_BASE
 		include : MarkSet.e
 		include : ExtendAboveBaseAnchors (XH + LongVJut - HalfStroke)
-		include : ExtendBelowBaseAnchors (-LongVJut + HalfStroke)
+		include : ExtendBelowBaseAnchors (0  - LongVJut + HalfStroke)
 		include : VBar.m Middle XH (XH + LongVJut - HalfStroke)
-		include : VBar.m Middle (-LongVJut + HalfStroke) 0
+		include : VBar.m Middle 0  (0  - LongVJut + HalfStroke)
 
 	derive-composites 'oRetroflexHook' 0x1DF1B 'o' : RetroflexHook.l
 		x -- [mix [arch.adjust-x.bot Middle] SB 0.75]
@@ -308,7 +324,7 @@ glyph-block Letter-Latin-O : begin
 		include : intersection
 			OShapeOutline.NoOvershoot CAP 0 SB RightSB BBS ArchDepthA ArchDepthB
 			union
-				VBar.l  (SB + OX + BBD) 0 CAP BBS
+				VBar.l (SB + OX + BBD) 0 CAP BBS
 				VBar.r (RightSB - OX - BBD) 0 CAP BBS
 
 	create-glyph 'mathbb/o' 0x1D560 : glyph-proc
@@ -317,5 +333,5 @@ glyph-block Letter-Latin-O : begin
 		include : intersection
 			OShapeOutline.NoOvershoot XH 0 SB RightSB BBS
 			union
-				VBar.l  (SB + OX + BBD) 0 XH BBS
+				VBar.l (SB + OX + BBD) 0 XH BBS
 				VBar.r (RightSB - OX - BBD) 0 XH BBS


### PR DESCRIPTION
In IPA, `ɵ` is semantically a closed version of `ɘ` indicating roundedness, just as how `ɞ` indicates a rounded version of `ɜ` or how `ɷ` indicates a rounded version of `ω` (or `ɯ̽` in modern IPA).

In Cyrillic, `Ө`/`ө` is semantically an extension of `Ә`/`ә` as they are each equivalent to the Common Turkic `Ö`/`ö` and `Ä`/`ä` respectively. The capital forms of the Latin letters have a similar explanation.

```
ƆOƏƟꚚɔoəɵꚛ
ꞫɜɞƐɛʚꞶꞷɷ
```
Thin Before:
![image](https://github.com/user-attachments/assets/bad2d136-d24e-430f-9828-c6ef4d46f74f)
Thin After:
![image](https://github.com/user-attachments/assets/5ed2e84b-6ef7-4ce6-b0d3-455ed11df458)
Regular Before:
![image](https://github.com/user-attachments/assets/aa011485-7f19-4dc6-aa23-2265b3d98670)
Regular After:
![image](https://github.com/user-attachments/assets/970c4383-dfc5-4644-9fe1-50ae5d093fe9)
Heavy Before:
![image](https://github.com/user-attachments/assets/168aea3d-aadc-4852-b473-f28fb32e3099)
Heavy After:
![image](https://github.com/user-attachments/assets/d7afde79-d2ea-4694-ae2e-da5bfc5d220b)
