### PR TITLE
Unify length of diacritical ascenders with Cyrillic descenders.

### DIFF
--- a/packages/font-glyphs/src/letter/greek/lower-rho-symbol.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-rho-symbol.ptl
@@ -8,12 +8,11 @@ glyph-module
 glyph-block Letter-Greek-Lower-Rho-Symbol : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : OBarRight
+	glyph-block-import Letter-Shared-Shapes : OBarLeft
 
 	create-glyph 'grek/rhoSymbol' 0x3F1 : glyph-proc
 		include : MarkSet.p
-		include : tagged 'bowl' : OBarRight.rounded (yTerminal -- XH)
-		include : FlipAround Middle (XH / 2)
+		include : tagged 'bowl' : OBarLeft.roundedTop (yTerminal -- 0)
 		include : dispiro
 			widths.lhs
 			flat SB (XH - SmallArchDepthA)

--- a/packages/font-glyphs/src/letter/greek/phi.ptl
+++ b/packages/font-glyphs/src/letter/greek/phi.ptl
@@ -10,17 +10,18 @@ glyph-block Letter-Greek-Phi : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors ExtendBelowBaseAnchors
 	glyph-block-import Letter-Shared-Shapes : FlatHookDepth DiagTail OBarLeft OBarRight
-	glyph-block-import Letter-Latin-Lower-AE-OE : SubDfAndShift
 
 	define [VarPhiRing fFlatTB df y2 y3] : glyph-proc
+		local ada : df.archDepthA ArchDepth df.mvs
+		local adb : df.archDepthB ArchDepth df.mvs
 		include : VBar.m df.middle y2 y3 df.mvs
 		include : if fFlatTB
-			OShapeFlatTB y3 y2 df.leftSB df.rightSB df.mvs (ArchDepthA * df.div) (ArchDepthB * df.div)
+			OShapeFlatTB y3 y2 df.leftSB df.rightSB df.mvs ada adb
 				Math.max (0.25 * (df.rightSB - df.leftSB)) : HSwToV df.mvs
-			OShape y3 y2 df.leftSB df.rightSB df.mvs (ArchDepthA * df.div) (ArchDepthB * df.div)
+			OShape y3 y2 df.leftSB df.rightSB df.mvs ada adb
 
 	define [CyrlEfSplitRing fFlatTB df y2 y3] : glyph-proc
-		local { subDf } : SubDfAndShift 0 df OX
+		local subDf : df.slice 3 2 OX
 		local ada : subDf.archDepthA SmallArchDepth df.mvs
 		local adb : subDf.archDepthB SmallArchDepth df.mvs
 
@@ -129,10 +130,10 @@ glyph-block Letter-Greek-Phi : begin
 		local df : include : DivFrame para.diversityMM 3
 		include : df.markSet.capital
 
-		local vJut : Math.max (LongVJut - HalfStroke) : if SLAB (1.5 * Stroke) 0
+		local yExt : Math.max (LongVJut - QuarterStroke) : if SLAB (1.5 * Stroke) 0
 
-		local top : CAP + vJut
-		local bot : 0   - vJut
+		local top : CAP + yExt
+		local bot : 0   - yExt
 
 		include : ExtendAboveBaseAnchors top
 		include : ExtendBelowBaseAnchors bot
@@ -194,10 +195,10 @@ glyph-block Letter-Greek-Phi : begin
 			local df : include : DivFrame div 3
 			include : df.markSet.bp
 			include : Bowl true df 0 XH
-			local mvs : fallback barSw df.mvs
-			include : Bar df Descender 0 XH Ascender mvs
-			if sMT : include : sMT df Ascender  mvs
-			if sMB : include : sMB df Descender mvs
+			local vs : fallback barSw df.mvs
+			include : Bar df Descender 0 XH Ascender vs
+			if sMT : include : sMT df Ascender  vs
+			if sMB : include : sMB df Descender vs
 
 	select-variant 'cyrl/ef' 0x444
 	select-variant 'cyrl/ef.BGR' (shapeFrom -- 'cyrl/ef')

--- a/packages/font-glyphs/src/letter/greek/upper-gamma.ptl
+++ b/packages/font-glyphs/src/letter/greek/upper-gamma.ptl
@@ -20,7 +20,7 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 	define SLAB-BOTTOM 2
 	define SLAB-ALL    3
 
-	define GammaBarLeft (SB * 1.5)
+	define GammaBarLeft : SB * 1.5
 	define [GammaShape top bot slabType] : glyph-proc
 		include : LeaningAnchor.Below.VBar.l GammaBarLeft
 		include : VBar.l GammaBarLeft bot top
@@ -59,15 +59,15 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 		create-glyph "cyrl/GheDescender.\(suffix)" : glyph-proc
 			include [refer-glyph "grek/Gamma.\(suffix)"] AS_BASE ALSO_METRICS
 			include : CyrDescender.rSideJut
-				x -- (GammaBarLeft + [HSwToV Stroke])
-				y -- 0
+				x   -- (GammaBarLeft + [HSwToV Stroke])
+				y   -- 0
 				jut -- MidJutSide
 
 		create-glyph "cyrl/GheDHook.\(suffix)" : glyph-proc
 			include [refer-glyph "grek/Gamma.\(suffix)"] AS_BASE ALSO_METRICS
 			include : PalatalHook.rSideJut
-				x -- (GammaBarLeft + [HSwToV Stroke])
-				y -- 0
+				x   -- (GammaBarLeft + [HSwToV Stroke])
+				y   -- 0
 				jut -- MidJutSide
 
 		create-glyph "cyrl/ghe.upright.\(suffix)" : glyph-proc
@@ -77,30 +77,30 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 		create-glyph "cyrl/gheDescender.upright.\(suffix)" : glyph-proc
 			include [refer-glyph "cyrl/ghe.upright.\(suffix)"] AS_BASE ALSO_METRICS
 			include : CyrDescender.rSideJut
-				x -- (GammaBarLeft + [HSwToV Stroke])
-				y -- 0
+				x   -- (GammaBarLeft + [HSwToV Stroke])
+				y   -- 0
 				jut -- MidJutSide
 
 		create-glyph "cyrl/gheDHook.upright.\(suffix)" : glyph-proc
 			include [refer-glyph "cyrl/ghe.upright.\(suffix)"] AS_BASE ALSO_METRICS
 			include : PalatalHook.rSideJut
-				x -- (GammaBarLeft + [HSwToV Stroke])
-				y -- 0
+				x   -- (GammaBarLeft + [HSwToV Stroke])
+				y   -- 0
 				jut -- MidJutSide
 
 		create-glyph "cyrl/Ge.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : ExtendAboveBaseAnchors (CAP + LongVJut - HalfStroke)
+			include : ExtendAboveBaseAnchors (CAP + LongVJut - QuarterStroke)
 			include : GammaShape CAP 0 slabType
 			eject-contour 'serifRT'
-			include : VBar.r (RightSB - OX) CAP (CAP + LongVJut - HalfStroke)
+			include : VBar.r (RightSB - OX) CAP (CAP + LongVJut - QuarterStroke) VJutStroke
 
 		create-glyph "cyrl/ge.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			include : ExtendAboveBaseAnchors (XH + LongVJut - HalfStroke)
+			include : ExtendAboveBaseAnchors (XH + LongVJut - QuarterStroke)
 			include : GammaShape XH 0 slabType
 			eject-contour 'serifRT'
-			include : VBar.r (RightSB - OX) XH (XH + LongVJut - HalfStroke)
+			include : VBar.r (RightSB - OX) XH (XH + LongVJut - QuarterStroke) VJutStroke
 			if para.isItalic : eject-contour 'serifLB'
 
 		create-glyph "cyrl/GheMidHook.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
@@ -30,7 +30,8 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 	do "a subglyphs"
 		define [AAShape body hookStyle pShift df o] : begin
 			local { subDf shift } : SubDfAndShift pShift df o
-			return : with-transform [ApparentTranslate shift 0] [body subDf hookStyle df.mvs]
+			return : with-transform [ApparentTranslate shift 0]
+				body subDf hookStyle df.mvs
 
 		glyph-block-import Letter-Latin-Lower-A : DoubleStorey
 		define DoubleStoreyConfig : object
@@ -62,18 +63,18 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 				include : difference [right] : intersection
 					MaskAbove (XH * OverlayPos * 1.02)
 					union
-						with-transform [ApparentTranslate (-0.25 * df.mvs) 0] [left]
-						with-transform [ApparentTranslate (-0.50 * df.mvs) 0] [left]
-						with-transform [ApparentTranslate (-0.75 * df.mvs) 0] [left]
-						with-transform [ApparentTranslate (-1.00 * df.mvs) 0] [left]
+						with-transform [ApparentTranslate ((-0.25) * df.mvs) 0] [left]
+						with-transform [ApparentTranslate ((-0.50) * df.mvs) 0] [left]
+						with-transform [ApparentTranslate ((-0.75) * df.mvs) 0] [left]
+						with-transform [ApparentTranslate ((-1.00) * df.mvs) 0] [left]
 
 				include : difference [left] : intersection
 					MaskBelow (XH * OverlayPos * 1.02)
 					union
-						with-transform [ApparentTranslate (+0.25 * df.mvs) 0] [right]
-						with-transform [ApparentTranslate (+0.50 * df.mvs) 0] [right]
-						with-transform [ApparentTranslate (+0.75 * df.mvs) 0] [right]
-						with-transform [ApparentTranslate (+1.00 * df.mvs) 0] [right]
+						with-transform [ApparentTranslate ((+0.25) * df.mvs) 0] [right]
+						with-transform [ApparentTranslate ((+0.50) * df.mvs) 0] [right]
+						with-transform [ApparentTranslate ((+0.75) * df.mvs) 0] [right]
+						with-transform [ApparentTranslate ((+1.00) * df.mvs) 0] [right]
 
 	do "o subglyphs"
 		define [oeOPart pShift df top ad] : begin
@@ -112,14 +113,22 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 			local { subDf shift } : SubDfAndShift pShift df OX
 			local ada : subDf.archDepthA SmallArchDepth df.mvs
 			local adb : subDf.archDepthB SmallArchDepth df.mvs
-			return : with-transform [ApparentTranslate shift 0] [body subDf XH (stroke -- df.mvs) (ada -- ada) (adb -- adb)]
+			return : with-transform [ApparentTranslate shift 0]
+				body subDf XH
+					stroke -- df.mvs
+					ada    -- ada
+					adb    -- adb
 
 		define [InvEShape pShift df revbody] : begin
 			local { subDf shift } : SubDfAndShift pShift df OX
 			local ada : subDf.archDepthA SmallArchDepth df.mvs
 			local adb : subDf.archDepthB SmallArchDepth df.mvs
 			return : with-transform [ApparentTranslate shift 0]
-				with-transform [FlipAround subDf.middle (XH / 2)] [revbody subDf XH (stroke -- df.mvs) (ada -- ada) (adb -- adb)]
+				with-transform [FlipAround subDf.middle (XH / 2)]
+					revbody subDf XH
+						stroke -- df.mvs
+						ada    -- ada
+						adb    -- adb
 
 		define Config : object
 			flatCrossbar { SmallEShape        RevSmallEShape        }
@@ -257,7 +266,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 
 				include : Body
 					left  -- subDf.leftSB
-					right -- subDf.rightSB + OX
+					right -- (subDf.rightSB + OX)
 					sw    -- df.mvs
 				include : Serifs subDf XH df.mvs
 				include : LeaningAnchor.Below.VBar.l SB
@@ -380,7 +389,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 			local df : DivFrame para.diversityMM 3
 			local { subDf shift } : SubDfAndShift 1 df OX
 			include : dispiro
-				flat (shift + subDf.leftSB + OX + fine) [mix XH 0 1.05] [widths.center : 2 * fine]
+				flat (shift + subDf.leftSB  + OX + fine) [mix XH 0 1.05] [widths.center : 2 * fine]
 				curl (shift + subDf.rightSB - OX - fine) [mix 0 XH 1.05]
 
 		create-glyph "rightHalfBarOverlay" : glyph-proc
@@ -394,7 +403,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 			local kHeight2 : [Math.sqrt : [InnerDot.spaceOfDf : DivFrame 1] / space] * kHeight
 			local offset : 0.5 * (space + [HSwToV df.mvs])
 			include : InnerDot (-offset) 0 kHeight2 fRound kdr space 3
-			include : InnerDot   offset  0 kHeight2 fRound kdr space 3
+			include : InnerDot (+offset) 0 kHeight2 fRound kdr space 3
 
 		foreach { suffix { DrawAt kdr } } [Object.entries DotVariants] : do
 			create-glyph "OODots.\(suffix)" : glyph-proc
@@ -473,9 +482,9 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 			refer-glyph ra
 			difference
 				refer-glyph ha
-				with-transform [ApparentTranslate (-0.25 * df.mvs) 0] [refer-glyph ra]
-				with-transform [ApparentTranslate (-0.50 * df.mvs) 0] [refer-glyph ra]
-				with-transform [ApparentTranslate (-0.75 * df.mvs) 0] [refer-glyph ra]
-				with-transform [ApparentTranslate (-1.00 * df.mvs) 0] [refer-glyph ra]
+				with-transform [ApparentTranslate ((-0.25) * df.mvs) 0] [refer-glyph ra]
+				with-transform [ApparentTranslate ((-0.50) * df.mvs) 0] [refer-glyph ra]
+				with-transform [ApparentTranslate ((-0.75) * df.mvs) 0] [refer-glyph ra]
+				with-transform [ApparentTranslate ((-1.00) * df.mvs) 0] [refer-glyph ra]
 
 	derive-multi-part-glyphs 'cyrl/rha' 0x517 { 'cyrl/rha/left' 'cyrl/rha/right' } BuildRha

--- a/packages/font-glyphs/src/letter/latin-ext/lower-db-qp.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/lower-db-qp.ptl
@@ -8,24 +8,22 @@ glyph-module
 glyph-block Letter-Latin-Lower-DB-QP : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : OBarLeft UpwardHookShape SerifFrame
-	glyph-block-import Letter-Latin-Lower-AE-OE : SubDfAndShift
+	glyph-block-import Letter-Shared-Shapes : OBarLeft OBarRight
 
 	define [DbCenterShape df] : glyph-proc
-		local { subDf } : SubDfAndShift 0 df OX
+		local subDf : df.slice 3 2 OX
 		local ada : subDf.archDepthA SmallArchDepth df.mvs
 		local adb : subDf.archDepthB SmallArchDepth df.mvs
 
-		include : OBarLeft.roundedTop
-			left      -- df.middle - [HSwToV : 0.5 * df.mvs]
-			right     -- df.rightSB
-			yTerminal -- 0
+		include : OBarRight.rounded
+			left      -- df.leftSB
+			right     -- (df.middle + [HSwToV : 0.5 * df.mvs])
+			yTerminal -- XH
 			sw        -- df.mvs
 			ada       -- ada
 			adb       -- adb
-		include : FlipAround df.middle (XH / 2)
 		include : OBarLeft.rounded
-			left      -- df.middle - [HSwToV : 0.5 * df.mvs]
+			left      -- (df.middle - [HSwToV : 0.5 * df.mvs])
 			right     -- df.rightSB
 			yTerminal -- (XH / 2)
 			sw        -- df.mvs

--- a/packages/font-glyphs/src/letter/latin/o.ptl
+++ b/packages/font-glyphs/src/letter/latin/o.ptl
@@ -300,18 +300,18 @@ glyph-block Letter-Latin-O : begin
 	create-glyph 'OPolish' 0xA7C0 : glyph-proc
 		include [refer-glyph 'O'] AS_BASE
 		include : MarkSet.capital
-		include : ExtendAboveBaseAnchors (CAP + LongVJut - HalfStroke)
-		include : ExtendBelowBaseAnchors (0   - LongVJut + HalfStroke)
-		include : VBar.m Middle CAP (CAP + LongVJut - HalfStroke)
-		include : VBar.m Middle 0   (0   - LongVJut + HalfStroke)
+		include : ExtendAboveBaseAnchors (CAP + LongVJut - QuarterStroke)
+		include : ExtendBelowBaseAnchors (0   - LongVJut + QuarterStroke)
+		include : VBar.m Middle CAP (CAP + LongVJut - QuarterStroke) VJutStroke
+		include : VBar.m Middle 0   (0   - LongVJut + QuarterStroke) VJutStroke
 
 	create-glyph 'oPolish' 0xA7C1 : glyph-proc
 		include [refer-glyph 'o'] AS_BASE
 		include : MarkSet.e
-		include : ExtendAboveBaseAnchors (XH + LongVJut - HalfStroke)
-		include : ExtendBelowBaseAnchors (0  - LongVJut + HalfStroke)
-		include : VBar.m Middle XH (XH + LongVJut - HalfStroke)
-		include : VBar.m Middle 0  (0  - LongVJut + HalfStroke)
+		include : ExtendAboveBaseAnchors (XH + LongVJut - QuarterStroke)
+		include : ExtendBelowBaseAnchors (0  - LongVJut + QuarterStroke)
+		include : VBar.m Middle XH (XH + LongVJut - QuarterStroke) VJutStroke
+		include : VBar.m Middle 0  (0  - LongVJut + QuarterStroke) VJutStroke
 
 	derive-composites 'oRetroflexHook' 0x1DF1B 'o' : RetroflexHook.l
 		x -- [mix [arch.adjust-x.bot Middle] SB 0.75]

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -168,7 +168,7 @@ glyph-block Letter-Shared-Shapes : begin
 	define CurlyTail : namespace
 		define [normalBlender before _after args] : begin
 			local ltr : args.xOuter > before.x
-			local rInner : 0.5 * ([Math.abs (args.xOuter - before.x)] - (2 * [HSwToV args.fine]))
+			local rInner : 0.5 * [Math.abs : args.xOuter - before.x] - [HSwToV args.fine]
 			local top : fallback args.yLoopTop : args.bottom + 2 * (args.fine + rInner)
 			local yOuter : [if ltr YSmoothMidR YSmoothMidL] top args.bottom
 
@@ -687,7 +687,7 @@ glyph-block Letter-Shared-Shapes : begin
 	define [JutIn left right jut swRef hSplit] : begin
 		local ink : HSwToV swRef
 		local gap : (right - left - hSplit * ink) / (hSplit - 1)
-		Math.min jut : 0.5 * ink + [Math.max (Stroke * TanSlope) (0.375 * gap)]
+		return : Math.min jut : 0.5 * ink + [Math.max (Stroke * TanSlope) (0.375 * gap)]
 
 	class CSerifFrame
 		public [new top bot left right swRef swSerif div hSplit fForceSymmetric] : begin
@@ -816,7 +816,7 @@ glyph-block Letter-Shared-Shapes : begin
 		include : dispiro
 			widths.lhs sw
 			flat left ybegin [heading Downward]
-			curl left [Math.min (ybegin - TINY) adb]
+			curl left [Math.min adb : ybegin - TINY]
 			arcvh
 			g4 [mix left right 0.5] bottom [heading Rightward]
 			archv
@@ -923,7 +923,7 @@ glyph-block Letter-Shared-Shapes : begin
 		# Diacritical descender of cyrillics
 		glyph-block-export CyrDescender
 		define CyrDescender : Descenders : function [x y xLink yAttach yOverflow sw] : glyph-proc
-			local extension : QuarterStroke - LongVJut
+			local extension : (-LongVJut) + QuarterStroke
 			include : ExtendBelowBaseAnchors (y + extension)
 			include : union
 				xLinkStroke xLink x yAttach sw
@@ -931,7 +931,7 @@ glyph-block Letter-Shared-Shapes : begin
 
 		glyph-block-export CyrTailDescender
 		define CyrTailDescender : Descenders : function [x y xLink yAttach yOverflow sw] : glyph-proc
-			local extension : QuarterStroke - LongVJut
+			local extension : (-LongVJut) + QuarterStroke
 			include : ExtendBelowBaseAnchors (y + extension)
 			include : union
 				xLinkStroke xLink x yAttach sw
@@ -943,7 +943,7 @@ glyph-block Letter-Shared-Shapes : begin
 		# Palatal Hooks
 		glyph-block-export PalatalHook
 		define PalatalHook : Descenders : function [x y xLink yAttach yOverflow sw maskOut] : glyph-proc
-			local fullDepth : 0 - Descender - 0.5 * sw - O
+			local fullDepth : (-Descender) - 0.5 * sw - O
 			include : ExtendBelowBaseAnchors (y + Descender)
 			include : difference
 				union
@@ -960,7 +960,7 @@ glyph-block Letter-Shared-Shapes : begin
 		# Retroflex hooks
 		glyph-block-export RetroflexHook
 		define RetroflexHook : Descenders : function [x y xLink yAttach yOverflow sw] : glyph-proc
-			local fullDepth : 0 - Descender - 0.5 * sw - O
+			local fullDepth : (-Descender) - 0.5 * sw - O
 			include : ExtendBelowBaseAnchors (y + Descender)
 			include : union
 				xLinkStroke xLink x yAttach sw
@@ -1002,7 +1002,7 @@ glyph-block Letter-Shared-Shapes : begin
 		glyph-block-export EngHook
 		define [EngHook] : with-params [x yStart yEnd [sw Stroke]] : begin
 			return : VerticalHook.r x (yEnd + Hook + 0.5 * sw) (-HookX) Hook
-				yExtension -- [Math.max 0 (yStart - (yEnd + Hook + 0.5 * sw))]
+				yExtension -- [Math.max 0 : yStart - (yEnd + Hook + 0.5 * sw)]
 				sw -- sw
 
 		# Upward hook shape
@@ -1085,22 +1085,24 @@ glyph-block Letter-Shared-Shapes : begin
 		glyph-block-export LetterBarOverlay LetterObliqueBarOverlay
 		define [BarOverlayImpl] : with-params [barFunc x y space refSw pXInSw sw] : begin
 			local {xLeftSpace xRightSpace} space
-			local xLeftEdge  : x - pXInSw * [HSwToV refSw]
+			local xLeftEdge  : x - (0 + pXInSw) * [HSwToV refSw]
 			local xRightEdge : x + (1 - pXInSw) * [HSwToV refSw]
 			local p : (xLeftEdge - xLeftSpace) / ((xRightSpace - xRightEdge) + (xLeftEdge - xLeftSpace))
-			local xC : mix xLeftEdge xRightEdge [mix 0.5 (1 - p) 0.5]
+			local xC : mix xLeftEdge xRightEdge : mix 0.5 (1 - p) 0.5
 			local jut : 0.75 * LongJut
 			return : barFunc
 				Math.min (xLeftEdge - SideJut)
-					Math.max (xC - jut) [mix xLeftSpace xLeftEdge 0.3]
+					Math.max (xC - jut) : mix xLeftSpace xLeftEdge 0.3
 				Math.max (xRightEdge + SideJut)
-					Math.min [mix xRightSpace xRightEdge 0.3] (xC + jut)
+					Math.min (xC + jut) : mix xRightSpace xRightEdge 0.3
 				begin y
 				begin sw
 
 		define [calcYAndSw bot top py sw] : begin
 			local y : mix bot top py
-			local sw1 : Math.min sw (1.25 * (top - bot) * py) (1.25 * (top - bot) * (1 - py))
+			local sw1 : Math.min sw
+				1.25 * (top - bot) * (0 + py)
+				1.25 * (top - bot) * (1 - py)
 			return { y sw1 }
 
 		define [LetterBarOverlay] : with-params [x y space refSw pXInSw sw]


### PR DESCRIPTION
Continuation of #2640 .

Note that below shows `Ф` under Bulgarian locale; The default unlocalized glyph is unchanged.

`ФҐґꟀꟁ`

Sans Thin Before:
![image](https://github.com/user-attachments/assets/67a1a7c5-783c-46af-91be-4aa75723059f)
Sans Thin After:
![image](https://github.com/user-attachments/assets/32a826e6-0cbf-4720-820c-5010bddc3a9d)
Sans Regular Before:
![image](https://github.com/user-attachments/assets/892a3d73-2e3a-4033-90c8-5622345073c6)
Sans Regular After:
![image](https://github.com/user-attachments/assets/c787705f-baf3-4103-8e90-4faf32c15e82)
Sans Heavy Before:
![image](https://github.com/user-attachments/assets/ecfc2d9b-f2cc-4294-ad5a-51afd6ee5f27)
Sans Heavy After:
![image](https://github.com/user-attachments/assets/cdad9913-242a-4b3b-804f-16d9a17ce639)
Slab Thin Before:
![image](https://github.com/user-attachments/assets/2bf19924-b175-4bdb-9dea-2d66255c9ffc)
Slab Thin After:
![image](https://github.com/user-attachments/assets/1b7bd4ed-2536-40e7-b037-f776d6834bca)
Slab Regular Before:
![image](https://github.com/user-attachments/assets/f7006b52-bbce-4ad3-8a72-04a374b6067d)
Slab Regular After:
![image](https://github.com/user-attachments/assets/3106b752-67f9-4943-b08a-b23c5ed985f0)
Slab Heavy Before:
![image](https://github.com/user-attachments/assets/064ae91a-6610-47f5-b22c-556c332a5865)
Slab Heavy After:
![image](https://github.com/user-attachments/assets/96daf6a3-5040-4ab7-b95b-43c966fe4355)
