### PR TITLE
Optimize glyphs of currency symbols added by #2638 .

### DIFF
--- a/packages/font-glyphs/src/letter/armenian/lower-sha-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/lower-sha-group.ptl
@@ -67,11 +67,10 @@ glyph-block Letter-Armenian-Lower-Sha-Group : begin
 			local rhs : strokeOffset df.rightSB refY dx dy df.mvs HVContrast
 			local joinX : mix df.leftSB rhs.x 0.2
 			local joinY : mix (Descender + df.mvs) rhs.y 0.2
-			local fine : df.mvs * (ShoulderFine / Stroke)
 
 			include : dispiro
 				widths.lhs df.mvs
 				straight.down.start (x1 - [HSwToV df.mvs]) y1 [heading Downward]
-				flat joinX joinY [widths.lhs fine]
+				flat joinX joinY [widths.lhs df.shoulderFine]
 				curl df.leftSB (Descender + df.mvs)
 			include : [ArmHBar.normal df].desc

--- a/packages/font-glyphs/src/letter/armenian/lower-u-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/lower-u-group.ptl
@@ -279,13 +279,12 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			include : VBar.l df.leftSB 0 XH df.mvs
 
 			# Combination of nShoulder.knots and the straight 2 shape
-			local fine : ShoulderFine * (df.mvs / Stroke)
-			local left : Math.max (df.rightSB - [HSwToV df.mvs] - jut) df.middle
+			local left : Math.max df.middle : df.rightSB - [HSwToV df.mvs] - jut
 			include : dispiro
-				widths.rhs fine
-				flat (df.leftSB + [HSwToV : df.mvs - fine]) (XH - SmallArchDepthA - TINY)
-				curl (df.leftSB + [HSwToV : df.mvs - fine]) (XH - SmallArchDepthA)
-				arch.rhs XH (sw -- df.mvs) (swBefore -- fine)
+				widths.rhs df.shoulderFine
+				flat (df.leftSB + [HSwToV : df.mvs - df.shoulderFine]) (XH - SmallArchDepthA - TINY)
+				curl (df.leftSB + [HSwToV : df.mvs - df.shoulderFine]) (XH - SmallArchDepthA)
+				arch.rhs XH (sw -- df.mvs) (swBefore -- df.shoulderFine)
 				TwoNeck df XH 0 left
 			include : HBar.b left (left + [HSwToV df.mvs] + jut) 0 df.mvs
 			if SLAB : begin

--- a/packages/font-glyphs/src/letter/latin/upper-l.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-l.ptl
@@ -16,12 +16,12 @@ glyph-block Letter-Latin-Upper-L : begin
 	glyph-block-import Letter-Shared-Shapes : BeltOverlay LetterBarOverlay
 
 	define [LBarLeftX df] : df.leftSB * 1.5
-	define [LRightX df]   : df.rightSB - 0.75 * OX
+	define [LRightX   df] : df.rightSB - 0.75 * OX
 	define [LShape df top sgr swv] : glyph-proc
 		include : VBar.l [LBarLeftX df] 0 top swv
 		include : HBar.b ([LBarLeftX df] - O) [LRightX df] 0
 		if (sgr > 1) : begin
-			include : HSerif.lb ([LBarLeftX df] + [HSwToV : 0.5 * swv]) 0 Jut
+			include : HSerif.lb ([LBarLeftX df] + [HSwToV : 0.5 * swv]) 0   Jut
 			include : HSerif.lt ([LBarLeftX df] + [HSwToV : 0.5 * swv]) top Jut
 			include : HSerif.rt ([LBarLeftX df] + [HSwToV : 0.5 * swv]) top MidJutSide
 		if (sgr > 0) : include : VSerif.ur [LRightX df] 0 VJut

--- a/packages/font-glyphs/src/symbol/letter.ptl
+++ b/packages/font-glyphs/src/symbol/letter.ptl
@@ -78,19 +78,19 @@ glyph-block Symbol-Currency : begin
 			include : LetterObliqueBarOverlay.l SB (CAP * 0.60 - OverlayStroke * 0.25)
 			if serifGrade : begin
 				local sf : SerifFrame.fromDf [DivFrame 1] CAP 0
-				include : composite-proc sf.lt.full sf.lb.outer
+				include : composite-proc sf.lt.fullSide sf.lb.outer
 
 	select-variant 'currency/turkishLiraSign' 0x20BA
 
 	create-glyph 'currency/sheqelSign' 0x20AA : glyph-proc
-		local df : include : DivFrame para.diversityMM 4
+		local df : include : DivFrame para.diversityM 4
 		include : df.markSet.e
 
 		define pX 0.7
 		define pY 0.8
 
 		local vswPlusGap : (df.rightSB - df.leftSB - [HSwToV df.mvs]) / 3
-		local barShrink : Math.min (XH * 0.3) : vswPlusGap - [HSwToV df.mvs] + df.mvs * 1.5
+		local barShrink : Math.min (XH * 0.3) (vswPlusGap - [HSwToV df.mvs] + df.mvs * 1.5)
 		include : VBar.l df.leftSB 0 XH df.mvs
 		include : VBar.l (df.leftSB + vswPlusGap) 0 (XH - barShrink) df.mvs
 		include : lift-@ : dispiro
@@ -109,19 +109,29 @@ glyph-block Symbol-Currency : begin
 			curl df.rightSB XH [heading Upward]
 
 	create-glyph 'currency/manatSign' 0x20BC : glyph-proc
-		local df : include : DivFrame para.diversityM 3
+		local df : include : DivFrame para.diversityT 3
 		include : df.markSet.e
 
 		define pY 0.8
 		local archTop : mix 0 XH pY
-		include : VBar.m df.middle 0 XH df.mvs
+
+		local sw : Math.min df.mvs : AdviceStroke2 3 2 archTop df.div
+
+		local ada : df.archDepthA SmallArchDepth sw
+		local adb : df.archDepthB SmallArchDepth sw
+
+		include : VBar.m df.middle [if SLAB sw 0] XH sw
 		include : dispiro
-			widths.rhs df.mvs
-			flat df.leftSB 0 [heading Upward]
-			curl df.leftSB (archTop - SmallArchDepthA)
-			arch.rhs archTop (sw -- df.mvs)
-			flat df.rightSB (archTop - SmallArchDepthB)
+			widths.rhs sw
+			flat df.leftSB  0 [heading Upward]
+			curl df.leftSB  [if (ada + adb < archTop) (archTop - ada) : mix archTop 0 (ada / (ada + adb))]
+			arch.rhs archTop (sw -- sw)
+			flat df.rightSB [if (ada + adb < archTop) (archTop - adb) : mix archTop 0 (adb / (ada + adb))]
 			curl df.rightSB 0 [heading Downward]
+
+		if SLAB : begin
+			local sf : SerifFrame.fromDf df XH 0 (swSerif -- sw)
+			include : composite-proc sf.lb.full sf.rb.full
 
 	create-glyph 'currency/lariSign' 0x20BE : glyph-proc
 		local df : include : DivFrame para.diversityM 3
@@ -133,14 +143,17 @@ glyph-block Symbol-Currency : begin
 			CAP * 0.5
 			CAP - df.mvs + Descender
 
+		local ada : df.archDepthA ArchDepth df.mvs
+		local adb : df.archDepthB ArchDepth df.mvs
+
 		include : HBar.b df.leftSB df.rightSB 0 df.mvs
 		include : dispiro
 			widths.lhs df.mvs
 			g4 (df.rightSB - OX) (CAP - Hook)
 			hookstart CAP (sw -- df.mvs)
-			flatside.ld df.leftSB 0 CAP ArchDepthA ArchDepthB
+			flatside.ld df.leftSB 0 CAP ada adb
 			arcvh
-			flat df.middle (df.mvs - df.shoulderFine) [widths.lhs df.shoulderFine]
+			flat df.middle  (df.mvs - df.shoulderFine) [widths.lhs df.shoulderFine]
 			curl df.rightSB (df.mvs - df.shoulderFine) [heading Rightward]
 		include : VBar.r (df.middle - offset) barBot (CAP - Descender / 2) fine
 		include : VBar.l (df.middle + offset) barBot (CAP - Descender / 2) fine
@@ -151,7 +164,7 @@ glyph-block Symbol-Currency-Letter-Derived : begin
 	glyph-block-import Letter-Shared-Shapes : LetterObliqueBarOverlay
 
 	derive-composites 'currency/colonSign' 0x20A1 'C' 'dblLongSlash'
-	derive-composites 'currency/millSign' 0x20A5 'm' 'shortSlash'
+	derive-composites 'currency/millSign'  0x20A5 'm' 'shortSlash'
 
 	create-glyph 'currency/overlay/NS' : glyph-proc
 		define sw : Math.min OverlayStroke : AdviceStroke2 2 4 CAP
@@ -341,7 +354,7 @@ glyph-block Symbol-Letter : begin
 			dispiro
 				widths.rhs
 				g4 (SB + O) (y - O)
-				g4 Middle (y + O)
+				g4 Middle  (y + O)
 				g4 RightSB (y - O)
 
 		create-glyph 'tironianEt' 0x204A : glyph-proc
@@ -378,7 +391,7 @@ glyph-block Symbol-Cyrl-Thousands : begin
 	create-glyph 'cyrlThousandsSign' 0x482 : glyph-proc
 		define fine : AdviceStroke 3
 		include : ExtLineCenter (-0.1) fine SB Descender RightSB XH
-		include : ExtLineCenter (-0.1) fine [mix SB RightSB 0.1] [mix Descender XH 0.8] [mix SB RightSB 1.1] [mix Descender XH 0.5]
+		include : ExtLineCenter (-0.1) fine [mix SB RightSB (+0.1)] [mix Descender XH 0.8] [mix SB RightSB 1.1] [mix Descender XH 0.5]
 		include : ExtLineCenter (-0.1) fine [mix SB RightSB (-0.1)] [mix Descender XH 0.5] [mix SB RightSB 0.9] [mix Descender XH 0.2]
 
 glyph-block Symbol-Letter-Phonetic : begin


### PR DESCRIPTION
`m₪₺₼ᴪ₾`

Sans Monospace Thin:
![image](https://github.com/user-attachments/assets/3286ceb9-6a57-444d-b757-cdce67cbdd20)
Sans Monospace Regular:
![image](https://github.com/user-attachments/assets/c35530b2-d537-4459-afda-ccfb1d425e84)
Sans Monospace Heavy:
![image](https://github.com/user-attachments/assets/7f0ba938-c739-488f-998e-d94e9ea3b98e)
Slab Monospace Thin:
![image](https://github.com/user-attachments/assets/625db34c-f3ac-4e2c-baa7-1ba0e3707d33)
Slab Monospace Regular:
![image](https://github.com/user-attachments/assets/0b0c82a3-2f69-4f53-a33e-e14ee8346702)
Slab Monospace Heavy:
![image](https://github.com/user-attachments/assets/05b95f51-836e-4855-bfa5-4aa05eb4df86)
Aile Thin:
![image](https://github.com/user-attachments/assets/a0bdecb4-8c24-421c-ac6b-c3804e39eb53)
Aile Regular:
![image](https://github.com/user-attachments/assets/d253fbae-29f0-4696-a0cf-75c4e95e5cd9)
Aile Heavy:
![image](https://github.com/user-attachments/assets/4748fa02-5eec-4fd5-b744-ce3c9ad392cc)
Etoile Thin:
![image](https://github.com/user-attachments/assets/a7699151-6714-4306-9e2b-d1ccb675d426)
Etoile Regular:
![image](https://github.com/user-attachments/assets/e4660d61-5246-47fe-b182-b9e1300725c4)
Etoile Heavy:
![image](https://github.com/user-attachments/assets/ba6d5fe9-92ae-41f3-a896-dd11d751552d)
