### PR TITLE
Make instances of `[DivFrame]` predefine their own `ArchDepth`{`A`|`B`} constants as attributes.

### DIFF
--- a/packages/font-glyphs/src/auto-build/transformed-jobs-data.ptl
+++ b/packages/font-glyphs/src/auto-build/transformed-jobs-data.ptl
@@ -99,7 +99,7 @@ export : define Superscript : list
 	list 0x1DB3 'sRTail'
 	list 0x1DB4 'esh'
 	list 0x1DB5 'tLTail'
-	list 0x1DB6 'uLongBarOver'
+	list 0x1DB6 'uBar'
 	list 0x1DB7 'latn/upsilon'
 	list 0x1DB8 'smcpU'
 	list 0x1DB9 'vHookTop'

--- a/packages/font-glyphs/src/letter/armenian/feh.ptl
+++ b/packages/font-glyphs/src/letter/armenian/feh.ptl
@@ -33,8 +33,8 @@ glyph-block Letter-Armenian-Feh : begin
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.capital
 		local sw : Math.min df.mvs : AdviceStroke2 3 3 CAP df.div
-		local ada : df.archDepthA ArchDepth sw
-		local adb : df.archDepthB ArchDepth sw
+		local ada : df.archDepthAOf ArchDepth sw
+		local adb : df.archDepthBOf ArchDepth sw
 		include : FehBody df CAP 0 sw Hook ada adb
 		include : VBar.m df.middle 0 CAP sw
 		if SLAB : begin
@@ -45,8 +45,8 @@ glyph-block Letter-Armenian-Feh : begin
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.bp
 		local sw : Math.min df.mvs : AdviceStroke2 3 3 Ascender df.div
-		local ada : df.archDepthA SmallArchDepth sw
-		local adb : df.archDepthB SmallArchDepth sw
+		local ada : df.archDepthAOf SmallArchDepth sw
+		local adb : df.archDepthBOf SmallArchDepth sw
 		include : FehBody df Ascender 0 sw Hook ada adb
 		include : VBar.m df.middle Descender Ascender sw
 		if SLAB : begin

--- a/packages/font-glyphs/src/letter/armenian/hook-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/hook-group.ptl
@@ -140,9 +140,7 @@ glyph-block Letter-Armenian-Hook-Group : begin
 		create-glyph 'armn/Peh' 0x54A : glyph-proc
 			local df : include : DivFrame para.diversityM 3
 			include : df.markSet.capital
-			local ada : df.archDepthA ArchDepth df.mvs
-			local adb : df.archDepthB ArchDepth df.mvs
-			include : LeftHook df CAP 0 df.mvs Hook ada adb
+			include : LeftHook df CAP 0 df.mvs Hook df.archDepthA df.archDepthB
 			include : VBar.m df.middle (XH / 2) (CAP - 0.5 * df.mvs) df.mvs
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df CAP 0

--- a/packages/font-glyphs/src/letter/armenian/upper-yi.ptl
+++ b/packages/font-glyphs/src/letter/armenian/upper-yi.ptl
@@ -16,11 +16,11 @@ glyph-block Letter-Armenian-Upper-Yi : begin
 			local df : include : DivFrame 1
 			include : df.markSet.capital
 			local ze : CyrZe 0 0 CAP 0
-				left -- df.leftSB
+				left  -- df.leftSB
 				right -- df.rightSB
 				blend -- (1 + (2 * O) / (df.rightSB - df.leftSB))
-				hook -- Hook
-				op -- HBarPos
+				hook  -- Hook
+				op    -- HBarPos
 			include : ze.Shape
 			if SLAB : begin
 				local midy : mix 0 CAP HBarPos

--- a/packages/font-glyphs/src/letter/cyrillic/de.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/de.ptl
@@ -154,12 +154,12 @@ glyph-block Letter-Cyrillic-De : begin
 		local sw : fallback _sw df.mvs
 
 		local yRingTop : Math.min (XH + O) (XH - QuarterStroke)
-		local ada : df.archDepthA (SmallArchDepth * yRingTop / XH)
-		local adb : df.archDepthB (SmallArchDepth * yRingTop / XH)
+		local ada : df.archDepthAOf : SmallArchDepth * yRingTop / XH
+		local adb : df.archDepthBOf : SmallArchDepth * yRingTop / XH
 
 		return : sink
 			widths.lhs ShoulderFine
-			straight.up.start (right - OX - [HSwToV (sw - ShoulderFine)]) (yRingTop - adb)
+			straight.up.start (right - OX - [HSwToV : sw - ShoulderFine]) (yRingTop - adb)
 			arch.lhs yRingTop (sw -- sw) (swBefore -- ShoulderFine)
 			flat (left + OX) (yRingTop - ada)
 			curl (left + OX) adb

--- a/packages/font-glyphs/src/letter/cyrillic/lower-be.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/lower-be.ptl
@@ -9,11 +9,12 @@ glyph-block Letter-Cyrillic-Lower-Be : begin
 	glyph-block-import Common-Derivatives
 
 	create-glyph 'cyrl/be' 0x431 : glyph-proc
-		include : MarkSet.b
+		local df : include : DivFrame 1
+		include : df.markSet.b
 
 		local yRingTop : Math.min (XH + O) (XH - QuarterStroke)
-		local ada : [DivFrame 1].archDepthA (SmallArchDepth * yRingTop / XH)
-		local adb : [DivFrame 1].archDepthB (SmallArchDepth * yRingTop / XH)
+		local ada : df.archDepthAOf : SmallArchDepth * yRingTop / XH
+		local adb : df.archDepthBOf : SmallArchDepth * yRingTop / XH
 
 		include : dispiro
 			widths.rhs ShoulderFine

--- a/packages/font-glyphs/src/letter/cyrillic/multiocular-o.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/multiocular-o.ptl
@@ -28,20 +28,18 @@ glyph-block Letter-Cyrillic-Multiocular-O : begin
 				local yTop : middleRowTop + pY * (Ascender - middleRowTop)
 				local xLeft : subDf.leftSB + (pX / 3) * (df.width - subDf.width)
 				local xRight : subDf.rightSB + (pX / 3) * (df.width - subDf.width)
-				local ada : subDf.archDepthA SmallArchDepth
-				local adb : subDf.archDepthB SmallArchDepth
 
 				local dotSpace : InnerDot.spaceOfDf subDf
-				local kHeight2 : [Math.sqrt ([InnerDot.spaceOfDf : DivFrame 1] / dotSpace)] * 1.5
+				local kHeight2 : [Math.sqrt : [InnerDot.spaceOfDf : DivFrame 1] / dotSpace] * 1.5
 
 				return : union
-					OShape.NoOvershoot yTop yBot xLeft xRight subDf.mvs ada adb
+					OShape.NoOvershoot yTop yBot xLeft xRight subDf.mvs subDf.smallArchDepthA subDf.smallArchDepthB
 					InnerDot [mix xLeft xRight 0.5] [mix yTop yBot 0.5] kHeight2 (DrawAt === DotAt) kdr dotSpace 5
 
-			include : SingleEye 0 0
-			include : SingleEye 1 0
-			include : SingleEye 2 0
-			include : SingleEye 3 0
+			include : SingleEye 0   0
+			include : SingleEye 1.0 0
+			include : SingleEye 2.0 0
+			include : SingleEye 3.0 0
 			include : SingleEye 0.5 (+1)
 			include : SingleEye 1.5 (+1)
 			include : SingleEye 2.5 (+1)

--- a/packages/font-glyphs/src/letter/greek/phi.ptl
+++ b/packages/font-glyphs/src/letter/greek/phi.ptl
@@ -12,19 +12,14 @@ glyph-block Letter-Greek-Phi : begin
 	glyph-block-import Letter-Shared-Shapes : FlatHookDepth DiagTail OBarLeft OBarRight
 
 	define [VarPhiRing fFlatTB df y2 y3] : glyph-proc
-		local ada : df.archDepthA ArchDepth df.mvs
-		local adb : df.archDepthB ArchDepth df.mvs
 		include : VBar.m df.middle y2 y3 df.mvs
 		include : if fFlatTB
-			OShapeFlatTB y3 y2 df.leftSB df.rightSB df.mvs ada adb
+			OShapeFlatTB y3 y2 df.leftSB df.rightSB df.mvs df.archDepthA df.archDepthB
 				Math.max (0.25 * (df.rightSB - df.leftSB)) : HSwToV df.mvs
-			OShape y3 y2 df.leftSB df.rightSB df.mvs ada adb
+			OShape y3 y2 df.leftSB df.rightSB df.mvs df.archDepthA df.archDepthB
 
 	define [CyrlEfSplitRing fFlatTB df y2 y3] : glyph-proc
 		local subDf : df.slice 3 2 OX
-		local ada : subDf.archDepthA SmallArchDepth df.mvs
-		local adb : subDf.archDepthB SmallArchDepth df.mvs
-
 		include : VBar.m df.middle y2 y3 df.mvs
 		include : union
 			OBarRight.shape
@@ -33,16 +28,16 @@ glyph-block Letter-Greek-Phi : begin
 				left      -- df.leftSB
 				right     -- (df.middle + [HSwToV : 0.5 * df.mvs])
 				sw        -- df.mvs
-				ada       -- ada
-				adb       -- adb
+				ada       -- subDf.smallArchDepthA
+				adb       -- subDf.smallArchDepthB
 			OBarLeft.shape
 				top       -- y3
 				bot       -- y2
 				left      -- (df.middle - [HSwToV : 0.5 * df.mvs])
 				right     -- df.rightSB
 				sw        -- df.mvs
-				ada       -- ada
-				adb       -- adb
+				ada       -- subDf.smallArchDepthA
+				adb       -- subDf.smallArchDepthB
 
 	define [GrekLowerPhiCursiveRing fFlatTB df y2 y3] : glyph-proc
 		local l : df.leftSB + OX * 2

--- a/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
@@ -188,16 +188,14 @@ glyph-block Letter-Latin-Ezh : begin
 			local df : include : DivFrame para.diversityM 1
 			include : df.markSet.p
 			local dfSub : DivFrame (0.75 * para.diversityM) 2
-			local ada : dfSub.archDepthA SmallArchDepth dfSub.mvs
-			local adb : dfSub.archDepthB SmallArchDepth dfSub.mvs
 			local [object yMidBar] : include : EzhShape dfSub XH Descender
 				isCursive -- isCursive
 				isSerifed -- isSerifed
 				sw        -- dfSub.mvs
 				hook      -- Hook
-				ada       -- ada
-				adb       -- adb
-			local y : [mix yMidBar Descender : pArc ada adb] - 0.5 * dfSub.mvs
+				ada       -- dfSub.smallArchDepthA
+				adb       -- dfSub.smallArchDepthB
+			local y : [mix yMidBar Descender : pArc dfSub.smallArchDepthA dfSub.smallArchDepthB] - 0.5 * dfSub.mvs
 			include : PalatalHook.r
 				x       -- df.rightSB
 				y       -- y

--- a/packages/font-glyphs/src/letter/latin-ext/flattened-open-a.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/flattened-open-a.ptl
@@ -16,8 +16,8 @@ glyph-block Letter-Latin-Flattened-Open-A : begin
 		local top : 0.5 * XH
 
 		local subDf : df.slice 3 2 OX
-		local ada : Math.min (top - TINY) : subDf.archDepthA SmallArchDepth df.mvs
-		local adb : Math.min (top - TINY) : subDf.archDepthB SmallArchDepth df.mvs
+		local ada : Math.min subDf.smallArchDepthA : top - TINY
+		local adb : Math.min subDf.smallArchDepthB : top - TINY
 
 		include : dispiro
 			widths.lhs df.mvs

--- a/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
@@ -81,8 +81,8 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 			local { subDf shift } : SubDfAndShift pShift df OX
 			return : with-transform [ApparentTranslate shift 0]
 				OShape top 0 subDf.leftSB subDf.rightSB df.mvs
-					subDf.archDepthA ad df.mvs
-					subDf.archDepthB ad df.mvs
+					subDf.archDepthAOf ad df.mvs
+					subDf.archDepthBOf ad df.mvs
 
 		create-glyph 'oe/o' : glyph-proc
 			local df : include : DivFrame para.diversityMM 3
@@ -111,24 +111,20 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 
 		define [EShape pShift df body] : begin
 			local { subDf shift } : SubDfAndShift pShift df OX
-			local ada : subDf.archDepthA SmallArchDepth df.mvs
-			local adb : subDf.archDepthB SmallArchDepth df.mvs
 			return : with-transform [ApparentTranslate shift 0]
 				body subDf XH
 					stroke -- df.mvs
-					ada    -- ada
-					adb    -- adb
+					ada    -- subDf.smallArchDepthA
+					adb    -- subDf.smallArchDepthB
 
 		define [InvEShape pShift df revbody] : begin
 			local { subDf shift } : SubDfAndShift pShift df OX
-			local ada : subDf.archDepthA SmallArchDepth df.mvs
-			local adb : subDf.archDepthB SmallArchDepth df.mvs
 			return : with-transform [ApparentTranslate shift 0]
 				with-transform [FlipAround subDf.middle (XH / 2)]
 					revbody subDf XH
 						stroke -- df.mvs
-						ada    -- ada
-						adb    -- adb
+						ada    -- subDf.smallArchDepthA
+						adb    -- subDf.smallArchDepthB
 
 		define Config : object
 			flatCrossbar { SmallEShape        RevSmallEShape        }
@@ -152,9 +148,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 
 		define df : DivFrame para.diversityMM 3
 		define { subDf shift } : SubDfAndShift 1 df 0
-		local ada : subDf.archDepthA SmallArchDepth df.mvs
-		local adb : subDf.archDepthB SmallArchDepth df.mvs
-		define sg : UShapeGroup ada adb
+		define sg : UShapeGroup subDf.smallArchDepthA subDf.smallArchDepthB
 
 		foreach { suffix { Base Slabs } } [Object.entries : SmallUConfigT sg] : do
 			create-glyph "ue/u.\(suffix)" : glyph-proc
@@ -173,7 +167,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 				set-mark-anchor 'cvDecompose' 0 0
 				include : difference
 					Base subDf XH df.mvs
-					intersection [MaskLeft subDf.middle] [MaskAbove (XH - adb)]
+					intersection [MaskLeft subDf.middle] [MaskAbove (XH - subDf.smallArchDepthB)]
 				include : Slabs subDf XH
 				include : ApparentTranslate shift 0
 				eject-contour 'serifLT'
@@ -183,24 +177,18 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 
 		define [openOShape df sty styBot] : new-glyph : glyph-proc
 			local subDf : df.slice 3 2 OX
-			local ada : subDf.archDepthA SmallArchDepth df.mvs
-			local adb : subDf.archDepthB SmallArchDepth df.mvs
-
 			local lf : CLetterForm subDf sty styBot XH 0
-				ada -- [subDf.archDepthA SmallArchDepth df.mvs]
-				adb -- [subDf.archDepthB SmallArchDepth df.mvs]
+				ada -- subDf.smallArchDepthA
+				adb -- subDf.smallArchDepthB
 				sw  -- df.mvs
 			include : lf.full
 			include : FlipAround (subDf.width / 2) (XH / 2)
 
 		define FLAT-CONNECTION 3
 		define [EsTeLeftShape subDf styBot] : new-glyph : glyph-proc
-			local ada : subDf.archDepthA SmallArchDepth subDf.mvs
-			local adb : subDf.archDepthB SmallArchDepth subDf.mvs
-
 			local lf : CLetterForm subDf FLAT-CONNECTION styBot XH 0
-				ada -- [subDf.archDepthA SmallArchDepth subDf.mvs]
-				adb -- [subDf.archDepthB SmallArchDepth subDf.mvs]
+				ada -- subDf.smallArchDepthA
+				adb -- subDf.smallArchDepthB
 				sw  -- subDf.mvs
 			include : lf.full
 

--- a/packages/font-glyphs/src/letter/latin-ext/lower-db-qp.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/lower-db-qp.ptl
@@ -12,23 +12,20 @@ glyph-block Letter-Latin-Lower-DB-QP : begin
 
 	define [DbCenterShape df] : glyph-proc
 		local subDf : df.slice 3 2 OX
-		local ada : subDf.archDepthA SmallArchDepth df.mvs
-		local adb : subDf.archDepthB SmallArchDepth df.mvs
-
 		include : OBarRight.rounded
 			left      -- df.leftSB
 			right     -- (df.middle + [HSwToV : 0.5 * df.mvs])
 			yTerminal -- XH
 			sw        -- df.mvs
-			ada       -- ada
-			adb       -- adb
+			ada       -- subDf.smallArchDepthA
+			adb       -- subDf.smallArchDepthB
 		include : OBarLeft.rounded
 			left      -- (df.middle - [HSwToV : 0.5 * df.mvs])
 			right     -- df.rightSB
 			yTerminal -- (XH / 2)
 			sw        -- df.mvs
-			ada       -- ada
-			adb       -- adb
+			ada       -- subDf.smallArchDepthA
+			adb       -- subDf.smallArchDepthB
 
 	create-glyph 'db' 0x238 : glyph-proc
 		local df : include : DivFrame para.diversityMM 3

--- a/packages/font-glyphs/src/letter/latin-ext/thorn.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/thorn.ptl
@@ -69,7 +69,7 @@ glyph-block Letter-Latin-Thorn : begin
 				top -- (CAP - [if st Stroke 0])
 				bot -- (CAP - [yThornBowlBot CAP st])
 
-		create-glyph "ThornStrokeBot.\(suffix)" : glyph-proc
+		create-glyph "ThornStrokeBottom.\(suffix)" : glyph-proc
 			include [refer-glyph "Thorn.\(suffix)"] AS_BASE ALSO_METRICS
 			include : LetterBarOverlay.l.in
 				x   -- xThornLeftStroke
@@ -78,7 +78,7 @@ glyph-block Letter-Latin-Thorn : begin
 
 	select-variant 'Thorn' 0xDE
 	select-variant 'ThornStroke' 0xA764 (follow -- 'Thorn')
-	select-variant 'ThornStrokeBot' 0xA766 (follow -- 'Thorn')
+	select-variant 'ThornStrokeBottom' 0xA766 (follow -- 'Thorn')
 
 	create-glyph 'grek/Sho' 0x3F7 : glyph-proc
 		include : MarkSet.capital

--- a/packages/font-glyphs/src/letter/latin-ext/upper-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/upper-ae-oe.ptl
@@ -73,8 +73,8 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 				corner eleft 0
 
 	define [AEAHalfRoundTop df top eleft sw] : glyph-proc
-		define ada : df.archDepthA ArchDepth sw
-		define adb : df.archDepthB ArchDepth sw
+		define ada : df.archDepthAOf ArchDepth sw
+		define adb : df.archDepthBOf ArchDepth sw
 
 		local yMidLeft : if (top > ada + adb) (top - ada) : mix top 0 (ada / (ada + adb))
 
@@ -217,8 +217,8 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 		define eleft : df.middle - [HSwToV : sw * [if SLAB (1 / 3) (1 / 4)]]
 		define swVJut : Math.min sw : (df.rightSB - eleft - [HSwToV sw]) * (4 / 5)
 
-		define ada : df.archDepthA ArchDepth sw
-		define adb : df.archDepthB ArchDepth sw
+		define ada : df.archDepthAOf ArchDepth sw
+		define adb : df.archDepthBOf ArchDepth sw
 
 		local xMidRight : df.rightSB - sw / 4
 		local yBar : top * eBarPos

--- a/packages/font-glyphs/src/letter/latin/c.ptl
+++ b/packages/font-glyphs/src/letter/latin/c.ptl
@@ -216,8 +216,8 @@ glyph-block Letter-Latin-C : begin
 			local desc : (-LongVJut) + QuarterStroke
 			include : ExtendBelowBaseAnchors desc
 			local lf : CLetterForm df sty styBot XH desc
-				ada -- [df.archDepthA SmallArchDepth Stroke]
-				adb -- [df.archDepthB SmallArchDepth Stroke]
+				ada -- [df.archDepthAOf SmallArchDepth Stroke]
+				adb -- [df.archDepthBOf SmallArchDepth Stroke]
 			include : lf.full
 
 		create-glyph "cHookTop.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/lower-a.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-a.ptl
@@ -19,10 +19,10 @@ glyph-block Letter-Latin-Lower-A : begin
 		define [ADoubleStoreyStroke df] : AdviceStroke2 2 3 XH df.div
 		define [ADoubleStoreySmoothA df] : begin
 			local sw : ADoubleStoreyStroke df
-			return : df.archDepthA (ArchDepth * [StrokeWidthBlend 0.9 0.81 sw]) sw
+			return : df.archDepthAOf (ArchDepth * [StrokeWidthBlend 0.9 0.81 sw]) sw
 		define [ADoubleStoreySmoothB df] : begin
 			local sw : ADoubleStoreyStroke df
-			return : df.archDepthB (ArchDepth * [StrokeWidthBlend 0.9 0.81 sw]) sw
+			return : df.archDepthBOf (ArchDepth * [StrokeWidthBlend 0.9 0.81 sw]) sw
 
 		define [ADoubleStoreyHookAndBarT sink df hookStyle y0 stroke] : begin
 			local isMask : sink == spiro-outline
@@ -147,8 +147,8 @@ glyph-block Letter-Latin-Lower-A : begin
 			right -- df.rightSB
 			sw    -- sw
 			fine  -- (ShoulderFine * (sw / Stroke))
-			ada   -- [df.archDepthA SmallArchDepth sw]
-			adb   -- [df.archDepthB SmallArchDepth sw]
+			ada   -- [df.archDepthAOf SmallArchDepth sw]
+			adb   -- [df.archDepthBOf SmallArchDepth sw]
 
 		export : define [FullBarBody df top bar _sw] : glyph-proc
 			local sw : fallback _sw df.mvs
@@ -170,16 +170,16 @@ glyph-block Letter-Latin-Lower-A : begin
 				right -- df.rightSB
 				sw    -- sw
 				fine  -- (ShoulderFine * (sw / Stroke))
-				ada   -- [df.archDepthA SmallArchDepth sw]
-				adb   -- [df.archDepthB SmallArchDepth sw]
+				ada   -- [df.archDepthAOf SmallArchDepth sw]
+				adb   -- [df.archDepthBOf SmallArchDepth sw]
 				rise  -- DToothlessRise
 				mBlend -- DMBlend
 			include : FlipAround df.middle (top / 2)
 			include : bar df (top - DToothlessRise) sw
 		export : define [EarlessRoundedBody df top bar _sw] : glyph-proc
 			local sw : fallback _sw df.mvs
-			local ada : df.archDepthA SmallArchDepth sw
-			local adb : df.archDepthB SmallArchDepth sw
+			local ada : df.archDepthAOf SmallArchDepth sw
+			local adb : df.archDepthBOf SmallArchDepth sw
 			include : OBarLeft.rounded
 				top   -- top
 				left  -- df.leftSB

--- a/packages/font-glyphs/src/letter/latin/lower-d.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-d.ptl
@@ -20,8 +20,8 @@ glyph-block Letter-Latin-Lower-D : begin
 			left  -- df.leftSB
 			right -- df.rightSB
 			sw    -- df.mvs
-			ada   -- [df.archDepthA SmallArchDepth df.mvs]
-			adb   -- [df.archDepthB SmallArchDepth df.mvs]
+			ada   -- df.smallArchDepthA
+			adb   -- df.smallArchDepthB
 		tagged 'rightBar' : VBar.r df.rightSB 0 yTop
 
 	define [ToothlessCornerBody df yTop] : union
@@ -31,8 +31,8 @@ glyph-block Letter-Latin-Lower-D : begin
 			sw     -- df.mvs
 			rise   -- DToothlessRise
 			mBlend -- DMBlend
-			ada    -- [df.archDepthA SmallArchDepth df.mvs]
-			adb    -- [df.archDepthB SmallArchDepth df.mvs]
+			ada    -- df.smallArchDepthA
+			adb    -- df.smallArchDepthB
 		tagged 'rightBar' : VBar.r df.rightSB DToothlessRise yTop
 
 	define [ToothlessCornerHBBBody df yTop] : union
@@ -42,8 +42,8 @@ glyph-block Letter-Latin-Lower-D : begin
 			sw     -- df.mvs
 			rise   -- DToothlessRise
 			mBlend -- DMBlend
-			ada    -- [df.archDepthA SmallArchDepth df.mvs]
-			adb    -- [df.archDepthB SmallArchDepth df.mvs]
+			ada    -- df.smallArchDepthA
+			adb    -- df.smallArchDepthB
 		tagged 'rightBar' : VBar.r df.rightSB 0 yTop
 
 	define [ToothlessRoundedBody df yTop] : OBarRight.rounded
@@ -51,16 +51,16 @@ glyph-block Letter-Latin-Lower-D : begin
 		right     -- df.rightSB
 		sw        -- df.mvs
 		yTerminal -- yTop
-		ada       -- [df.archDepthA SmallArchDepth df.mvs]
-		adb       -- [df.archDepthB SmallArchDepth df.mvs]
+		ada       -- df.smallArchDepthA
+		adb       -- df.smallArchDepthB
 
 	define [TailedBody df yTop] : union
 		OBarRight.shape
 			left  -- df.leftSB
 			right -- df.rightSB
 			sw    -- df.mvs
-			ada   -- [df.archDepthA SmallArchDepth df.mvs]
-			adb   -- [df.archDepthB SmallArchDepth df.mvs]
+			ada   -- df.smallArchDepthA
+			adb   -- df.smallArchDepthB
 		RightwardTailedBar df.rightSB 0 yTop
 
 	define [TopSerif df yTop] : tagged 'serifRT'
@@ -136,11 +136,11 @@ glyph-block Letter-Latin-Lower-D : begin
 				right  -- dfHalf.rightSB
 				ybegin -- Ascender
 				yend   -- (XH / 2)
-				ada    -- [dfHalf.archDepthA SmallArchDepth df.mvs]
-				adb    -- [dfHalf.archDepthB SmallArchDepth df.mvs]
+				ada    -- [dfHalf.archDepthAOf SmallArchDepth df.mvs]
+				adb    -- [dfHalf.archDepthBOf SmallArchDepth df.mvs]
 				sw     -- df.mvs
 
-			if topSerif    : include : topSerif dfHalf Ascender
+			if topSerif : include : topSerif dfHalf Ascender
 			if SLAB : begin
 				local sf2 : [SerifFrame.fromDf df (XH / 2) 0].slice 1 2
 				include sf2.rt.full

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -243,8 +243,8 @@ glyph-block Letter-Latin-Lower-E : begin
 			local stroke : AdviceStroke2 2 3 XH divSub
 			include : Body dfSub XH
 				stroke -- stroke
-				ada -- [dfSub.archDepthA SmallArchDepth stroke]
-				adb -- [dfSub.archDepthB SmallArchDepth stroke]
+				ada -- [dfSub.archDepthAOf SmallArchDepth stroke]
+				adb -- [dfSub.archDepthBOf SmallArchDepth stroke]
 			include : FlipAround dfSub.middle (XH / 2)
 			include : RhoticHookShape (dfSub.rightSB - [HSwToV : 1.25 * markFine]) df.width (XH * 0.5) (XH * 0.2)
 
@@ -256,8 +256,8 @@ glyph-block Letter-Latin-Lower-E : begin
 			local stroke : AdviceStroke2 2 3 XH divSub
 			include : Body dfSub XH
 				stroke -- stroke
-				ada -- [dfSub.archDepthA SmallArchDepth stroke]
-				adb -- [dfSub.archDepthB SmallArchDepth stroke]
+				ada -- [dfSub.archDepthAOf SmallArchDepth stroke]
+				adb -- [dfSub.archDepthBOf SmallArchDepth stroke]
 			include : FlipAround dfSub.middle (XH / 2)
 			include : RetroflexHook.r
 				x -- [mix RightSB df.width 0.5]

--- a/packages/font-glyphs/src/letter/latin/lower-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-m.ptl
@@ -287,16 +287,17 @@ glyph-block Letter-Latin-Lower-M : begin
 					local subDf : df.slice 4 3 0
 					include : Body subDf XH 0 0 (XH / 2)
 					include : UpwardHookShape
-						left -- subDf.rightSB - [HSwToV subDf.mvs]
-						right -- df.rightSB
+						left   -- (subDf.rightSB - [HSwToV subDf.mvs])
+						right  -- df.rightSB
 						ybegin -- (XH / 2)
-						yend -- (XH / 2)
-						ada -- (SmallArchDepthA * 0.6 * df.div)
-						adb -- (SmallArchDepthB * 0.6 * df.div)
-						sw -- subDf.mvs
+						yend   -- (XH / 2)
+						ada    -- (SmallArchDepthA * 0.6 * df.div)
+						adb    -- (SmallArchDepthB * 0.6 * df.div)
+						sw     -- subDf.mvs
 					include : Serifs subDf XH 0 0 (XH / 2) true false
-					local sf2 : [SerifFrame.fromDf df (XH / 2) 0].slice 2 3
-					if SLAB : include sf2.rt.full
+					if SLAB : begin
+						local sf2 : [SerifFrame.fromDf df (XH / 2) 0].slice 2 3
+						include sf2.rt.full
 
 				create-glyph "cyrl/tje.italic/base/corner.\(suffix)" : glyph-proc
 					local df : include : DivFrame [mix 1 para.diversityMM 2] 4
@@ -317,7 +318,7 @@ glyph-block Letter-Latin-Lower-M : begin
 				include : MidHook.general
 					left   -- subDf.rightSB
 					right  -- df.rightSB
-					top    -- XH * 0.625 + df.mvs / 4
+					top    -- (XH * 0.625 + df.mvs / 4)
 					ada    -- ArchDepthA
 					adb    -- ArchDepthB
 					sw     -- subDf.mvs
@@ -338,15 +339,15 @@ glyph-block Letter-Latin-Lower-M : begin
 	alias 'cyrl/te.BGR' null 'cyrl/te.italic'
 	alias 'cyrl/te/reduced.BGR' null 'cyrl/te.italic'
 	alias 'cyrl/teThreeLeg.italic' null 'cyrl/te.italic'
-	derive-composites 'cyrl/teDescender.italic' null 'cyrl/te.italic/descBase' : do
-		local df : DivFrame para.diversityMM 3
+
+	derive-composites 'cyrl/teDescender.italic' null 'cyrl/te.italic/descBase' : let [df : dfM]
 		CyrDescender.rSideJut df.rightSB 0 (refSw -- df.mvs)
-	derive-composites 'mPalatalHook' 0x1D86 'm/descBase' : do
-		local df : DivFrame para.diversityMM 3
+
+	derive-composites 'mPalatalHook' 0x1D86 'm/descBase' : let [df : dfM]
 		PalatalHook.r
 			xLink -- df.rightSB
-			x -- df.rightSB + SideJut
-			y -- 0
+			x     -- (df.rightSB + SideJut)
+			y     -- 0
 			refSw -- df.mvs
 
 	select-variant 'meng' 0x271
@@ -456,30 +457,30 @@ glyph-block Letter-Latin-Lower-M : begin
 			HBar.b (xMid - bbd) xMid 0 bbs
 			nShoulder.shape
 				stroke -- bbs
-				left -- (df.leftSB + bbd + [HSwToV bbs])
-				right -- xMid
-				fine -- ShoulderFine
+				left   -- (df.leftSB + bbd + [HSwToV bbs])
+				right  -- xMid
+				fine   -- ShoulderFine
 			intersection
 				VBar.r (xMid - bbd) 0 XH bbs
 				nShoulder.mask
 					stroke -- bbs
-					left -- (df.leftSB + bbd + [HSwToV bbs] + 1)
-					right -- (xMid - 1)
-					top -- (XH - 1)
-					fine -- ShoulderFine
+					left   -- (df.leftSB + bbd + [HSwToV bbs] + 1)
+					right  -- (xMid - 1)
+					top    -- (XH - 1)
+					fine   -- ShoulderFine
 		include : union
 			HBar.b (df.rightSB - bbd) df.rightSB 0 bbs
 			nShoulder.shape
 				leftY0 -- 0
 				stroke -- bbs
-				left -- xMid
-				right -- df.rightSB
-				fine -- ShoulderFine
+				left   -- xMid
+				right  -- df.rightSB
+				fine   -- ShoulderFine
 			intersection
 				VBar.r (df.rightSB - bbd) 0 XH bbs
 				nShoulder.mask
 					stroke -- bbs
-					left -- (xMid + 1)
-					right -- (df.rightSB - 1)
-					top -- (XH - 1)
-					fine -- ShoulderFine
+					left   -- (xMid + 1)
+					right  -- (df.rightSB - 1)
+					top    -- (XH - 1)
+					fine   -- ShoulderFine

--- a/packages/font-glyphs/src/letter/latin/lower-n.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-n.ptl
@@ -49,11 +49,11 @@ glyph-block Letter-Latin-Lower-N : begin
 	define [EaredBody top left right yBR sw] : glyph-proc
 		include : VBar.l left 0 top sw
 		include : nShoulder.shape
-			left -- (left + [HSwToV sw])
-			right -- right
-			top -- top
+			left   -- (left + [HSwToV sw])
+			right  -- right
+			top    -- top
 			bottom -- yBR
-			fine -- ShoulderFine
+			fine   -- ShoulderFine
 			stroke -- sw
 
 	define [EarlessCornerBody top left right yBR sw] : glyph-proc
@@ -338,14 +338,14 @@ glyph-block Letter-Latin-Lower-N : begin
 		include : HBar.b (df.rightSB - bbd) df.rightSB 0 bbs
 		include : nShoulder.shape
 			stroke -- bbs
-			left -- (df.leftSB + bbd + [HSwToV bbs])
-			right -- df.rightSB
-			fine -- ShoulderFine
+			left   -- (df.leftSB + bbd + [HSwToV bbs])
+			right  -- df.rightSB
+			fine   -- ShoulderFine
 		include : intersection
 			VBar.r (df.rightSB - bbd) 0 XH bbs
 			nShoulder.mask
 				stroke -- bbs
-				left -- (df.leftSB + bbd + [HSwToV bbs] + 1)
-				right -- (df.rightSB - 1)
-				top -- (XH - 1)
-				fine -- ShoulderFine
+				left   -- (df.leftSB + bbd + [HSwToV bbs] + 1)
+				right  -- (df.rightSB - 1)
+				top    -- (XH - 1)
+				fine   -- ShoulderFine

--- a/packages/font-glyphs/src/letter/latin/lower-p.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-p.ptl
@@ -71,7 +71,7 @@ glyph-block Letter-Latin-Lower-P : begin
 			set-base-anchor 'overlayOnExtension' (SB + [HSwToV HalfStroke]) yOverlay
 			set-base-anchor 'strike' Middle (XH / 2)
 
-		create-glyph "pStrokeBot.\(suffix)" : glyph-proc
+		create-glyph "pStrokeBottom.\(suffix)" : glyph-proc
 			include [refer-glyph "p.\(suffix)"] AS_BASE ALSO_METRICS
 			include : LetterBarOverlay.l.in
 				x   -- SB
@@ -91,7 +91,7 @@ glyph-block Letter-Latin-Lower-P : begin
 			include [refer-glyph "thorn.\(suffix)"] AS_BASE ALSO_METRICS
 			include : LetterBarOverlay.l.in SB XH (Ascender - [if doTS Stroke 0])
 
-		create-glyph "thornStrokeBot.\(suffix)" : glyph-proc
+		create-glyph "thornStrokeBottom.\(suffix)" : glyph-proc
 			include [refer-glyph "thorn.\(suffix)"] AS_BASE ALSO_METRICS
 			include : LetterBarOverlay.l.in
 				x   -- SB
@@ -120,15 +120,15 @@ glyph-block Letter-Latin-Lower-P : begin
 
 	alias 'grek/rho' 0x3C1 'p.earlessRoundedSerifless'
 
-	select-variant 'pStrokeBot' 0xA751 (follow -- 'p')
+	select-variant 'pStrokeBottom' 0xA751 (follow -- 'p')
 
-	alias 'grek/rhoStroke' 0x3FC 'pStrokeBot.earlessRoundedSerifless'
+	alias 'grek/rhoStroke' 0x3FC 'pStrokeBottom.earlessRoundedSerifless'
 
 	select-variant 'thorn' 0xFE
 	alias 'grek/sho' 0x3F8 'thorn.earedSerifless'
 
 	select-variant 'thornStroke' 0xA765 (follow -- 'thorn')
-	select-variant 'thornStrokeBot' 0xA767 (follow -- 'thorn')
+	select-variant 'thornStrokeBottom' 0xA767 (follow -- 'thorn')
 
 	derive-glyphs 'cyrl/erTick' 0x48F 'cyrl/er' : lambda [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS

--- a/packages/font-glyphs/src/letter/latin/lower-y.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-y.ptl
@@ -46,9 +46,9 @@ glyph-block Letter-Latin-Lower-Y : begin
 			local pds     0.1
 			local pds2    0.01
 			local slabyvx 0.625
-			local ds0 : (top - bottom) * pds
+			local ds0  : (top - bottom) * pds
 			local ds20 : (top - bottom) * pds2
-			local ds  : if slabCurly [Math.max [AdviceStroke2 3 6 (top - bottom)] ds0] ds0
+			local ds  : if slabCurly [Math.max ds0 : AdviceStroke2 3 6 (top - bottom)] ds0
 			local ds2 : if slabCurlyNoTurnB ds : ds20 + [if bottomIsNotVertical (slabysize * slabyvx) 0]
 			return {ds ds2}
 
@@ -131,11 +131,11 @@ glyph-block Letter-Latin-Lower-Y : begin
 							curl [mix me.yrstroker joinX ((top - bottom) / (top - joinY))] bottom [widths.rhs.heading ([me.diagCor (top - bottom)] * Stroke) Downward]
 						(bottomShape == BS-LOOP) : begin
 							local joinHeight1 : me.yJoinHeight top bottom
-							local k : 1 / [Math.sin : Math.atan2 (joinX - Middle) (joinY - joinHeight1)] - 0.25
-							local joinHeight3 : [Math.abs k] * Stroke + joinHeight1
-							local deltaX : Math.max yBottomJut [HSwToV : 1.2 * Stroke]
+							local k : Math.abs : 1 / [Math.sin : Math.atan2 (joinX - Middle) (joinY - joinHeight1)] - 0.25
+							local joinHeight3 : k * Stroke + joinHeight1
+							local deltaX : Math.max yBottomJut : HSwToV : 1.2 * Stroke
 							local fine : AdviceStroke 3
-							local xLoopLeft : Math.min [Math.max (SB * -0.25) [mix joinX (me.yrstrokel - deltaX) 2]] (joinX - 1.5 * [HSwToV fine])
+							local xLoopLeft : Math.min (joinX - [HSwToV : 1.5 * fine]) : Math.max ((-0.25) * SB) : mix joinX (me.yrstrokel - deltaX) 2
 							local xCenter : mix xLoopLeft joinX 0.5
 							list
 								ConnectZ me.yshrink
@@ -343,10 +343,10 @@ glyph-block Letter-Latin-Lower-Y : begin
 
 	define Cursive : namespace
 		export : define [Arc top bottom] : uBowl.shape
-			top -- top
+			top    -- top
 			bottom -- bottom
-			left -- SB
-			right -- (RightSB - [HSwToV Stroke])
+			left   -- SB
+			right  -- (RightSB - [HSwToV Stroke])
 
 		export : define [Hook y0 bottom] : dispiro
 			widths.rhs
@@ -443,14 +443,14 @@ glyph-block Letter-Latin-Lower-Y : begin
 		include : intersection
 			spiro-outline
 				corner [mix RightSB Middle (-1)] [mix XH 0 (-1)]
-				corner [mix RightSB Middle (2)]  [mix XH 0 (2)]
-				corner (-Width * 2)              [mix XH 0 (2)]
-				corner (-Width * 2)              [mix XH 0 (-1)]
+				corner [mix RightSB Middle (+2)] [mix XH 0 (+2)]
+				corner ((-2) * Width)            [mix XH 0 (+2)]
+				corner ((-2) * Width)            [mix XH 0 (-1)]
 			Rect XH Descender (-Width) (2 * Width)
 			union
-				ExtLineCenter 1 BBS  SB                 XH (Middle - 0.25 * kDiag * BBD) 0
-				ExtLineCenter 1 BBS  (SB + kDiag * BBD) XH (Middle + 0.75 * kDiag * BBD) 0
+				ExtLineCenter 1 BBS  SB                XH (Middle - 0.25 * kDiag * BBD) 0
+				ExtLineCenter 1 BBS (SB + kDiag * BBD) XH (Middle + 0.75 * kDiag * BBD) 0
 
 		include : intersection
 			Rect XH Descender (-Width) (2 * Width)
-			ExtLineCenter 1 BBS  RightSB XH Middle 0
+			ExtLineCenter 1 BBS RightSB XH Middle 0

--- a/packages/font-glyphs/src/letter/latin/o.ptl
+++ b/packages/font-glyphs/src/letter/latin/o.ptl
@@ -40,25 +40,19 @@ glyph-block Letter-Latin-O : begin
 	create-glyph 'cyrl/Uk/O' : glyph-proc
 		local df : include : DivFrame para.diversityF 2
 		include : df.markSet.capital
-		local ada : df.archDepthA ArchDepth df.mvs
-		local adb : df.archDepthB ArchDepth df.mvs
-		include : OShape CAP 0 df.leftSB df.rightSB df.mvs ada adb
+		include : OShape CAP 0 df.leftSB df.rightSB df.mvs df.archDepthA df.archDepthB
 
 	create-glyph 'cyrl/uk/o' : glyph-proc
 		local df : include : DivFrame para.diversityF 2
 		include : df.markSet.e
-		local ada : df.archDepthA SmallArchDepth df.mvs
-		local adb : df.archDepthB SmallArchDepth df.mvs
-		include : OShape XH 0 df.leftSB df.rightSB df.mvs ada adb
+		include : OShape XH 0 df.leftSB df.rightSB df.mvs df.smallArchDepthA df.smallArchDepthB
 
 	create-glyph 'cyrl/oNarrow' 0x1C82 : glyph-proc
 		local df : include : DivFrame para.diversityF 2
 		include : df.markSet.e
 		local subDf : DivFrame (5 / 6) 2
-		local ada : subDf.archDepthA SmallArchDepth subDf.mvs
-		local adb : subDf.archDepthB SmallArchDepth subDf.mvs
 		include : with-transform [ApparentTranslate (0.5 * (df.width - subDf.width)) 0]
-			OShape XH 0 subDf.leftSB subDf.rightSB subDf.mvs ada adb
+			OShape XH 0 subDf.leftSB subDf.rightSB subDf.mvs subDf.smallArchDepthA subDf.smallArchDepthB
 
 	define rBroadOn : DotRadius * [StrokeWidthBlend 1.625 1]
 	create-glyph 'cyrl/BroadOn' 0x47A : glyph-proc
@@ -68,9 +62,7 @@ glyph-block Letter-Latin-O : begin
 		local gap : Math.min
 			Math.max (0.25 * dist) [HSwToV : Math.SQRT2 * rBroadOn]
 			Math.max (dist - [HSwToV : 3 * df.mvs]) [HSwToV df.mvs]
-		local ada : df.archDepthA ArchDepth df.mvs
-		local adb : df.archDepthB ArchDepth df.mvs
-		include : OShapeFlatTB CAP 0 df.leftSB df.rightSB df.mvs ada adb gap
+		include : OShapeFlatTB CAP 0 df.leftSB df.rightSB df.mvs df.archDepthA df.archDepthB gap
 		include : DotAt df.middle (df.mvs / 2 + O) rBroadOn
 		include : DotAt df.middle (CAP - df.mvs / 2 - O) rBroadOn
 
@@ -81,9 +73,7 @@ glyph-block Letter-Latin-O : begin
 		local gap : Math.min
 			Math.max (0.25 * dist) [HSwToV : Math.SQRT2 * rBroadOn]
 			Math.max (dist - [HSwToV : 3 * df.mvs]) [HSwToV df.mvs]
-		local ada : df.archDepthA SmallArchDepth df.mvs
-		local adb : df.archDepthB SmallArchDepth df.mvs
-		include : OShapeFlatTB XH 0 df.leftSB df.rightSB df.mvs ada adb gap
+		include : OShapeFlatTB XH 0 df.leftSB df.rightSB df.mvs df.smallArchDepthA df.smallArchDepthB gap
 		include : DotAt df.middle (df.mvs / 2 + O) rBroadOn
 		include : DotAt df.middle (XH - df.mvs / 2 - O) rBroadOn
 

--- a/packages/font-glyphs/src/letter/latin/s.ptl
+++ b/packages/font-glyphs/src/letter/latin/s.ptl
@@ -404,12 +404,11 @@ glyph-block Letter-Latin-S : begin
 		local fine : sw * [mix CThinB 1 0.6]
 		local hd : FlatHookDepth DfCapital
 		local yStart : XH - [ArcStartSerifDepth SHook]
-		local neckLength HalfStroke
 		local leftExt : 0.3 * (RightSB - SB) - [HSwToV : 0.25 * sw]
 		include : dispiro
 			widths.rhs fine
-			flat (RightSB - [HSwToV fine]) yStart [heading Upward]
-			curl (RightSB - [HSwToV fine]) (yStart + neckLength) [heading Upward]
+			flat (RightSB - [HSwToV fine])  yStart               [heading Upward]
+			curl (RightSB - [HSwToV fine]) (yStart + HalfStroke) [heading Upward]
 			alsoThru.g2 0.5 0.5 [widths.center : mix fine sw 0.35]
 			g4 (RightSB - leftExt) [Math.min (Ascender - 1.375 * sw) : mix XH Ascender 0.5] [widths.lhs : mix fine sw 0.7]
 			arcvh

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -8,13 +8,10 @@ glyph-module
 glyph-block Letter-Latin-U : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Mark-Shared-Metrics : markHalfStroke
 	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared : CreateAccentedComposition SetGrekUpperTonos
 	glyph-block-import Letter-Shared-Shapes : uBowl RightwardTailedBar DToothlessRise SerifFrame
-	glyph-block-import Letter-Shared-Shapes : CyrDescender CyrTailDescender RetroflexHook VerticalHook TopHook
-
-	glyph-block-export UShape USerifs
+	glyph-block-import Letter-Shared-Shapes : CyrDescender CyrTailDescender RetroflexHook TopHook
 
 	define [UArcT] : with-params [sink df top bottom [stroke Stroke] [ada ArchDepthA] [adb ArchDepthB] [offset 0]] : sink
 		widths.lhs stroke
@@ -24,14 +21,15 @@ glyph-block Letter-Latin-U : begin
 		flat (df.rightSB - offset) (bottom + ada + offset)
 		[if (sink == spiro-outline) corner curl] (df.rightSB - offset) top [heading Upward]
 
+	glyph-block-export UShape
 	define [UShape] : with-params [df top bottom [stroke Stroke] [ada ArchDepthA] [adb ArchDepthB] [offset 0]] : glyph-proc
 		include : UArcT dispiro
-			df -- df
-			top -- top
+			df     -- df
+			top    -- top
 			bottom -- bottom
 			stroke -- stroke
-			ada -- ada
-			adb -- adb
+			ada    -- ada
+			adb    -- adb
 			offset -- offset
 
 	glyph-block-export UShapeGroup
@@ -39,28 +37,28 @@ glyph-block Letter-Latin-U : begin
 		export : define [Toothed df top sw fHookLeft fShortLeg] : glyph-proc
 			set-base-anchor 'trailing' df.rightSB 0
 			include : uBowl.shape
-				top -- (top - [if fHookLeft (TailY + HalfStroke) 0])
+				top    -- (top - [if fHookLeft (TailY + HalfStroke) 0])
 				bottom -- 0
-				left -- df.leftSB
-				right -- (df.rightSB - [HSwToV sw])
+				left   -- df.leftSB
+				right  -- (df.rightSB - [HSwToV sw])
 				stroke -- sw
-				fine -- ShoulderFine
-				ada -- ada
-				adb -- adb
+				fine   -- ShoulderFine
+				ada    -- ada
+				adb    -- adb
 			if fHookLeft : include : TopHook.toLeft.lBarInner df.leftSB (adb + TINY) top (sw -- sw)
 			include : tagged 'strokeR' : VBar.r df.rightSB 0 [if fShortLeg [mix ada top 0.5] top] sw
 
 		export : define [Tailed df top sw fHookLeft fShortLeg] : glyph-proc
 			set-base-anchor 'trailing' (df.rightSB + SideJut) 0
 			include : uBowl.shape
-				top -- (top - [if fHookLeft (TailY + HalfStroke) 0])
+				top    -- (top - [if fHookLeft (TailY + HalfStroke) 0])
 				bottom -- 0
-				left -- df.leftSB
-				right -- (df.rightSB - [HSwToV sw])
+				left   -- df.leftSB
+				right  -- (df.rightSB - [HSwToV sw])
 				stroke -- sw
-				fine -- ShoulderFine
-				ada -- ada
-				adb -- adb
+				fine   -- ShoulderFine
+				ada    -- ada
+				adb    -- adb
 			if fHookLeft : include : TopHook.toLeft.lBarInner df.leftSB (adb + TINY) top (sw -- sw)
 			include : tagged 'strokeR' : RightwardTailedBar df.rightSB 0 [if fShortLeg [mix ada top 0.5] top] (sw -- sw)
 
@@ -99,7 +97,7 @@ glyph-block Letter-Latin-U : begin
 	define UUpper : UShapeGroup ArchDepthA ArchDepthB
 	define ULower : UShapeGroup SmallArchDepthA SmallArchDepthB
 
-	define [UTopLeftSerif df yTop _sw]  : tagged 'serifLT'
+	define [UTopLeftSerif df yTop _sw] : tagged 'serifLT'
 		HSerif.lt df.leftSB yTop SideJut _sw
 
 	define [UTopRightSerif df yTop _sw] : tagged 'serifRT'
@@ -111,6 +109,7 @@ glyph-block Letter-Latin-U : begin
 		if trAnchor : begin
 			set-base-anchor 'trailing' (trAnchor.x + SideJut) trAnchor.y
 
+	glyph-block-export USerifs
 	define USerifs : namespace
 		export : define [Toothed df top _sw] : glyph-proc
 			include : UTopLeftSerif df top _sw
@@ -356,44 +355,8 @@ glyph-block Letter-Latin-U : begin
 		include [refer-glyph src] AS_BASE ALSO_METRICS
 		include [refer-glyph 'tildeAbove']
 
-	derive-composites 'uRTailBR' 0x1D99 'u/uRTailBase'
+	derive-composites 'uRetroflexHook' 0x1D99 'u/uRTailBase'
 		RetroflexHook.rSideJut RightSB 0 (yOverflow -- Stroke)
-
-	do "Labiodental Approximant"
-		local df : DivFrame 1
-		define [VHookTopShape top ada adb] : glyph-proc
-			include : dispiro
-				widths.lhs
-				flat df.leftSB top [heading Downward]
-				curl df.leftSB adb
-				arch.lhs 0
-				flat df.rightSB ada
-				curl df.rightSB (top - Hook - HalfStroke) [heading Upward]
-			include : VerticalHook.r
-				x -- df.rightSB
-				y -- (top - Hook - HalfStroke)
-				xDepth -- (-(RightSB - [HSwToV HalfStroke] - Middle))
-				yDepth -- (-Hook)
-
-		create-glyph 'VHookTop.serifless' : glyph-proc
-			include : MarkSet.capital
-			include : VHookTopShape CAP ArchDepthA ArchDepthB
-
-		create-glyph 'VHookTop.serifed' : glyph-proc
-			include [refer-glyph "VHookTop.serifless"] AS_BASE ALSO_METRICS
-			include : UTopLeftSerif df CAP
-
-		select-variant 'VHookTop' 0x1B2
-
-		create-glyph 'vHookTop.serifless' : glyph-proc
-			include : MarkSet.e
-			include : VHookTopShape XH SmallArchDepthA SmallArchDepthB
-
-		create-glyph 'vHookTop.serifed' : glyph-proc
-			include [refer-glyph "vHookTop.serifless"] AS_BASE ALSO_METRICS
-			include : UTopLeftSerif df XH
-
-		select-variant 'vHookTop' 0x28B
 
 	derive-glyphs 'uWithLightCentralizationStroke' null 'u' : function [src gr] : glyph-proc
 		include : MarkSet.p
@@ -417,7 +380,7 @@ glyph-block Letter-Latin-U : begin
 			include : HSerif.lt SB XH SideJut
 
 	CreateAccentedComposition 'uDieresis' 0xFC 'u' 'dieresisAbove'
-	CreateAccentedComposition 'uLongBarOver' 0x289 'u' 'hStrike'
+	CreateAccentedComposition 'uBar' 0x289 'u' 'hStrike'
 	CreateAccentedComposition 'smcpUStroke' 0x1D7E 'smcpU' 'hStrike'
 
 	# Sideways dieresis for U+1D1E
@@ -442,11 +405,10 @@ glyph-block Letter-Latin-U : begin
 			VBar.l (SB + BBD) 0 CAP BBS
 			UArcT spiro-outline [DivFrame 1] CAP 0
 				stroke -- BBS
-				oper -- true
+				oper   -- true
 				offset -- 1
 
 	create-glyph 'mathbb/u' 0x1D566 : glyph-proc
-		local df : DivFrame 1 2
-		include : df.markSet.e
+		include : MarkSet.e
 		include [refer-glyph 'mathbb/n']
 		include : FlipAround Middle (XH / 2)

--- a/packages/font-glyphs/src/letter/latin/upper-p.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-p.ptl
@@ -185,7 +185,7 @@ glyph-block Letter-Latin-Upper-P : begin
 				PShape XH (slab -- slabs)
 				if fGap [PShape.OpenGap (top -- XH) (bot -- [if fSlabBot Stroke 0])] [glyph-proc]
 
-		create-glyph "PStrokeBot.\(suffix)" : glyph-proc
+		create-glyph "PStrokeBottom.\(suffix)" : glyph-proc
 			include [refer-glyph "P.\(suffix)"] AS_BASE ALSO_METRICS
 			include : LetterBarOverlay.l.in
 				x   -- (SB * PShape.defaultMul)
@@ -245,7 +245,7 @@ glyph-block Letter-Latin-Upper-P : begin
 		space -- { 0 (RightSB - [HSwToV Stroke]) }
 	derive-composites 'PStroke' 0x2C63 'P' 'PStroke/overlay'
 
-	select-variant 'PStrokeBot' 0xA750 (follow -- 'P')
+	select-variant 'PStrokeBottom' 0xA750 (follow -- 'P')
 
 	define [BBPShape] : with-params [[mul PShape.defaultMul] [overshoot PShape.defaultOvershoot]] : glyph-proc
 		define sb : SB * mul

--- a/packages/font-glyphs/src/letter/latin/v.ptl
+++ b/packages/font-glyphs/src/letter/latin/v.ptl
@@ -8,9 +8,8 @@ glyph-module
 glyph-block Letter-Latin-V : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-export VShape VShapeOutline
 	glyph-block-import Letter-Shared : CreateTurnedLetter
-	glyph-block-import Letter-Shared-Shapes : DiagTail SerifFrame PalatalHook
+	glyph-block-import Letter-Shared-Shapes : DiagTail SerifFrame PalatalHook VerticalHook
 	glyph-block-import Letter-Blackboard : BBS BBD
 
 	glyph-block-export VCornerHalfWidth
@@ -26,6 +25,7 @@ glyph-block Letter-Latin-V : begin
 	define StraightSbShrink : mix 1 (DesignParameters.straightVShapeSbShrink * [StrokeWidthBlend 1 0.75]) : if SLAB 0.75 1
 	define [VShapeTopFlat top] : if SLAB [Math.min (top - Stroke) (top * 0.9)] (top * 0.9)
 
+	glyph-block-export VShapeOutline
 	define [VShapeOutline] : with-params [df fBarStraight top [sw Stroke]] : glyph-proc
 		define cornerHW : VCornerHalfWidth * sw / Stroke
 		define dgCor : DiagCor top (Width / 2) 0 (sw * 2)
@@ -63,6 +63,7 @@ glyph-block Letter-Latin-V : begin
 			corner (df.middle - cornerHW) 0
 			corner df.middle [Math.min sw : if fBarStraight VShapeFineStraight VShapeFine]
 
+	glyph-block-export VShape
 	define [VShape] : with-params [df fBarStraight top [sw Stroke]] : glyph-proc
 		define cornerHW : VCornerHalfWidth * (sw / Stroke)
 		define fine : Math.min sw : [if fBarStraight VShapeFineStraight VShapeFine] * (sw / Stroke)
@@ -137,7 +138,7 @@ glyph-block Letter-Latin-V : begin
 			straight.left.start (df.rightSB + hookWidthOuter) (top - sw - O)
 			g4 (df.rightSB - hookWidthInner) (top - 0.5 * sw - TailY)
 			quadControls 0.4 0.75 64 unimportant
-			g4 (df.middle + VCornerHalfWidth * sw / Stroke) 0 [widths.rhs (VShapeFine * sw / Stroke)]
+			g4 (df.middle + VCornerHalfWidth * sw / Stroke) 0 [widths.rhs : VShapeFine * sw / Stroke]
 
 	define [VLoopShape] : with-params [df fBarStraight top [sw Stroke]] : glyph-proc
 		include : VShape df fBarStraight top (sw -- sw)
@@ -248,11 +249,11 @@ glyph-block Letter-Latin-V : begin
 				x -- (Middle + [HSwToV HalfStroke] + [PalatalHook.adviceGap Stroke])
 				y -- 0
 
-	define CursiveConfig : object
+	define VCursiveConfig : object
 		cursiveSerifless     { (1/24) false }
 		cursiveSerifed       { (1/16) true  }
 
-	foreach { suffix { pxBar fDoSerif } } [Object.entries CursiveConfig] : do
+	foreach { suffix { pxBar fDoSerif } } [Object.entries VCursiveConfig] : do
 		create-glyph "v.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : VCursiveShape pxBar XH Stroke
@@ -290,6 +291,40 @@ glyph-block Letter-Latin-V : begin
 	CreateTurnedLetter 'turnV' 0x245 'V' HalfAdvance (CAP / 2)
 	CreateTurnedLetter 'turnv' 0x28C 'v' HalfAdvance (XH / 2)
 
+	define [VHookTopShape df top ada adb] : glyph-proc
+		include : dispiro
+			widths.lhs
+			flat df.leftSB top [heading Downward]
+			curl df.leftSB adb
+			arch.lhs 0
+			flat df.rightSB ada
+			curl df.rightSB (top - Hook - HalfStroke) [heading Upward]
+		include : VerticalHook.r
+			x -- df.rightSB
+			y -- (top - Hook - HalfStroke)
+			xDepth -- ((-RightSB) + Middle + [HSwToV HalfStroke])
+			yDepth -- (-Hook)
+
+	create-glyph 'VHookTop.serifless' : glyph-proc
+		include : MarkSet.capital
+		include : VHookTopShape [DivFrame 1] CAP ArchDepthA ArchDepthB
+
+	create-glyph 'VHookTop.serifed' : glyph-proc
+		include [refer-glyph "VHookTop.serifless"] AS_BASE ALSO_METRICS
+		include : tagged 'serifLT' : HSerif.lt SB CAP SideJut
+
+	select-variant 'VHookTop' 0x1B2
+
+	create-glyph 'vHookTop.serifless' : glyph-proc
+		include : MarkSet.e
+		include : VHookTopShape [DivFrame 1] XH SmallArchDepthA SmallArchDepthB
+
+	create-glyph 'vHookTop.serifed' : glyph-proc
+		include [refer-glyph "vHookTop.serifless"] AS_BASE ALSO_METRICS
+		include : tagged 'serifLT' : HSerif.lt SB XH SideJut
+
+	select-variant 'vHookTop' 0x28B
+
 	glyph-block-export BBVShape BBVInnerMaskShape BBVOuterMaskShape
 	define [BBVShape l r kd ks top] : glyph-proc
 		local m : mix l r 0.5
@@ -299,10 +334,10 @@ glyph-block Letter-Latin-V : begin
 		include : intersection
 			Rect top 0 (-Width) (2 * Width)
 			union
-				ExtLineCenter 1 bbs  l                 top (m - kDiag * bbd / 2) 0
-				ExtLineCenter 1 bbs  (l + kDiag * bbd) top (m + kDiag * bbd / 2) 0
-				ExtLineCenter 1 bbs  r                 top (m + kDiag * bbd / 2) 0
-		include : HBar.t    l                     (l + kDiag * bbd)     top bbs
+				ExtLineCenter 1 bbs  l                top (m - kDiag * bbd / 2) 0
+				ExtLineCenter 1 bbs (l + kDiag * bbd) top (m + kDiag * bbd / 2) 0
+				ExtLineCenter 1 bbs  r                top (m + kDiag * bbd / 2) 0
+		include : HBar.t  l                    (l + kDiag * bbd)     top bbs
 		include : HBar.b (m - kDiag * bbd / 2) (m + kDiag * bbd / 2) 0   bbs
 
 	define [BBVInnerMaskShape l r kd ks top] : glyph-proc
@@ -311,7 +346,7 @@ glyph-block Letter-Latin-V : begin
 		local kDiag : DiagCorDs top ((r - l) / 2) (bbd / 2)
 		include : spiro-outline
 			corner (l + kDiag * bbd) top
-			corner r                 top
+			corner  r                top
 			corner (m + kDiag * bbd / 2) 0
 
 	define [BBVOuterMaskShape l r kd ks top] : glyph-proc
@@ -319,8 +354,8 @@ glyph-block Letter-Latin-V : begin
 		local bbd : BBD * kd
 		local kDiag : DiagCorDs top ((r - l) / 2) (bbd / 2)
 		include : spiro-outline
-			corner l top
-			corner r top
+			corner  l top
+			corner  r top
 			corner (m + kDiag * bbd / 2) 0
 			corner (m - kDiag * bbd / 2) 0
 

--- a/packages/font-glyphs/src/meta/aesthetics.ptl
+++ b/packages/font-glyphs/src/meta/aesthetics.ptl
@@ -441,12 +441,20 @@ export : define [GenDivFrame metrics] : begin
 			set this.widthNoOvershoot : this.width - ox
 			set this.divNoOvershoot   : this.widthNoOvershoot / metrics.Width
 
-		public [archDepth d _stroke] : begin
+			set this.archDepth  : this.archDepthOf  metrics.ArchDepth mvs
+			set this.archDepthA : this.archDepthAOf metrics.ArchDepth mvs
+			set this.archDepthB : this.archDepthBOf metrics.ArchDepth mvs
+
+			set this.smallArchDepth  : this.archDepthOf  metrics.SmallArchDepth mvs
+			set this.smallArchDepthA : this.archDepthAOf metrics.SmallArchDepth mvs
+			set this.smallArchDepthB : this.archDepthBOf metrics.SmallArchDepth mvs
+
+		public [archDepthOf d _stroke] : begin
 			return : Math.max (d * this.divNoOvershoot) (1.125 * [fallback _stroke this.mvs])
-		public [archDepthA d _stroke] : begin
-			return : metrics.ArchDepthAOf [this.archDepth d _stroke] this.widthNoOvershoot
-		public [archDepthB d _stroke] : begin
-			return : metrics.ArchDepthBOf [this.archDepth d _stroke] this.widthNoOvershoot
+		public [archDepthAOf d _stroke] : begin
+			return : metrics.ArchDepthAOf [this.archDepthOf d _stroke] this.widthNoOvershoot
+		public [archDepthBOf d _stroke] : begin
+			return : metrics.ArchDepthBOf [this.archDepthOf d _stroke] this.widthNoOvershoot
 
 		public [slice _divisions _keeps _o] : begin
 			local o : fallback _o 0

--- a/packages/font-glyphs/src/symbol/letter.ptl
+++ b/packages/font-glyphs/src/symbol/letter.ptl
@@ -117,8 +117,8 @@ glyph-block Symbol-Currency : begin
 
 		local sw : Math.min df.mvs : AdviceStroke2 3 2 archTop df.div
 
-		local ada : df.archDepthA SmallArchDepth sw
-		local adb : df.archDepthB SmallArchDepth sw
+		local ada : df.archDepthAOf SmallArchDepth sw
+		local adb : df.archDepthBOf SmallArchDepth sw
 
 		include : VBar.m df.middle [if SLAB sw 0] XH sw
 		include : dispiro
@@ -143,15 +143,12 @@ glyph-block Symbol-Currency : begin
 			CAP * 0.5
 			CAP - df.mvs + Descender
 
-		local ada : df.archDepthA ArchDepth df.mvs
-		local adb : df.archDepthB ArchDepth df.mvs
-
 		include : HBar.b df.leftSB df.rightSB 0 df.mvs
 		include : dispiro
 			widths.lhs df.mvs
 			g4 (df.rightSB - OX) (CAP - Hook)
 			hookstart CAP (sw -- df.mvs)
-			flatside.ld df.leftSB 0 CAP ada adb
+			flatside.ld df.leftSB 0 CAP df.archDepthA df.archDepthB
 			arcvh
 			flat df.middle  (df.mvs - df.shoulderFine) [widths.lhs df.shoulderFine]
 			curl df.rightSB (df.mvs - df.shoulderFine) [heading Rightward]
@@ -420,14 +417,14 @@ glyph-block Symbol-Letter-Phonetic : begin
 
 		include : BreveShape
 			xMiddle -- Middle
-			width   -- markExtend * 3.0
+			width   -- (3 * markExtend)
 			top     -- XH
-			bottom  -- XH - AccentHeight
+			bottom  -- (XH - AccentHeight)
 			hs      -- markHalfStroke
 
 		include : InvBreveShape
 			xMiddle -- Middle
-			width   -- markExtend * 3.0
+			width   -- (3 * markExtend)
 			top     -- AccentHeight
 			bottom  -- 0
 			hs      -- markHalfStroke


### PR DESCRIPTION
This simplifies any instance of e.g. `df.archDepthA SmallArchDepth df.mvs` etc. to just e.g. `df.smallArchDepthA` etc.

This also consequentially renames the original `[DivFrame].archDepth`{`A`|`B`} functions to `[DivFrame].archDepth`{`A`|`B`}`Of`, to match the generic `ArchDepth`{`A`|`B`}`Of` functions defined elsewhere in `aesthetics.ptl`, freeing up the names to add ordinary attributes named `[DivFrame].archDepth`{`A`|`B`} in their place, which also matches the generic `ArchDepth`{`A`|`B`} _constants_ also defined elsewhere in `aesthetics.ptl`.