### PR TITLE
Make unsplit variants of Cyrillic Lower Ef and non-cursive variants of Greek Lower Phi use `SmallArchDepth`{`A`|`B`}.

### DIFF
--- a/changes/32.5.0.md
+++ b/changes/32.5.0.md
@@ -1,1 +1,2 @@
 * Add variant selector for decorative angle brackets (U+276C...U+2771) (#2603, #2623).
+* Optimize metrics for bowl of Cyrillic Lower Ef (`ф`) and Greek Small Letter Phi Symbol (`ϕ`).

--- a/packages/font-glyphs/src/letter/greek/phi.ptl
+++ b/packages/font-glyphs/src/letter/greek/phi.ptl
@@ -11,17 +11,16 @@ glyph-block Letter-Greek-Phi : begin
 	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors ExtendBelowBaseAnchors
 	glyph-block-import Letter-Shared-Shapes : FlatHookDepth DiagTail OBarLeft OBarRight
 
-	define [VarPhiRing fFlatTB df y2 y3] : glyph-proc
+	define [VarPhiRing fFlatTB df y2 y3 ada adb] : glyph-proc
 		include : VBar.m df.middle y2 y3 df.mvs
 		include : if fFlatTB
-			OShapeFlatTB y3 y2 df.leftSB df.rightSB df.mvs df.archDepthA df.archDepthB
+			OShapeFlatTB y3 y2 df.leftSB df.rightSB df.mvs ada adb
 				Math.max (0.25 * (df.rightSB - df.leftSB)) : HSwToV df.mvs
-			OShape y3 y2 df.leftSB df.rightSB df.mvs df.archDepthA df.archDepthB
+			OShape y3 y2 df.leftSB df.rightSB df.mvs ada adb
 
-	define [CyrlEfSplitRing fFlatTB df y2 y3] : glyph-proc
-		local subDf : df.slice 3 2 OX
+	define [CyrlEfSplitRing fFlatTB df y2 y3 ada adb] : glyph-proc
 		include : VBar.m df.middle y2 y3 df.mvs
-		include : union
+		include : let [subDf : df.slice 3 2 OX] : union
 			OBarRight.shape
 				top       -- y3
 				bot       -- y2
@@ -39,7 +38,7 @@ glyph-block Letter-Greek-Phi : begin
 				ada       -- subDf.smallArchDepthA
 				adb       -- subDf.smallArchDepthB
 
-	define [GrekLowerPhiCursiveRing fFlatTB df y2 y3] : glyph-proc
+	define [GrekLowerPhiCursiveRing fFlatTB df y2 y3 ada adb] : glyph-proc
 		local l : df.leftSB + OX * 2
 		local r : df.width - l
 		include : dispiro
@@ -104,7 +103,7 @@ glyph-block Letter-Greek-Phi : begin
 	define [GrekCapitalPhiImpl fFlatTB df] : glyph-proc
 		local y2 : mix [if SLAB Stroke 0] [if SLAB (CAP - Stroke) CAP] 0.125
 		local y3 : mix [if SLAB Stroke 0] [if SLAB (CAP - Stroke) CAP] 0.875
-		include : VarPhiRing fFlatTB df y2 y3
+		include : VarPhiRing fFlatTB df y2 y3 df.archDepthA df.archDepthB
 		include : StraightBar df 0 y2 y3 CAP
 
 		if SLAB : begin
@@ -133,7 +132,7 @@ glyph-block Letter-Greek-Phi : begin
 		include : ExtendAboveBaseAnchors top
 		include : ExtendBelowBaseAnchors bot
 
-		include : VarPhiRing true df 0 CAP
+		include : VarPhiRing true df 0 CAP df.archDepthA df.archDepthB
 		include : StraightBar df bot 0 CAP top
 
 		if SLAB : begin
@@ -143,24 +142,24 @@ glyph-block Letter-Greek-Phi : begin
 	create-glyph 'taillessphi' 0x2C77 : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.e
-		include : GrekLowerPhiCursiveRing false df 0 XH
+		include : GrekLowerPhiCursiveRing false df 0 XH df.smallArchDepthA df.smallArchDepthB
 
 	create-glyph 'grek/phi.cursive' : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.p
-		include : GrekLowerPhiCursiveRing false df 0 XH
+		include : GrekLowerPhiCursiveRing false df 0 XH df.smallArchDepthA df.smallArchDepthB
 		include : VBar.m df.middle Descender (0.2 * df.mvs)
 
 	create-glyph 'grek/phi.straight' : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.bp
-		include : VarPhiRing false df 0 XH
+		include : VarPhiRing false df 0 XH df.smallArchDepthA df.smallArchDepthB
 		include : StraightBar df Descender 0 XH Ascender
 
 	create-glyph 'grek/phi.neohellenic' : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.p
-		include : VarPhiRing false df 0 XH
+		include : VarPhiRing false df 0 XH df.smallArchDepthA df.smallArchDepthB
 		include : VBar.m df.middle Descender (0.2 * df.mvs)
 
 	select-variant 'grek/phi' 0x3C6
@@ -189,7 +188,7 @@ glyph-block Letter-Greek-Phi : begin
 		create-glyph "cyrl/ef.\(suffix)" : glyph-proc
 			local df : include : DivFrame div 3
 			include : df.markSet.bp
-			include : Bowl true df 0 XH
+			include : Bowl true df 0 XH df.smallArchDepthA df.smallArchDepthB
 			local vs : fallback barSw df.mvs
 			include : Bar df Descender 0 XH Ascender vs
 			if sMT : include : sMT df Ascender  vs


### PR DESCRIPTION
Basically further parity with the conventions of existing letters, much like the prior PR's of #2590 and #2602 , and made easier to implement via #2645 .

`ΦϕФф`

Thin Upright Before:
![image](https://github.com/user-attachments/assets/8cce3fa0-4c4e-4dd9-b35f-cea3853d524c)
Thin Upright After:
![image](https://github.com/user-attachments/assets/c8e88d9c-c441-4b69-b931-669c6344e705)
Regular Upright Before:
![image](https://github.com/user-attachments/assets/9b1499b9-7fd1-475f-8eda-6ee72fc53092)
Regular Upright After:
![image](https://github.com/user-attachments/assets/25b1dc2e-c012-4f6c-ad34-07c2c163749a)
Heavy Upright Before:
![image](https://github.com/user-attachments/assets/173ef50f-d2a5-43dd-8bec-35bf6c8980ae)
Heavy Upright After:
![image](https://github.com/user-attachments/assets/5850fbb1-edf5-48e4-b4a5-18bd3a8ed611)
Thin Italic Before:
![image](https://github.com/user-attachments/assets/d859aba7-3d6a-4760-a594-ad0c7c6a4814)
Thin Italic After:
![image](https://github.com/user-attachments/assets/9fb6886c-31db-4706-86f4-565afa31c9dd)
Regular Italic Before:
![image](https://github.com/user-attachments/assets/2624a32e-4670-472c-9701-cd43ff925cb7)
Regular Italic After:
![image](https://github.com/user-attachments/assets/12a81ee6-456a-41ef-9cc9-0fc2f8187f61)
Heavy Italic Before:
![image](https://github.com/user-attachments/assets/df288be8-eb6f-42b3-8f94-c3f3780be2df)
Heavy Italic After:
![image](https://github.com/user-attachments/assets/c86ed8ae-6c27-4e0e-bf1d-c781daa48e1d)
Stress test under Aile under `SS03`:
`ΦϕФфo`
Thin Upright:
![image](https://github.com/user-attachments/assets/eaac8d88-70c5-46c4-a401-e4e26b478585)
Regular Upright:
![image](https://github.com/user-attachments/assets/03892450-e823-4e13-a9ec-ce4dcfa461ad)
Heavy Upright:
![image](https://github.com/user-attachments/assets/adebbfa4-b08d-49e7-b42f-a82c77bb1580)
Thin Italic:
![image](https://github.com/user-attachments/assets/2c1e5fde-bff5-47cf-99a2-ecdb052c93fb)
Regular Italic:
![image](https://github.com/user-attachments/assets/b4a6d80b-baac-4d43-8bd5-b7e952c24f14)
Heavy Italic:
![image](https://github.com/user-attachments/assets/7d10c166-7111-4be3-a7b3-6c2ee13d6bbf)
