### PR TITLE
Add italic form for Cyrillic Lower Ghe with Upturn (`ґ`).

### DIFF
--- a/changes/32.5.0.md
+++ b/changes/32.5.0.md
@@ -10,3 +10,4 @@
   - VERTICAL RESISTOR SEGMENT (`U+1CC0A`).
   - HORIZONTAL ZIGZAG LINE (`U+1CEB0`).
 * Optimize metrics for bowl of Cyrillic Lower Ef (`ф`) and Greek Small Letter Phi Symbol (`ϕ`).
+* Add italic form for Cyrillic Small Letter Ghe with Upturn (`ґ`).

--- a/packages/font-glyphs/src/letter/cyrillic/de.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/de.ptl
@@ -11,7 +11,7 @@ glyph-block Letter-Cyrillic-De : begin
 	glyph-block-import Letter-Greek-Lower-Epsilon : CyrZe EpsilonConfig
 
 	glyph-block-export BottomExtension
-	local BottomExtension : QuarterStroke - LongVJut
+	local BottomExtension : (-LongVJut) + QuarterStroke
 
 	glyph-block-export CyrDeBottom
 	define [CyrDeBottom left right _sw _desc] : glyph-proc
@@ -30,7 +30,7 @@ glyph-block Letter-Cyrillic-De : begin
 			VBar.r (right + descenderOverflow) desc 0.1 swOuter
 
 	glyph-block-export CyrDeShape
-	define [CyrDeShape top left right _sw _desc] : glyph-proc
+	define [CyrDeShape top left right _sw _desc fLower] : glyph-proc
 		local descenderOverflow : if SLAB SideJut ((right - left) * 0.075)
 		local xTopLeft : mix left right : StrokeWidthBlend 0.15 0.1
 		local xTopRight : mix left right : StrokeWidthBlend 0.95 0.96
@@ -50,13 +50,15 @@ glyph-block Letter-Cyrillic-De : begin
 		include : if SLAB
 			then : dispiro
 				widths.rhs swOuter
-				flat (xTopLeft  - descenderOverflow) top
-				curl (xTopRight + descenderOverflow) top
+				flat (xTopLeft - descenderOverflow) top
+				if (fLower && para.isItalic)
+					then : list : curl xTopRight top [heading Rightward]
+					else : list : curl (xTopRight + descenderOverflow) top
 			else : HBar.t xTopLeft xTopRight top swOuter
 
 		return : object desc xTopLeft xTopRight
 
-	define [CyrSoftDeShape df top _sw vSlab] : glyph-proc
+	define [CyrSoftDeShape df top _sw _desc fLower vSlab] : glyph-proc
 		local descenderOverflow : if SLAB SideJut ((df.rightSB - df.leftSB) * 0.075)
 		local sw : fallback _sw Stroke
 		local xm : if SLAB
@@ -65,9 +67,9 @@ glyph-block Letter-Cyrillic-De : begin
 		local xTopRight : mix df.leftSB xm : StrokeWidthBlend 0.95 0.96
 		local xTopBarRightEnd : mix df.width df.rightSB : if vSlab 0.25 0.375
 
-		include : CyrDeShape top df.leftSB xm sw
+		include : CyrDeShape top df.leftSB xm sw _desc fLower
 
-		include : if SLAB
+		include : if (SLAB && !(fLower && para.isItalic))
 			then : HBar.t (xTopRight + descenderOverflow) xTopBarRightEnd top sw
 			else : HBar.t xTopRight xTopBarRightEnd top sw
 
@@ -85,19 +87,19 @@ glyph-block Letter-Cyrillic-De : begin
 
 	create-glyph 'cyrl/deLongLeg' 0x1C81 : glyph-proc
 		include : MarkSet.p
-		include : CyrDeShape XH SB RightSB Stroke Descender
+		include : CyrDeShape XH SB RightSB nothing Descender true
 
 	create-glyph 'cyrl/DeSoft.serifless' : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.capital
 		include : ExtendBelowBaseAnchors BottomExtension
-		include : CyrSoftDeShape df CAP df.mvs false
+		include : CyrSoftDeShape df CAP df.mvs nothing false false
 
 	create-glyph 'cyrl/DeSoft.topRightSerifed' : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.capital
 		include : ExtendBelowBaseAnchors BottomExtension
-		include : CyrSoftDeShape df CAP df.mvs true
+		include : CyrSoftDeShape df CAP df.mvs nothing false true
 
 	select-variant 'cyrl/DeSoft' 0xA662 (follow -- 'cyrl/EnGhe/GhePart')
 
@@ -105,13 +107,13 @@ glyph-block Letter-Cyrillic-De : begin
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.e
 		include : ExtendBelowBaseAnchors BottomExtension
-		include : CyrSoftDeShape df XH df.mvs false
+		include : CyrSoftDeShape df XH df.mvs nothing true false
 
 	create-glyph 'cyrl/deSoft.topRightSerifed' : glyph-proc
 		local df : include : DivFrame para.diversityM 3
 		include : df.markSet.e
 		include : ExtendBelowBaseAnchors BottomExtension
-		include : CyrSoftDeShape df XH df.mvs true
+		include : CyrSoftDeShape df XH df.mvs nothing true true
 
 	select-variant 'cyrl/deSoft' 0xA663 (follow -- 'cyrl/enghe/ghePart')
 
@@ -170,8 +172,9 @@ glyph-block Letter-Cyrillic-De : begin
 			g4 (left + sw * 1.1) Ascender
 
 	create-glyph 'cyrl/de.italic' : glyph-proc
-		include : MarkSet.b
-		include : CyrDeItalicShapeT dispiro [DivFrame 1]
+		local df : include : DivFrame 1
+		include : df.markSet.b
+		include : CyrDeItalicShapeT dispiro df
 
 	foreach { suffix { st sb }} [Object.entries EpsilonConfig] : do
 		create-glyph "cyrl/dzze.italic.\(suffix)" : glyph-proc
@@ -192,6 +195,6 @@ glyph-block Letter-Cyrillic-De : begin
 				stroke   -- df.mvs
 			include : union [ze.Shape] [ze.AutoEndSerifL]
 
-	select-variant 'cyrl/Dzze' 0xA688 (follow -- 'cyrl/ZeBottomSerifOnly')
+	select-variant 'cyrl/Dzze' 0xA688  (follow -- 'cyrl/ZeBottomSerifOnly')
 	select-variant 'cyrl/dzze.upright' (follow -- 'cyrl/zeBottomSerifOnly')
-	select-variant 'cyrl/dzze.italic' (follow -- 'cyrl/zeBottomSerifOnly')
+	select-variant 'cyrl/dzze.italic'  (follow -- 'cyrl/zeBottomSerifOnly')

--- a/packages/font-glyphs/src/letter/cyrillic/el.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/el.ptl
@@ -156,13 +156,13 @@ glyph-block Letter-Cyrillic-El : begin
 		local xm : df.middle + [HSwToV : 0.5 * df.mvs]
 		include : CyrElShape df.leftSB xm CAP BODY-NONE [if SLAB SLAB-ALL SLAB-NONE] df.mvs
 		include : UpwardHookShape
-			left -- df.middle - [HSwToV : 0.5 * df.mvs]
-			right -- df.rightSB
+			left   -- (df.middle - [HSwToV : 0.5 * df.mvs])
+			right  -- df.rightSB
 			ybegin -- CAP
-			yend -- (CAP / 2)
-			ada -- (SmallArchDepthA * 0.6 * df.div)
-			adb -- (SmallArchDepthB * 0.6 * df.div)
-			sw -- df.mvs
+			yend   -- (CAP / 2)
+			ada    -- (SmallArchDepthA * 0.6 * df.div)
+			adb    -- (SmallArchDepthB * 0.6 * df.div)
+			sw     -- df.mvs
 		local sf2 : [SerifFrame.fromDf df (CAP / 2) 0].slice 1 2
 		if SLAB : include sf2.rt.full
 
@@ -173,12 +173,12 @@ glyph-block Letter-Cyrillic-El : begin
 		local xm : df.middle + [HSwToV : 0.5 * df.mvs]
 		include : CyrElShape df.leftSB xm XH BODY-NONE [if SLAB [if para.isItalic SLAB-LOWER SLAB-ALL] SLAB-NONE] df.mvs
 		include : UpwardHookShape
-			left -- df.middle - [HSwToV : 0.5 * df.mvs]
-			right -- df.rightSB
+			left   -- (df.middle - [HSwToV : 0.5 * df.mvs])
+			right  -- df.rightSB
 			ybegin -- XH
-			yend -- (XH / 2)
-			ada -- (SmallArchDepthA * 0.6 * df.div)
-			adb -- (SmallArchDepthB * 0.6 * df.div)
-			sw -- df.mvs
+			yend   -- (XH / 2)
+			ada    -- (SmallArchDepthA * 0.6 * df.div)
+			adb    -- (SmallArchDepthB * 0.6 * df.div)
+			sw     -- df.mvs
 		local sf2 : [SerifFrame.fromDf df (XH / 2) 0].slice 1 2
 		if SLAB : include sf2.rt.full

--- a/packages/font-glyphs/src/letter/cyrillic/orthography.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/orthography.ptl
@@ -22,6 +22,7 @@ glyph-block Letter-Cyrillic-Orthography : begin
 	orthographic-italic 'cyrl/dzhe'           0x45F
 	orthographic-italic 'cyrl/yat'            0x463
 	orthographic-italic 'cyrl/iShortTail'     0x48B
+	orthographic-italic 'cyrl/ge'             0x491
 	orthographic-italic 'cyrl/ghayn'          0x493
 	orthographic-italic 'cyrl/peMidHook'      0x4A7
 	orthographic-italic 'cyrl/teDescender'    0x4AD

--- a/packages/font-glyphs/src/letter/greek/lower-gamma.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-gamma.ptl
@@ -40,8 +40,8 @@ glyph-block Letter-Greek-Lower-Gamma : begin
 		local xMid : [mix SB RightSB 0.46] + [HSwToV : 0.46 * swEqv]
 		local xStart : SB + [HSwToV : 0.4 * swEqv]
 
-		include : HBar.t    (xStart - BBD) (xStart + (cor - 1) * BBD) XH        BBS
-		include : HBar.b (xMid - BBD)   (xMid)                     Descender BBS
+		include : HBar.t (xStart - BBD) (xStart + (cor - 1) * BBD) XH        BBS
+		include : HBar.b (xMid   - BBD) (xMid)                     Descender BBS
 
 		foreach {ob ot} [items-of {{ 0 (cor - 1) } { (-1) (-1) }}] : include : dispiro
 			g4 (xStart + ot * BBD) XH [widths.rhs.heading BBS Downward]

--- a/packages/font-glyphs/src/letter/greek/pi.ptl
+++ b/packages/font-glyphs/src/letter/greek/pi.ptl
@@ -26,25 +26,15 @@ glyph-block Letter-Greek-Pi : begin
 			local sf : SerifFrame top bottom (df.leftSB + shrink) (df.rightSB - shrink) (swRef -- fine)
 			include : composite-proc sf.lt.outer sf.rt.outer sf.lb.full sf.rb.full
 
-	define [MathBBPiShape] : with-params [df top bottom [shrinkRate 0.05] [endShrink 0]] : glyph-proc
-		local shrink : shrinkRate * (df.rightSB - df.leftSB)
-		local endexpand : (-endShrink) * (df.rightSB - df.leftSB) || shrink / 2
-		include : HBar.t (df.leftSB - endexpand) (df.rightSB + endexpand) top BBS
-		include : BBBarLeft (df.leftSB + shrink) bottom top
-		include : BBBarRight (df.rightSB - shrink) bottom top
-
 	create-glyph 'grek/Pi' 0x3A0 : glyph-proc
 		include : MarkSet.capital
 		include : PiShape [DivFrame 1] CAP 0 (shrinkRate -- 0) (doSerif -- SLAB)
+
 	alias 'cyrl/Pe' 0x41F 'grek/Pi'
 
 	create-glyph 'grek/smcpPi' 0x1D28 : glyph-proc
 		include : MarkSet.e
 		include : PiShape [DivFrame 1] XH 0 (shrinkRate -- 0) (doSerif -- SLAB)
-
-	create-glyph 'mathbb/grek/Pi' 0x213F : glyph-proc
-		include : MarkSet.capital
-		include : MathBBPiShape [DivFrame 1] CAP 0 (shrinkRate -- 0)
 
 	create-glyph 'cyrl/pe.upright' : glyph-proc
 		include : MarkSet.e
@@ -67,10 +57,6 @@ glyph-block Letter-Greek-Pi : begin
 			include : PiShape df XH 0 (shrinkRate -- shrink) (doSerif -- slab) (tailed -- tail)
 
 	select-variant 'grek/pi' 0x3C0
-
-	create-glyph 'mathbb/grek/pi' 0x213C : glyph-proc
-		include : MarkSet.e
-		include : MathBBPiShape [DivFrame 1] XH 0 (shrinkRate -- 0.06)
 
 	define [CyrlPeHookShape df top] : glyph-proc
 		local xm : df.middle + [HSwToV : 0.5 * df.mvs]
@@ -102,3 +88,18 @@ glyph-block Letter-Greek-Pi : begin
 		define df : include : DivFrame para.diversityMM 3
 		include : df.markSet.p
 		include : CyrlPeHookShape df XH
+
+	define [MathBBPiShape] : with-params [df top bottom [shrinkRate 0.05] [endShrink 0]] : glyph-proc
+		local shrink : shrinkRate * (df.rightSB - df.leftSB)
+		local endexpand : (-endShrink) * (df.rightSB - df.leftSB) || shrink / 2
+		include : HBar.t (df.leftSB - endexpand) (df.rightSB + endexpand) top BBS
+		include : BBBarLeft (df.leftSB + shrink) bottom top
+		include : BBBarRight (df.rightSB - shrink) bottom top
+
+	create-glyph 'mathbb/grek/Pi' 0x213F : glyph-proc
+		include : MarkSet.capital
+		include : MathBBPiShape [DivFrame 1] CAP 0 (shrinkRate -- 0)
+
+	create-glyph 'mathbb/grek/pi' 0x213C : glyph-proc
+		include : MarkSet.e
+		include : MathBBPiShape [DivFrame 1] XH 0 (shrinkRate -- 0.06)

--- a/packages/font-glyphs/src/letter/greek/upper-gamma.ptl
+++ b/packages/font-glyphs/src/letter/greek/upper-gamma.ptl
@@ -1,6 +1,7 @@
 $$include '../../meta/macros.ptl'
 
 import [mix linreg clamp fallback] from "@iosevka/util"
+import [Point] from "@iosevka/geometry/point"
 import [MathSansSerif] from "@iosevka/glyph/relation"
 import [DesignParameters] from "../../meta/aesthetics.mjs"
 
@@ -9,7 +10,7 @@ glyph-module
 glyph-block Letter-Greek-Upper-Gamma: begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : CyrDescender MidHook
+	glyph-block-import Letter-Shared-Shapes : CyrDescender MidHook LegShape
 	glyph-block-import Letter-Shared-Shapes : LetterBarOverlay PalatalHook
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarLeft
 	glyph-block-import Letter-Latin-Upper-F : xMidBarShrink
@@ -23,8 +24,8 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 	define GammaBarLeft : SB * 1.5
 	define [GammaShape top bot slabType] : glyph-proc
 		include : LeaningAnchor.Below.VBar.l GammaBarLeft
-		include : VBar.l GammaBarLeft bot top
-		include : HBar.t (GammaBarLeft - O) (RightSB - OX) top
+		include : tagged 'strokeV' : VBar.l GammaBarLeft bot top
+		include : tagged 'strokeH' : HBar.t (GammaBarLeft - O) (RightSB - OX) top
 		match slabType
 			[Just SLAB-ALL] : begin
 				include : HSerif.lt GammaBarLeft top SideJut
@@ -95,13 +96,21 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 			eject-contour 'serifRT'
 			include : VBar.r (RightSB - OX) CAP (CAP + LongVJut - QuarterStroke) VJutStroke
 
-		create-glyph "cyrl/ge.\(suffix)" : glyph-proc
+		create-glyph "cyrl/ge.upright.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : ExtendAboveBaseAnchors (XH + LongVJut - QuarterStroke)
 			include : GammaShape XH 0 slabType
 			eject-contour 'serifRT'
 			include : VBar.r (RightSB - OX) XH (XH + LongVJut - QuarterStroke) VJutStroke
-			if para.isItalic : eject-contour 'serifLB'
+
+		create-glyph "cyrl/ge.italic.\(suffix)" : glyph-proc
+			include [refer-glyph "cyrl/ge.upright.\(suffix)"] AS_BASE ALSO_METRICS
+			eject-contour 'serifLB'
+			eject-contour 'strokeV'
+			include : LegShape
+				ztop -- [Point.fromXY Point.Type.Corner GammaBarLeft XH]
+				zbot -- [Point.fromXY Point.Type.Corner [mix SB 0 : if doST 1 0.75] 0]
+				xb   -- GammaBarLeft
 
 		create-glyph "cyrl/GheMidHook.\(suffix)" : glyph-proc
 			include [refer-glyph "grek/Gamma.\(suffix)"] AS_BASE ALSO_METRICS
@@ -135,9 +144,10 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 	select-variant 'cyrl/ghe.upright'
 	select-variant 'cyrl/gheDescender.upright' (follow -- 'cyrl/ghe.upright')
 	select-variant 'cyrl/gheDHook.upright' (follow -- 'cyrl/ghe.upright')
-	select-variant 'grek/smcpGamma' 0x1D26 (shapeFrom -- 'cyrl/ghe.upright') (follow -- 'grek/Gamma')
-	select-variant 'cyrl/ge' 0x491
+	select-variant 'cyrl/ge.upright' (follow -- 'cyrl/ge')
+	select-variant 'cyrl/ge.italic' (follow -- 'cyrl/ge')
 	select-variant 'cyrl/gheMidHook' 0x495 (follow -- 'cyrl/ghe.upright')
+	select-variant 'grek/smcpGamma' 0x1D26 (shapeFrom -- 'cyrl/ghe.upright') (follow -- 'grek/Gamma')
 
 	select-variant 'grek/Digamma' 0x3DC (follow -- 'grek/Gamma')
 


### PR DESCRIPTION
Using a leftward tail similar to `л`.
```
Чуєш їх, доцю, га?
Кумедна ж ти,
прощайся без ґольфів!
```

Sans Thin Upright:
![image](https://github.com/user-attachments/assets/868c4d5d-572a-4bfd-87dd-1bfe7fc7fa91)
Sans Thin Italic:
![image](https://github.com/user-attachments/assets/d9b4c4f3-f51f-4ec8-a5ed-b2d6758d0917)
Sans Regular Upright:
![image](https://github.com/user-attachments/assets/a8112f06-886f-42c1-a029-17a52a3ee9e9)
Sans Regular Italic:
![image](https://github.com/user-attachments/assets/563c6753-4c61-4714-8579-5c4bb0d97da6)
Sans Heavy Upright:
![image](https://github.com/user-attachments/assets/83dc25b4-4adc-453b-ac4b-cf4fdf73be2e)
Sans Heavy Italic:
![image](https://github.com/user-attachments/assets/dc6895f1-7bb2-4f52-8833-e6f7277cce0f)
Slab Thin Upright:
![image](https://github.com/user-attachments/assets/99cb643a-fb0c-430a-9cfa-3f734540dccc)
Slab Thin Italic:
![image](https://github.com/user-attachments/assets/f1b75fe4-d694-4973-b535-d6ab1e14471f)
Slab Regular Upright:
![image](https://github.com/user-attachments/assets/2cd34d68-14e9-40c5-ad74-89a9e9f8ed8e)
Slab Regular Italic:
![image](https://github.com/user-attachments/assets/4690bd33-aeba-4181-a23f-a53b0f8336c5)
Slab Heavy Upright:
![image](https://github.com/user-attachments/assets/605154d0-0fe9-41e1-9aa6-a4a77e0eaeb7)
Slab Heavy Italic:
![image](https://github.com/user-attachments/assets/f1ff26e5-805f-4c23-ab16-4edddbca31f3)
Compared to Source Serif:
Upright:
![image](https://github.com/user-attachments/assets/c8e84b0c-33b0-4a76-bf69-5baf92d2726d)
Italic:
![image](https://github.com/user-attachments/assets/a60b9b4f-6821-4c59-b7f7-91e39ee8e6e3)
Example on [Wikimedia](https://commons.wikimedia.org/wiki/File:Cyrillic_letter_Ghe_with_upturn.svg):
![image](https://github.com/user-attachments/assets/53a074d9-c633-4bcd-a7a6-ede6b107296d)
Handwritten form:
![image](https://github.com/user-attachments/assets/0fc2ade7-f731-43fc-9597-5fac02a79659)
The notch on the left of the handwritten form matches the style for `л`/`м`/`я`:
![image](https://github.com/user-attachments/assets/f40a7c76-8f11-46d5-b166-95816d38c78a)

Also improve serif behavior for `д` derived letters which do not use a dedicated italic form, such as `ᲁ`, to match `л`:
`дᲁлꙣꙥ`
Slab Thin Upright:
![image](https://github.com/user-attachments/assets/99ba1a4f-4d34-400c-a8ac-7fa003c508f8)
Slab Thin Italic:
![image](https://github.com/user-attachments/assets/e5ea9560-8b51-4189-a03f-467197a89b7e)
Slab Regular Upright:
![image](https://github.com/user-attachments/assets/b6d5cc3d-9c4d-4215-8eb1-f692f6eda77c)
Slab Regular Italic:
![image](https://github.com/user-attachments/assets/ddbf7f3e-c4d2-4a54-a744-3a06cfb20cdc)
Slab Heavy Upright:
![image](https://github.com/user-attachments/assets/87a18b75-77a8-4b08-96ac-b41172c78428)
Slab Heavy Italic:
![image](https://github.com/user-attachments/assets/a81721e3-1817-43fd-89ce-c5e5483f1306)

