### PR TITLE
Refine shape of Armenian Capital/Lower K'eh (`Ք`, `ք`).

### DIFF
--- a/changes/32.5.0.md
+++ b/changes/32.5.0.md
@@ -1,6 +1,10 @@
 * Add variant selector for decorative angle brackets (U+276C...U+2771) (#2603, #2623).
-* Refine shape of:
+* Refine shape of the following characters:
+  - GREEK PHI SYMBOL (`U+03D5`).
+  - CYRILLIC SMALL LETTER EF (`U+0444`).
+  - ARMENIAN CAPITAL LETTER KEH (`U+0554`).
   - ARMENIAN SMALL LETTER CA (`U+056E`).
+  - ARMENIAN SMALL LETTER KEH (`U+0584`).
   - VERTICAL ZIGZAG LINE (`U+299A`).
   - LEFT WIGGLY FENCE (`U+29D8`).
   - RIGHT WIGGLY FENCE (`U+29D9`).
@@ -9,7 +13,6 @@
   - HORIZONTAL RESISTOR SEGMENT (`U+1CC09`).
   - VERTICAL RESISTOR SEGMENT (`U+1CC0A`).
   - HORIZONTAL ZIGZAG LINE (`U+1CEB0`).
-* Optimize metrics for bowl of Cyrillic Lower Ef (`ф`) and Greek Small Letter Phi Symbol (`ϕ`).
 * Add italic form for Cyrillic Small Letter Ghe with Upturn (`ґ`).
 * Add characters:
   - ELECTRIC ARROW (`U+2301`).

--- a/packages/font-glyphs/src/letter/armenian/keh.ptl
+++ b/packages/font-glyphs/src/letter/armenian/keh.ptl
@@ -19,15 +19,23 @@ glyph-block Letter-Armenian-Keh : begin
 		create-glyph 'armn/Keh' 0x554 : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.capital
-			local bot : Math.max (XH - (CAP - XH)) (2.2 * df.mvs)
+			local ostroke : OverlayStroke * (df.mvs / Stroke)
+			local bot : CAP * HBarPos - df.mvs / 2
 			include : OBarLeft.roundedTop
-				top -- CAP
-				bot -- bot
-				left -- df.leftSB
+				top   -- CAP
+				bot   -- bot
+				left  -- df.leftSB
 				right -- df.rightSB
+				sw    -- df.mvs
+				fine  -- df.shoulderFine
+				ada   -- ArchDepthA
+				adb   -- ArchDepthB
 				yTerminal -- 0
-				sw -- df.mvs
-			include : HBar.m (df.leftSB - jut + [HSwToV : 0.5 * df.mvs]) (df.rightSB) [mix [if SLAB df.mvs 0] bot 0.5] df.mvs
+			include : HBar.m
+				df.leftSB - jut + [HSwToV : 0.5 * df.mvs]
+				df.rightSB + 0
+				mix [if SLAB df.mvs 0] bot 0.5
+				Math.min ostroke : 0.5 * (bot - [if SLAB df.mvs 0])
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df CAP 0
 				include sf.lb.full
@@ -35,16 +43,23 @@ glyph-block Letter-Armenian-Keh : begin
 		create-glyph 'armn/keh' 0x584 : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.p
-			local ostroke : df.adviceStroke 3.75
-			local bot : Math.max (0.1 * XH) (1 * ostroke)
+			local ostroke : OverlayStroke * (df.mvs / Stroke)
+			local bot : Math.max (0.1 * XH) (1.5 * ostroke)
 			include : OBarLeft.shape
+				top   -- XH
+				bot   -- bot
 				left  -- df.leftSB
 				right -- df.rightSB
-				bot   -- bot
 				sw    -- df.mvs
 				fine  -- df.shoulderFine
+				ada   -- SmallArchDepthA
+				adb   -- SmallArchDepthB
 			include : VBar.l df.leftSB Descender XH df.mvs
-			include : HCrossBar (df.leftSB - jut + [HSwToV : 0.5 * df.mvs]) df.rightSB 0 ostroke
+			include : HBar.b
+				df.leftSB - jut + [HSwToV : 0.5 * df.mvs]
+				df.rightSB + 0
+				XH - highBarPos
+				1 * ostroke
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH Descender
 				include : composite-proc sf.lt.outer sf.lb.fullSide


### PR DESCRIPTION
Much more subtle than my attempt from yesterday. Instead of completely changing the glyphs, this simply tweaks the bowl/bar height.
Sans Thin Upright:
![image](https://github.com/user-attachments/assets/b92961f4-c94e-453e-bfa0-7225ed1fe440)
Sans Regular Upright:
![image](https://github.com/user-attachments/assets/ef1ebdcb-71ef-4831-b3aa-2bc643fc8722)
Sans Heavy Upright:
![image](https://github.com/user-attachments/assets/4692d1dc-8804-4383-8af6-db0550922993)
Sans Thin Italic:
![image](https://github.com/user-attachments/assets/381072c0-0f9e-4706-a554-ffb230fa7771)
Sans Regular Italic:
![image](https://github.com/user-attachments/assets/99a24461-44a0-4ddb-8fec-110742f8f1dc)
Sans Heavy Italic:
![image](https://github.com/user-attachments/assets/d21bcdbe-5601-4390-a5e8-13c124c909a9)
Slab Thin Upright:
![image](https://github.com/user-attachments/assets/2687292f-4489-431f-abcf-c5cf571cf95b)
Slab Regular Upright:
![image](https://github.com/user-attachments/assets/67d0c4a0-d759-456c-b4cb-c2ac98350a09)
Slab Heavy Upright:
![image](https://github.com/user-attachments/assets/b3bc0fa1-4928-44ad-99c6-cc817a4a4601)
Slab Thin Italic:
![image](https://github.com/user-attachments/assets/3168befe-1a86-4ffd-85bc-b1d47e85b29d)
Slab Regular Italic:
![image](https://github.com/user-attachments/assets/46986b3a-8d57-4287-8bd1-646cab5c31e0)
Slab Heavy Italic:
![image](https://github.com/user-attachments/assets/07492bc1-59d7-499f-b5cb-2353514d4307)
