### PR TITLE
Optimize serifs of capital half/turned H (`Ⱶ`/`ⱶ`/`Ɥ`/`Ꟶ`/`ꟶ`).

### DIFF
--- a/packages/font-glyphs/src/letter/latin/upper-h.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-h.ptl
@@ -39,6 +39,42 @@ glyph-block Letter-Latin-Upper-H : begin
 			[Just SLAB-TAILED-CYRILLIC-BGR] : composite-proc sf.lt.outer sf.rt.inner sf.lb.full
 			[Just SLAB-SMALL-HETA] : NeedSlab SLAB : begin sf.lt.outer
 
+	define [LeftHalfSerifs slabType t b l r sw] : begin
+		local sf : SerifFrame t b l r (swRef -- [fallback sw Stroke])
+		return : match slabType
+			[Just SLAB-NONE] : glyph-proc
+			[Just SLAB-TOP-LEFT] : begin sf.lt.outer
+			[Just SLAB-TOP-LEFT-BOTTOM-RIGHT] : begin sf.lt.outer
+			[Just SLAB-TAILED-CYRILLIC] : composite-proc sf.lt.fullSide sf.lb.fullSide
+			[Just SLAB-ALL] : composite-proc sf.lt.fullSide sf.lb.fullSide
+			[Just SLAB-ALL-BGR] : composite-proc sf.lt.outer sf.lb.fullSide
+			[Just SLAB-TAILED-CYRILLIC-BGR] : composite-proc sf.lt.outer sf.lb.fullSide
+			[Just SLAB-SMALL-HETA] : NeedSlab SLAB : begin sf.lt.outer
+
+	define [RightHalfSerifs slabType t b l r sw] : begin
+		local sf : SerifFrame t b l r (swRef -- [fallback sw Stroke])
+		return : match slabType
+			[Just SLAB-NONE] : glyph-proc
+			[Just SLAB-TOP-LEFT] : glyph-proc
+			[Just SLAB-TOP-LEFT-BOTTOM-RIGHT] : begin sf.rb.outer
+			[Just SLAB-TAILED-CYRILLIC] : begin sf.rt.fullSide
+			[Just SLAB-ALL] : composite-proc sf.rt.fullSide sf.rb.fullSide
+			[Just SLAB-ALL-BGR] : composite-proc sf.rt.inner sf.rb.fullSide
+			[Just SLAB-TAILED-CYRILLIC-BGR] : begin sf.rt.inner
+			[Just SLAB-SMALL-HETA] : glyph-proc
+
+	define [TurnedSerifs slabType t b l r sw] : begin
+		local sf : SerifFrame t b l r (swRef -- [fallback sw Stroke])
+		return : match slabType
+			[Just SLAB-NONE] : glyph-proc
+			[Just SLAB-TOP-LEFT] : begin sf.lt.outer
+			[Just SLAB-TOP-LEFT-BOTTOM-RIGHT] : composite-proc sf.lt.outer sf.rb.outer
+			[Just SLAB-TAILED-CYRILLIC] : composite-proc sf.lt.full sf.rt.full
+			[Just SLAB-ALL] : composite-proc sf.lt.full sf.rt.full sf.rb.fullSide
+			[Just SLAB-ALL-BGR] : composite-proc sf.lt.outer sf.rt.inner sf.rb.fullSide
+			[Just SLAB-TAILED-CYRILLIC-BGR] : composite-proc sf.lt.outer sf.rt.inner
+			[Just SLAB-SMALL-HETA] : NeedSlab SLAB : begin sf.lt.outer
+
 	define [HShape l r top _sw] : glyph-proc
 		local sw : fallback _sw Stroke
 		include : tagged 'strokeL' : VBar.l l 0 top sw
@@ -139,8 +175,7 @@ glyph-block Letter-Latin-Upper-H : begin
 		create-glyph "HTurned.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : TurnedBody SB RightSB CAP
-			include : HSerifs slabType CAP 0 SB RightSB
-			eject-contour 'serifLB'
+			include : TurnedSerifs slabType CAP 0 SB RightSB
 
 		create-glyph "smcpH.\(suffix)" : glyph-proc
 			include : MarkSet.e
@@ -151,33 +186,25 @@ glyph-block Letter-Latin-Upper-H : begin
 			local df : include : DivFrame para.advanceScaleF
 			include : df.markSet.capital
 			include : LeftHalfBody df.leftSB df.rightSB CAP
-			include : HSerifs slabType CAP 0 df.leftSB df.rightSB
-			eject-contour 'serifRT'
-			eject-contour 'serifRB'
+			include : LeftHalfSerifs slabType CAP 0 df.leftSB df.rightSB
 
 		create-glyph "rightHalfH.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleF
 			include : df.markSet.capital
 			include : RightHalfBody df.leftSB df.rightSB CAP
-			include : HSerifs slabType CAP 0 df.leftSB df.rightSB
-			eject-contour 'serifLT'
-			eject-contour 'serifLB'
+			include : RightHalfSerifs slabType CAP 0 df.leftSB df.rightSB
 
 		create-glyph "leftHalfSmcpH.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleF
 			include : df.markSet.e
 			include : LeftHalfBody df.leftSB df.rightSB XH
-			include : HSerifs slabType XH 0 df.leftSB df.rightSB
-			eject-contour 'serifRT'
-			eject-contour 'serifRB'
+			include : LeftHalfSerifs slabType XH 0 df.leftSB df.rightSB
 
 		create-glyph "rightHalfSmcpH.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleF
 			include : df.markSet.e
 			include : RightHalfBody df.leftSB df.rightSB XH
-			include : HSerifs slabType XH 0 df.leftSB df.rightSB
-			eject-contour 'serifLT'
-			eject-contour 'serifLB'
+			include : RightHalfSerifs slabType XH 0 df.leftSB df.rightSB
 
 		define enGheDf : DivFrame para.advanceScaleM 3
 
@@ -276,7 +303,7 @@ glyph-block Letter-Latin-Upper-H : begin
 		local df : include : DivFrame para.advanceScaleF
 		include : df.markSet.e
 		include : LeftHalfBody df.leftSB df.rightSB XH
-		include : HSerifs SLAB-SMALL-HETA XH 0 df.leftSB df.rightSB
+		include : LeftHalfSerifs SLAB-SMALL-HETA XH 0 df.leftSB df.rightSB
 
 	derive-composites 'HDescender' 0x2C67 'H/descBase' [CyrDescender.rSideJut RightSB 0]
 


### PR DESCRIPTION
This uses `sf.`{`lt`|`rt`|`lb`|`rb`}`.fullSide` instead of `full` for better balancing of top/bottom serifs which are only present on one side, to match `Þ`/`F`/`ꜰ`/`Ч`/`ꟻ`/etc.

`FⱵꜰⱶЧꞍℲꟵⅎꟶ`

Slab Monospace Thin Before:
![image](https://github.com/user-attachments/assets/da2f3597-af78-4e91-8807-119af7a4d27c)
Slab Monospace Thin After:
![image](https://github.com/user-attachments/assets/3315da2a-14ef-4b47-9b28-1e0fc22c1118)
Slab Monospace Regular Before:
![image](https://github.com/user-attachments/assets/c0c2ec19-8c54-49ef-a474-94479c3d4449)
Slab Monospace Regular After:
![image](https://github.com/user-attachments/assets/bf969460-ce36-4e68-9f8a-2003d8a055fe)
Slab Monospace Heavy Before:
![image](https://github.com/user-attachments/assets/9706e134-88a9-4925-8126-43d9d95200dd)
Slab Monospace Heavy After:
![image](https://github.com/user-attachments/assets/9ff88895-39b8-4a05-ad70-93ef253cf658)
Etoile Thin Before:
![image](https://github.com/user-attachments/assets/b2dd4aeb-96bf-4dad-9605-d4a0ba678592)
Etoile Thin After:
![image](https://github.com/user-attachments/assets/ee436984-19db-4be2-aa7b-7c51111abb61)
Etoile Regular Before:
![image](https://github.com/user-attachments/assets/76e1770b-6b7a-4535-9500-f9212a0f7ec5)
Etoile Regular After:
![image](https://github.com/user-attachments/assets/8f9786d4-9ad6-447a-86d6-e45d74e59f18)
Etoile Heavy Before:
![image](https://github.com/user-attachments/assets/428d80c2-4620-4d7e-a7a7-cb04743aed83)
Etoile Heavy After:
![image](https://github.com/user-attachments/assets/acd09183-3d03-4753-8d56-2ce93f6daea5)
