### PR TITLE
Reorder variants of `capital-w` to match lower w.

### DIFF
--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1816,40 +1816,40 @@ selectorAffix.W = "curly"
 selectorAffix."W/sansSerif" = "curly"
 selectorAffix.WHookTop = "curly"
 
-[prime.capital-w.variants-buildup.stages.body.straight-flat-top]
-rank = 3
-descriptionAffix = "straight body shape that the middle is forced to be aligned the top"
-selectorAffix.W = "straightFlatTop"
-selectorAffix."W/sansSerif" = "straightFlatTop"
-selectorAffix.WHookTop = "straightFlatTop"
-
-[prime.capital-w.variants-buildup.stages.body.straight-double-v]
-rank = 4
-descriptionAffix = "body shape like double V"
-selectorAffix.W = "straightDoubleV"
-selectorAffix."W/sansSerif" = "straightDoubleV"
-selectorAffix.WHookTop = "straightDoubleV"
-
-[prime.capital-w.variants-buildup.stages.body.straight-asymmetric]
-rank = 5
-descriptionAffix = "asymmetric shape"
-selectorAffix.W = "straightAsymmetric"
-selectorAffix."W/sansSerif" = "straightAsymmetric"
-selectorAffix.WHookTop = "straightAsymmetric"
-
 [prime.capital-w.variants-buildup.stages.body.straight-vertical-sides]
-rank = 6
+rank = 3
 descriptionAffix = "straight body shape with vertical sides"
 selectorAffix.W = "straightVerticalSides"
 selectorAffix."W/sansSerif" = "straightVerticalSides"
 selectorAffix.WHookTop = "straightVerticalSides"
 
 [prime.capital-w.variants-buildup.stages.body.rounded-vertical-sides]
-rank = 7
+rank = 4
 descriptionAffix = "rounded body shape with vertical sides"
 selectorAffix.W = "roundedVerticalSides"
 selectorAffix."W/sansSerif" = "roundedVerticalSides"
 selectorAffix.WHookTop = "roundedVerticalSides"
+
+[prime.capital-w.variants-buildup.stages.body.straight-flat-top]
+rank = 5
+descriptionAffix = "straight body shape that the middle is forced to be aligned the top"
+selectorAffix.W = "straightFlatTop"
+selectorAffix."W/sansSerif" = "straightFlatTop"
+selectorAffix.WHookTop = "straightFlatTop"
+
+[prime.capital-w.variants-buildup.stages.body.straight-double-v]
+rank = 6
+descriptionAffix = "body shape like double V"
+selectorAffix.W = "straightDoubleV"
+selectorAffix."W/sansSerif" = "straightDoubleV"
+selectorAffix.WHookTop = "straightDoubleV"
+
+[prime.capital-w.variants-buildup.stages.body.straight-asymmetric]
+rank = 7
+descriptionAffix = "asymmetric shape"
+selectorAffix.W = "straightAsymmetric"
+selectorAffix."W/sansSerif" = "straightAsymmetric"
+selectorAffix.WHookTop = "straightAsymmetric"
 
 [prime.capital-w.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -6917,36 +6917,36 @@ rank = 1
 description = "Cyrillic Capital En (`Н`) without serifs"
 selector."cyrl/En" = "serifless"
 selector."cyrl/En/descBase" = "serifless"
-selector."cyrl/NjeKomi" = "serifless"
 selector."cyrl/Nje/leftHalf" = "serifless"
 selector."cyrl/Nje/leftHalf/reduced" = "serifless"
+selector."cyrl/NjeKomi" = "serifless"
 
 [prime.cyrl-capital-en.variants.top-left-serifed]
 rank = 2
 description = "Cyrillic Capital En (`Н`) with serif only at top left"
 selector."cyrl/En" = "topLeftSerifed"
 selector."cyrl/En/descBase" = "topLeftSerifed"
-selector."cyrl/NjeKomi" = "topLeftSerifed"
 selector."cyrl/Nje/leftHalf" = "topLeftSerifed"
 selector."cyrl/Nje/leftHalf/reduced" = "topLeftSerifed"
+selector."cyrl/NjeKomi" = "topLeftSerifed"
 
 [prime.cyrl-capital-en.variants.top-left-bottom-right-serifed]
 rank = 3
 description = "Cyrillic Capital En (`Н`) with serif only at top left and bottom right"
 selector."cyrl/En" = "topLeftBottomRightSerifed"
 selector."cyrl/En/descBase" = "topLeftSerifed"
-selector."cyrl/NjeKomi" = "topLeftSerifed"
 selector."cyrl/Nje/leftHalf" = "topLeftSerifed"
 selector."cyrl/Nje/leftHalf/reduced" = "topLeftSerifed"
+selector."cyrl/NjeKomi" = "topLeftSerifed"
 
 [prime.cyrl-capital-en.variants.serifed]
 rank = 4
 description = "Cyrillic Capital En (`Н`) with serifs"
 selector."cyrl/En" = "serifed"
 selector."cyrl/En/descBase" = "serifed"
-selector."cyrl/NjeKomi" = "serifedExceptBottomRight"
 selector."cyrl/Nje/leftHalf" = "serifed"
 selector."cyrl/Nje/leftHalf/reduced" = "serifedExceptBottomRight"
+selector."cyrl/NjeKomi" = "serifedExceptBottomRight"
 
 
 


### PR DESCRIPTION
My original placement of `rounded-vertical-sides` at the very end for `capital-w` was actually a side effect of placing it after `straight-vertical-sides` to match the order of lowercase, but the latter variant was already not in the same spot for the capital as it is for the lowercase.

This makes both capital and lower W follow the same variant order, with the obvious exception of the lowercase having cursive variants at the very end.

I had actually been waiting for a breaking change for an opportunity to do this.