### PR TITLE
Make f ligatures slightly wider under Quasi-Proportional.

### DIFF
--- a/changes/33.0.0.md
+++ b/changes/33.0.0.md
@@ -31,3 +31,5 @@
   - CYRILLIC CAPITAL LETTER HWE (`U+A694`).
   - LATIN CAPITAL LETTER REVERSED HALF H (`U+A7F5`).
   - LATIN SMALL LETTER REVERSED HALF H (`U+A7F6`).
+* Make certain characters slightly wider under Quasi-Proportional. Affected characters:
+  - LATIN SMALL LIGATURE FF (`U+FB00`) ... LATIN SMALL LIGATURE FFL (`U+FB04`).

--- a/packages/font-glyphs/src/auto-build/composite.ptl
+++ b/packages/font-glyphs/src/auto-build/composite.ptl
@@ -1618,7 +1618,7 @@ glyph-block Autobuild-Pnonetic-Ligatures : begin
 	define [ToLetter] : glyph-proc
 
 	define stdShrink : clamp 0.625 0.9 : StrokeWidthBlend 0.625 0.9
-	createPhoneticLigatures ToLetter 'phonetic1' 1 2 stdShrink 1 : list
+	createPhoneticLigatures ToLetter 'phonetic1' (para.advanceScaleF * para.advanceScaleMM) 2 stdShrink 1 : list
 		list 0xFB00  { 'f'               'f'                     } null
 		list 0xFB01  { 'f/compLigLeft1'  'dotlessi/compLigRight' } null
 		list 0xFB02  { 'f/compLigLeft2'  'l/compLigRight'        } null
@@ -1642,7 +1642,7 @@ glyph-block Autobuild-Pnonetic-Ligatures : begin
 		list 0xFB05  { 'longs/compLigLeft' 't/compLigRight'                 } null
 		list 0xFB06  { 's/compLigLeft'     't/compLigRight'                 } null
 
-	createPhoneticLigatures ToLetter 'phonetic3' para.advanceScaleMM 3 stdShrink 1 : list
+	createPhoneticLigatures ToLetter 'phonetic3' (para.advanceScaleF * [mix 1 para.advanceScaleMM 2]) 3 stdShrink 1 : list
 		list 0xFB03  { 'f/compLigLeft1' 'f/compLigLeft1' 'dotlessi/compLigRight' } null
 		list 0xFB04  { 'f/compLigLeft3' 'f/compLigLeft2' 'l/compLigRight'        } null
 


### PR DESCRIPTION
Rather than treating the widths as two to three `advanceScaleII`-width sub-characters adding up to one `1` or `advanceScaleMM` width composite character respectively, this instead calculates it the other way around, starting with `advanceScaleMM` or `[mix 1 advanceScaleMM 2]` and then multiplying it by `advanceScaleF`, which results in a more accurate approximation of two to three `advanceScaleF` characters, which, while effectively wider than before, also allows it to be sensitive to the different `f` metrics enforced by `quasi-proportional-extension-only`.

```
fﬀﬁﬃﬂﬄ
aﬀect affect
inﬁnite infinite
oﬃce office
inﬂect inflect
aﬄuent affluent
```

Aile Thin Before:
![image](https://github.com/user-attachments/assets/86c135e0-019e-4222-a315-f420db2bd731)
Aile Thin After:
![image](https://github.com/user-attachments/assets/e9bdcd6d-52af-4078-bb8d-e5d70412c161)
Aile Regular Before:
![image](https://github.com/user-attachments/assets/d2c2bd3f-510a-42ba-bdb9-c1a36468d30d)
Aile Regular After:
![image](https://github.com/user-attachments/assets/848d296d-931b-43b8-9d0e-3ab2cc07001d)
Aile Heavy Before:
![image](https://github.com/user-attachments/assets/ab079fc8-e7ea-41f0-9323-b715817c0411)
Aile Heavy After:
![image](https://github.com/user-attachments/assets/aa3e55e0-ab7e-4372-b57a-96f4b144a9c3)
Etoile Thin Before:
![image](https://github.com/user-attachments/assets/209aec71-1a65-4b12-8278-424fdc7e6030)
Etoile Thin After:
![image](https://github.com/user-attachments/assets/f0ac2f4a-a9ab-49cd-af5b-fc2f1feee899)
Etoile Regular Before:
![image](https://github.com/user-attachments/assets/fbfefecc-f3fd-450e-bd69-01e602cbd568)
Etoile Regular After:
![image](https://github.com/user-attachments/assets/20a76161-c7b6-4c2a-979b-7383f2ba29bc)
Etoile Heavy Before:
![image](https://github.com/user-attachments/assets/91dcd88c-9bd4-46c0-b3a3-02200bd05913)
Etoile Heavy After:
![image](https://github.com/user-attachments/assets/60b80f29-e96d-4ddf-97f5-c84bec49a5d2)
