### PR TITLE
Add Latin Small Letter Script R (`U+AB4B`).

### DIFF
--- a/changes/33.0.0.md
+++ b/changes/33.0.0.md
@@ -33,3 +33,6 @@
   - LATIN SMALL LETTER REVERSED HALF H (`U+A7F6`).
 * Make certain characters slightly wider under Quasi-Proportional. Affected characters:
   - LATIN SMALL LIGATURE FF (`U+FB00`) ... LATIN SMALL LIGATURE FFL (`U+FB04`).
+* Add Characters:
+  - LATIN SMALL LETTER SCRIPT R (`U+AB4B`).
+  - LATIN SMALL LETTER SCRIPT R WITH RING (`U+AB4C`).

--- a/packages/font-glyphs/src/letter/latin-ext/script-r.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/script-r.ptl
@@ -1,0 +1,68 @@
+$$include '../../meta/macros.ptl'
+
+import [mix linreg clamp fallback] from "@iosevka/util"
+
+glyph-module
+
+glyph-block Letter-Latin-Script-R : begin
+	glyph-block-import CommonShapes
+	glyph-block-import Common-Derivatives
+	glyph-block-import Mark-Adjustment : LeaningAnchor
+	glyph-block-import Letter-Shared-Shapes : RightwardTailedBar
+
+	define [xBarRight df] : df.width - df.leftSB * 1.5
+
+	define [ScriptRShape top left right fTailed sw] : glyph-proc
+		include : tagged 'strokeR' : if fTailed
+			RightwardTailedBar right 0 (top - 0.5 * sw) (sw -- sw)
+			VBar.r right 0 (top - 0.5 * sw) sw
+		include : dispiro
+			widths.rhs sw
+			g4      left             (top - O) [heading Rightward]
+			g4 [mix left right 0.5]  (top + O)
+			g4           right       (top - O) [heading Rightward]
+		if SLAB : begin
+			include : VSerif.dl left (top - 0.5 * sw) (VJut - 0.5 * sw) (VJutStroke * (sw / Stroke))
+			if [not fTailed] : include : if para.isItalic [HSerif.rb right 0 SideJut] : composite-proc
+				HSerif.rb (right - [HSwToV : 0.5 * sw]) 0 Jut
+				HSerif.lb (right - [HSwToV : 0.5 * sw]) 0 MidJutSide
+
+	define ScriptRConfig : object
+		standard  false
+		tailed    true
+
+	foreach { suffix doTail } [pairs-of ScriptRConfig] : do
+		create-glyph "rScript.\(suffix)" : glyph-proc
+			local df : include : DivFrame 1
+			include : df.markSet.e
+			include : ScriptRShape XH SB [xBarRight df] doTail df.mvs
+			include : LeaningAnchor.Below.VBar.r [xBarRight df]
+
+	select-variant 'rScript' 0xAB4B (follow -- 'cyrl/che')
+
+	create-glyph 'rScriptBowl' 0xAB4C : glyph-proc
+		local df : include : DivFrame para.advanceScaleM
+		include : df.markSet.e
+		local subDf : DivFrame (0.75 * para.advanceScaleM) 2
+
+		include : ScriptRShape XH SB [xBarRight subDf] true subDf.mvs
+		eject-contour 'strokeR'
+
+		local swBowl : [AdviceStroke 2.75] * (subDf.mvs / Stroke)
+		local fineBowl : ShoulderFine * (swBowl / Stroke)
+
+		local yBar : 0.5 * XH + 0.5 * swBowl
+
+		local ada : ArchDepthAOf ArchDepth : df.rightSB - [xBarRight subDf] + [HSwToV swBowl] + SB * 2
+		local adb : ArchDepthBOf ArchDepth : df.rightSB - [xBarRight subDf] + [HSwToV swBowl] + SB * 2
+
+		include : dispiro
+			flat ([xBarRight subDf] - [HSwToV subDf.mvs]) (XH - 0.5 * subDf.mvs) [widths.lhs.heading subDf.mvs Downward]
+			curl ([xBarRight subDf] - [HSwToV subDf.mvs]) [YSmoothMidL yBar 0 ada adb]
+			arch.lhs 0 (sw -- subDf.mvs) (swAfter -- swBowl)
+			g4 (df.rightSB - OX) [YSmoothMidR yBar 0 ada adb]
+			arch.lhs yBar (sw -- swBowl) (swAfter -- fineBowl)
+			g4.down.end ([xBarRight subDf] - [HSwToV fineBowl]) [YSmoothMidL yBar 0 ada adb] [widths.lhs.heading fineBowl Downward]
+
+		include : LeaningAnchor.Above.VBar.m subDf.middle
+		include : LeaningAnchor.Below.VBar.m [mix ([xBarRight subDf] - [HSwToV subDf.mvs]) df.rightSB 0.5]

--- a/packages/font-glyphs/src/letter/latin-ext/script-r.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/script-r.ptl
@@ -35,7 +35,7 @@ glyph-block Letter-Latin-Script-R : begin
 		create-glyph "rScript.\(suffix)" : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.e
-			include : ScriptRShape XH SB [xBarRight df] doTail df.mvs
+			include : ScriptRShape XH df.leftSB [xBarRight df] doTail df.mvs
 			include : LeaningAnchor.Below.VBar.r [xBarRight df]
 
 	select-variant 'rScript' 0xAB4B (follow -- 'cyrl/che')
@@ -53,8 +53,8 @@ glyph-block Letter-Latin-Script-R : begin
 
 		local yBar : 0.5 * XH + 0.5 * swBowl
 
-		local ada : ArchDepthAOf ArchDepth : df.rightSB - [xBarRight subDf] + [HSwToV swBowl] + SB * 2
-		local adb : ArchDepthBOf ArchDepth : df.rightSB - [xBarRight subDf] + [HSwToV swBowl] + SB * 2
+		local ada : ArchDepthAOf ArchDepth : df.rightSB - ([xBarRight subDf] - [HSwToV subDf.mvs]) + SB * 2
+		local adb : ArchDepthBOf ArchDepth : df.rightSB - ([xBarRight subDf] - [HSwToV subDf.mvs]) + SB * 2
 
 		include : dispiro
 			flat ([xBarRight subDf] - [HSwToV subDf.mvs]) (XH - 0.5 * subDf.mvs) [widths.lhs.heading subDf.mvs Downward]

--- a/packages/font-glyphs/src/letter/latin.ptl
+++ b/packages/font-glyphs/src/letter/latin.ptl
@@ -68,6 +68,7 @@ export : define [apply] : begin
 	run-glyph-module "./latin-ext/rams-horn.mjs"
 	run-glyph-module "./latin-ext/rhotic.mjs"
 	run-glyph-module "./latin-ext/sakha-yat.mjs"
+	run-glyph-module "./latin-ext/script-r.mjs"
 	run-glyph-module "./latin-ext/thorn.mjs"
 	run-glyph-module "./latin-ext/upper-ae-oe.mjs"
 	run-glyph-module "./latin-ext/upper-aa-ao.mjs"


### PR DESCRIPTION
This uses the pre-[L2/L2024/24243](https://www.unicode.org/L2/L2024/24243-latin-script-r-glyphs.pdf) (i.e. pre-17.0.0 Unicode) glyphs because these characters have more applications (phonetic or otherwise) than just the ones in the contexts of which they proposed the glyph changes based on. The example glyphs in Unicode 16.0.0 (i.e. the current version) and prior I feel are more usage-agnostic than the future turned-2 forms.

`ч ꭋꭌ ъ`

Sans Monospace Thin Upright:
![image](https://github.com/user-attachments/assets/41eae268-1d90-4931-829d-2423e2974f94)
Sans Monospace Regular Upright:
![image](https://github.com/user-attachments/assets/98c8e143-405e-402e-82c6-337f18a7c830)
Sans Monospace Heavy Upright:
![image](https://github.com/user-attachments/assets/5f80093a-1e84-4e06-aaa6-ea28f18e61e0)
Sans Monospace Thin Italic:
![image](https://github.com/user-attachments/assets/51e20288-8fe2-4c99-9d2f-3bff84e42076)
Sans Monospace Regular Italic:
![image](https://github.com/user-attachments/assets/0a456852-21e5-4dad-a527-2571c712b086)
Sans Monospace Heavy Italic:
![image](https://github.com/user-attachments/assets/67d4da76-02b6-4e58-81df-94668d02c84a)
Slab Monospace Thin Upright:
![image](https://github.com/user-attachments/assets/8addf27d-85e2-4018-9c1d-2c9ff064bd0e)
Slab Monospace Regular Upright:
![image](https://github.com/user-attachments/assets/43f2e8b7-c915-47b1-89bf-a78af491b075)
Slab Monospace Heavy Upright:
![image](https://github.com/user-attachments/assets/ed8f9d22-838e-49fb-a096-c768ecf2e112)
Slab Monospace Thin Italic:
![image](https://github.com/user-attachments/assets/58a8ecd0-0328-4ca9-823e-cfc4e5ecd840)
Slab Monospace Regular Italic:
![image](https://github.com/user-attachments/assets/5a49e645-71d1-4648-a97f-8be71522f573)
Slab Monospace Heavy Italic:
![image](https://github.com/user-attachments/assets/07c12e8c-b0c4-465a-80e1-024944166624)
Aile Thin Upright:
![image](https://github.com/user-attachments/assets/374dc985-24e0-4dfb-88ff-e3b40ba4474b)
Aile Regular Upright:
![image](https://github.com/user-attachments/assets/b3c7d181-4f39-4601-aaae-833ae149a80f)
Aile Heavy Upright:
![image](https://github.com/user-attachments/assets/15c8dbcf-e226-40c0-a32a-f99ce87066af)
Aile Thin Italic:
![image](https://github.com/user-attachments/assets/95250242-569b-4052-b267-b46974542e2a)
Aile Regular Italic:
![image](https://github.com/user-attachments/assets/fcdad25a-6091-4f8c-87ab-8888e540f7cb)
Aile Heavy Italic:
![image](https://github.com/user-attachments/assets/19c6655b-c733-4576-9770-dafba35de240)
Etoile Thin Upright:
![image](https://github.com/user-attachments/assets/e44a705e-1ea0-4b62-b641-9ed6ccb583ba)
Etoile Regular Upright:
![image](https://github.com/user-attachments/assets/60b89fdf-6ff5-40af-abf1-e7f0cebc3a55)
Etoile Heavy Upright:
![image](https://github.com/user-attachments/assets/370cdead-7bcd-40c8-8df1-a0db9bba1b1a)
Etoile Thin Italic:
![image](https://github.com/user-attachments/assets/1fd699b1-8c1c-40b4-ad7b-f56f70165866)
Etoile Regular Italic:
![image](https://github.com/user-attachments/assets/2c3fc446-6ffa-40c1-bb7d-91e5c5e24206)
Etoile Heavy Italic:
![image](https://github.com/user-attachments/assets/330b36d4-4a8d-433a-a42f-c6cd62a0115c)

With `font-feature-settings:'cv94'2;`:

Sans Monospace Upright:
![image](https://github.com/user-attachments/assets/d066d78d-925a-4f0f-92f2-205621326dfa)
Sans Monospace Italic:
![image](https://github.com/user-attachments/assets/916fe602-e4fb-4847-bdf4-4963d8206fd3)
Slab Monospace Upright:
![image](https://github.com/user-attachments/assets/cf71894d-bd64-4253-97ee-25604a87cc4b)
Slab Monospace Italic:
![image](https://github.com/user-attachments/assets/f00ca00c-d974-4304-9b52-ab4157a0d599)
Aile Upright:
![image](https://github.com/user-attachments/assets/d418b641-f235-43b9-988f-e230d3520535)
Aile Italic:
![image](https://github.com/user-attachments/assets/d53257e4-55c1-400a-be74-bc27f3b5b88c)
Etoile Upright:
![image](https://github.com/user-attachments/assets/e1c0e3ee-8494-4b81-b9d8-cdabef474333)
Etoile Italic:
![image](https://github.com/user-attachments/assets/2b36e3ed-dccf-4e3e-b345-8d2feaa923bb)
