### PR TITLE
Cleanup/Optimize glyph shape of Latin Small Letter Script R (`U+AB4B`).

### DIFF
--- a/packages/font-glyphs/src/letter/latin-ext/script-r.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/script-r.ptl
@@ -15,7 +15,7 @@ glyph-block Letter-Latin-Script-R : begin
 	define [ScriptRShape top left right fTailed sw] : glyph-proc
 		include : tagged 'strokeR' : if fTailed
 			RightwardTailedBar right 0 (top - 0.5 * sw) (sw -- sw)
-			VBar.r right 0 (top - 0.5 * sw) sw
+			VBar.r             right 0 (top - 0.5 * sw) sw
 		include : dispiro
 			widths.rhs sw
 			g4      left             (top - O) [heading Rightward]
@@ -48,19 +48,19 @@ glyph-block Letter-Latin-Script-R : begin
 		include : ScriptRShape XH SB [xBarRight subDf] true subDf.mvs
 		eject-contour 'strokeR'
 
-		local swBowl : [AdviceStroke 2.75] * (subDf.mvs / Stroke)
+		local swBowl : [AdviceStroke 3] * (subDf.mvs / Stroke)
 		local fineBowl : ShoulderFine * (swBowl / Stroke)
 
 		local yBar : 0.5 * XH + 0.5 * swBowl
 
-		local ada : ArchDepthAOf ArchDepth : df.rightSB - ([xBarRight subDf] - [HSwToV subDf.mvs]) + SB * 2
-		local adb : ArchDepthBOf ArchDepth : df.rightSB - ([xBarRight subDf] - [HSwToV subDf.mvs]) + SB * 2
+		local ada : ArchDepthAOf SmallArchDepth : df.rightSB - ([xBarRight subDf] - [HSwToV subDf.mvs]) + SB * 2
+		local adb : ArchDepthBOf SmallArchDepth : df.rightSB - ([xBarRight subDf] - [HSwToV subDf.mvs]) + SB * 2
 
 		include : dispiro
 			flat ([xBarRight subDf] - [HSwToV subDf.mvs]) (XH - 0.5 * subDf.mvs) [widths.lhs.heading subDf.mvs Downward]
 			curl ([xBarRight subDf] - [HSwToV subDf.mvs]) [YSmoothMidL yBar 0 ada adb]
 			arch.lhs 0 (sw -- subDf.mvs) (swAfter -- swBowl)
-			g4 (df.rightSB - OX) [YSmoothMidR yBar 0 ada adb]
+			g4 (df.rightSB - OX) [YSmoothMidR yBar 0 ada adb] [widths.lhs swBowl]
 			arch.lhs yBar (sw -- swBowl) (swAfter -- fineBowl)
 			g4.down.end ([xBarRight subDf] - [HSwToV fineBowl]) [YSmoothMidL yBar 0 ada adb] [widths.lhs.heading fineBowl Downward]
 

--- a/packages/font-glyphs/src/letter/latin-ext/script-r.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/script-r.ptl
@@ -53,8 +53,8 @@ glyph-block Letter-Latin-Script-R : begin
 
 		local yBar : 0.5 * XH + 0.5 * swBowl
 
-		local ada : ArchDepthAOf SmallArchDepth : df.rightSB - ([xBarRight subDf] - [HSwToV subDf.mvs]) + SB * 2
-		local adb : ArchDepthBOf SmallArchDepth : df.rightSB - ([xBarRight subDf] - [HSwToV subDf.mvs]) + SB * 2
+		local ada : ArchDepthAOf SmallArchDepth : df.width - ([xBarRight subDf] - subDf.leftSB) + [HSwToV subDf.mvs]
+		local adb : ArchDepthBOf SmallArchDepth : df.width - ([xBarRight subDf] - subDf.leftSB) + [HSwToV subDf.mvs]
 
 		include : dispiro
 			flat ([xBarRight subDf] - [HSwToV subDf.mvs]) (XH - 0.5 * subDf.mvs) [widths.lhs.heading subDf.mvs Downward]

--- a/packages/font-glyphs/src/letter/latin-ext/script-r.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/script-r.ptl
@@ -16,16 +16,16 @@ glyph-block Letter-Latin-Script-R : begin
 		include : tagged 'strokeR' : if fTailed
 			RightwardTailedBar right 0 (top - 0.5 * sw) (sw -- sw)
 			VBar.r             right 0 (top - 0.5 * sw) sw
-		include : dispiro
-			widths.rhs sw
-			g4      left             (top - O) [heading Rightward]
-			g4 [mix left right 0.5]  (top + O)
-			g4           right       (top - O) [heading Rightward]
-		if SLAB : begin
-			include : VSerif.dl left (top - 0.5 * sw) (VJut - 0.5 * sw) (VJutStroke * (sw / Stroke))
-			if [not fTailed] : include : if para.isItalic [HSerif.rb right 0 SideJut] : composite-proc
-				HSerif.rb (right - [HSwToV : 0.5 * sw]) 0 Jut
-				HSerif.lb (right - [HSwToV : 0.5 * sw]) 0 MidJutSide
+		include : union
+			VBar.l left (top - VJut) (top - 0.5 * sw) (VJutStroke * (sw / Stroke))
+			dispiro
+				widths.rhs sw
+				g4      left             (top - O) [heading Rightward]
+				g4 [mix left right 0.5]  (top + O)
+				g4           right       (top - O) [heading Rightward]
+		if (SLAB && !fTailed) : include : if para.isItalic [HSerif.rb right 0 SideJut] : composite-proc
+			HSerif.rb (right - [HSwToV : 0.5 * sw]) 0 Jut
+			HSerif.lb (right - [HSwToV : 0.5 * sw]) 0 MidJutSide
 
 	define ScriptRConfig : object
 		standard  false


### PR DESCRIPTION
This optimizes the stroke width of the bowl part of `ꭌ` and also treats the top-left "protrusion" of both letters as a permanent orthographic feature of the base letter, functioning more like a tooth (like in `b`) or like a descender (like in `д`/`ґ`) than like a serif as it was previously handled in  #2679 . This is because it counterintuitively corresponds to the _left bar_ of `r` in handwriting when going from left to right.

`ч ꭋꭌ ъ`

Sans Monospace Thin Upright:
![image](https://github.com/user-attachments/assets/1a2cacbb-0c56-46eb-bc63-fedb3722512d)
Sans Monospace Regular Upright:
![image](https://github.com/user-attachments/assets/f0797699-0d4f-4258-a433-f528be0c6c65)
Sans Monospace Heavy Upright:
![image](https://github.com/user-attachments/assets/247f3239-2d00-4099-8daf-33970180bf08)
Sans Monospace Thin Italic:
![image](https://github.com/user-attachments/assets/dd811640-1cd5-45fc-ba03-c19a71b99c91)
Sans Monospace Regular Italic:
![image](https://github.com/user-attachments/assets/e603bf5f-f381-4eca-90a6-33cb5fead87f)
Sans Monospace Heavy Italic:
![image](https://github.com/user-attachments/assets/ae5e4bfb-fa05-4492-a429-868ac985d4ce)
Slab Monospace Thin Upright:
![image](https://github.com/user-attachments/assets/8dbc810b-3062-4bd7-a519-5d3c10283877)
Slab Monospace Regular Upright:
![image](https://github.com/user-attachments/assets/20f032bd-7c70-48e2-971c-a24859ff613a)
Slab Monospace Heavy Upright:
![image](https://github.com/user-attachments/assets/a6a0fc38-ea81-406a-95c8-5523b43870ff)
Slab Monospace Thin Italic:
![image](https://github.com/user-attachments/assets/1d6d3eec-da44-458e-8b75-12363af555c0)
Slab Monospace Regular Italic:
![image](https://github.com/user-attachments/assets/addc744a-b3e5-48c7-8968-6ad3941aecec)
Slab Monospace Heavy Italic:
![image](https://github.com/user-attachments/assets/d0bb069b-6788-4129-89a4-9246a7cb342a)
Aile Thin Upright:
![image](https://github.com/user-attachments/assets/f97d0261-5380-4cf5-9b71-e64d2aba8d1c)
Aile Regular Upright:
![image](https://github.com/user-attachments/assets/361171eb-0a44-423e-a7a1-fe57a0887cb4)
Aile Heavy Upright:
![image](https://github.com/user-attachments/assets/cf9203f0-6936-494a-ac85-e19fb9b34c43)
Aile Thin Italic:
![image](https://github.com/user-attachments/assets/a4c8d4ab-25a7-483e-818f-8a339fc32548)
Aile Regular Italic:
![image](https://github.com/user-attachments/assets/096ed06d-959a-4566-aafb-22993404a571)
Aile Heavy Italic:
![image](https://github.com/user-attachments/assets/23c45053-6692-4347-8180-8022427c75c0)
Etoile Thin Upright:
![image](https://github.com/user-attachments/assets/739e2f1f-401f-47ad-89b9-09946a7e1853)
Etoile Regular Upright:
![image](https://github.com/user-attachments/assets/a784e14d-d3d7-45e7-9c03-43cb2e12e741)
Etoile Heavy Upright:
![image](https://github.com/user-attachments/assets/432a4f55-3b79-432c-9373-e99a20faf740)
Etoile Thin Italic:
![image](https://github.com/user-attachments/assets/ee22f63b-e7a9-485a-959f-3bb224eea41a)
Etoile Regular Italic:
![image](https://github.com/user-attachments/assets/2c37ab36-a68b-4e22-8543-eff28fc47b5e)
Etoile Heavy Italic:
![image](https://github.com/user-attachments/assets/546eec51-fb0d-4867-8a10-680cadb8afe8)
