### PR TITLE
Optimize serif behavior of `Ꜷ`/`ꜷ`/`խ` under monospace.

### DIFF
--- a/packages/font-glyphs/src/letter/armenian/lower-u-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/lower-u-group.ptl
@@ -158,9 +158,9 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 				local sf : SerifFrame.fromDf df Ascender Descender
 				local sf2 : SerifFrame.fromDf df XH 0
 				include : composite-proc sf.lt.outer sf.lb.fullSide
-				if ([not para.isItalic] && sf2.enoughSpaceForFullSerifs)
-					include : composite-proc sf2.rt.inner sf2.rb.outer
+				if para.isItalic
 					include sf2.rb.outer
+					include : composite-proc sf2.rt.inner sf2.rb.outer
 
 	do "Ken"
 		create-glyph 'armn/ken' 0x56F : glyph-proc

--- a/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
@@ -11,7 +11,6 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared : CreateTurnedLetter
 	glyph-block-import Letter-Shared-Shapes : OBarLeft
-	glyph-block-import Letter-Latin-Lower-M : MEnoughSpaceForFullSerifs
 
 	glyph-block-export SubDfAndShift
 	define [SubDfAndShift pShift df _o] : begin

--- a/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
@@ -156,7 +156,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 				include : df.markSet.e
 				set-base-anchor 'cvDecompose' 0 0
 				include : Base subDf XH df.mvs
-				include : Slabs subDf XH
+				include : Slabs subDf XH df.mvs
 
 				eject-contour 'strokeR'
 				eject-contour 'serifRT'
@@ -168,7 +168,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 				include : difference
 					Base subDf XH df.mvs
 					intersection [MaskLeft subDf.middle] [MaskAbove (XH - subDf.smallArchDepthB)]
-				include : Slabs subDf XH
+				include : Slabs subDf XH df.mvs
 				include : ApparentTranslate shift 0
 				eject-contour 'serifLT'
 
@@ -278,7 +278,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 			define [LhaRightLetterShape df top bot turn tension] : glyph-proc
 				local stroke1f : if (stroke1 == 3) 4 stroke1
 				local lf : XLetterForm df top bot stroke1f stroke2 turn tension
-					sw -- df.mvs
+					sw             -- df.mvs
 					swCursiveEnd   -- [AdviceStroke 3 df.adws]
 					swCursiveCoEnd -- df.mvs
 					swCursiveMid   -- df.mvs
@@ -411,7 +411,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 	select-variant "ae/e" (follow -- 'e')
 	select-variant "aeInvE/right" (follow -- 'e')
 	select-variant "ue/u"
-	select-variant "au/u" (follow -- [conditional-follow [MEnoughSpaceForFullSerifs] 'au/u/full' 'au/u/reduced'])
+	select-variant "au/u"
 	select-variant "oeOpenO/left" (follow -- 'c')
 	select-variant "cyrl/ae/a" (shapeFrom -- 'ae/a')
 	select-variant "cyrl/yae/left"

--- a/packages/font-glyphs/src/letter/latin-ext/upper-aa-ao.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/upper-aa-ao.ptl
@@ -9,7 +9,6 @@ glyph-block Letter-Latin-Upper-AA-AO : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Latin-Lower-AE-OE : SubDfAndShift
-	glyph-block-import Letter-Latin-Lower-M : MEnoughSpaceForFullSerifs
 
 	do "A glyphs"
 		glyph-block-import Letter-Latin-Upper-A : AShape AConfig

--- a/packages/font-glyphs/src/letter/latin-ext/upper-aa-ao.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/upper-aa-ao.ptl
@@ -114,9 +114,9 @@ glyph-block Letter-Latin-Upper-AA-AO : begin
 				define df : DivFrame para.advanceScaleMM 3.5
 				local { subDf shift } : SubDfAndShift 1 df
 				include : with-transform [ApparentTranslate shift 0]
-					union [Base subDf CAP df.mvs] [Slabs subDf CAP]
+					union [Base subDf CAP df.mvs] [Slabs subDf CAP df.mvs]
 
-		select-variant "AU/Right" (follow -- [conditional-follow [MEnoughSpaceForFullSerifs] 'AU/U/full' 'AU/U/reduced'])
+		select-variant "AU/Right" (follow -- 'AU/U')
 
 	do "AU"
 		select-variant 'AA/AU/Left' (follow -- 'A')

--- a/packages/font-glyphs/src/letter/latin/lower-n.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-n.ptl
@@ -207,9 +207,7 @@ glyph-block Letter-Latin-Lower-N : begin
 				straight.down.start RightSB y2 [widths.rhs.heading sw Downward]
 				CurlyTail.f fine 0 m2 x2 (swBefore -- sw)
 			if sLT : include : sLT [DivFrame 1] XH
-			if sLB : include : if (m2 - (SB + [HSwToV HalfStroke] + Jut) > 0.01 * Width)
-				NBottomLeftSerif      [DivFrame 1] 0
-				NBottomLeftOuterSerif [DivFrame 1] 0
+			if sLB : include : sLB [DivFrame 1] 0
 
 		if (!tailed) : create-glyph "engCrossedTail.\(suffix)" : glyph-proc
 			include : MarkSet.p

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -128,9 +128,8 @@ glyph-block Letter-Latin-U : begin
 			include : UTopRightSerif df top _sw
 
 		export : define [BilateralMotion df top _sw] : glyph-proc
-			local sw : fallback _sw Stroke
-			include : HSerif.lt df.leftSB top (Jut - [HSwToV : 0.5 * sw]) sw
-			include : HSerif.rt df.rightSB top (Jut - [HSwToV : 0.5 * sw]) sw
+			local sf : SerifFrame.fromDf df top 0 (swSerif -- [fallback _sw Stroke])
+			include : composite-proc sf.lt.outer sf.rt.outer
 
 		export : define [SmallToothless df top _sw] : glyph-proc
 			include : UTopLeftSerif df top _sw

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -97,17 +97,20 @@ glyph-block Letter-Latin-U : begin
 	define UUpper : UShapeGroup ArchDepthA ArchDepthB
 	define ULower : UShapeGroup SmallArchDepthA SmallArchDepthB
 
-	define [UTopLeftSerif df yTop _sw] : tagged 'serifLT'
-		HSerif.lt df.leftSB yTop SideJut _sw
+	define [UTopLeftSerif df yTop _sw] : begin
+		local sw : fallback _sw Stroke
+		return : tagged 'serifLT' : HSerif.lt df.leftSB yTop (Jut - [HSwToV : 0.5 * sw]) sw
 
-	define [UTopRightSerif df yTop _sw] : tagged 'serifRT'
-		HSerif.lt (df.rightSB - [HSwToV Stroke]) yTop SideJut _sw
+	define [UTopRightSerif df yTop _sw] : begin
+		local sw : fallback _sw Stroke
+		return : tagged 'serifRT' : HSerif.lt (df.rightSB - [HSwToV sw]) yTop (Jut - [HSwToV : 0.5 * sw]) sw
 
 	define [UBottomRightSerif df yTop _sw] : glyph-proc
-		include : tagged 'serifRB' : HSerif.rb df.rightSB 0 SideJut _sw
+		local sw : fallback _sw Stroke
+		include : tagged 'serifRB' : HSerif.rb df.rightSB 0 (Jut - [HSwToV : 0.5 * sw]) sw
 		define trAnchor currentGlyph.baseAnchors.trailing
 		if trAnchor : begin
-			set-base-anchor 'trailing' (trAnchor.x + SideJut) trAnchor.y
+			set-base-anchor 'trailing' (trAnchor.x + Jut - [HSwToV : 0.5 * sw]) trAnchor.y
 
 	glyph-block-export USerifs
 	define USerifs : namespace
@@ -125,8 +128,9 @@ glyph-block Letter-Latin-U : begin
 			include : UTopRightSerif df top _sw
 
 		export : define [BilateralMotion df top _sw] : glyph-proc
-			include : HSerif.lt df.leftSB top SideJut _sw
-			include : HSerif.rt df.rightSB top SideJut _sw
+			local sw : fallback _sw Stroke
+			include : HSerif.lt df.leftSB top (Jut - [HSwToV : 0.5 * sw]) sw
+			include : HSerif.rt df.rightSB top (Jut - [HSwToV : 0.5 * sw]) sw
 
 		export : define [SmallToothless df top _sw] : glyph-proc
 			include : UTopLeftSerif df top _sw

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -98,15 +98,15 @@ glyph-block Letter-Latin-U : begin
 	define ULower : UShapeGroup SmallArchDepthA SmallArchDepthB
 
 	define [UTopLeftSerif df yTop _sw] : begin
-		local sf : SerifFrame.fromDf df yTop 0 (swSerif -- [fallback _sw Stroke])
+		local sf : SerifFrame.fromDf df yTop 0 (swSerif -- _sw)
 		return sf.lt.outer
 
 	define [UTopRightSerif df yTop _sw] : begin
-		local sf : SerifFrame.fromDf df yTop 0 (swSerif -- [fallback _sw Stroke])
+		local sf : SerifFrame.fromDf df yTop 0 (swSerif -- _sw)
 		return sf.rt.inner
 
 	define [UBottomRightSerif df yTop _sw] : glyph-proc
-		local sf : SerifFrame.fromDf df yTop 0 (swSerif -- [fallback _sw Stroke])
+		local sf : SerifFrame.fromDf df yTop 0 (swSerif -- _sw)
 		include sf.rb.outer
 		define trAnchor currentGlyph.baseAnchors.trailing
 		if trAnchor : begin
@@ -127,9 +127,9 @@ glyph-block Letter-Latin-U : begin
 			include : UTopLeftSerif df top _sw
 			include : UTopRightSerif df top _sw
 
-		export : define [BilateralMotion df top _sw] : glyph-proc
-			local sf : SerifFrame.fromDf df top 0 (swSerif -- [fallback _sw Stroke])
-			include : composite-proc sf.lt.outer sf.rt.outer
+		export : define [BilateralMotion df top _sw] : begin
+			local sf : SerifFrame.fromDf df top 0 (swSerif -- _sw)
+			return : composite-proc sf.lt.outer sf.rt.outer
 
 		export : define [SmallToothless df top _sw] : glyph-proc
 			include : UTopLeftSerif df top _sw

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -98,19 +98,19 @@ glyph-block Letter-Latin-U : begin
 	define ULower : UShapeGroup SmallArchDepthA SmallArchDepthB
 
 	define [UTopLeftSerif df yTop _sw] : begin
-		local sw : fallback _sw Stroke
-		return : tagged 'serifLT' : HSerif.lt df.leftSB yTop (Jut - [HSwToV : 0.5 * sw]) sw
+		local sf : SerifFrame.fromDf df yTop 0 (swSerif -- [fallback _sw Stroke])
+		return sf.lt.outer
 
 	define [UTopRightSerif df yTop _sw] : begin
-		local sw : fallback _sw Stroke
-		return : tagged 'serifRT' : HSerif.lt (df.rightSB - [HSwToV sw]) yTop (Jut - [HSwToV : 0.5 * sw]) sw
+		local sf : SerifFrame.fromDf df yTop 0 (swSerif -- [fallback _sw Stroke])
+		return sf.rt.inner
 
 	define [UBottomRightSerif df yTop _sw] : glyph-proc
-		local sw : fallback _sw Stroke
-		include : tagged 'serifRB' : HSerif.rb df.rightSB 0 (Jut - [HSwToV : 0.5 * sw]) sw
+		local sf : SerifFrame.fromDf df yTop 0 (swSerif -- [fallback _sw Stroke])
+		include sf.rb.outer
 		define trAnchor currentGlyph.baseAnchors.trailing
 		if trAnchor : begin
-			set-base-anchor 'trailing' (trAnchor.x + Jut - [HSwToV : 0.5 * sw]) trAnchor.y
+			set-base-anchor 'trailing' (trAnchor.x + sf.sideJut) trAnchor.y
 
 	glyph-block-export USerifs
 	define USerifs : namespace

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1655,32 +1655,28 @@ rank = 1
 descriptionAffix = "toothed shape"
 selectorAffix.U = "toothed"
 selectorAffix."U/sansSerif" = "toothed"
-selectorAffix."AU/U/full" = "toothed"
-selectorAffix."AU/U/reduced" = "toothed"
+selectorAffix."AU/U" = "toothed"
 
 [prime.capital-u.variants-buildup.stages.body.tailed]
 rank = 2
 descriptionAffix = "tailed shape"
 selectorAffix.U = "tailed"
 selectorAffix."U/sansSerif" = "tailed"
-selectorAffix."AU/U/full" = "tailed"
-selectorAffix."AU/U/reduced" = "tailed"
+selectorAffix."AU/U" = "tailed"
 
 [prime.capital-u.variants-buildup.stages.body.toothless-corner]
 rank = 3
 descriptionAffix = "toothless (corner bottom-right) shape"
 selectorAffix.U = "toothlessCorner"
 selectorAffix."U/sansSerif" = "toothlessCorner"
-selectorAffix."AU/U/full" = "toothlessCorner"
-selectorAffix."AU/U/reduced" = "toothlessCorner"
+selectorAffix."AU/U" = "toothlessCorner"
 
 [prime.capital-u.variants-buildup.stages.body.toothless-rounded]
 rank = 4
 descriptionAffix = "toothless (rounded) shape"
 selectorAffix.U = "toothlessRounded"
 selectorAffix."U/sansSerif" = "toothlessRounded"
-selectorAffix."AU/U/full" = "toothlessRounded"
-selectorAffix."AU/U/reduced" = "toothlessRounded"
+selectorAffix."AU/U" = "toothlessRounded"
 
 [prime.capital-u.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -1688,8 +1684,7 @@ descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix.U = "serifless"
 selectorAffix."U/sansSerif" = "serifless"
-selectorAffix."AU/U/full" = "serifless"
-selectorAffix."AU/U/reduced" = "serifless"
+selectorAffix."AU/U" = "serifless"
 
 [prime.capital-u.variants-buildup.stages.serifs.bottom-right-serifed]
 rank = 2
@@ -1697,8 +1692,7 @@ disableIf = [{ body = "NOT toothed" }]
 descriptionAffix = "serif at bottom-right"
 selectorAffix.U = "bottomRightSerifed"
 selectorAffix."U/sansSerif" = "serifless"
-selectorAffix."AU/U/full" = "bottomRightSerifed"
-selectorAffix."AU/U/reduced" = "bottomRightSerifed"
+selectorAffix."AU/U" = "bottomRightSerifed"
 
 [prime.capital-u.variants-buildup.stages.serifs.motion-serifed]
 rank = 3
@@ -1706,8 +1700,7 @@ disableIf = [{ body = "toothless-corner" }, { body = "toothless-rounded" }]
 descriptionAffix = "motion serifs at top-left and bottom-right"
 selectorAffix.U = "unilateralMotionSerifed"
 selectorAffix."U/sansSerif" = "serifless"
-selectorAffix."AU/U/full" = { if = [{ body = "toothed" }], then = "bottomRightSerifed", else = "serifless" }
-selectorAffix."AU/U/reduced" = { if = [{ body = "toothed" }], then = "bottomRightSerifed", else = "serifless" }
+selectorAffix."AU/U" = { if = [{ body = "toothed" }], then = "bottomRightSerifed", else = "serifless" }
 
 [prime.capital-u.variants-buildup.stages.serifs.unilateral-motion-serifed]
 rank = 4
@@ -1715,8 +1708,7 @@ disableIf = [{ body = "toothed" }, { body = "tailed" }]
 descriptionAffix = "motion serifs at left side"
 selectorAffix.U = "unilateralMotionSerifed"
 selectorAffix."U/sansSerif" = "serifless"
-selectorAffix."AU/U/full" = "serifless"
-selectorAffix."AU/U/reduced" = "serifless"
+selectorAffix."AU/U" = "serifless"
 
 [prime.capital-u.variants-buildup.stages.serifs.bilateral-motion-serifed]
 rank = 5
@@ -1724,16 +1716,14 @@ disableIf = [{ body = "toothed" }, { body = "tailed" }]
 descriptionAffix = "motion serifs at both sides"
 selectorAffix.U = "bilateralMotionSerifed"
 selectorAffix."U/sansSerif" = "serifless"
-selectorAffix."AU/U/full" = "bilateralMotionSerifed"
-selectorAffix."AU/U/reduced" = "bilateralMotionSerifed"
+selectorAffix."AU/U" = "bilateralMotionSerifed"
 
 [prime.capital-u.variants-buildup.stages.serifs.serifed]
 rank = 6
 descriptionAffix = "serifs"
 selectorAffix.U = "serifed"
 selectorAffix."U/sansSerif" = "serifless"
-selectorAffix."AU/U/full" = "serifed"
-selectorAffix."AU/U/reduced" = { if = [{ body = "toothed" }], then = "bottomRightSerifed", else = { if = [{ body = "tailed" }], then = "serifless", else = "bilateralMotionSerifed" } }
+selectorAffix."AU/U" = "serifed"
 
 
 
@@ -4446,8 +4436,7 @@ selectorAffix."cyrl/dzhe.italic" = "toothed"
 selectorAffix."cyrl/tse.italic" = "toothed"
 selectorAffix."cyrl/tseRev.italic" = "toothed"
 selectorAffix."ue/u" = "toothed"
-selectorAffix."au/u/full" = "toothed"
-selectorAffix."au/u/reduced" = "toothed"
+selectorAffix."au/u" = "toothed"
 
 [prime.u.variants-buildup.stages.body.tailed]
 rank = 2
@@ -4474,8 +4463,7 @@ selectorAffix."cyrl/dzhe.italic" = "tailed"
 selectorAffix."cyrl/tse.italic" = "toothed"
 selectorAffix."cyrl/tseRev.italic" = "tailed"
 selectorAffix."ue/u" = "toothed"
-selectorAffix."au/u/full" = "tailed"
-selectorAffix."au/u/reduced" = "tailed"
+selectorAffix."au/u" = "tailed"
 
 [prime.u.variants-buildup.stages.body.toothless-corner]
 rank = 3
@@ -4502,8 +4490,7 @@ selectorAffix."cyrl/dzhe.italic" = "toothed"
 selectorAffix."cyrl/tse.italic" = "toothed"
 selectorAffix."cyrl/tseRev.italic" = "toothed"
 selectorAffix."ue/u" = "toothed"
-selectorAffix."au/u/full" = "toothlessCorner"
-selectorAffix."au/u/reduced" = "toothlessCorner"
+selectorAffix."au/u" = "toothlessCorner"
 
 [prime.u.variants-buildup.stages.body.toothless-rounded]
 rank = 4
@@ -4530,8 +4517,7 @@ selectorAffix."cyrl/dzhe.italic" = "toothed"
 selectorAffix."cyrl/tse.italic" = "toothed"
 selectorAffix."cyrl/tseRev.italic" = "toothed"
 selectorAffix."ue/u" = "toothed"
-selectorAffix."au/u/full" = "toothlessRounded"
-selectorAffix."au/u/reduced" = "toothlessRounded"
+selectorAffix."au/u" = "toothlessRounded"
 
 [prime.u.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -4559,8 +4545,7 @@ selectorAffix."cyrl/dzhe.italic" = "serifless"
 selectorAffix."cyrl/tse.italic" = "serifless"
 selectorAffix."cyrl/tseRev.italic" = "serifless"
 selectorAffix."ue/u" = "serifless"
-selectorAffix."au/u/full" = "serifless"
-selectorAffix."au/u/reduced" = "serifless"
+selectorAffix."au/u" = "serifless"
 
 [prime.u.variants-buildup.stages.serifs.bottom-right-serifed]
 rank = 2
@@ -4588,8 +4573,7 @@ selectorAffix."cyrl/dzhe.italic" = "bottomRightSerifed"
 selectorAffix."cyrl/tse.italic" = "serifless"
 selectorAffix."cyrl/tseRev.italic" = "bottomRightSerifed"
 selectorAffix."ue/u" = "serifless"
-selectorAffix."au/u/full" = "bottomRightSerifed"
-selectorAffix."au/u/reduced" = "bottomRightSerifed"
+selectorAffix."au/u" = "bottomRightSerifed"
 
 [prime.u.variants-buildup.stages.serifs.motion-serifed]
 rank = 3
@@ -4616,8 +4600,7 @@ selectorAffix."cyrl/dzhe.italic" = "motionSerifed"
 selectorAffix."cyrl/tse.italic" = "motionSerifed"
 selectorAffix."cyrl/tseRev.italic" = "motionSerifed"
 selectorAffix."ue/u" = "serifed"
-selectorAffix."au/u/full" = {if = [{body = "toothed"}], then = "bottomRightSerifed", else = "serifless"}
-selectorAffix."au/u/reduced" = {if = [{body = "toothed"}], then = "bottomRightSerifed", else = "serifless"}
+selectorAffix."au/u" = {if = [{body = "toothed"}], then = "bottomRightSerifed", else = "serifless"}
 
 [prime.u.variants-buildup.stages.serifs.serifed]
 rank = 4
@@ -4644,8 +4627,7 @@ selectorAffix."cyrl/dzhe.italic" = "serifed"
 selectorAffix."cyrl/tse.italic" = "serifed"
 selectorAffix."cyrl/tseRev.italic" = "serifed"
 selectorAffix."ue/u" = "serifed"
-selectorAffix."au/u/full" = "serifed"
-selectorAffix."au/u/reduced" = {if = [{body = "toothed"}], then = "bottomRightSerifed", else = "serifless"}
+selectorAffix."au/u" = "serifed"
 
 
 


### PR DESCRIPTION
Basically, these three characters have more space for their top-right serif than `Ɯ`/`ɯ`/`ա` as each one of the three affected characters has its left component character "pull away" from the middle via an arch depth or similar, yielding enough room for the serif.

`UꜶuꜷխ`

Slab Thin Upright Before:
![image](https://github.com/user-attachments/assets/dac6876b-bafa-4be1-ad03-2015c3ed0510)
Slab Thin Upright After:
![image](https://github.com/user-attachments/assets/c71cae37-9e6e-4c6c-a4d3-6c000490e7fb)
Slab Regular Upright Before:
![image](https://github.com/user-attachments/assets/be44f3b6-4777-455d-85d5-302fbfa8346b)
Slab Regular Upright After:
![image](https://github.com/user-attachments/assets/124e4ef6-a1cd-4a10-aab7-a74d30abb1d2)
Slab Heavy Upright Before:
![image](https://github.com/user-attachments/assets/d761a010-dfac-437c-9571-46f996e86c6e)
Slab Heavy Upright After:
![image](https://github.com/user-attachments/assets/c35d173b-b552-4d98-97e7-ea4f231483cb)
Slab Thin Italic Before:
![image](https://github.com/user-attachments/assets/6de7f901-bf9c-481b-908a-970776c82a18)
Slab Thin Italic After:
![image](https://github.com/user-attachments/assets/f3a42960-7d47-4974-9a2c-0ca95eb270d4)
Slab Regular Italic Before:
![image](https://github.com/user-attachments/assets/66e76b77-12f7-457f-b4f7-fc0e9ab8c8ae)
Slab Regular Italic After:
![image](https://github.com/user-attachments/assets/33a30d02-bae7-462b-b4d1-be06c88bbdb6)
Slab Heavy Italic Before:
![image](https://github.com/user-attachments/assets/116c61fb-a849-48fa-ac10-2673506af83f)
Slab Heavy Italic After:
![image](https://github.com/user-attachments/assets/88763b11-5136-4104-92a3-37d4d26251b9)
