### PR TITLE
Add symmetric/asymmetric variants for Capital Thorn.

### DIFF
--- a/changes/33.0.0.md
+++ b/changes/33.0.0.md
@@ -2,6 +2,7 @@
   - Slightly narrower by default
   - Adjustable via metric override
 * \[**Breaking**\] Reordered variants for `W`, `a`, `b`, `g`, `q`, `w`, `α`, Cyrillic `а`, Cyrillic `ф`, and `$`.
+* \[**Breaking**\] Add variants for Capital Thorn (`Þ`) with symmetric/asymmetric bowl position.
 * Refine shape of the following characters:
   - GREEK CAPITAL LETTER HETA (`U+0370`).
   - GREEK SMALL LETTER HETA (`U+0371`).

--- a/packages/font-glyphs/src/letter/latin-ext/thorn.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/thorn.ptl
@@ -1,6 +1,6 @@
 $$include '../../meta/macros.ptl'
 
-import [mix linreg clamp fallback] from "@iosevka/util"
+import [mix linreg clamp fallback SuffixCfg] from "@iosevka/util"
 
 glyph-module
 
@@ -13,16 +13,13 @@ glyph-block Letter-Latin-Thorn : begin
 
 	define xThornLeftStroke : SB * 1.25
 
-	define [yThornBowlBot top slab] : top * 0.25 + [if slab (Stroke * 0.125) 0]
-	define [yThornBowlTop top slab] : top - 0.7 * [yThornBowlBot top slab] + [if slab (-0.125) 0.25] * Stroke
+	define [yThornBowlAsymmetricBot top slab] : top * 0.25 + [if slab (Stroke * 0.125) 0]
+	define [yThornBowlAsymmetricTop top slab] : top - 0.7 * [yThornBowlAsymmetricBot top slab] + [if slab (-0.125) 0.25] * Stroke
 
-	define [yShoBowlBot top slab] : mix [yThornBowlBot top slab] (top - [yThornBowlTop top slab]) 0.5
-	define [yShoBowlTop top slab] : top - [yShoBowlBot top slab]
+	define [yThornBowlSymmetricBot top slab] : mix [yThornBowlAsymmetricBot top slab] (top - [yThornBowlAsymmetricTop top slab]) 0.5
+	define [yThornBowlSymmetricTop top slab] : top - [yThornBowlSymmetricBot top slab]
 
-	define [ThornShape top slabTop slabBot _yBowlBot _yBowlTop] : glyph-proc
-		local yBowlBot : fallback _yBowlBot [yThornBowlBot top slabBot]
-		local yBowlTop : fallback _yBowlTop [yThornBowlTop top slabBot]
-
+	define [ThornShapeImpl top slabTop slabBot yBowlBot yBowlTop] : glyph-proc
 		local turn : mix yBowlTop yBowlBot (ArchDepthB / (ArchDepthA + ArchDepthB))
 		local turnRadius : (yBowlTop - yBowlBot) / 2
 
@@ -43,45 +40,54 @@ glyph-block Letter-Latin-Thorn : begin
 				then : include : composite-proc sf.lt.fullSide sf.lb.fullSide
 				else : include   sf.lt.outer
 
-	define [GrekShoShapeImpl top slabTop slabBot] : ThornShape top slabTop slabBot
-		yShoBowlBot top slabBot
-		yShoBowlTop top slabBot
+		include : LeaningAnchor.Above.VBar.l xThornLeftStroke
+		include : LeaningAnchor.Below.VBar.l xThornLeftStroke
 
-	define ThornConfig : object
-		serifless     { false false }
-		motionSerifed { true  false }
-		serifed       { true  true  }
+	define [ThornAsymmetricShape top slabTop slabBot] : ThornShapeImpl top slabTop slabBot
+		yThornBowlAsymmetricBot top slabBot
+		yThornBowlAsymmetricTop top slabBot
 
-	foreach { suffix { st sb } } [Object.entries ThornConfig] : do
+	define [ThornSymmetricShape top slabTop slabBot] : ThornShapeImpl top slabTop slabBot
+		yThornBowlSymmetricBot top slabBot
+		yThornBowlSymmetricTop top slabBot
+
+	define ThornConfig : SuffixCfg.weave
+		object # symmetry
+			""            ThornSymmetricShape
+			asymmetric    ThornAsymmetricShape
+		object # serifs
+			serifless     { false false }
+			motionSerifed { true  false }
+			serifed       { true  true  }
+
+	foreach { suffix { Body { doST doSB } } } [Object.entries ThornConfig] : do
 		create-glyph "Thorn.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : ThornShape CAP st sb
-			include : LeaningAnchor.Above.VBar.l xThornLeftStroke
-			include : LeaningAnchor.Below.VBar.l xThornLeftStroke
+			include : Body CAP doST doSB
 
-		create-glyph "ThornStroke.\(suffix)" : glyph-proc
-			include : MarkSet.capital
-			include : ThornShape CAP st sb (CAP - [yThornBowlTop CAP sb]) (CAP - [yThornBowlBot CAP st])
-			include : LeaningAnchor.Above.VBar.l xThornLeftStroke
-			include : LeaningAnchor.Below.VBar.l xThornLeftStroke
-			include : LetterBarOverlay.l.in
-				x   -- xThornLeftStroke
-				top -- (CAP - [if st Stroke 0])
-				bot -- (CAP - [yThornBowlBot CAP st])
+		if (Body !== ThornAsymmetricShape) : begin
+			create-glyph "ThornStroke.\(suffix)" : glyph-proc
+				include : MarkSet.capital
+				include : ThornShapeImpl CAP doST doSB
+					CAP - [yThornBowlAsymmetricTop CAP doSB]
+					CAP - [yThornBowlAsymmetricBot CAP doST]
+				include : LetterBarOverlay.l.in
+					x   -- xThornLeftStroke
+					top -- (CAP - [if doST Stroke 0])
+					bot -- (CAP - [yThornBowlAsymmetricBot CAP doST])
 
-		create-glyph "ThornStrokeBottom.\(suffix)" : glyph-proc
-			include [refer-glyph "Thorn.\(suffix)"] AS_BASE ALSO_METRICS
-			include : LetterBarOverlay.l.in
-				x   -- xThornLeftStroke
-				bot -- (0 + [if sb Stroke 0])
-				top -- (0 + [yThornBowlBot CAP sb])
+		if (Body === ThornAsymmetricShape) : begin
+			create-glyph "ThornStrokeBottom.\(suffix)" : glyph-proc
+				include [refer-glyph "Thorn.\(suffix)"] AS_BASE ALSO_METRICS
+				include : LetterBarOverlay.l.in
+					x   -- xThornLeftStroke
+					bot -- (0 + [if doSB Stroke 0])
+					top -- (0 + [yThornBowlAsymmetricBot CAP doSB])
 
 	select-variant 'Thorn' 0xDE
-	select-variant 'ThornStroke' 0xA764 (follow -- 'Thorn')
-	select-variant 'ThornStrokeBottom' 0xA766 (follow -- 'Thorn')
+	select-variant 'ThornStroke' 0xA764
+	select-variant 'ThornStrokeBottom' 0xA766
 
 	create-glyph 'grek/Sho' 0x3F7 : glyph-proc
 		include : MarkSet.capital
-		include : GrekShoShapeImpl CAP SLAB SLAB
-		include : LeaningAnchor.Above.VBar.l xThornLeftStroke
-		include : LeaningAnchor.Below.VBar.l xThornLeftStroke
+		include : ThornSymmetricShape CAP SLAB SLAB

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -5373,7 +5373,7 @@ selectorAffix.eszet = "tailed"
 
 [prime.eszet.variants-buildup.stages.serifs.serifless]
 rank = 1
-desceiptioAffix = "serifs"
+descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix.eszet = "serifless"
 
@@ -5430,26 +5430,56 @@ selector."eth" = "curly-bar"
 
 [prime.capital-thorn]
 sampler = "Þ"
-samplerExplain = "Capital Thorn (`Þ`)"
+samplerExplain = "Capital Thorn"
 tagKind = "letter"
 
-[prime.capital-thorn.variants.serifless]
+[prime.capital-thorn.variants-buildup]
+entry = "symmetry"
+descriptionLeader = "Capital Thorn (`Þ`)"
+
+[prime.capital-thorn.variants-buildup.stages.symmetry."*"]
+next = "serifs"
+
+[prime.capital-thorn.variants-buildup.stages.symmetry.symmetric]
 rank = 1
-description = "Capital Thorn (`Þ`) without serifs"
-selector.Thorn = "serifless"
-selector.Wynn = "serifless"
+keyAffix = ""
+selectorAffix.Thorn = ""
+selectorAffix.ThornStroke = ""
+selectorAffix.ThornStrokeBottom = "asymmetric"
+selectorAffix.Wynn = ""
 
-[prime.capital-thorn.variants.motion-serifed]
+[prime.capital-thorn.variants-buildup.stages.symmetry.asymmetric]
 rank = 2
-description = "Capital Thorn (`Þ`) with motion serifs"
-selector.Thorn = "motionSerifed"
-selector.Wynn = "motionSerifed"
+descriptionAffix = "asymmetric shape"
+selectorAffix.Thorn = "asymmetric"
+selectorAffix.ThornStroke = ""
+selectorAffix.ThornStrokeBottom = "asymmetric"
+selectorAffix.Wynn = ""
 
-[prime.capital-thorn.variants.serifed]
+[prime.capital-thorn.variants-buildup.stages.serifs.serifless]
+rank = 1
+descriptionAffix = "serifs"
+descriptionJoiner = "without"
+selectorAffix.Thorn = "serifless"
+selectorAffix.ThornStroke = "serifless"
+selectorAffix.ThornStrokeBottom = "serifless"
+selectorAffix.Wynn = "serifless"
+
+[prime.capital-thorn.variants-buildup.stages.serifs.motion-serifed]
+rank = 2
+descriptionAffix = "motion serifs"
+selectorAffix.Thorn = "motionSerifed"
+selectorAffix.ThornStroke = "motionSerifed"
+selectorAffix.ThornStrokeBottom = "motionSerifed"
+selectorAffix.Wynn = "motionSerifed"
+
+[prime.capital-thorn.variants-buildup.stages.serifs.serifed]
 rank = 3
-description = "Capital Thorn (`Þ`) with serifs"
-selector.Thorn = "serifed"
-selector.Wynn = "serifed"
+descriptionAffix = "serifs"
+selectorAffix.Thorn = "serifed"
+selectorAffix.ThornStroke = "serifed"
+selectorAffix.ThornStrokeBottom = "serifed"
+selectorAffix.Wynn = "serifed"
 
 
 
@@ -10687,6 +10717,7 @@ y = "straight-turn-serifless"
 capital-eszet = "rounded-serifless"
 long-s = "bent-hook-middle-serifed"
 eszet = "longs-s-lig-middle-serifed"
+capital-thorn = "asymmetric-serifless"
 lower-thorn = "motion-serifed"
 capital-gamma = "serifed"
 lower-iota = "serifed-semi-tailed"
@@ -10748,6 +10779,7 @@ z = "straight-serifed"
 capital-eszet = "rounded-serifed"
 long-s = "bent-hook-double-serifed"
 eszet = "longs-s-lig-dual-serifed"
+capital-thorn = "asymmetric-serifed"
 lower-thorn = "serifed"
 lower-mu = "toothed-serifed"
 cyrl-a = "double-storey-hook-inward-serifed-serifed"


### PR DESCRIPTION
Basically restoring the symmetric shape used before #1854 , and reallocating the asymmetric shape as a variant, used by SS16 in particular.

```
ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ
abc.def.ghi.jkl.mno.pqrs.tuv.wxyz
!iIlL17|¦ ¢coO08BDQ $5SZ2zs ∂96µm
float il1[]={1-2/3.4,5+6=7/8%90};
1234567890 ,._-+= >< «¯-¬_» ~–÷+×
{*}[]()<>`+-=$/#_%^@\&|~?'" !,.;:
G6Qg9q¶ Þẞðþſß ΓΔΛαβγδιλμνξπτυφχψ
ЖЗКНРУЭЯавжзклмнруфчьыэя <= != ==
```

Comparison to most fonts each stylistic set is based on:
<details>
<summary>Preview</summary>

Andale Mono:
![image](https://github.com/user-attachments/assets/e2d0a3d3-174e-4a99-b038-a940ace3d98f)
Anonymous Pro:
![image](https://github.com/user-attachments/assets/63c79f0d-a26c-4831-a091-09f9a5ec9c9f)
Consolas:
![image](https://github.com/user-attachments/assets/d763acb6-c498-4e1b-b684-edba1f46d57c)
DejaVu Sans Mono:
![image](https://github.com/user-attachments/assets/436485d6-c1e9-4a94-89bb-596974db8e02)
Fira Mono:
![image](https://github.com/user-attachments/assets/e76d1727-d820-46c6-b7f2-26b303b90a99)
Liberation Mono:
![image](https://github.com/user-attachments/assets/a52fac7f-791b-42e8-b03f-20d1c31c6299)
Monaco:
![image](https://github.com/user-attachments/assets/c37f41b5-4705-40eb-856a-d5e2775216c8)
PragmataPro:
![image](https://github.com/user-attachments/assets/73888e5c-a6b6-4cd5-a0e8-59bcd43da008)
Source Code Pro:
![image](https://github.com/user-attachments/assets/528484b4-2896-4486-9cab-002cbb48d56b)
Envy Code R:
![image](https://github.com/user-attachments/assets/e497954b-b5d9-44d3-86c6-5ea767fa5184)
Ubuntu Mono:
![image](https://github.com/user-attachments/assets/1c83cc85-ae5b-41d0-8d29-07ff09d28f97)
Lucida Console:
![image](https://github.com/user-attachments/assets/df390e11-f71b-44a2-a16a-81f21cc2db7c)
Jetbrains Mono:
![image](https://github.com/user-attachments/assets/d4d30c14-e744-43d8-bd05-475f940ca853)
IBM Plex Mono:
![image](https://github.com/user-attachments/assets/12c32be2-8187-48be-bc8b-6e4400eea6fd)

</details>

-----

Default Sans Upright:
![image](https://github.com/user-attachments/assets/2da009ab-557f-415f-8cea-95aa175ae4b9)
Default Sans Italic:
![image](https://github.com/user-attachments/assets/ef84cfd9-5eee-4d90-a346-174de1c42ea6)
Default Slab Upright:
![image](https://github.com/user-attachments/assets/8edfc967-7894-4a4c-9b93-f710ff231353)
Default Slab Italic:
![image](https://github.com/user-attachments/assets/b0753922-f4f3-4dc3-ad24-51e94080383c)

-----

SS16 Sans Upright:
![image](https://github.com/user-attachments/assets/44f3683f-7292-4453-b01c-72962e4b2d86)
SS16 Sans Italic:
![image](https://github.com/user-attachments/assets/4b2d408f-5e9f-4b50-a77e-c93af3226b69)
Compared to PT Mono:
![image](https://github.com/user-attachments/assets/6da74330-d78d-4b41-9056-81d4f90099a9)