### PR TITLE
Cleanup of #2684 .

### DIFF
--- a/packages/font-glyphs/src/letter/latin-ext/thorn.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/thorn.ptl
@@ -13,11 +13,11 @@ glyph-block Letter-Latin-Thorn : begin
 
 	define xThornLeftStroke : SB * 1.25
 
+	define [yThornBowlSymmetricBot top slab] : top * 0.19 + [if slab (Stroke * 0.375) 0]
+	define [yThornBowlSymmetricTop top slab] : top - [yThornBowlSymmetricBot top slab]
+
 	define [yThornBowlAsymmetricBot top slab] : top * 0.25 + [if slab (Stroke * 0.125) 0]
 	define [yThornBowlAsymmetricTop top slab] : top - 0.7 * [yThornBowlAsymmetricBot top slab] + [if slab (-0.125) 0.25] * Stroke
-
-	define [yThornBowlSymmetricBot top slab] : mix [yThornBowlAsymmetricBot top slab] (top - [yThornBowlAsymmetricTop top slab]) 0.5
-	define [yThornBowlSymmetricTop top slab] : top - [yThornBowlSymmetricBot top slab]
 
 	define [ThornShapeImpl top slabTop slabBot yBowlBot yBowlTop] : glyph-proc
 		local turn : mix yBowlTop yBowlBot (ArchDepthB / (ArchDepthA + ArchDepthB))
@@ -43,13 +43,13 @@ glyph-block Letter-Latin-Thorn : begin
 		include : LeaningAnchor.Above.VBar.l xThornLeftStroke
 		include : LeaningAnchor.Below.VBar.l xThornLeftStroke
 
-	define [ThornAsymmetricShape top slabTop slabBot] : ThornShapeImpl top slabTop slabBot
-		yThornBowlAsymmetricBot top slabBot
-		yThornBowlAsymmetricTop top slabBot
-
 	define [ThornSymmetricShape top slabTop slabBot] : ThornShapeImpl top slabTop slabBot
 		yThornBowlSymmetricBot top slabBot
 		yThornBowlSymmetricTop top slabBot
+
+	define [ThornAsymmetricShape top slabTop slabBot] : ThornShapeImpl top slabTop slabBot
+		yThornBowlAsymmetricBot top slabBot
+		yThornBowlAsymmetricTop top slabBot
 
 	define ThornConfig : SuffixCfg.weave
 		object # symmetry
@@ -81,13 +81,11 @@ glyph-block Letter-Latin-Thorn : begin
 				include [refer-glyph "Thorn.\(suffix)"] AS_BASE ALSO_METRICS
 				include : LetterBarOverlay.l.in
 					x   -- xThornLeftStroke
-					bot -- (0 + [if doSB Stroke 0])
-					top -- (0 + [yThornBowlAsymmetricBot CAP doSB])
+					bot -- [if doSB Stroke 0]
+					top -- [yThornBowlAsymmetricBot CAP doSB]
 
 	select-variant 'Thorn' 0xDE
 	select-variant 'ThornStroke' 0xA764
 	select-variant 'ThornStrokeBottom' 0xA766
 
-	create-glyph 'grek/Sho' 0x3F7 : glyph-proc
-		include : MarkSet.capital
-		include : ThornSymmetricShape CAP SLAB SLAB
+	alias 'grek/Sho' 0x3F7 : if SLAB 'Thorn.serifed' 'Thorn.serifless'


### PR DESCRIPTION
This uses the exact bowl top/bottom values from before 35b96cc for symmetric Thorn.
Asymmetric is unchanged.

```
ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ
abc.def.ghi.jkl.mno.pqrs.tuv.wxyz
!iIlL17|¦ ¢coO08BDQ $5SZ2zs ∂96µm
float il1[]={1-2/3.4,5+6=7/8%90};
1234567890 ,._-+= >< «¯-¬_» ~–÷+×
{*}[]()<>`+-=$/#_%^@\&|~?'" !,.;:
G6Qg9q¶ Þẞðþſß ΓΔΛαβγδιλμνξπτυφχψ
ЖЗКНРУЭЯавжзклмнруфчьыэя <= != ==
```

Sans Upright:
![image](https://github.com/user-attachments/assets/f53d7162-0e27-4303-9f1f-127519e7f5b5)
Sans Italic:
![image](https://github.com/user-attachments/assets/daf92334-52b7-4b70-bf2a-b10a835a4420)
Slab Upright:
![image](https://github.com/user-attachments/assets/f11e513b-bcfd-452c-a011-c0e860466149)
Slab Italic:
![image](https://github.com/user-attachments/assets/0102cd7c-d346-48f6-a128-40aa848aff29)
