### PR TITLE
Move `partial-derivative` variant selector tag to the end of Greek section.

### DIFF
--- a/changes/33.0.0.md
+++ b/changes/33.0.0.md
@@ -4,7 +4,7 @@
 * \[**Breaking**\] Reordered variants for `W`, `a`, `b`, `g`, `q`, `w`, `α`, Cyrillic `а`, Cyrillic `ф`, and `$`.
 * \[**Breaking**\] Add variants for Capital Thorn (`Þ`) with symmetric/asymmetric bowl position.
 * \[**Breaking**\] Add variant selector for Greek Lower Theta (#2630).
-  - As a result, feature tags for `cv71` ... `cv99`, `VAAA` are shifted by one place to `cv72` ... `cv99`, `VSAA`, `VSAB`.
+  - As a result, character variant feature tags are reordered.
 * Add `closed-contour` variant for Partial derivative symbol (#2148).
 * Refine shape of the following characters:
   - GREEK CAPITAL LETTER HETA (`U+0370`).

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -6287,6 +6287,28 @@ selectorAffix."cyrl/psi" = "serifed"
 
 
 
+[prime.partial-derivative]
+sampler = "∂"
+samplerExplain = "Partial derivative symbol"
+tagKind = "letter"
+
+[prime.partial-derivative.variants.straight-bar]
+rank = 1
+description = "Partial derivative symbol (`∂`) with a straight upper bar"
+selector."partial" = "straight-bar"
+
+[prime.partial-derivative.variants.curly-bar]
+rank = 2
+description = "Partial derivative symbol (`∂`) with a curly upper bar"
+selector."partial" = "curly-bar"
+
+[prime.partial-derivative.variants.closed-contour]
+rank = 3
+description = "Partial derivative symbol (`∂`) with a full hook"
+selector."partial" = "closed-contour"
+
+
+
 [prime.cyrl-a]
 sampler = "а"
 samplerExplain = "Cyrillic Lower A"
@@ -8489,28 +8511,6 @@ selector.revPilcrow = "curved"
 
 
 
-[prime.partial-derivative]
-sampler = "∂"
-samplerExplain = "Partial derivative symbol"
-tagKind = "symbol"
-
-[prime.partial-derivative.variants.straight-bar]
-rank = 1
-description = "The upper bar of the partial derivative symbol is straight"
-selector."partial" = "straight-bar"
-
-[prime.partial-derivative.variants.curly-bar]
-rank = 2
-description = "The upper bar of the partial derivative symbol is curly"
-selector."partial" = "curly-bar"
-
-[prime.partial-derivative.variants.closed-contour]
-rank = 3
-description = "The upper part of the partial derivative symbol is a full hook"
-selector."partial" = "closed-contour"
-
-
-
 [prime.micro-sign]
 sampler = "µ"
 samplerExplain = "Micro sign"
@@ -8853,6 +8853,7 @@ lower-upsilon = "casual-serifless"
 lower-phi = "cursive"
 lower-chi = "straight-serifless"
 lower-psi = "serifless"
+partial-derivative = "curly-bar"
 cyrl-a = "double-storey-serifless"
 cyrl-ve = "standard-serifless"
 cyrl-capital-zhe = "symmetric-connected"
@@ -8914,7 +8915,6 @@ percent = "rings-segmented-slash"
 bar = "natural-slope"
 question = "smooth"
 pilcrow = "high"
-partial-derivative = "curly-bar"
 micro-sign = "toothed-serifless"
 decorative-angle-brackets = "middle"
 lig-ltgteq = "flat"
@@ -9107,6 +9107,7 @@ lower-pi = "tailless"
 lower-tau = "tailless"
 lower-phi = "straight"
 lower-chi = "semi-chancery-straight-serifless"
+partial-derivative = "closed-contour"
 cyrl-a = "double-storey-serifless"
 cyrl-ve = "standard-serifless"
 cyrl-capital-zhe = "straight"
@@ -9133,7 +9134,6 @@ number-sign = "slanted"
 at = "fourfold"
 percent = "rings-continuous-slash"
 pilcrow = "low"
-partial-derivative = "closed-contour"
 micro-sign = "toothed-serifless"
 
 [composite.ss01.slab-override.design]
@@ -9216,6 +9216,7 @@ lower-iota = "serifed-flat-tailed"
 lower-lambda = "straight-turn"
 lower-xi = "rounded"
 lower-tau = "short-tailed"
+partial-derivative = "straight-bar"
 cyrl-a = "double-storey-serifless"
 cyrl-ve = "standard-serifless"
 cyrl-capital-zhe = "straight"
@@ -9247,7 +9248,6 @@ number-sign = "upright"
 at = "fourfold"
 cent = "through-cap"
 percent = "rings-continuous-slash"
-partial-derivative = "straight-bar"
 micro-sign = "toothed-serifless"
 
 [composite.ss02.slab-override.design]
@@ -9315,6 +9315,7 @@ lower-chi = "semi-chancery-straight-serifless"
 lower-eth = "straight-bar"
 lower-lambda = "tailed-turn"
 lower-phi = "straight"
+partial-derivative = "closed-contour"
 cyrl-a = "double-storey-serifless"
 cyrl-ve = "standard-serifless"
 cyrl-capital-zhe = "symmetric-touching"
@@ -9342,7 +9343,6 @@ cent = "slanted-through-cap"
 percent = "rings-continuous-slash"
 pilcrow = "curved"
 question = "corner-flat-hooked"
-partial-derivative = "closed-contour"
 micro-sign = "tailed-serifless"
 
 [composite.ss03.italic]
@@ -9445,6 +9445,7 @@ lower-tau = "flat-tailed"
 lower-upsilon = "casual-serifed"
 lower-chi = "semi-chancery-straight-serifless"
 lower-psi = "flat-top-serifless"
+partial-derivative = "closed-contour"
 cyrl-a = "double-storey-serifless"
 cyrl-ve = "standard-serifless"
 cyrl-capital-zhe = "straight"
@@ -9478,7 +9479,6 @@ ampersand = "upper-open"
 at = "threefold"
 percent = "rings-continuous-slash"
 bar = "force-upright"
-partial-derivative = "closed-contour"
 micro-sign = "tailed-serifless"
 
 [composite.ss04.slab-override.design]
@@ -9660,6 +9660,7 @@ lower-iota = "tailed-serifed"
 lower-lambda = "straight-turn"
 lower-tau = "short-tailed"
 lower-chi = "straight-unilateral-motion-serifed"
+partial-derivative = "closed-contour"
 cyrl-a = "double-storey-tailed"
 cyrl-ve = "standard-serifless"
 cyrl-capital-u = "straight-turn-serifless"
@@ -9686,7 +9687,6 @@ cent = "open-cap"
 percent = "rings-continuous-slash"
 bar = "force-upright"
 pilcrow = "low"
-partial-derivative = "closed-contour"
 micro-sign = "toothed-serifless"
 
 [composite.ss06.slab-override.design]
@@ -9865,11 +9865,12 @@ long-s = "bent-hook-middle-serifed"
 eszet = "longs-s-lig-serifless"
 capital-delta = "curly"
 lower-delta = "flat-top"
+lower-theta = "diamond"
 capital-lambda = "curly-serifless"
 lower-lambda = "curly-tailed-turn"
 lower-mu = "toothed-serifless"
 lower-chi = "semi-chancery-curly-serifless"
-lower-theta = "diamond"
+partial-derivative = "closed-contour"
 cyrl-a = "double-storey-serifless"
 cyrl-capital-zhe = "curly"
 cyrl-zhe = "curly"
@@ -9898,7 +9899,6 @@ at = "threefold"
 dollar = "open"
 cent = "open"
 percent = "dots"
-partial-derivative = "closed-contour"
 micro-sign = "toothed-serifless"
 lig-ltgteq = "slanted"
 lig-neq = "slightly-slanted-dotted"
@@ -9995,6 +9995,7 @@ eszet = "longs-s-lig-serifless"
 lower-lambda = "straight-turn"
 lower-tau = "short-tailed"
 lower-phi = "straight"
+partial-derivative = "closed-contour"
 cyrl-a = "double-storey-serifless"
 cyrl-ve = "standard-serifless"
 cyrl-capital-u = "straight-turn-serifless"
@@ -10019,7 +10020,6 @@ dollar = "open"
 cent = "through-cap"
 percent = "rings-segmented-slash"
 bar = "force-upright"
-partial-derivative = "closed-contour"
 micro-sign = "tailed-serifless"
 
 [composite.ss09.italic]
@@ -10254,6 +10254,7 @@ lower-pi = "small-capital"
 lower-upsilon = "straight-serifless"
 lower-phi = "neo-hellenic"
 lower-psi = "flat-top-serifless"
+partial-derivative = "closed-contour"
 cyrl-a = "double-storey-tailed"
 cyrl-capital-zhe = "symmetric-touching"
 cyrl-zhe = "symmetric-touching"
@@ -10282,7 +10283,6 @@ dollar = "open"
 cent = "open"
 percent = "rings-continuous-slash"
 pilcrow = "low"
-partial-derivative = "closed-contour"
 micro-sign = "toothless-corner-serifless"
 
 [composite.ss12.italic]
@@ -10384,6 +10384,7 @@ lower-mu = "toothed-serifless"
 lower-pi = "tailless"
 lower-tau = "tailless"
 lower-phi = "straight"
+partial-derivative = "closed-contour"
 cyrl-a = "double-storey-tailed"
 cyrl-ve = "standard-serifless"
 cyrl-capital-u = "straight-turn-serifless"
@@ -10408,7 +10409,6 @@ at = "threefold"
 cent = "through-cap"
 percent = "rings-continuous-slash"
 pilcrow = "low"
-partial-derivative = "closed-contour"
 micro-sign = "toothed-serifless"
 
 [composite.ss13.slab-override.design]
@@ -10482,8 +10482,8 @@ lower-eth = "straight-bar"
 lower-alpha = "barred"
 lower-gamma = "straight"
 lower-delta = "flat-top"
-lower-iota = "serifed-flat-tailed"
 lower-theta = "capsule"
+lower-iota = "serifed-flat-tailed"
 lower-lambda = "straight"
 lower-mu = "toothed-serifless"
 lower-nu = "straight"
@@ -10878,6 +10878,7 @@ lower-iota = "serifed-flat-tailed"
 lower-lambda = "tailed-turn"
 lower-tau = "flat-tailed"
 lower-chi = "semi-chancery-straight-serifless"
+partial-derivative = "straight-bar"
 cyrl-a = "double-storey-tailed"
 cyrl-capital-ze = "unilateral-inward-serifed"
 cyrl-ze = "serifless"
@@ -10910,7 +10911,6 @@ dollar = "interrupted"
 cent = "bar-interrupted-cap"
 percent = "rings-segmented-slash"
 pilcrow = "low"
-partial-derivative = "straight-bar"
 micro-sign = "tailed-serifless"
 
 [composite.ss17.italic]


### PR DESCRIPTION
This basically treats it like an equivalent to e.g. _var-delta_ like how it's treated in many mathematical alphanumeric character sets (not just the Unicode block but also some (La)TeX implementations as well as multiple Symbolics Lisp terminal keyboards).