### PR TITLE
Make Cyrillic Capital Letter Uk (`Ѹ`) slightly wider under Quasi-Proportional.

### DIFF
--- a/changes/33.0.0.md
+++ b/changes/33.0.0.md
@@ -37,6 +37,7 @@
   - LATIN CAPITAL LETTER REVERSED HALF H (`U+A7F5`).
   - LATIN SMALL LETTER REVERSED HALF H (`U+A7F6`).
 * Make certain characters slightly wider under Quasi-Proportional. Affected characters:
+  - CYRILLIC CAPITAL LETTER UK (`U+0478`).
   - LATIN SMALL LIGATURE FF (`U+FB00`) ... LATIN SMALL LIGATURE FFL (`U+FB04`).
 * Add Characters:
   - OBSERVER EYE SYMBOL (`U+23FF`).

--- a/packages/font-glyphs/src/auto-build/composite.ptl
+++ b/packages/font-glyphs/src/auto-build/composite.ptl
@@ -1463,7 +1463,7 @@ glyph-block Autobuild-Ligatures : begin
 		list 0x1F1 { 'D' 'Z' }
 		list 0x1F2 { 'D' 'z' }
 		list 0x1F3 { 'd' 'z' }
-		list 0x478 { 'cyrl/Uk/O' 'cyrl/u' }
+		list 0x478 { 'cyrl/O' 'cyrl/u' }
 		list 0x479 { 'cyrl/uk/o' 'cyrl/u' }
 		list 0x20A7 { 'P' 't' }
 		list 0x20A8 { 'R' 's' }
@@ -1618,7 +1618,7 @@ glyph-block Autobuild-Pnonetic-Ligatures : begin
 	define [ToLetter] : glyph-proc
 
 	define stdShrink : clamp 0.625 0.9 : StrokeWidthBlend 0.625 0.9
-	createPhoneticLigatures ToLetter 'phonetic1' (para.advanceScaleF * para.advanceScaleMM) 2 stdShrink 1 : list
+	createPhoneticLigatures ToLetter 'phonetic1' [Math.max 1 : para.advanceScaleF * para.advanceScaleMM] 2 stdShrink 1 : list
 		list 0xFB00  { 'f'               'f'                     } null
 		list 0xFB01  { 'f/compLigLeft1'  'dotlessi/compLigRight' } null
 		list 0xFB02  { 'f/compLigLeft2'  'l/compLigRight'        } null
@@ -1642,7 +1642,7 @@ glyph-block Autobuild-Pnonetic-Ligatures : begin
 		list 0xFB05  { 'longs/compLigLeft' 't/compLigRight'                 } null
 		list 0xFB06  { 's/compLigLeft'     't/compLigRight'                 } null
 
-	createPhoneticLigatures ToLetter 'phonetic3' (para.advanceScaleF * [mix 1 para.advanceScaleMM 2]) 3 stdShrink 1 : list
+	createPhoneticLigatures ToLetter 'phonetic3' [Math.max 1 : para.advanceScaleF * [mix 1 para.advanceScaleMM 2]] 3 stdShrink 1 : list
 		list 0xFB03  { 'f/compLigLeft1' 'f/compLigLeft1' 'dotlessi/compLigRight' } null
 		list 0xFB04  { 'f/compLigLeft3' 'f/compLigLeft2' 'l/compLigRight'        } null
 

--- a/packages/font-glyphs/src/letter/latin/o.ptl
+++ b/packages/font-glyphs/src/letter/latin/o.ptl
@@ -37,11 +37,6 @@ glyph-block Letter-Latin-O : begin
 	alias 'cyrl/O' 0x41E 'O'
 	alias 'cyrl/o' 0x43E 'o'
 
-	create-glyph 'cyrl/Uk/O' : glyph-proc
-		local df : include : DivFrame para.advanceScaleF 2
-		include : df.markSet.capital
-		include : OShape CAP 0 df.leftSB df.rightSB df.mvs df.archDepthA df.archDepthB
-
 	create-glyph 'cyrl/uk/o' : glyph-proc
 		local df : include : DivFrame para.advanceScaleF 2
 		include : df.markSet.e


### PR DESCRIPTION
Basically, the existence of Cyrillic lower narrow o, which was intended (in part) for usage in the Cyrillic Uk digraph for the lowercase in particular, implies that the Uk digraph is intended to be narrower for the lowercase than the capital, similar to how many other crowded characters are currently handled as being wider in capital form than lowercase.

I believe I've even seen a _typikon manuscript_ typeface specimen that showed the lone narrow o as being homoglyphic to the o-part of the lowercase Uk digraph, but I can no longer find that image online.

```
Оѵᲂѵ
Ѹѹ
```
Aile Thin Before:
![image](https://github.com/user-attachments/assets/a3abcd29-9857-4ef9-aaf8-53f32fc461f6)
Aile Thin After:
![image](https://github.com/user-attachments/assets/6d7ec53d-f770-4cd4-92ed-c40f37243568)
Aile Regular Before:
![image](https://github.com/user-attachments/assets/610291d6-8410-40e0-b4e6-85c77991c32f)
Aile Regular After:
![image](https://github.com/user-attachments/assets/2e6f591f-b10d-4c61-87da-931a80799453)
Aile Heavy Before:
![image](https://github.com/user-attachments/assets/cc7e8460-9c3a-4eca-900c-d8d6a44e0f34)
Aile Heavy After:
![image](https://github.com/user-attachments/assets/b5b14dc7-e1f5-4e11-82d3-3e8fe8706e4a)
Etoile Thin Before:
![image](https://github.com/user-attachments/assets/cc02add6-25f6-49fb-8ad2-ad86aac9cf2a)
Etoile Thin After:
![image](https://github.com/user-attachments/assets/de8430f9-1ba3-4b6c-a61e-aa1a8cbabf17)
Etoile Regular Before:
![image](https://github.com/user-attachments/assets/d9de0c4e-5df5-4cb9-a88f-adf19e7da178)
Etoile Regular After:
![image](https://github.com/user-attachments/assets/440aa9e5-18c4-4a6f-89a8-3d53eabacfd3)
Etoile Heavy Before:
![image](https://github.com/user-attachments/assets/ef836030-15bc-4af8-badc-c9b7d80bb904)
Etoile Heavy After:
![image](https://github.com/user-attachments/assets/33092f12-c139-492a-b601-b0291ac06b69)
