### PR TITLE
Make Latin Small Letter TH with Strikethrough (`ᵺ`) slightly wider under Quasi-Proportional.

### DIFF
--- a/changes/33.0.0.md
+++ b/changes/33.0.0.md
@@ -39,6 +39,7 @@
   - LATIN SMALL LETTER REVERSED HALF H (`U+A7F6`).
 * Make certain characters slightly wider under Quasi-Proportional. Affected characters:
   - CYRILLIC CAPITAL LETTER UK (`U+0478`).
+  - LATIN SMALL LETTER TH WITH STRIKETHROUGH (`U+1D7A`).
   - LATIN SMALL LIGATURE FF (`U+FB00`) ... LATIN SMALL LIGATURE FFL (`U+FB04`).
 * Add Characters:
   - OBSERVER EYE SYMBOL (`U+23FF`).

--- a/packages/font-glyphs/src/auto-build/composite.ptl
+++ b/packages/font-glyphs/src/auto-build/composite.ptl
@@ -1642,7 +1642,7 @@ glyph-block Autobuild-Pnonetic-Ligatures : begin
 		list 0xFB05  { 'longs/compLigLeft' 't/compLigRight'                 } null
 		list 0xFB06  { 's/compLigLeft'     't/compLigRight'                 } null
 
-	createPhoneticLigatures ToLetter 'phonetic3' [Math.max 1 : para.advanceScaleF * [mix 1 para.advanceScaleMM 2]] 3 stdShrink 1 : list
+	createPhoneticLigatures ToLetter 'phonetic3' [Math.max para.advanceScaleMM : para.advanceScaleF * [mix 1 para.advanceScaleMM 2]] 3 stdShrink 1 : list
 		list 0xFB03  { 'f/compLigLeft1' 'f/compLigLeft1' 'dotlessi/compLigRight' } null
 		list 0xFB04  { 'f/compLigLeft3' 'f/compLigLeft2' 'l/compLigRight'        } null
 
@@ -1666,7 +1666,7 @@ glyph-block Autobuild-Pnonetic-Ligatures : begin
 	createPhoneticLigatures ToSubscript 'tenSubscript' 1 2 1 0.5 : list
 		list 0x23E8 { 'one.lnum' 'zero.lnum' } 'capital'
 
-	createPhoneticLigatures ToLetter 'thSlash' 1 2 stdShrink 1 : list
+	createPhoneticLigatures ToLetter 'thSlash' para.advanceScaleMM 2 stdShrink 1 : list
 		list 0x1D7A { 't/phoneticLeft1' 'h' 'wideSlash' } 'b'
 
 glyph-block Autobuild-Double-Emotions : begin

--- a/packages/font-glyphs/src/marks/overlay.ptl
+++ b/packages/font-glyphs/src/marks/overlay.ptl
@@ -183,14 +183,14 @@ glyph-block Mark-Overlay : begin
 			set-width 0
 			set-mark-anchor 'slash' markMiddle (XH / 2) markMiddle (XH / 2)
 			include : dispiro
-				flat (SB - O * 3 + 0.5 * fine - Width) (XH * (-0.1)) [widths.center fine]
-				curl (RightSB + O * 3 - 0.5 * fine - Width) (XH * 1.1)
+				flat (SB      - O * 3 + 0.5 * fine - Width) (XH * (-0.1)) [widths.center fine]
+				curl (RightSB + O * 3 - 0.5 * fine - Width) (XH * (+1.1))
 
 		create-glyph 'longSlash' 0x338 : glyph-proc
 			set-width 0
 			set-mark-anchor 'slash' markMiddle (XH / 2) markMiddle (XH / 2)
 			include : dispiro
-				flat (SB - O * 3 + 0.5 * fine - Width) (XH * 0.5 - CAP * 0.6) [widths.center fine]
+				flat (SB      - O * 3 + 0.5 * fine - Width) (XH * 0.5 - CAP * 0.6) [widths.center fine]
 				curl (RightSB + O * 3 - 0.5 * fine - Width) (XH * 0.5 + CAP * 0.6)
 
 		create-glyph 'longVStrokeOver' 0x20D2 : glyph-proc
@@ -205,14 +205,14 @@ glyph-block Mark-Overlay : begin
 			set-mark-anchor 'slash' markMiddle (XH * 0.5) markMiddle (XH * 0.5)
 			include : dispiro
 				flat markMiddle (XH * (-0.1)) [widths.center fine]
-				curl markMiddle (XH * 1.1)
+				curl markMiddle (XH * (+1.1))
 
 		create-glyph 'revLongSlash' 0x20E5 : glyph-proc
 			set-width 0
 			set-mark-anchor 'slash' markMiddle (XH * 0.5) markMiddle (XH * 0.5)
 			include : dispiro
 				flat (RightSB + O * 3 - 0.5 * fine - Width) (XH * 0.5 - CAP * 0.6) [widths.center fine]
-				curl (SB - O * 3 + 0.5 * fine - Width) (XH * 0.5 + CAP * 0.6)
+				curl (SB      - O * 3 + 0.5 * fine - Width) (XH * 0.5 + CAP * 0.6)
 
 		create-glyph 'dblLongVStrokeOver' 0x20E6 : glyph-proc
 			set-width 0
@@ -228,7 +228,7 @@ glyph-block Mark-Overlay : begin
 
 		create-glyph 'dblLongSlash' 0x20EB : glyph-proc
 			set-width 0
-			local l : SB - O * 3 + 0.5 * fineDbl - Width
+			local l : SB      - O * 3 + 0.5 * fineDbl - Width
 			local r : RightSB + O * 3 - 0.5 * fineDbl - Width
 			local dy : CAP * 0.6
 			local gap : Math.max fineDbl (Width * 0.1)
@@ -241,11 +241,14 @@ glyph-block Mark-Overlay : begin
 				curl (r + gap) (XH * 0.5 + dy)
 
 		create-glyph 'wideSlash' : glyph-proc
+			local df : DivFrame para.advanceScaleMM 3
 			set-width 0
+			local l : markMiddle - (df.rightSB - df.leftSB) / 2 + O * 3 + 0.5 * fine
+			local r : markMiddle + (df.rightSB - df.leftSB) / 2 - O * 3 - 0.5 * fine
 			set-mark-anchor 'slash' markMiddle (XH / 2) markMiddle (XH / 2)
 			include : dispiro
-				flat (SB + O * 3 + 0.5 * fine - Width) (XH * (-0.1)) [widths.center fine]
-				curl (RightSB - O * 3 - 0.5 * fine - Width) (XH * 1.1)
+				flat l (XH * (-0.1)) [widths.center fine]
+				curl r (XH * (+1.1))
 
 	do "Arrow overlays"
 		local fine : AdviceStroke 6
@@ -335,7 +338,7 @@ glyph-block Mark-Overlay : begin
 			set-width 0
 			set-mark-anchor 'overlay' 0 0 0 0
 
-			include : VBar.m (markExtend) (-XH / 4) (XH / 4) MarkStroke
+			include : VBar.m (+markExtend) (-XH / 4) (XH / 4) MarkStroke
 			include : HBar.m (-markExtend) (markExtend) 0 MarkStroke
 
 		create-glyph 'rightTackOver' : glyph-proc


### PR DESCRIPTION
The reason for this PR should be self-explanatory; This character has so far basically been unaccounted for in prior advance-width overhauls for composite characters up until now.

```
th
ᵺ
m
```

Aile Thin Before:
![image](https://github.com/user-attachments/assets/674b3645-5ebe-4715-b2d4-54221df3145b)
Aile Thin After:
![image](https://github.com/user-attachments/assets/20bc120e-7ec9-4327-a349-de93f33bfc4b)
Aile Regular Before:
![image](https://github.com/user-attachments/assets/492f218d-e518-4b58-a9c5-e1598ab102f3)
Aile Regular After:
![image](https://github.com/user-attachments/assets/d67cd4a6-e5d8-41b3-9597-8a18927539f2)
Aile Heavy Before:
![image](https://github.com/user-attachments/assets/21709daf-15f1-42ed-813d-5fb7209513f8)
Aile Heavy After:
![image](https://github.com/user-attachments/assets/e133a99e-492c-4353-a2f1-323840090669)
Etoile Thin Before:
![image](https://github.com/user-attachments/assets/55086486-50b3-4a36-86b0-7ba2e18711a0)
Etoile Thin After:
![image](https://github.com/user-attachments/assets/f1fa6039-2947-445a-a938-debbe01ee3b8)
Etoile Regular Before:
![image](https://github.com/user-attachments/assets/97ccfdc2-3659-4fb8-8bef-f74e387a1eb2)
Etoile Regular After:
![image](https://github.com/user-attachments/assets/5b0339c6-f8c0-4ef9-9fae-84b4c4529d58)
Etoile Heavy Before:
![image](https://github.com/user-attachments/assets/87c376a3-ca44-464c-8874-44ca46a642bc)
Etoile Heavy After:
![image](https://github.com/user-attachments/assets/ac974ffc-eaa6-414a-be68-959c91efce68)
