### PR TITLE
Optimize bar position metrics of Yeri ligatures.

### DIFF
--- a/packages/font-glyphs/src/letter/cyrillic/che.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/che.ptl
@@ -74,7 +74,7 @@ glyph-block Letter-Cyrillic-Che : begin
 	define [CyrCcheShape] : with-params [df top pyBar bodyType slabType [sw df.mvs] [yBarOffset 0]] : glyph-proc
 		local bar : top * [fallback pyBar 0.5] + yBarOffset
 
-		include : EarlessCornerDoubleArchSmallMShape df (top - bar + HalfStroke) 0 0 0
+		include : EarlessCornerDoubleArchSmallMShape df (top - (bar - 0.5 * sw)) 0 0 0
 		eject-contour 'barL'
 		include : FlipAround df.middle (top / 2)
 

--- a/packages/font-glyphs/src/letter/cyrillic/dje.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/dje.ptl
@@ -31,7 +31,7 @@ glyph-block Letter-Cyrillic-Dje : begin
 			ada    -- ArchDepthA
 			adb    -- ArchDepthB
 			sw     -- sw
-			xDepth -- [Math.max ((left - right) / 2 + sw / 2) (-HookX * 1.2)]
+			xDepth -- [Math.max ((left - right) / 2 + sw / 2) (HookX * (-1.2))]
 
 		if SLAB : begin
 			local swVJut : Math.min (0.625 * (left - xTopBarLeft)) : AdviceStroke 4.5

--- a/packages/font-glyphs/src/letter/cyrillic/lje.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/lje.ptl
@@ -24,10 +24,10 @@ glyph-block Letter-Cyrillic-Lje : begin
 			xb   -- xTopLeft
 			fine -- df.mvs
 		include : Yeri top
-			left -- (middle - [HSwToV : 0.5 * df.mvs])
-			right -- (r - O)
+			left   -- (middle - [HSwToV : 0.5 * df.mvs])
+			right  -- (r - O)
 			stroke -- df.mvs
-			jut -- jut
+			jut    -- jut
 		include : HBar.t xTopLeft middle top df.mvs
 		if SLAB : begin
 			include : HSerif.lt xTopLeft top (jut - [HSwToV : 0.5 * df.mvs]) df.mvs

--- a/packages/font-glyphs/src/letter/cyrillic/nje.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/nje.ptl
@@ -21,7 +21,7 @@ glyph-block Letter-Cyrillic-Nje : begin
 	define [LeftHalf slabType df top] : glyph-proc
 		local dfSub : df.slice 3 2
 		include : VBar.l dfSub.leftSB 0 top dfSub.mvs
-		include : HBar.m dfSub.leftSB dfSub.rightSB (top * HBarPos)
+		include : HBar.m dfSub.leftSB dfSub.rightSB (top * HBarPos) dfSub.mvs
 
 		local sf : SerifFrame.fromDf dfSub top 0
 		include : match slabType
@@ -37,8 +37,8 @@ glyph-block Letter-Cyrillic-Nje : begin
 
 	define [RightHalf Yeri df top] : glyph-proc
 		include : Yeri top
-			left -- (df.middle - [HSwToV : 0.5 * df.mvs])
-			right -- (df.rightSB - O)
+			left   -- (df.middle - [HSwToV : 0.5 * df.mvs])
+			right  -- (df.rightSB - O)
 			stroke -- df.mvs
 		eject-contour 'serifYeriLT'
 		eject-contour 'serifYeriLB'

--- a/packages/font-glyphs/src/letter/cyrillic/tje.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/tje.ptl
@@ -32,12 +32,10 @@ glyph-block Letter-Cyrillic-Tje : begin
 			include : HSerif.lb left 0 SideJut
 
 	define [RightHalf Yeri df top] : glyph-proc
-		local { jutTop jutBot jutMid } : EFVJutLength top YeriBarPos df.mvs
 		include : Yeri top
 			left   -- ([mix df.leftSB df.rightSB 0.3] + OX)
 			right  -- df.rightSB
 			stroke -- df.mvs
-			bowl   -- (YeriBarPos * top + [Math.min HalfStroke jutMid])
 		eject-contour 'serifYeriLT'
 		eject-contour 'serifYeriLB'
 

--- a/packages/font-glyphs/src/letter/cyrillic/yeri.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/yeri.ptl
@@ -23,8 +23,8 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			local-parameter : jut    -- Jut
 			local-parameter : pBar   -- YeriBarPos
 			local-parameter : yStart -- top
-			local-parameter : bowl   -- (top * pBar + HalfStroke)
 
+			local bowl : top * pBar + stroke / 2
 			local turnRadius : BowlXDepth bowl 0 left right stroke
 			local ada : ArchDepthAOf ArchDepth (right - left + SB * 2)
 			local adb : ArchDepthBOf ArchDepth (right - left + SB * 2)
@@ -53,7 +53,6 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			local-parameter : jut    -- Jut
 			local-parameter : pBar   -- YeriBarPos
 			local-parameter : yStart -- top
-			local-parameter : bowl   -- (top * pBar + HalfStroke)
 
 			include : CornerCommon.apply null $-flex-arguments
 			if SLAB : begin
@@ -68,7 +67,6 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			local-parameter : jut    -- Jut
 			local-parameter : pBar   -- YeriBarPos
 			local-parameter : yStart -- top
-			local-parameter : bowl   -- (top * pBar + HalfStroke)
 
 			include : CornerCommon.apply null $-flex-arguments
 			if SLAB : begin
@@ -87,8 +85,8 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			local-parameter : jut    -- Jut
 			local-parameter : pBar   -- YeriBarPos
 			local-parameter : yStart -- top
-			local-parameter : bowl   -- (top * pBar + HalfStroke)
 
+			local bowl : top * pBar + stroke / 2
 			local turnRadius : BowlXDepth bowl 0 left right stroke
 			local ada : ArchDepthAOf ArchDepth (right - left + SB * 2)
 			local adb : ArchDepthBOf ArchDepth (right - left + SB * 2)
@@ -117,8 +115,8 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			local-parameter : jut    -- Jut
 			local-parameter : pBar   -- YeriBarPos
 			local-parameter : yStart -- top
-			local-parameter : bowl   -- (top * pBar + HalfStroke)
 
+			local bowl : top * pBar + stroke / 2
 			local turnRadius : BowlXDepth bowl 0 left right stroke
 			local ada : ArchDepthAOf ArchDepth (right - left + SB * 2)
 			local adb : ArchDepthBOf ArchDepth (right - left + SB * 2)
@@ -140,7 +138,7 @@ glyph-block Letter-Cyrillic-Yeri : begin
 
 	define RevYeri : namespace
 		export : define flex-params [Shape top [left SB] [right RightSB] [stroke Stroke] [jut Jut] [pBar YeriBarPos]] : glyph-proc
-			local bowl : top * pBar + HalfStroke
+			local bowl : top * pBar + stroke / 2
 			local turnRadius : bowl * 0.45
 			local turnbottom : mix 0 bowl (ArchDepthB / (ArchDepthA + ArchDepthB))
 			local trShrink : Math.sqrt : (right - left) / (RightSB - SB)
@@ -161,7 +159,7 @@ glyph-block Letter-Cyrillic-Yeri : begin
 					HSerif.mt (right - [HSwToV : 0.5 * stroke]) top jut stroke
 
 		export : define flex-params [RoundShape top [left SB] [right RightSB] [stroke Stroke] [jut Jut] [pBar YeriBarPos] [yStart top]] : glyph-proc
-			local bowl : top * pBar + HalfStroke
+			local bowl : top * pBar + stroke / 2
 			local turnRadius : BowlXDepth bowl 0 left right stroke
 			local ada : ArchDepthAOf ArchDepth (right - left + SB * 2)
 			local adb : ArchDepthBOf ArchDepth (right - left + SB * 2)

--- a/packages/font-glyphs/src/letter/latin/lower-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-m.ptl
@@ -90,7 +90,6 @@ glyph-block Letter-Latin-Lower-M : begin
 
 	define [dfM] : DivFrame para.advanceScaleMM 3
 
-	glyph-block-export MEnoughSpaceForFullSerifs
 	define [MEnoughSpaceForFullSerifs _df _mid] : begin
 		local df : fallback _df : dfM
 		local mid : fallback _mid df.middle
@@ -264,16 +263,16 @@ glyph-block Letter-Latin-Lower-M : begin
 				local df : include : DivFrame para.advanceScaleMM 3.25
 				include : df.markSet.e
 
-				local fine : AdviceStroke 4.5 df.adws
+				local fine : [AdviceStroke 4] * (df.mvs / Stroke)
 				local rinner : XH * 0.15 - fine * 0.75
-				local gap : (df.rightSB - df.leftSB - 3 * [HSwToV df.mvs] - [HSwToV fine]) / 3
+				local gap : (df.rightSB - df.leftSB - [HSwToV fine]) / 3
 				local m1 : df.rightSB - [HSwToV df.mvs]
-				local m2 : df.leftSB + 2 * ([HSwToV df.mvs] + gap) - [HSwToV : 0.25 * fine]
+				local m2 : df.leftSB + gap * 2 - [HSwToV : 0.25 * fine]
 				local x2 : df.rightSB + SideJut
 				local y2 : rinner * 2 + fine - O
 				include : Body df XH 0 [if shortLeg [SmallMShortLegHeight XH df] 0] (y2 + O)
 				include : dispiro
-					straight.down.start df.rightSB (y2 + O) [widths.rhs.heading df.mvs Downward]
+					straight.down.start df.rightSB y2 [widths.rhs.heading df.mvs Downward]
 					CurlyTail.f fine 0 m2 x2 (swBefore -- df.mvs)
 
 				include : Serifs df XH 0 [if shortLeg [SmallMShortLegHeight XH df] 0] 0 true earless

--- a/packages/font-glyphs/src/letter/latin/upper-h.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-h.ptl
@@ -77,21 +77,21 @@ glyph-block Letter-Latin-Upper-H : begin
 		include : tagged 'strokeR' : VBar.r r 0 top sw
 		include : HBar.m (l - O) (r + O) (top * HBarPos) sw
 
-	define [HTurned l r top _sw] : glyph-proc
+	define [TurnedHShape l r top _sw] : glyph-proc
 		local sw : fallback _sw Stroke
 		include : LeaningAnchor.Below.VBar.r r
 		include : tagged 'strokeL' : VBar.l l (top * HBarPos - sw / 2) top sw
 		include : tagged 'strokeR' : VBar.r r 0 top sw
 		include : HBar.m (l - O) (r + O) (top * HBarPos) sw
 
-	define [HLeftHalf l r top _sw] : glyph-proc
+	define [LeftHalfHShape l r top _sw] : glyph-proc
 		local sw : fallback _sw Stroke
 		include : LeaningAnchor.Above.VBar.l l
 		include : LeaningAnchor.Below.VBar.l l
 		include : tagged 'strokeL' : VBar.l l 0 top sw
 		include : HBar.m (l - O) (r + O) (top * HBarPos) sw
 
-	define [HRightHalf l r top _sw] : glyph-proc
+	define [RightHalfHShape l r top _sw] : glyph-proc
 		local sw : fallback _sw Stroke
 		include : LeaningAnchor.Above.VBar.r r
 		include : LeaningAnchor.Below.VBar.r r
@@ -143,16 +143,16 @@ glyph-block Letter-Latin-Upper-H : begin
 			Math.min OverlayStroke : 0.625 * (yt - yb)
 
 	define HConfig : object
-		serifless                        { HShape       HTurned HLeftHalf HRightHalf SLAB-NONE                  }
-		tailedSerifless                  { TailedHShape HTurned HLeftHalf HRightHalf SLAB-NONE                  }
-		topLeftSerifed                   { HShape       HTurned HLeftHalf HRightHalf SLAB-TOP-LEFT              }
-		tailedTopLeftSerifed             { TailedHShape HTurned HLeftHalf HRightHalf SLAB-TOP-LEFT              }
-		topLeftBottomRightSerifed        { HShape       HTurned HLeftHalf HRightHalf SLAB-TOP-LEFT-BOTTOM-RIGHT }
-		serifed                          { HShape       HTurned HLeftHalf HRightHalf SLAB-ALL                   }
-		tailedSerifed                    { TailedHShape HTurned HLeftHalf HRightHalf SLAB-TAILED-CYRILLIC       }
-		serifedExceptBottomRight         { HShape       HTurned HLeftHalf HRightHalf SLAB-TAILED-CYRILLIC       }
-		serifedBGR                       { HShape       HTurned HLeftHalf HRightHalf SLAB-ALL-BGR               }
-		tailedSerifedBGR                 { TailedHShape HTurned HLeftHalf HRightHalf SLAB-TAILED-CYRILLIC-BGR   }
+		serifless                        { HShape       TurnedHShape LeftHalfHShape RightHalfHShape SLAB-NONE                  }
+		tailedSerifless                  { TailedHShape TurnedHShape LeftHalfHShape RightHalfHShape SLAB-NONE                  }
+		topLeftSerifed                   { HShape       TurnedHShape LeftHalfHShape RightHalfHShape SLAB-TOP-LEFT              }
+		tailedTopLeftSerifed             { TailedHShape TurnedHShape LeftHalfHShape RightHalfHShape SLAB-TOP-LEFT              }
+		topLeftBottomRightSerifed        { HShape       TurnedHShape LeftHalfHShape RightHalfHShape SLAB-TOP-LEFT-BOTTOM-RIGHT }
+		serifed                          { HShape       TurnedHShape LeftHalfHShape RightHalfHShape SLAB-ALL                   }
+		tailedSerifed                    { TailedHShape TurnedHShape LeftHalfHShape RightHalfHShape SLAB-TAILED-CYRILLIC       }
+		serifedExceptBottomRight         { HShape       TurnedHShape LeftHalfHShape RightHalfHShape SLAB-TAILED-CYRILLIC       }
+		serifedBGR                       { HShape       TurnedHShape LeftHalfHShape RightHalfHShape SLAB-ALL-BGR               }
+		tailedSerifedBGR                 { TailedHShape TurnedHShape LeftHalfHShape RightHalfHShape SLAB-TAILED-CYRILLIC-BGR   }
 
 	define EnGheGheConfig : object
 		serifless       false

--- a/packages/font-glyphs/src/marks/overlay.ptl
+++ b/packages/font-glyphs/src/marks/overlay.ptl
@@ -338,15 +338,15 @@ glyph-block Mark-Overlay : begin
 			set-width 0
 			set-mark-anchor 'overlay' 0 0 0 0
 
-			include : VBar.m (+markExtend) (-XH / 4) (XH / 4) MarkStroke
-			include : HBar.m (-markExtend) (markExtend) 0 MarkStroke
+			include : VBar.m (+markExtend) (XH * (-0.25)) (XH * (+0.25)) MarkStroke
+			include : HBar.m (-markExtend) (+markExtend) 0 MarkStroke
 
 		create-glyph 'rightTackOver' : glyph-proc
 			set-width 0
 			set-mark-anchor 'overlay' 0 0 0 0
 
-			include : VBar.m (-markExtend) (-XH / 4) (XH / 4) MarkStroke
-			include : HBar.m (-markExtend) (markExtend) 0 MarkStroke
+			include : VBar.m (-markExtend) (XH * (-0.25)) (XH * (+0.25)) MarkStroke
+			include : HBar.m (-markExtend) (+markExtend) 0 MarkStroke
 
 		create-glyph 'upTackOver' : glyph-proc
 			set-width 0
@@ -458,7 +458,7 @@ glyph-block Mark-Overlay : begin
 			local kHeight2 : adws / 4 * kHeight
 			local offset : (0.5 * space - 2 * halfDotWidth) / 3 + halfDotWidth
 			include : InnerDot (-offset) 0 kHeight2 fRound kdr space adws
-			include : InnerDot   offset  0 kHeight2 fRound kdr space adws
+			include : InnerDot (+offset) 0 kHeight2 fRound kdr space adws
 
 		foreach { suffix { DrawAt kdr } } [Object.entries DotVariants] : do
 			create-glyph "innerDot.\(suffix)" : glyph-proc


### PR DESCRIPTION
This basically makes the bowl height offset by half its `stroke` argument (instead of by `HalfStroke` independently of its `stroke` argument).

Quasi-proportional is substantially unchanged as it naturally compensates for the crowdedness arguments of its `DivFrame`s' stroke widths via `advanceScaleMM`.

`ЉЊᲉљњᲊ`

Sans Thin Before:
![image](https://github.com/user-attachments/assets/c644f719-d576-44ca-955e-72a0aeebbd24)
Sans Thin After:
![image](https://github.com/user-attachments/assets/e6115ef3-16d9-43b8-ad3c-e466d3cc86fb)
Sans Regular Before:
![image](https://github.com/user-attachments/assets/3c4b0152-59d9-49d5-88c0-908a0ba51227)
Sans Regular After:
![image](https://github.com/user-attachments/assets/3081e252-fff6-43b8-8b1e-ce063be69140)
Sans Heavy Before:
![image](https://github.com/user-attachments/assets/1aa56eb4-c66d-4713-a73a-4bc568b35e80)
Sans Heavy After:
![image](https://github.com/user-attachments/assets/12611b7a-d597-46b3-8b95-c409a0a086b6)
Slab Thin Before:
![image](https://github.com/user-attachments/assets/f8ee332c-5a76-4036-a833-9a5affdc2b33)
Slab Thin After:
![image](https://github.com/user-attachments/assets/8b3aca77-4b83-40e4-9ea3-70507e4ddda8)
Slab Regular Before:
![image](https://github.com/user-attachments/assets/bc7a0bb7-6f08-4559-8186-5859025579db)
Slab Regular After:
![image](https://github.com/user-attachments/assets/08698ee5-700a-44d2-b3d1-e468579e770e)
Slab Heavy Before:
![image](https://github.com/user-attachments/assets/b62618c6-e014-41c2-8a0b-4d2aaeeb8ee7)
Slab Heavy After:
![image](https://github.com/user-attachments/assets/fe954105-e518-4d89-a062-728b485fddbd)

