### PR TITLE
Add `IPPH`/`APPH` localization override for `ǥ`.

### DIFF
--- a/changes/33.1.0.md
+++ b/changes/33.1.0.md
@@ -1,1 +1,2 @@
 * Add full-serifed variants for `K` and `k`, and related letters (#2696).
+* Add IPA localization form for Latin Lower G with Stroke (`ǥ`).

--- a/packages/font-glyphs/src/letter/greek/orthography.ptl
+++ b/packages/font-glyphs/src/letter/greek/orthography.ptl
@@ -9,5 +9,6 @@ glyph-block Letter-Greek-Orthography : begin
 
 	# Link localization forms
 
+	link-gr LocalizedForm.IPPH 'gBar'      'gScriptBar'
 	link-gr LocalizedForm.IPPH 'grek/beta' 'latn/beta'
 	link-gr LocalizedForm.IPPH 'grek/chi'  'latn/chi'

--- a/packages/font-glyphs/src/letter/latin/lower-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-g.ptl
@@ -210,6 +210,7 @@ glyph-block Letter-Latin-Lower-G : begin
 	select-variant 'gScript' 0x261  (follow -- [conditional-follow SLAB 'g/singleStorey/autoSerifed/slab' 'g/singleStorey/autoSerifed/sans']) (shapeFrom -- 'g')
 	select-variant 'GScript' 0xA7AC (follow -- [conditional-follow SLAB 'g/singleStorey/autoSerifed/slab' 'g/singleStorey/autoSerifed/sans'])
 	select-variant 'gScriptPalatalHook' 0x1D83 (follow -- [conditional-follow SLAB 'g/singleStorey/autoSerifed/slab' 'g/singleStorey/autoSerifed/sans']) (shapeFrom -- 'gPalatalHook')
+	select-variant 'gScriptBar' (follow -- [conditional-follow SLAB 'g/singleStorey/autoSerifed/slab' 'g/singleStorey/autoSerifed/sans']) (shapeFrom -- 'gBar')
 	select-variant 'gScriptCrossedTail' 0xAB36 (follow -- [conditional-follow SLAB 'g/singleStoreyBentHook/autoSerifed/slab' 'g/singleStoreyBentHook/autoSerifed/sans'])
 
 	alias 'cyrl/de.BGR' null 'gScript'

--- a/packages/font-otl/src/gsub-locl.ptl
+++ b/packages/font-otl/src/gsub-locl.ptl
@@ -32,6 +32,8 @@ export : define [buildLOCL gsub para glyphStore] : begin
 	define latnUDI  : gsub.copyLanguage 'latn_UDI ' 'latn_DFLT'
 	define latnZZA  : gsub.copyLanguage 'latn_ZZA ' 'latn_DFLT'
 	define latnVIT  : gsub.copyLanguage 'latn_VIT ' 'latn_DFLT'
+	define latnIPPH : gsub.copyLanguage 'latn_IPPH' 'latn_DFLT'
+	define latnAPPH : gsub.copyLanguage 'latn_APPH' 'latn_DFLT'
 	define grekIPPH : gsub.copyLanguage 'grek_IPPH' 'grek_DFLT'
 	define grekAPPH : gsub.copyLanguage 'grek_APPH' 'grek_DFLT'
 
@@ -125,6 +127,8 @@ export : define [buildLOCL gsub para glyphStore] : begin
 
 	# IPPH
 	define loclIPPH : gsub.createFeature 'locl'
+	latnIPPH.addFeature loclIPPH
+	latnAPPH.addFeature loclIPPH
 	grekIPPH.addFeature loclIPPH
 	grekAPPH.addFeature loclIPPH
 	loclIPPH.addLookup : createGsubLookupFromGr gsub glyphStore LocalizedForm.IPPH


### PR DESCRIPTION
Closes #2632 .

The solution to get this working might have been to just declare all IPA/APA overrides in the same `orthography.ptl` file (preferably the latest possible executed one upon compilation).

```
<span lang='und-fonipa'>
aɑɐɒᶏᶐ<br>
gɡɠꬶ<br>
ꭤ𝼁<br>
ꬰǥ
</span>
```

Sans `SS03` Upright:
![image](https://github.com/user-attachments/assets/ebc24c9f-28ad-43ce-b7b0-a4f081202943)
Sans `SS03` Italic:
![image](https://github.com/user-attachments/assets/d63da21e-439e-43d2-b53e-de56c022363f)
Slab `SS03` Upright:
![image](https://github.com/user-attachments/assets/ca88e548-a8fe-449a-8019-fe83543e3e12)
Slab `SS03` Italic:
![image](https://github.com/user-attachments/assets/8572adf4-78b6-4acf-8390-36c82832605d)
Sans `SS15` Upright:
![image](https://github.com/user-attachments/assets/13f5cd88-40b2-44b5-8251-d85dc4256840)
Sans `SS15` Italic:
![image](https://github.com/user-attachments/assets/4f38ac77-2ff9-44b5-af2a-084b210b36d1)
Slab `SS15` Upright:
![image](https://github.com/user-attachments/assets/f5db5f62-e36f-4298-9793-208d5cef8caa)
Slab `SS15` Italic:
![image](https://github.com/user-attachments/assets/814a807e-9c68-41fc-bff9-622c8d301f94)
