### PR TITLE
Add `cursive` variant for Greek Lower Theta.

### DIFF
--- a/changes/33.1.0.md
+++ b/changes/33.1.0.md
@@ -1,3 +1,3 @@
 * Add full-serifed variants for `K` and `k`, and related letters (#2696).
-* Add cursive variants for Greek Lower Theta (`θ`).
+* Add cursive variant for Greek Lower Theta (`θ`).
 * Add IPA localization form for Latin Lower G with Stroke (`ǥ`).

--- a/changes/33.1.0.md
+++ b/changes/33.1.0.md
@@ -1,2 +1,3 @@
 * Add full-serifed variants for `K` and `k`, and related letters (#2696).
+* Add cursive variants for Greek Lower Theta (`θ`).
 * Add IPA localization form for Latin Lower G with Stroke (`ǥ`).

--- a/packages/font-glyphs/src/letter/greek/lower-theta.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-theta.ptl
@@ -32,13 +32,7 @@ glyph-block Letter-Greek-Lower-Theta : begin
 				ShapeBase.Mask Ascender
 				HBar.m SB RightSB (0.5 * Ascender)
 
-	select-variant 'grek/theta' 0x3B8
-
-glyph-block Letter-Greek-Lower-Theta-Var : begin
-	glyph-block-import CommonShapes
-	glyph-block-import Common-Derivatives
-
-	create-glyph 'grek/thetaSymbol' 0x03D1 : glyph-proc
+	create-glyph 'grek/theta.cursive' : glyph-proc
 		include : MarkSet.b
 
 		define pXTopLeft 0.2
@@ -59,3 +53,7 @@ glyph-block Letter-Greek-Lower-Theta-Var : begin
 			g4 [mix xTopLeft RightSB 0.5] [mix (Ascender - topSMA) (Ascender / 2 - HalfStroke) 0.9]
 			g4 [mix RightSB Width 0.5] (Ascender / 2 - HalfStroke)
 			g4 coXTopLeft (Ascender - topSMA)
+
+	select-variant 'grek/theta' 0x3B8
+	select-variant 'grek/theta/nonCursive' (shapeFrom -- 'grek/theta')
+	alias 'grek/thetaSymbol' 0x03D1 'grek/theta.cursive'

--- a/packages/font-glyphs/src/letter/greek/orthography.ptl
+++ b/packages/font-glyphs/src/letter/greek/orthography.ptl
@@ -9,6 +9,7 @@ glyph-block Letter-Greek-Orthography : begin
 
 	# Link localization forms
 
-	link-gr LocalizedForm.IPPH 'gBar'      'gScriptBar'
-	link-gr LocalizedForm.IPPH 'grek/beta' 'latn/beta'
-	link-gr LocalizedForm.IPPH 'grek/chi'  'latn/chi'
+	link-gr LocalizedForm.IPPH 'gBar'       'gScriptBar'
+	link-gr LocalizedForm.IPPH 'grek/beta'  'latn/beta'
+	link-gr LocalizedForm.IPPH 'grek/theta' 'grek/theta/nonCursive'
+	link-gr LocalizedForm.IPPH 'grek/chi'   'latn/chi'

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2154,7 +2154,6 @@ rank = 1
 next = "double-storey-hook"
 descriptionAffix = "double-storey body"
 selectorAffix.a = "doubleStorey"
-selectorAffix."ae/a" = "doubleStorey"
 selectorAffix."a/sansSerif" = "doubleStorey"
 selectorAffix."aRetroflexHook" = "doubleStorey"
 selectorAffix."a/doubleStorey" = "doubleStorey"
@@ -2162,13 +2161,13 @@ selectorAffix."a/singleStorey/autoSerifed/slab" = "singleStorey"
 selectorAffix."a/singleStorey/autoSerifed/sans" = "singleStorey"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "singleStorey"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "singleStorey"
+selectorAffix."ae/a" = "doubleStorey"
 
 [prime.a.variants-buildup.stages.storey.single-storey]
 rank = 2
 next = "ear"
 descriptionAffix = "single-storey body"
 selectorAffix.a = "singleStorey"
-selectorAffix."ae/a" = "doubleStorey"
 selectorAffix."a/sansSerif" = "singleStorey"
 selectorAffix."aRetroflexHook" = "singleStorey"
 selectorAffix."a/doubleStorey" = "doubleStorey"
@@ -2176,6 +2175,7 @@ selectorAffix."a/singleStorey/autoSerifed/slab" = "singleStorey"
 selectorAffix."a/singleStorey/autoSerifed/sans" = "singleStorey"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "singleStorey"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "singleStorey"
+selectorAffix."ae/a" = "doubleStorey"
 
 [prime.a.variants-buildup.stages.double-storey-hook."*"]
 next = "bar"
@@ -2185,7 +2185,6 @@ rank = 1
 keyAffix = ""
 descriptionAffix = "serifless hook"
 selectorAffix.a = ""
-selectorAffix."ae/a" = ""
 selectorAffix."a/sansSerif" = ""
 selectorAffix."aRetroflexHook" = ""
 selectorAffix."a/doubleStorey" = ""
@@ -2193,13 +2192,13 @@ selectorAffix."a/singleStorey/autoSerifed/slab" = ""
 selectorAffix."a/singleStorey/autoSerifed/sans" = ""
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = ""
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = ""
+selectorAffix."ae/a" = ""
 
 [prime.a.variants-buildup.stages.double-storey-hook.hook-serifed]
 rank = 2
 keyAffix = "hook-inward-serifed"
 descriptionAffix = "serifed hook"
 selectorAffix.a = "hookInwardSerifed"
-selectorAffix."ae/a" = "hookInwardSerifed"
 selectorAffix."a/sansSerif" = ""
 selectorAffix."aRetroflexHook" = "hookInwardSerifed"
 selectorAffix."a/doubleStorey" = "hookInwardSerifed"
@@ -2207,6 +2206,7 @@ selectorAffix."a/singleStorey/autoSerifed/slab" = ""
 selectorAffix."a/singleStorey/autoSerifed/sans" = ""
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = ""
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = ""
+selectorAffix."ae/a" = "hookInwardSerifed"
 
 [prime.a.variants-buildup.stages.ear."*"]
 next = "bar"
@@ -2215,7 +2215,6 @@ next = "bar"
 rank = 1
 keyAffix = ""
 selectorAffix.a = ""
-selectorAffix."ae/a" = ""
 selectorAffix."a/sansSerif" = ""
 selectorAffix."aRetroflexHook" = ""
 selectorAffix."a/doubleStorey" = ""
@@ -2223,12 +2222,12 @@ selectorAffix."a/singleStorey/autoSerifed/slab" = ""
 selectorAffix."a/singleStorey/autoSerifed/sans" = ""
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = ""
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = ""
+selectorAffix."ae/a" = ""
 
 [prime.a.variants-buildup.stages.ear.top-cut]
 rank = 2
 descriptionAffix = "a diagonal cut at top"
 selectorAffix.a = "topCut"
-selectorAffix."ae/a" = ""
 selectorAffix."a/sansSerif" = "topCut"
 selectorAffix."aRetroflexHook" = "topCut"
 selectorAffix."a/doubleStorey" = ""
@@ -2236,12 +2235,12 @@ selectorAffix."a/singleStorey/autoSerifed/slab" = "topCut"
 selectorAffix."a/singleStorey/autoSerifed/sans" = "topCut"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "topCut"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "topCut"
+selectorAffix."ae/a" = ""
 
 [prime.a.variants-buildup.stages.ear.earless-corner]
 rank = 3
 descriptionAffix = "earless (cornered top-right)"
 selectorAffix.a = "earlessCorner"
-selectorAffix."ae/a" = ""
 selectorAffix."a/sansSerif" = "earlessCorner"
 selectorAffix."aRetroflexHook" = "earlessCorner"
 selectorAffix."a/doubleStorey" = ""
@@ -2249,12 +2248,12 @@ selectorAffix."a/singleStorey/autoSerifed/slab" = "earlessCorner"
 selectorAffix."a/singleStorey/autoSerifed/sans" = "earlessCorner"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "earlessCorner"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "earlessCorner"
+selectorAffix."ae/a" = ""
 
 [prime.a.variants-buildup.stages.ear.earless-rounded]
 rank = 4
 descriptionAffix = "earless (rounded top-right)"
 selectorAffix.a = "earlessRounded"
-selectorAffix."ae/a" = ""
 selectorAffix."a/sansSerif" = "earlessRounded"
 selectorAffix."aRetroflexHook" = "earlessRounded"
 selectorAffix."a/doubleStorey" = ""
@@ -2262,13 +2261,13 @@ selectorAffix."a/singleStorey/autoSerifed/slab" = "earlessRounded"
 selectorAffix."a/singleStorey/autoSerifed/sans" = "earlessRounded"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "earlessRounded"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "earlessRounded"
+selectorAffix."ae/a" = ""
 
 [prime.a.variants-buildup.stages.bar.serifless]
 rank = 1
 descriptionAffix = "serif at terminal"
 descriptionJoiner = "without"
 selectorAffix.a = "serifless"
-selectorAffix."ae/a" = "serifless"
 selectorAffix."a/sansSerif" = "serifless"
 selectorAffix."aRetroflexHook" = "serifless"
 selectorAffix."a/doubleStorey" = "serifless"
@@ -2276,12 +2275,12 @@ selectorAffix."a/singleStorey/autoSerifed/slab" = "serifless"
 selectorAffix."a/singleStorey/autoSerifed/sans" = "serifless"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "serifless"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "serifless"
+selectorAffix."ae/a" = "serifless"
 
 [prime.a.variants-buildup.stages.bar.serifed]
 rank = 2
 descriptionAffix = "serif at terminal"
 selectorAffix.a = "serifed"
-selectorAffix."ae/a" = "serifless"
 selectorAffix."a/sansSerif" = "serifless"
 selectorAffix."aRetroflexHook" = "serifless"
 selectorAffix."a/doubleStorey" = "serifed"
@@ -2289,13 +2288,13 @@ selectorAffix."a/singleStorey/autoSerifed/slab" = { if = [{ storey = "double-sto
 selectorAffix."a/singleStorey/autoSerifed/sans" = "serifed"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = { if = [{ storey = "double-storey" }], then = "topSerifed", else = "serifless" }
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "serifless"
+selectorAffix."ae/a" = "serifless"
 
 [prime.a.variants-buildup.stages.bar.double-serifed]
 rank = 3
 disableIf = [{ storey = "double-storey" }, { ear = "NOT eared" }]
 descriptionAffix = "serifs at top and bottom"
 selectorAffix.a = "doubleSerifed"
-selectorAffix."ae/a" = "serifless"
 selectorAffix."a/sansSerif" = "serifless"
 selectorAffix."aRetroflexHook" = "topSerifed"
 selectorAffix."a/doubleStorey" = "serifed"
@@ -2303,12 +2302,12 @@ selectorAffix."a/singleStorey/autoSerifed/slab" = "doubleSerifed"
 selectorAffix."a/singleStorey/autoSerifed/sans" = "doubleSerifed"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "topSerifed"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "topSerifed"
+selectorAffix."ae/a" = "serifless"
 
 [prime.a.variants-buildup.stages.bar.tailed]
 rank = 4
 descriptionAffix = "curly tail"
 selectorAffix.a = "tailed"
-selectorAffix."ae/a" = "serifless"
 selectorAffix."a/sansSerif" = "tailed"
 selectorAffix."aRetroflexHook" = "serifless"
 selectorAffix."a/doubleStorey" = "tailed"
@@ -2316,13 +2315,13 @@ selectorAffix."a/singleStorey/autoSerifed/slab" = { if = [{ storey = "double-sto
 selectorAffix."a/singleStorey/autoSerifed/sans" = "tailed"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = { if = [{ storey = "double-storey" }], then = "topSerifed", else = "serifless" }
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "serifless"
+selectorAffix."ae/a" = "serifless"
 
 [prime.a.variants-buildup.stages.bar.tailed-serifed]
 rank = 5
 disableIf = [{ storey = "double-storey" }, { ear = "NOT eared" }]
 descriptionAffix = "curly tail; with serifs at top and bottom"
 selectorAffix.a = "tailedSerifed"
-selectorAffix."ae/a" = "serifless"
 selectorAffix."a/sansSerif" = "tailed"
 selectorAffix."aRetroflexHook" = "topSerifed"
 selectorAffix."a/doubleStorey" = "tailed"
@@ -2330,13 +2329,13 @@ selectorAffix."a/singleStorey/autoSerifed/slab" = "tailedSerifed"
 selectorAffix."a/singleStorey/autoSerifed/sans" = "tailedSerifed"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "topSerifed"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "topSerifed"
+selectorAffix."ae/a" = "serifless"
 
 [prime.a.variants-buildup.stages.bar.toothless-corner]
 rank = 6
 disableIf = [{ storey = "single-storey" }]
 descriptionAffix = "toothless (cornered bottom-right)"
 selectorAffix.a = "toothlessCorner"
-selectorAffix."ae/a" = "serifless"
 selectorAffix."a/sansSerif" = "toothlessCorner"
 selectorAffix."aRetroflexHook" = "serifless"
 selectorAffix."a/doubleStorey" = "toothlessCorner"
@@ -2344,13 +2343,13 @@ selectorAffix."a/singleStorey/autoSerifed/slab" = "doubleSerifed"
 selectorAffix."a/singleStorey/autoSerifed/sans" = "serifless"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "topSerifed"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "serifless"
+selectorAffix."ae/a" = "serifless"
 
 [prime.a.variants-buildup.stages.bar.toothless-rounded]
 rank = 7
 disableIf = [{ storey = "single-storey" }]
 descriptionAffix = "toothless (rounded bottom-right)"
 selectorAffix.a = "toothlessRounded"
-selectorAffix."ae/a" = "serifless"
 selectorAffix."a/sansSerif" = "toothlessRounded"
 selectorAffix."aRetroflexHook" = "serifless"
 selectorAffix."a/doubleStorey" = "toothlessRounded"
@@ -2358,6 +2357,7 @@ selectorAffix."a/singleStorey/autoSerifed/slab" = "doubleSerifed"
 selectorAffix."a/singleStorey/autoSerifed/sans" = "serifless"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "topSerifed"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "serifless"
+selectorAffix."ae/a" = "serifless"
 
 
 
@@ -5785,16 +5785,25 @@ tagKind = "letter"
 rank = 1
 description = "Greek lower Theta (`θ`) with a capsule (O-like) body shape"
 selector."grek/theta" = "capsule"
+selector."grek/theta/nonCursive" = "capsule"
 
 [prime.lower-theta.variants.oval]
 rank = 2
 description = "Greek lower Theta (`θ`) with a standard (oval) body shape"
 selector."grek/theta" = "oval"
+selector."grek/theta/nonCursive" = "oval"
 
 [prime.lower-theta.variants.diamond]
 rank = 3
 description = "Greek lower Theta (`θ`) with a diamond body shape"
 selector."grek/theta" = "diamond"
+selector."grek/theta/nonCursive" = "diamond"
+
+[prime.lower-theta.variants.cursive]
+rank = 4
+description = "Greek lower Theta (`θ`) with a cursive body shape"
+selector."grek/theta" = "cursive"
+selector."grek/theta/nonCursive" = "oval"
 
 
 
@@ -9367,6 +9376,7 @@ capital-eszet = "rounded-serifless"
 long-s = "flat-hook-serifless"
 eszet = "longs-s-lig-serifless"
 lower-beta = "standard"
+lower-theta = "oval"
 lower-chi = "semi-chancery-straight-serifless"
 lower-eth = "straight-bar"
 lower-lambda = "tailed-turn"
@@ -9411,6 +9421,7 @@ l = "tailed"
 long-s = "flat-hook-descending"
 eszet = "longs-s-lig-descending-serifless"
 lower-beta = "cursive"
+lower-theta = "cursive"
 lower-phi = "cursive"
 cyrl-a = "single-storey-top-cut-serifless"
 cyrl-ve = "cursive-tall"
@@ -10668,6 +10679,7 @@ capital-eszet = "corner-serifless"
 long-s = "flat-hook-double-serifed-xh"
 eszet = "traditional-flat-hook-serifless"
 lower-delta = "flat-top"
+lower-theta = "oval"
 lower-iota = "serifed-flat-tailed"
 lower-lambda = "tailed-turn"
 lower-tau = "flat-tailed"
@@ -10719,6 +10731,7 @@ x = "cursive"
 y = "cursive-serifless"
 z = "cursive"
 long-s = "flat-hook-diagonal-tailed-middle-serifed-xh"
+lower-theta = "cursive"
 lower-iota = "serifed-diagonal-tailed"
 lower-tau = "diagonal-tailed"
 cyrl-a = "single-storey-tailed"
@@ -10930,6 +10943,7 @@ long-s = "bent-hook-serifless"
 eszet = "longs-s-lig-serifless"
 lower-eth = "straight-bar"
 capital-thorn = "motion-serifed"
+lower-theta = "capsule"
 lower-iota = "serifed-flat-tailed"
 lower-lambda = "tailed-turn"
 lower-tau = "flat-tailed"

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -6359,12 +6359,12 @@ tagKind = "letter"
 
 [prime.partial-derivative.variants.straight-bar]
 rank = 1
-description = "Partial derivative symbol (`∂`) with a straight upper bar"
+description = "Partial derivative symbol (`∂`) with a straight bar"
 selector."partial" = "straight-bar"
 
 [prime.partial-derivative.variants.curly-bar]
 rank = 2
-description = "Partial derivative symbol (`∂`) with a curly upper bar"
+description = "Partial derivative symbol (`∂`) with a curly bar"
 selector."partial" = "curly-bar"
 
 [prime.partial-derivative.variants.closed-contour]
@@ -9375,12 +9375,12 @@ y = "straight-turn-serifless"
 capital-eszet = "rounded-serifless"
 long-s = "flat-hook-serifless"
 eszet = "longs-s-lig-serifless"
+lower-eth = "straight-bar"
 lower-beta = "standard"
 lower-theta = "oval"
-lower-chi = "semi-chancery-straight-serifless"
-lower-eth = "straight-bar"
 lower-lambda = "tailed-turn"
 lower-phi = "straight"
+lower-chi = "semi-chancery-straight-serifless"
 partial-derivative = "closed-contour"
 cyrl-a = "double-storey-serifless"
 cyrl-ve = "standard-serifless"


### PR DESCRIPTION
Theta shown at the bottom row along with some additional Greek letters.

Additionally, I've implemented an IPA locale override for avoiding the cursive variant in phonetic transcription, partially in anticipation of [L2/24-146](https://www.unicode.org/L2/L2024/24146-greek-with-palatal-hook.pdf).

```
 ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ
abc.def.ghi.jkl.mno.pqrs.tuv.wxyz
!iIlL17|¦ ¢coO08BDQ $5SZ2zs ∂96µm
float il1[]={1-2/3.4,5+6=7/8%90};
1234567890 ,._-+= >< «¯-¬_» ~–÷+×
{*}[]()<>`+-=$/#_%^@\&|~?'" !,.;:
G6Qg9q¶ Þẞðþſß ΓΔΛαβγδιλμνξπτυφχψ
ЖЗКНРУЭЯавжзклмнруфчьыэя <= != ==

εζηθκρςσω
```

`SS03` Upright:
![image](https://github.com/user-attachments/assets/a9c7bd88-b9b3-4da9-9200-aaa022e883b4)
Compared to Consolas Upright:
![image](https://github.com/user-attachments/assets/4c7ce03a-2d1e-4965-82d1-a28fa5f52889)
`SS03` Italic:
![image](https://github.com/user-attachments/assets/2d1116d0-f134-4b5a-bdfb-8ab1dfeea0e7)
Compared to Consolas Italic:
![image](https://github.com/user-attachments/assets/50010bba-fc85-49b9-919c-cf8aa2985a19)

-----

`SS15` Upright:
![image](https://github.com/user-attachments/assets/5cbcebb5-6853-4abd-9377-d99505a41ba8)
Compared to IBM Plex Mono Upright (with IBM Plex Sans as a fallback):
![image](https://github.com/user-attachments/assets/8c5c39c4-2e6a-45bd-bdf3-3df2fc1063a5)
`SS15` Italic:
![image](https://github.com/user-attachments/assets/1a3fd000-d949-47c7-8c9a-3b223a94ec1c)
Compared to IBM Plex Mono Italic (again with IBM Plex Sans as a fallback):
![image](https://github.com/user-attachments/assets/50c01242-0500-460e-b6cc-c85f402dbf00)
