### PR TITLE
Add `top-right-serifed` variants for Greek Lower Kappa (`κ`), for `ss15`.

### DIFF
--- a/changes/33.1.0.md
+++ b/changes/33.1.0.md
@@ -1,4 +1,5 @@
-* Add `full-serifed` and `tri-serifed` variants for `K` and `k`, and related letters (#2696).
+* Add `full-serifed` variants for `K` and `k`, and related letters (#2696).
+* Add `top-right-serifed` and `tri-serifed` variants for `K` and `k`, and related letters.
 * Add `cursive` variant for Greek Lower Theta (`θ`).
 * Add IPA localization form for Latin Lower G with Stroke (`ǥ`).
 * Add variant selectors for Greek Lower Eta (`η`) and Kappa (`κ`).

--- a/packages/font-glyphs/src/letter/latin/k.ptl
+++ b/packages/font-glyphs/src/letter/latin/k.ptl
@@ -414,14 +414,14 @@ glyph-block Letter-Latin-K : begin
 			topLeftSerifed                     { 2 0 0 }
 			bottomRightSerifed                 { 0 0 1 }
 			topLeftAndBottomRightSerifed       { 2 0 1 }
-			triSerifed : match body
-				[Just 'symmetricConnectedKH']  { 2 0 2 }
-				__                             { 2 0 3 }
-			serifedKappa                           { 2 1 3 }
+			topRightSerifed                    { 0 0 2 }
+			topLeftAndTopRightSerifed          { 2 0 2 }
+			triSerifed                         { 2 0 3 }
+			serifedKappa                       { 2 1 3 }
+			fullSerifedKappa                   { 2 1 7 }
 			serifed : match body
 				[Just 'symmetricConnectedKH']  { 1 1 2 }
 				__                             { 1 1 3 }
-			fullSerifedKappa                       { 2 1 7 }
 			fullSerifed : match body
 				[Just 'symmetricConnectedKH']  { 1 1 6 }
 				__                             { 1 1 7 }
@@ -561,6 +561,8 @@ glyph-block Letter-Latin-K : begin
 			topLeftSerifed               { 1 0 0 }
 			bottomRightSerifed           { 0 0 1 }
 			topLeftAndBottomRightSerifed { 1 0 1 }
+			topRightSerifed              { 0 0 2 }
+			topLeftAndTopRightSerifed    { 1 0 2 }
 			triSerifed                   { 1 0 3 }
 			serifed                      { 1 1 3 }
 			fullSerifed                  { 1 1 7 }

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1193,17 +1193,26 @@ selectorAffix."K/sansSerif" = "serifless"
 selectorAffix.KHookTop = "topLeftAndBottomRightSerifed"
 selectorAffix.KDescender = "topLeftSerifed"
 
-[prime.capital-k.variants-buildup.stages.serifs.tri-serifed]
+[prime.capital-k.variants-buildup.stages.serifs.top-right-serifed]
 rank = 5
+nonBreakingVariantAdditionPriority = 100
+descriptionAffix = "serifs at top right"
+selectorAffix.K = "topRightSerifed"
+selectorAffix."K/sansSerif" = "serifless"
+selectorAffix.KHookTop = "serifless"
+selectorAffix.KDescender = "topRightSerifed"
+
+[prime.capital-k.variants-buildup.stages.serifs.tri-serifed]
+rank = 6
 nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "serifs at top left and both legs"
 selectorAffix.K = "triSerifed"
 selectorAffix."K/sansSerif" = "serifless"
 selectorAffix.KHookTop = "topLeftAndBottomRightSerifed"
-selectorAffix.KDescender = "triSerifed"
+selectorAffix.KDescender = "topLeftAndTopRightSerifed"
 
 [prime.capital-k.variants-buildup.stages.serifs.serifed]
-rank = 6
+rank = 7
 descriptionAffix = "serifs"
 selectorAffix.K = "serifed"
 selectorAffix."K/sansSerif" = "serifless"
@@ -1211,7 +1220,7 @@ selectorAffix.KHookTop = "serifed"
 selectorAffix.KDescender = "serifed"
 
 [prime.capital-k.variants-buildup.stages.serifs.full-serifed]
-rank = 7
+rank = 8
 nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "full serifs at legs"
 selectorAffix.K = "fullSerifed"
@@ -3330,19 +3339,30 @@ selectorAffix."latn/kappa" = "topLeftAndBottomRightSerifed"
 selectorAffix.kHookTop = "bottomRightSerifed"
 selectorAffix.kDescender = "topLeftSerifed"
 
-[prime.k.variants-buildup.stages.serifs.tri-serifed]
+[prime.k.variants-buildup.stages.serifs.top-right-serifed]
 rank = 5
 nonBreakingVariantAdditionPriority = 100
-disableIf = [{ body = "cursive" }, { body = "diagonal-tailed-cursive" } ]
+disableIf = [ { body = "cursive" }, { body = "diagonal-tailed-cursive" } ]
+descriptionAffix = "serifs at top right"
+selectorAffix.k = "topRightSerifed"
+selectorAffix."k/sansSerif" = "serifless"
+selectorAffix."latn/kappa" = "topRightSerifed"
+selectorAffix.kHookTop = "topRightSerifed"
+selectorAffix.kDescender = "topRightSerifed"
+
+[prime.k.variants-buildup.stages.serifs.tri-serifed]
+rank = 6
+nonBreakingVariantAdditionPriority = 100
+disableIf = [ { body = "cursive" }, { body = "diagonal-tailed-cursive" } ]
 descriptionAffix = "serifs at top left and both legs"
 selectorAffix.k = "triSerifed"
 selectorAffix."k/sansSerif" = "serifless"
 selectorAffix."latn/kappa" = "triSerifed"
 selectorAffix.kHookTop = "triSerifed"
-selectorAffix.kDescender = "triSerifed"
+selectorAffix.kDescender = "topLeftAndTopRightSerifed"
 
 [prime.k.variants-buildup.stages.serifs.serifed]
-rank = 6
+rank = 7
 disableIf = [ { body = "diagonal-tailed-cursive" } ]
 descriptionAffix = "serifs"
 selectorAffix.k = "serifed"
@@ -3352,7 +3372,7 @@ selectorAffix.kHookTop = "serifed"
 selectorAffix.kDescender = "serifed"
 
 [prime.k.variants-buildup.stages.serifs.full-serifed]
-rank = 7
+rank = 8
 nonBreakingVariantAdditionPriority = 100
 disableIf = [ { body = "diagonal-tailed-cursive" } ]
 descriptionAffix = "full serifs at legs"
@@ -4957,28 +4977,28 @@ next = "hook"
 rank = 1
 descriptionAffix = "straight shape"
 selectorAffix.y = "straight"
-selectorAffix.yLoop = "straightLoop"
 selectorAffix."y/sansSerif" = "straight"
 selectorAffix."y/nonCursive" = "straight"
 selectorAffix.yHookTop = "straight"
+selectorAffix.yLoop = "straightLoop"
 
 [prime.y.variants-buildup.stages.body.curly]
 rank = 2
 descriptionAffix = "curly shape"
 selectorAffix.y = "curly"
-selectorAffix.yLoop = "curlyLoop"
 selectorAffix."y/sansSerif" = "curly"
 selectorAffix."y/nonCursive" = "curly"
 selectorAffix.yHookTop = "curly"
+selectorAffix.yLoop = "curlyLoop"
 
 [prime.y.variants-buildup.stages.body.cursive]
 rank = 3
 descriptionAffix = "cursive shape"
 selectorAffix.y = "cursive"
-selectorAffix.yLoop = "straightLoop"
 selectorAffix."y/sansSerif" = "cursive"
 selectorAffix."y/nonCursive" = "straight"
 selectorAffix.yHookTop = "cursive"
+selectorAffix.yLoop = "straightLoop"
 
 [prime.y.variants-buildup.stages.hook."*"]
 next = "serifs"
@@ -4987,58 +5007,58 @@ next = "serifs"
 rank = 1
 keyAffix = ""
 selectorAffix.y = ""
-selectorAffix.yLoop = ""
 selectorAffix."y/sansSerif" = ""
 selectorAffix."y/nonCursive" = ""
 selectorAffix.yHookTop = ""
+selectorAffix.yLoop = ""
 
 [prime.y.variants-buildup.stages.hook.turn]
 rank = 2
 disableIf = [{ body = "cursive" }]
 descriptionAffix = "a tail turns leftward"
 selectorAffix.y = "turn"
-selectorAffix.yLoop = ""
 selectorAffix."y/sansSerif" = "turn"
 selectorAffix."y/nonCursive" = "turn"
 selectorAffix.yHookTop = "turn"
+selectorAffix.yLoop = ""
 
 [prime.y.variants-buildup.stages.hook.flat-hook]
 rank = 3
 disableIf = [{ body = "NOT cursive" }]
 descriptionAffix = "a flat terminal hook"
 selectorAffix.y = "flatHook"
-selectorAffix.yLoop = ""
 selectorAffix."y/sansSerif" = "flatHook"
 selectorAffix."y/nonCursive" = ""
 selectorAffix.yHookTop = "flatHook"
+selectorAffix.yLoop = ""
 
 [prime.y.variants-buildup.stages.serifs.serifless]
 rank = 1
 descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix.y = "serifless"
-selectorAffix.yLoop = "serifless"
 selectorAffix."y/sansSerif" = "serifless"
 selectorAffix."y/nonCursive" = "serifless"
 selectorAffix.yHookTop = "serifless"
+selectorAffix.yLoop = "serifless"
 
 [prime.y.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
 descriptionAffix = "motion serifs"
 selectorAffix.y = "motionSerifed"
-selectorAffix.yLoop = "motionSerifed"
 selectorAffix."y/sansSerif" = "serifless"
 selectorAffix."y/nonCursive" = "motionSerifed"
 selectorAffix.yHookTop = "motionSerifed"
+selectorAffix.yLoop = "motionSerifed"
 
 [prime.y.variants-buildup.stages.serifs.serifed]
 rank = 3
 descriptionAffix = "serifs"
 selectorAffix.y = "serifed"
-selectorAffix.yLoop = "serifed"
 selectorAffix."y/sansSerif" = "serifless"
 selectorAffix."y/nonCursive" = "serifed"
 selectorAffix.yHookTop = { if = [{ body = "cursive" }], then = "motionSerifed", else = "serifed" }
+selectorAffix.yLoop = "serifed"
 
 
 
@@ -6001,20 +6021,26 @@ descriptionAffix = "serifs at top left and bottom right"
 selectorAffix."grek/kappa" = "topLeftAndBottomRightSerifed"
 selectorAffix."grek/kappa/sansSerif" = "serifless"
 
-[prime.lower-kappa.variants-buildup.stages.serifs.tri-serifed]
+[prime.lower-kappa.variants-buildup.stages.serifs.top-right-serifed]
 rank = 5
+descriptionAffix = "serifs at top right"
+selectorAffix."grek/kappa" = "topRightSerifed"
+selectorAffix."grek/kappa/sansSerif" = "serifless"
+
+[prime.lower-kappa.variants-buildup.stages.serifs.tri-serifed]
+rank = 6
 descriptionAffix = "serifs at top left and both legs"
 selectorAffix."grek/kappa" = "triSerifed"
 selectorAffix."grek/kappa/sansSerif" = "serifless"
 
 [prime.lower-kappa.variants-buildup.stages.serifs.serifed]
-rank = 6
+rank = 7
 descriptionAffix = "serifs"
 selectorAffix."grek/kappa" = "serifedKappa"
 selectorAffix."grek/kappa/sansSerif" = "serifless"
 
 [prime.lower-kappa.variants-buildup.stages.serifs.full-serifed]
-rank = 7
+rank = 8
 descriptionAffix = "full serifs at legs"
 selectorAffix."grek/kappa" = "fullSerifedKappa"
 selectorAffix."grek/kappa/sansSerif" = "serifless"
@@ -6967,18 +6993,28 @@ selectorAffix."cyrl/KaVBar" = "topLeftAndBottomRightSerifed"
 selectorAffix."cyrl/KaHook" = "topLeftSerifed"
 selectorAffix."cyrl/KaBashkir" = "bottomRightSerifed"
 
-[prime.cyrl-capital-ka.variants-buildup.stages.serifs.tri-serifed]
+[prime.cyrl-capital-ka.variants-buildup.stages.serifs.top-right-serifed]
 rank = 5
+nonBreakingVariantAdditionPriority = 100
+descriptionAffix = "serifs at top right"
+selectorAffix."cyrl/Ka" = "topRightSerifed"
+selectorAffix."cyrl/KaDescender" = "topRightSerifed"
+selectorAffix."cyrl/KaVBar" = "topRightSerifed"
+selectorAffix."cyrl/KaHook" = "topRightSerifed"
+selectorAffix."cyrl/KaBashkir" = "topRightSerifed"
+
+[prime.cyrl-capital-ka.variants-buildup.stages.serifs.tri-serifed]
+rank = 6
 nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "serifs at top left and both legs"
 selectorAffix."cyrl/Ka" = "triSerifed"
-selectorAffix."cyrl/KaDescender" = "triSerifed"
+selectorAffix."cyrl/KaDescender" = "topLeftAndTopRightSerifed"
 selectorAffix."cyrl/KaVBar" = "triSerifed"
-selectorAffix."cyrl/KaHook" = "triSerifed"
+selectorAffix."cyrl/KaHook" = "topLeftAndTopRightSerifed"
 selectorAffix."cyrl/KaBashkir" = "triSerifed"
 
 [prime.cyrl-capital-ka.variants-buildup.stages.serifs.serifed]
-rank = 6
+rank = 7
 descriptionAffix = "serifs"
 selectorAffix."cyrl/Ka" = "serifed"
 selectorAffix."cyrl/KaDescender" = "serifed"
@@ -7073,18 +7109,28 @@ selectorAffix."cyrl/kaVBar" = "topLeftAndBottomRightSerifed"
 selectorAffix."cyrl/kaHook" = "topLeftSerifed"
 selectorAffix."cyrl/kaBashkir" = "bottomRightSerifed"
 
-[prime.cyrl-ka.variants-buildup.stages.serifs.tri-serifed]
+[prime.cyrl-ka.variants-buildup.stages.serifs.top-right-serifed]
 rank = 5
+nonBreakingVariantAdditionPriority = 100
+descriptionAffix = "serifs at top right"
+selectorAffix."cyrl/ka" = "topRightSerifed"
+selectorAffix."cyrl/kaDescender" = "topRightSerifed"
+selectorAffix."cyrl/kaVBar" = "topRightSerifed"
+selectorAffix."cyrl/kaHook" = "topRightSerifed"
+selectorAffix."cyrl/kaBashkir" = "topRightSerifed"
+
+[prime.cyrl-ka.variants-buildup.stages.serifs.tri-serifed]
+rank = 6
 nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "serifs at top left and bottom right"
 selectorAffix."cyrl/ka" = "triSerifed"
-selectorAffix."cyrl/kaDescender" = "triSerifed"
+selectorAffix."cyrl/kaDescender" = "topLeftAndTopRightSerifed"
 selectorAffix."cyrl/kaVBar" = "triSerifed"
-selectorAffix."cyrl/kaHook" = "triSerifed"
+selectorAffix."cyrl/kaHook" = "topLeftAndTopRightSerifed"
 selectorAffix."cyrl/kaBashkir" = "triSerifed"
 
 [prime.cyrl-ka.variants-buildup.stages.serifs.serifed]
-rank = 6
+rank = 7
 descriptionAffix = "serifs"
 selectorAffix."cyrl/ka" = "serifed"
 selectorAffix."cyrl/kaDescender" = "serifed"
@@ -9216,7 +9262,7 @@ capital-thorn = "serifed"
 lower-thorn = "serifed"
 capital-gamma = "serifed"
 lower-eta = "motion-serifed"
-lower-kappa = "straight-top-left-serifed"
+lower-kappa = "straight-tri-serifed"
 capital-lambda = "straight-base-serifed"
 lower-lambda = "straight-turn"
 lower-mu = "tailed-serifed"
@@ -9270,6 +9316,7 @@ y = "cursive-motion-serifed"
 z = "cursive"
 long-s = "flat-hook-tailed"
 eszet = "sulzbacher-tailed-serifless"
+lower-kappa = "straight-top-left-serifed"
 lower-lambda = "straight"
 lower-mu = "tailed-motion-serifed"
 cyrl-a = "single-storey-tailed"
@@ -9310,8 +9357,8 @@ y = "straight-turn-serifless"
 long-s = "flat-hook-middle-serifed-xh"
 eszet = "longs-s-lig-serifless"
 lower-eth = "straight-bar"
-lower-iota = "tailed"
 lower-gamma = "straight"
+lower-iota = "tailed"
 lower-lambda = "tailed-turn"
 lower-mu = "toothed-serifless"
 lower-nu = "straight"
@@ -9374,6 +9421,7 @@ z = "straight-serifed"
 long-s = "flat-hook-double-serifed-xh"
 eszet = "longs-s-lig-bottom-serifed"
 lower-iota = "tailed-serifed"
+lower-kappa = "straight-tri-serifed"
 lower-mu = "toothed-serifed"
 cyrl-a = "double-storey-serifed"
 cyrl-ve = "standard-bilateral-serifed"
@@ -9481,6 +9529,7 @@ v = "straight-serifed"
 w = "straight-flat-top-serifed"
 y = "straight-turn-serifed"
 eszet = "longs-s-lig-bottom-serifed"
+lower-kappa = "straight-tri-serifed"
 lower-mu = "tailed-serifed"
 cyrl-a = "double-storey-serifed"
 cyrl-ve = "standard-bilateral-serifed"
@@ -9597,7 +9646,7 @@ z = "straight-serifed"
 capital-eszet = "rounded-serifed"
 long-s = "flat-hook-bottom-serifed"
 eszet = "longs-s-lig-bottom-serifed"
-lower-kappa = "symmetric-touching-top-left-serifed"
+lower-kappa = "symmetric-touching-tri-serifed"
 cyrl-a = "double-storey-serifed"
 cyrl-ve = "standard-bilateral-serifed"
 cyrl-capital-ka = "symmetric-touching-serifed"
@@ -9621,9 +9670,10 @@ x = "straight-bilateral-motion-serifed"
 y = "straight-turn-motion-serifed"
 long-s = "flat-hook-descending"
 eszet = "longs-s-lig-descending-serifless"
+lower-kappa = "symmetric-touching-top-left-and-bottom-right-serifed"
 cyrl-a = "single-storey-top-cut-serifed"
 cyrl-ve = "cursive-tall"
-cyrl-ka = "symmetric-connected-top-left-and-bottom-right-serifed"
+cyrl-ka = "symmetric-connected-tri-serifed"
 cyrl-u = "straight-turn-motion-serifed"
 cyrl-ef = "serifless"
 micro-sign = "tailed-motion-serifed"
@@ -9724,6 +9774,7 @@ z = "straight-serifed"
 capital-eszet = "rounded-serifed"
 long-s = "flat-hook-double-serifed-xh"
 eszet = "longs-s-lig-bottom-serifed"
+lower-kappa = "straight-tri-serifed"
 lower-mu = "tailed-serifed"
 lower-psi = "flat-top-serifed"
 cyrl-a = "double-storey-serifed"
@@ -9832,7 +9883,7 @@ z = "straight-serifed"
 capital-eszet = "rounded-serifed"
 long-s = "bent-hook-bottom-serifed"
 eszet = "longs-s-lig-bottom-serifed"
-lower-kappa = "symmetric-touching-top-left-serifed"
+lower-kappa = "symmetric-touching-tri-serifed"
 lower-mu = "toothed-serifed"
 lower-psi = "flat-top-serifed"
 cyrl-ve = "standard-bilateral-serifed"
@@ -9932,6 +9983,7 @@ z = "straight-serifed"
 capital-eszet = "rounded-serifed"
 long-s = "flat-hook-bottom-serifed"
 eszet = "longs-s-lig-bottom-serifed"
+lower-kappa = "straight-tri-serifed"
 lower-mu = "tailed-serifed"
 lower-chi = "straight-bilateral-motion-serifed"
 cyrl-ve = "standard-bilateral-serifed"
@@ -10031,7 +10083,7 @@ y = "straight-turn-serifed"
 z = "straight-serifed"
 long-s = "bent-hook-double-serifed"
 eszet = "longs-s-lig-bottom-serifed"
-lower-kappa = "symmetric-touching-top-left-serifed"
+lower-kappa = "symmetric-touching-tri-serifed"
 lower-mu = "toothed-serifed"
 cyrl-a = "double-storey-serifed"
 cyrl-ve = "standard-bilateral-serifed"
@@ -10158,7 +10210,7 @@ y = "curly-serifed"
 z = "curly-serifed"
 long-s = "bent-hook-double-serifed"
 eszet = "longs-s-lig-bottom-serifed"
-lower-kappa = "curly-top-left-serifed"
+lower-kappa = "curly-tri-serifed"
 capital-lambda = "curly-base-serifed"
 lower-mu = "toothed-serifed"
 cyrl-a = "double-storey-serifed"
@@ -10182,6 +10234,7 @@ v = "curly-motion-serifed"
 w = "curly-motion-serifed"
 x = "curly-bilateral-motion-serifed"
 y = "curly-motion-serifed"
+lower-kappa = "curly-top-left-and-bottom-right-serifed"
 lower-mu = "toothed-motion-serifed"
 cyrl-ka = "curly-top-left-and-bottom-right-serifed"
 cyrl-u = "curly-motion-serifed"
@@ -10268,6 +10321,7 @@ z = "straight-serifed"
 capital-eszet = "rounded-serifed"
 long-s = "bent-hook-double-serifed"
 eszet = "longs-s-lig-bottom-serifed"
+lower-kappa = "straight-tri-serifed"
 cyrl-a = "double-storey-serifed"
 cyrl-ve = "standard-bilateral-serifed"
 cyrl-ka = "symmetric-connected-serifed"
@@ -10289,6 +10343,7 @@ u = "toothed-motion-serifed"
 w = "straight-flat-top-motion-serifed"
 x = "straight-bilateral-motion-serifed"
 y = "straight-turn-motion-serifed"
+lower-kappa = "straight-top-left-and-bottom-right-serifed"
 cyrl-ve = "standard-unilateral-serifed"
 cyrl-ka = "symmetric-connected-top-left-and-bottom-right-serifed"
 cyrl-u = "straight-turn-motion-serifed"
@@ -10375,7 +10430,7 @@ y = "cursive-flat-hook-serifed"
 z = "straight-serifed"
 long-s = "flat-hook-double-serifed"
 eszet = "sulzbacher-bottom-serifed"
-lower-kappa = "symmetric-connected-top-left-serifed"
+lower-kappa = "symmetric-connected-tri-serifed"
 cyrl-ka = "symmetric-connected-serifed"
 cyrl-capital-u = "straight-serifed"
 cyrl-u = "straight-serifed"
@@ -10394,6 +10449,7 @@ q = "top-cut-straight-serifed"
 w = "rounded-vertical-sides-motion-serifed"
 x = "straight-bilateral-motion-serifed"
 y = "cursive-flat-hook-motion-serifed"
+lower-kappa = "symmetric-connected-top-left-and-bottom-right-serifed"
 cyrl-ka = "symmetric-connected-top-left-and-bottom-right-serifed"
 cyrl-u = "cursive-flat-hook-motion-serifed"
 micro-sign = "toothless-rounded-motion-serifed"
@@ -10548,7 +10604,7 @@ capital-eszet = "rounded-serifed"
 long-s = "bent-hook-bottom-serifed"
 eszet = "longs-s-lig-bottom-serifed"
 capital-gamma = "serifed"
-lower-kappa = "symmetric-touching-top-left-serifed"
+lower-kappa = "symmetric-touching-tri-serifed"
 lower-mu = "toothless-corner-serifed"
 lower-upsilon = "straight-serifed"
 lower-psi = "flat-top-serifed"
@@ -10575,6 +10631,7 @@ x = "straight-bilateral-motion-serifed"
 y = "straight-turn-motion-serifed"
 long-s = "bent-hook-tailed"
 eszet = "longs-s-lig-tailed-serifless"
+lower-kappa = "symmetric-touching-top-left-and-bottom-right-serifed"
 lower-mu = "tailed-motion-serifed"
 cyrl-ka = "symmetric-touching-top-left-and-bottom-right-serifed"
 cyrl-u = "straight-turn-motion-serifed"
@@ -10667,7 +10724,7 @@ z = "straight-serifed"
 long-s = "bent-hook-double-serifed"
 eszet = "longs-s-lig-bottom-serifed"
 lower-iota = "tailed-serifed"
-lower-kappa = "symmetric-touching-top-left-serifed"
+lower-kappa = "symmetric-touching-tri-serifed"
 lower-mu = "toothed-serifed"
 cyrl-ve = "standard-bilateral-serifed"
 cyrl-ze = "unilateral-serifed"
@@ -10781,7 +10838,7 @@ z = "straight-serifed"
 long-s = "flat-hook-bottom-serifed"
 eszet = "sulzbacher-bottom-serifed"
 lower-alpha = "barred-double-serifed"
-lower-kappa = "symmetric-connected-top-left-serifed"
+lower-kappa = "symmetric-connected-tri-serifed"
 lower-mu = "toothed-serifed"
 lower-upsilon = "straight-serifed"
 lower-psi = "flat-top-serifed"
@@ -10809,6 +10866,7 @@ y = "cursive-flat-hook-motion-serifed"
 long-s = "flat-hook-tailed"
 eszet = "sulzbacher-tailed-serifless"
 lower-alpha = "barred-tailed"
+lower-kappa = "symmetric-connected-top-left-and-bottom-right-serifed"
 lower-mu = "toothed-motion-serifed"
 cyrl-a = "single-storey-tailed"
 cyrl-ve = "standard-unilateral-serifed"
@@ -10847,6 +10905,7 @@ lower-delta = "flat-top"
 lower-eta = "motion-serifed"
 lower-theta = "oval"
 lower-iota = "serifed-flat-tailed"
+lower-kappa = "straight-top-right-serifed"
 lower-lambda = "tailed-turn"
 lower-tau = "flat-tailed"
 lower-upsilon = "straight-serifless"
@@ -10918,6 +10977,7 @@ x = "straight-serifed"
 y = "straight-turn-serifed"
 capital-eszet = "corner-bottom-serifed"
 eszet = "traditional-flat-hook-bottom-serifed"
+lower-kappa = "straight-tri-serifed"
 lower-upsilon = "straight-serifed"
 cyrl-capital-ka = "symmetric-connected-serifed"
 cyrl-ka = "symmetric-connected-serifed"
@@ -10938,6 +10998,7 @@ u = "toothed-motion-serifed"
 w = "cursive-serifed"
 x = "cursive"
 y = "cursive-motion-serifed"
+eszet = "traditional-flat-hook-serifless"
 cyrl-ka = "symmetric-connected-top-left-and-bottom-right-serifed"
 cyrl-u = "cursive-motion-serifed"
 cyrl-ef = "split-diagonal-tailed-cursive"
@@ -11047,7 +11108,7 @@ long-s = "bent-hook-double-serifed"
 eszet = "longs-s-lig-dual-serifed"
 capital-thorn = "asymmetric-serifed"
 lower-thorn = "serifed"
-lower-kappa = "straight-top-left-and-bottom-right-serifed"
+lower-kappa = "straight-tri-serifed"
 lower-mu = "toothed-serifed"
 cyrl-a = "double-storey-hook-inward-serifed-serifed"
 cyrl-ve = "standard-bilateral-serifed"
@@ -11210,7 +11271,7 @@ capital-eszet = "corner-serifed"
 long-s = "bent-hook-bottom-serifed"
 eszet = "longs-s-lig-bottom-serifed"
 capital-thorn = "serifed"
-lower-kappa = "straight-top-left-serifed"
+lower-kappa = "straight-tri-serifed"
 cyrl-a = "double-storey-hook-inward-serifed-tailed"
 cyrl-ze = "unilateral-inward-serifed"
 cyrl-capital-ka = "symmetric-connected-serifed"
@@ -11331,7 +11392,7 @@ z = "straight-serifed"
 long-s = "bent-hook-double-serifed-xh"
 eszet = "longs-s-lig-bottom-serifed"
 lower-alpha = "barred-tailed-serifed"
-lower-kappa = "symmetric-connected-top-left-serifed"
+lower-kappa = "symmetric-connected-tri-serifed"
 lower-upsilon = "straight-serifed"
 lower-psi = "flat-top-serifed"
 cyrl-ve = "standard-bilateral-serifed"
@@ -11354,6 +11415,7 @@ y = "straight-turn-motion-serifed"
 long-s = "bent-hook-descending-middle-serifed-xh"
 eszet = "longs-s-lig-descending-serifless"
 lower-alpha = "barred-tailed"
+lower-kappa = "symmetric-connected-top-left-and-bottom-right-serifed"
 cyrl-ve = "standard-unilateral-serifed"
 cyrl-ka = "symmetric-connected-top-left-and-bottom-right-serifed"
 cyrl-u = "straight-turn-motion-serifed"
@@ -11416,7 +11478,7 @@ w = "curly-serifed"
 x = "curly-serifed"
 y = "curly-turn-serifed"
 z = "curly-serifed"
-lower-kappa = "curly-top-left-serifed"
+lower-kappa = "curly-tri-serifed"
 capital-lambda = "curly-base-serifed"
 lower-lambda = "curly-turn"
 lower-chi = "curly-bilateral-motion-serifed"
@@ -11434,4 +11496,5 @@ w = "curly-motion-serifed"
 x = "cursive"
 y = "cursive-motion-serifed"
 z = "cursive"
+lower-kappa = "curly-top-left-serifed"
 cyrl-u = "cursive-motion-serifed"


### PR DESCRIPTION
This is probably the last serif variant I will be adding for the time being.
I've also also added it to Latin `K`/`k` and Cyrillic `К`/`к` on principle.

This also adds an (internal-only) variant `topLeftAndTopRightSerifed` for letters like `KDescender` etc., whose bottom-right leg is occupied by some orthographic feature.

```
ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ
abc.def.ghi.jkl.mno.pqrs.tuv.wxyz
!iIlL17|¦ ¢coO08BDQ $5SZ2zs ∂96µm
float il1[]={1-2/3.4,5+6=7/8%90};
1234567890 ,._-+= >< «¯-¬_» ~–÷+×
{*}[]()<>`+-=$/#_%^@\&|~?'" !,.;:
g9q¶ Þẞðþſß ΓΔΛαβγδηθικλμνξπτυφχψ
ЖЗКНРУЭЯавжзклмнруфчьыэя <= != ==
```

`ss15` Upright:
![image](https://github.com/user-attachments/assets/c7ff3ccb-9765-442e-bd79-75a0e477d667)
Compared to IBM Plex Mono Upright (with IBM Plex Sans as a fallback):
![image](https://github.com/user-attachments/assets/8aefd259-e6a8-4267-8000-dc745882c39c)
`ss15` Italic:
![image](https://github.com/user-attachments/assets/6bab6b15-c2e1-4eb2-b3ea-bff4ff5d2438)
Compared to IBM Plex Mono Italic (again with IBM Plex Sans as a fallback):
![image](https://github.com/user-attachments/assets/4ac31090-5d00-4a80-b345-030cfd7cc108)
