### PR TITLE
Move/rename `greek/lower-epsilon.ptl` to `cyrillic/ze.ptl`.

### DIFF
--- a/packages/font-glyphs/src/letter/armenian/upper-yi.ptl
+++ b/packages/font-glyphs/src/letter/armenian/upper-yi.ptl
@@ -9,7 +9,7 @@ glyph-block Letter-Armenian-Upper-Yi : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Shapes : SerifFrame
-	glyph-block-import Letter-Greek-Lower-Epsilon : CyrZe
+	glyph-block-import Letter-Cyrillic-Ze : CyrZe
 
 	do "Yi"
 		create-glyph 'armn/Yi' 0x545 : glyph-proc

--- a/packages/font-glyphs/src/letter/cyrillic.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic.ptl
@@ -31,6 +31,7 @@ export : define [apply] : begin
 	run-glyph-module "./cyrillic/yat.mjs"
 	run-glyph-module "./cyrillic/yeri.mjs"
 	run-glyph-module "./cyrillic/yu.mjs"
+	run-glyph-module "./cyrillic/ze.mjs"
 	run-glyph-module "./cyrillic/zhe.mjs"
 
 	run-glyph-module "./cyrillic/orthography.mjs"

--- a/packages/font-glyphs/src/letter/cyrillic/de.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/de.ptl
@@ -8,7 +8,7 @@ glyph-block Letter-Cyrillic-De : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Adjustment : ExtendBelowBaseAnchors
-	glyph-block-import Letter-Greek-Lower-Epsilon : CyrZe EpsilonConfig
+	glyph-block-import Letter-Cyrillic-Ze : CyrZe ZeConfig
 
 	glyph-block-export BottomExtension
 	local BottomExtension : (-LongVJut) + QuarterStroke
@@ -117,7 +117,7 @@ glyph-block Letter-Cyrillic-De : begin
 
 	select-variant 'cyrl/deSoft' 0xA663 (follow -- 'cyrl/enghe/ghePart')
 
-	foreach { suffix { st sb }} [Object.entries EpsilonConfig] : do
+	foreach { suffix { st sb }} [Object.entries ZeConfig] : do
 		define [DzzeDescendershape de] : begin
 			local sr : [mix RightSB Width 0.5] - O * 2
 			local sl : mix sr de.xTopRight 2
@@ -176,7 +176,7 @@ glyph-block Letter-Cyrillic-De : begin
 		include : df.markSet.b
 		include : CyrDeItalicShapeT dispiro df
 
-	foreach { suffix { st sb }} [Object.entries EpsilonConfig] : do
+	foreach { suffix { st sb }} [Object.entries ZeConfig] : do
 		create-glyph "cyrl/dzze.italic.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleMM 3
 			include : df.markSet.bp

--- a/packages/font-glyphs/src/letter/cyrillic/dzzhe-zhwe.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/dzzhe-zhwe.ptl
@@ -7,7 +7,7 @@ glyph-module
 glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Greek-Lower-Epsilon : CyrZe EpsilonConfig
+	glyph-block-import Letter-Cyrillic-Ze : CyrZe ZeConfig
 
 	glyph-block-export SubDfDimBy4
 	define [SubDfDimBy4 pShift keeps df _o] : begin
@@ -63,7 +63,7 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 			include : ze.AutoStartSerifL
 			include : ze.AutoEndSerifL
 
-		foreach { suffix { slabTop slabBot } } [Object.entries EpsilonConfig] : do
+		foreach { suffix { slabTop slabBot } } [Object.entries ZeConfig] : do
 			create-glyph "cyrl/Zhwe/left.\(suffix)" : glyph-proc
 				define df : include : DivFrame (para.advanceScaleM ** 2) 3.5
 				include : df.markSet.capital

--- a/packages/font-glyphs/src/letter/cyrillic/ze.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/ze.ptl
@@ -6,7 +6,7 @@ import [mix linreg clamp fallback SuffixCfg] from "@iosevka/util"
 
 glyph-module
 
-glyph-block Letter-Greek-Lower-Epsilon : begin
+glyph-block Letter-Cyrillic-Ze : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Shared-Metrics : markFine
@@ -209,8 +209,8 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 				[Just SLAB-INWARD]    : ArcEndSerif.InwardL   left bot stroke hook
 				__ : glyph-proc
 
-	glyph-block-export EpsilonConfig
-	define EpsilonConfig : object
+	glyph-block-export ZeConfig
+	define ZeConfig : object
 		serifless               { SLAB-NONE      SLAB-NONE      }
 		bottomSerifed           { SLAB-NONE      SLAB-CLASSICAL }
 		bottomInwardSerifed     { SLAB-NONE      SLAB-INWARD    }
@@ -220,7 +220,7 @@ glyph-block Letter-Greek-Lower-Epsilon : begin
 		bilateralInwardSerifed  { SLAB-INWARD    SLAB-INWARD    }
 		hybridSerifed1          { SLAB-INWARD    SLAB-CLASSICAL }
 
-	foreach { suffix { slabTop slabBot } } [Object.entries EpsilonConfig] : do
+	foreach { suffix { slabTop slabBot } } [Object.entries ZeConfig] : do
 		create-glyph "latn/Epsilon.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : let [eps : SmallEpsilon slabTop slabBot CAP 0 (hook -- Hook)]

--- a/packages/font-glyphs/src/letter/greek.ptl
+++ b/packages/font-glyphs/src/letter/greek.ptl
@@ -14,7 +14,6 @@ export : define [apply] : begin
 
 	run-glyph-module "./greek/lower-gamma.mjs"
 	run-glyph-module "./greek/lower-delta.mjs"
-	run-glyph-module "./greek/lower-epsilon.mjs"
 	run-glyph-module "./greek/lower-lunate-epsilon.mjs"
 	run-glyph-module "./greek/lower-zeta.mjs"
 	run-glyph-module "./greek/lower-theta.mjs"


### PR DESCRIPTION
This is basically just an organizational/cleanup thing; The CV feature is already named after Cyrillic Ze so this moves the file closer to that.

This also happens to make it so that `grek/epsilon` is defined _after_ `cyrl/e` which may possibly set things up for potential character variants in the future, but that part is totally optional.