### PR TITLE
Clicks with Curl + Variants of `Q`

### DIFF
--- a/changes/33.1.0.md
+++ b/changes/33.1.0.md
@@ -1,6 +1,11 @@
 * Add `full-serifed` variants for `K` and `k`, and related letters (#2696).
 * Add `top-right-serifed` and `tri-serifed` variants for `K` and `k`, and related letters.
 * Add `cursive` variant for Greek Lower Theta (`θ`).
+* Add `closed-swash' variant for `Q` (#2392).
 * Add IPA localization form for Latin Lower `a` and `g`.
 * Add IPA localization form for Latin Lower G with Stroke (`ǥ`) (#2632).
 * Add variant selectors for Greek Lower Eta (`η`) and Kappa (`κ`).
+* Add Characters:
+  - LATIN SMALL LETTER TURNED T WITH CURL (`U+1DF0D`) (#1931).
+  - LATIN LETTER INVERTED GLOTTAL STOP WITH CURL (`U+1DF0E`) (#1931).
+  - LATIN LETTER STRETCHED C WITH CURL (`U+1DF0F`) (#1931).

--- a/packages/font-glyphs/src/letter/latin-ext/glottal-stop.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/glottal-stop.ptl
@@ -10,7 +10,7 @@ glyph-block Letter-Latin-Glottal-Stop : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Shared-Metrics : markHalfStroke
 	glyph-block-import Letter-Shared : CreateTurnedLetter
-	glyph-block-import Letter-Shared-Shapes : LetterBarOverlay
+	glyph-block-import Letter-Shared-Shapes : LetterBarOverlay CurlyTail
 
 	create-glyph 'glottalStop' 0x294 : glyph-proc
 		include : MarkSet.b
@@ -66,7 +66,25 @@ glyph-block Letter-Latin-Glottal-Stop : begin
 		if SLAB : begin
 			include : HSerif.mb Middle 0 Jut
 
-	CreateTurnedLetter 'invGlottalStop' 0x296 'revGlottalStop' HalfAdvance (Ascender / 2)
+	CreateTurnedLetter 'glottalStopTurned' 0x296 'revGlottalStop' HalfAdvance (Ascender / 2)
+
+	create-glyph 'glottalStopTurnedCurlyTail' 0x1DF0E : glyph-proc
+		include : MarkSet.b
+
+		local yMid : AdviceGlottalStopArchDepth Ascender 1
+		local fine : AdviceStroke 3.5
+
+		include : dispiro
+			widths.rhs
+			flat (Middle + [HSwToV HalfStroke]) Ascender [heading Downward]
+			curl (Middle + [HSwToV HalfStroke]) (Ascender - XH * 0.3)
+			alsoThru.g2 0.5 0.5 important
+			g4 RightSB yMid
+			CurlyTail.n fine 0 SB RightSB 0 yMid
+
+		if SLAB : begin
+			include : HSerif.mt Middle Ascender Jut
+
 
 	create-glyph 'glottalStopBar' 0x2A1 : glyph-proc
 		include [refer-glyph 'glottalStop'] AS_BASE

--- a/packages/font-glyphs/src/letter/latin/c.ptl
+++ b/packages/font-glyphs/src/letter/latin/c.ptl
@@ -95,17 +95,18 @@ glyph-block Letter-Latin-C : begin
 		[Just SLAB-INWARD]    : ArcEndSerif.InwardL df.leftSB bot [fallback sw Stroke] [fallback hook Hook]
 		__ : glyph-proc
 
-	define [CCurlyTailShape slabType] : glyph-proc
-		local sw : AdviceStroke2 2 3 XH
-		local fine : AdviceStroke2 3 3 XH
+	define [CCurlyTailShape df slabType top bot] : glyph-proc
+		local sw : df.adviceStroke2 2 3 (top - bot)
+		local fine : df.adviceStroke2 3 3 (top - bot)
+		local loopTop : bot + 0.45 * XH
 
 		include : dispiro
 			match slabType
-				[Just SLAB-CLASSICAL] : SerifedArcStart.RtlLhs RightSB XH sw Hook
-				[Just SLAB-INWARD] : InwardSlabArcStart.RtlLhs RightSB XH sw Hook
-				__ : list [g4 RightSB (XH - Hook) [widths.lhs sw]] [hookstart XH (sw -- sw)]
-			flatside.ld SB 0 XH SmallArchDepthA SmallArchDepthB
-			CurlyTail.n fine 0 RightSB 0 0 (yLoopTop -- (XH * 0.45))
+				[Just SLAB-CLASSICAL] : SerifedArcStart.RtlLhs df.rightSB top sw Hook
+				[Just SLAB-INWARD] : InwardSlabArcStart.RtlLhs df.rightSB top sw Hook
+				__ : list [g4 df.rightSB (top - Hook) [widths.lhs sw]] [hookstart top (sw -- sw)]
+			flatside.ld df.leftSB bot top SmallArchDepthA SmallArchDepthB
+			CurlyTail.n fine bot df.rightSB 0 bot (yLoopTop -- loopTop)
 
 	glyph-block-export CLetterForm
 	define [CLetterForm] : with-params [df sty styBot top bot [ada ArchDepthA] [adb ArchDepthB] [hook Hook] [sw Stroke] [ob nothing]] : namespace
@@ -230,7 +231,7 @@ glyph-block Letter-Latin-C : begin
 
 		create-glyph "cCurlyTail.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			include : CCurlyTailShape sty
+			include : CCurlyTailShape [DivFrame 1] sty XH 0
 			include : AutoStartSerifR [DivFrame 1] sty XH
 
 		create-glyph "stretchedC.\(suffix)" : glyph-proc
@@ -239,6 +240,11 @@ glyph-block Letter-Latin-C : begin
 				ada -- SmallArchDepthA
 				adb -- SmallArchDepthB
 			include : lf.full
+
+		create-glyph "stretchedCCurlyTail.\(suffix)" : glyph-proc
+			include : MarkSet.p
+			include : CCurlyTailShape [DivFrame 1] sty XH Descender
+			include : AutoStartSerifR [DivFrame 1] sty XH
 
 		define [KoppaShapeT styTop styBot top base] : union
 			VBar.r (Middle + [HSwToV Stroke]) Descender HalfStroke
@@ -314,6 +320,7 @@ glyph-block Letter-Latin-C : begin
 	select-variant 'cCurlyTail' 0x255
 	select-variant 'cHookTop' 0x188
 	select-variant 'stretchedC' 0x297 (follow -- 'c')
+	select-variant 'stretchedCCurlyTail' 0x1DF0F (follow -- 'cHookTop')
 
 	select-variant 'cyrl/Koppa' 0x480 (follow -- 'CTopSerifOnly')
 	select-variant 'cyrl/koppa' 0x481 (follow -- 'cTopSerifOnly')

--- a/packages/font-glyphs/src/letter/latin/lower-t.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-t.ptl
@@ -293,6 +293,29 @@ glyph-block Letter-Latin-Lower-T : begin
 				curl xLeft LongJut
 				CurlyTail.n fine 0 (xLeft + [HSwToV Stroke] + LongJut) 0 0
 
+		if (top == Ascender) : begin
+			create-glyph "tTurnedCurlyTail.\(suffix)" : glyph-proc
+				# local df : DivFrame 1
+
+				set-width df.width
+				include : df.markSet.b
+
+				local fine : AdviceStroke2 3.5 2.5 (-Descender)
+				# local rinner : LongJut / 2 - fine / 2
+
+				local xLeft : Style.BarLeftPos df sym
+
+				include : Style.Body df sym XH 0
+				include : FlipAround df.middle (XH / 2)
+
+				local xRight : df.width - xLeft
+				include : dispiro
+					widths.rhs
+					flat xRight TINY [heading Downward]
+					curl xRight 0    [heading Downward]
+					CurlyTail.n fine Descender (xRight - [HSwToV Stroke] - LongJut) df.rightSB Descender (Descender / 2 + fine)
+
+
 	select-variant 't' 't'
 	select-variant 't/teshLeft' (follow -- 't')
 	select-variant 't/phoneticLeft1' (shapeFrom -- 't')
@@ -302,10 +325,11 @@ glyph-block Letter-Latin-Lower-T : begin
 	derive-glyphs 'tCedilla' 0x163 't' ConnectedCedilla
 	CreateAccentedComposition 'tComma' 0x21B 't' 'commaBelow'
 
-	select-variant "tHookTop" 0x1AD
+	select-variant 'tHookTop' 0x1AD
 	select-variant 'tPalatalHook' 0x1AB (follow -- 't')
 	select-variant 'tRTail' 0x288
 	select-variant 'tCurlyTail' 0x236
+	select-variant 'tTurnedCurlyTail' 0x1DF0D (follow -- 'tHookTop')
 
 	select-variant "tHookTopRTail" 0x1DF09
 

--- a/packages/font-glyphs/src/letter/latin/upper-q.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-q.ptl
@@ -18,17 +18,16 @@ glyph-block Letter-Latin-Upper-Q : begin
 	define [QStdBody df top sw] : OShape top 0 df.leftSB df.rightSB sw ArchDepthA ArchDepthB
 	define [QHorizontalTailedBody df top sw] : begin
 		define fine : mix ShoulderFine sw 0.125
+		define tailRB : mix df.rightSB df.width 0.7
 		return : dispiro
 			g4.right.mid [arch.adjust-x.bot df.middle fine] (sw - fine) [widths.lhs fine]
 			archv
-			flat df.rightSB ArchDepthA [widths.lhs sw]
-			curl df.rightSB (top - ArchDepthB)
+			flatside.ru df.rightSB 0 top ArchDepthA ArchDepthB (af -- [widths.lhs sw])
 			arch.lhs top
-			flat df.leftSB (top - ArchDepthA)
-			curl df.leftSB ArchDepthB
+			flatside.ld df.leftSB  0 top ArchDepthA ArchDepthB
 			arcvh
 			flat [arch.adjust-x.bot df.middle] 0
-			curl df.rightSB 0
+			curl tailRB 0
 
 	define [QOpenSwashyBody df top] : glyph-proc
 		define fine : AdviceStroke 3.5
@@ -42,19 +41,23 @@ glyph-block Letter-Latin-Upper-Q : begin
 		define yRingStart : XH / 12
 		define notchOffset : ((-Descender) * 0.625) + Stroke * 0.625 + yRingStart / 2
 		define tailSlope : 0.2 + 0.5 * (1 - fine / Stroke)
-		# Lower part
+
+		# Lower-left OShape cutoff
 		include : difference
 			dispiro
 				flat df.width (yRingStart + O) [widths.rhs.heading fine Leftward]
 				curl [arch.adjust-x.bot df.middle] (yRingStart + O)
 				archv
-				flat (df.leftSB + OX) (yRingStart + ArchDepthB) [widths.rhs Stroke]
-				curl (df.leftSB + OX) [mix yRingStart top 0.5] [heading Upward]
+				flatside.lu df.leftSB yRingStart top ArchDepthA ArchDepthB (af -- [widths.rhs Stroke])
+				arch.rhs top
+				flatside.rd df.rightSB 0 top ArchDepthA ArchDepthB
 			MaskBelowLine
 				mix xMBArc xLB0 4
 				[mix yMBArc yLB 4] + notchOffset
 				mix xLB0 xMBArc 4
 				[mix yLB yMBArc 4] + notchOffset
+			MaskRightLine df.middle 0 df.middle top 2
+		# OShape to Swash stroke
 		include : dispiro
 			flat (df.leftSB + OX) [mix yRingStart top 0.5] [widths.rhs.heading Stroke Upward]
 			curl (df.leftSB + OX) (top - ArchDepthA)
@@ -65,6 +68,7 @@ glyph-block Letter-Latin-Upper-Q : begin
 			g2 xMBArc yMBArc [widths.rhs : 0.8 * [mix Stroke fine 0.5]]
 			alsoThru.g2 0.55 0.35 [widths.rhs : 0.9 * [mix Stroke fine 0.75]]
 			g2 xLB yLB [widths.rhs fine]
+		# Final Swash stroke
 		include : difference
 			dispiro
 				g2 xLB yLB [widths.lhs (fine * CThin)]
@@ -144,7 +148,31 @@ glyph-block Letter-Latin-Upper-Q : begin
 		corner [xBendTailStart df] yBendTailStart    [heading Rightward]
 		corner df.middle           yObliqueTailStart [heading Rightward]
 
-	define [QSwashyTail] : return : glyph-proc
+	define [QSwashyTail df top sw] : glyph-proc
+		define fine : df.adviceStroke 3.5
+		define xLB0 : mix df.leftSB df.rightSB (1 / 16)
+		define xLB : xLB0 + [HSwToV : 0.6 * fine]
+		define yLB : [mix 0 Descender (31 / 32)] + O
+		define xRB0 : mix df.rightSB df.width 0.7
+		define xRB : xRB0 - [HSwToV : 0.75 * Stroke]
+		define tailSlope : 0.2 + 0.5 * (1 - fine / Stroke)
+
+		# Body to Swash stroke
+		include : difference
+			dispiro
+				flat (df.middle + [HSwToV : 0.5 * Stroke]) [mix 0 top 0.1] [widths.rhs Stroke]
+				curl xLB yLB [widths.rhs fine]
+			OShapeOutline top 0 df.leftSB df.rightSB Stroke ArchDepthA ArchDepthB
+		# Final Swash stroke
+		include : difference
+			dispiro
+				g2 xLB yLB [widths.lhs (fine * CThin)]
+				g2.right.mid [mix xLB xRB (1 / 4)] (yLB - Descender / 4 - Stroke * (1 / 16)) [widths.lhs.heading (fine * CThin) {.x (TanSlope + tailSlope) .y 1}]
+				alsoThru.g2 0.5 0.5
+				g2.right.mid ([mix xLB xRB (3 / 4)] + Stroke * tailSlope) (Descender + O) [widths.lhs.heading Stroke {.x (TanSlope - tailSlope) .y 1}]
+				archv
+				g2 xRB0 [mix Descender xLB 0.5] [widths.lhs.heading fine Upward]
+			MaskLeft xLB
 
 	###################################
 
@@ -163,7 +191,8 @@ glyph-block Letter-Latin-Upper-Q : begin
 		horizontalTailed    { QHorizontalTailedBody  [AdviceStroke 3]    no-shape           'capital' 'e' }
 		detachedTailed      { QStdBody                Stroke             QDetachedTail      'capDesc' 'p' }
 		detachedBendTailed  { QStdBody                Stroke             QDetachedBendTail  'capDesc' 'p' }
-		openSwash           { QOpenSwashyBody         Stroke             QSwashyTail        'capDesc' 'p' }
+		openSwash           { QOpenSwashyBody         Stroke             no-shape           'capDesc' 'p' }
+		closedSwash         { QStdBody                Stroke             QSwashyTail        'capDesc' 'p' }
 
 
 	foreach { suffix { body swTailInner tailShape mkCapital mkSmcp } } [Object.entries QConfig] : do

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1476,6 +1476,12 @@ groupRank = 2
 description = "`Q` with open contour and swash-y shape"
 selector.Q = "openSwash"
 
+[prime.capital-q.variants.closed-swash]
+rank = 11
+groupRank = 2
+description = "`Q` with a swashy tail"
+selector.Q = "closedSwash"
+
 
 
 [prime.capital-r]


### PR DESCRIPTION
Closes #1931 and #2392.

<details> <summary> <code>𝼍ʇʖ𝼎ʗ𝼏ɕ</code> </summary>

![image](https://github.com/user-attachments/assets/145b7d4c-cee8-4112-baff-79e3f02f5d5d)

</details>

<details> <summary> <code>Q</code> </summary>

![image](https://github.com/user-attachments/assets/4c0e74bf-8a48-47ec-8a2d-7791845796b8)

</details>

Curls:
- `𝼍` follows the design in Gentium, which uses the non-flat hook.
- Preview under `t` body variants: (the other 2 aren't that notable) ![image](https://github.com/user-attachments/assets/8ac8b733-78ae-4fdc-8732-522959060eba)

Closed-swash `Q`:
- Basically implemented as `O` + the swash stroke + a straight line connecting both (after appropriate masking).
- Extended the horizontal-tail `Q` terminal a bit outward, a bit closer to what #808 shows.
- Fixed broken geometry for open-swash `ꞯ` under heavy italic. 
![image](https://github.com/user-attachments/assets/19681534-d4f8-46c5-b13b-37492d6660d7)
