### PR TITLE
Flat top variants of `Ww`

### DIFF
--- a/changes/33.1.0.md
+++ b/changes/33.1.0.md
@@ -1,7 +1,7 @@
 * Add `full-serifed` variants for `K` and `k`, and related letters (#2696).
 * Add `top-right-serifed` and `tri-serifed` variants for `K` and `k`, and related letters.
 * Add `cursive` variant for Greek Lower Theta (`θ`).
-* Add `closed-swash' variant for `Q` (#2392).
+* Add `closed-swash` variant for `Q` (#2392).
 * Add IPA localization form for Latin Lower `a` and `g`.
 * Add IPA localization form for Latin Lower G with Stroke (`ǥ`) (#2632).
 * Add variant selectors for Greek Lower Eta (`η`) and Kappa (`κ`).

--- a/changes/33.1.1.md
+++ b/changes/33.1.1.md
@@ -2,3 +2,4 @@
   - ARMENIAN SMALL LIGATURE ECH YIWN (`U+0587`).
   - LATIN CAPITAL LETTER AU (`U+A736`).
   - LATIN SMALL LIGATURE FFI (`U+FB03`).
+* Fix variant application of `cv38` on `U+1DF0F`.

--- a/changes/33.2.0.md
+++ b/changes/33.2.0.md
@@ -1,3 +1,4 @@
+* Add `flat-top` variants for `curly`, `straight-vertical-sides` and `rounded-vertical-sides` forms of `W` and `w` (#2146).
 * Refine shape of the following characters:
   - ARMENIAN SMALL LIGATURE ECH YIWN (`U+0587`).
   - LATIN CAPITAL LETTER AU (`U+A736`).

--- a/packages/font-glyphs/src/letter/latin/upper-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-m.ptl
@@ -26,7 +26,7 @@ glyph-block Letter-Latin-Upper-M : begin
 	define SLAB-FULL            4
 
 	glyph-block-export MShape
-	define [MShape] : with-params [top df form slabType slanted [kMidHang df.adws]] : glyph-proc
+	define [MShape] : with-params [top df form slabType slanted [kMidHang df.adws] [middleYExt nothing]] : glyph-proc
 		local sidesSlope : if slanted 0.04 0
 		local xLeftTop  : df.leftSB  + top * sidesSlope
 		local xRightTop : df.rightSB - top * sidesSlope
@@ -76,6 +76,7 @@ glyph-block Letter-Latin-Upper-M : begin
 		include : dispiro
 			flat (xRightTop - kMidShift * [HSwToV swSideTop]) top [widths.rhs.heading swMiddle Downward]
 			curl (df.middle + [HSwToV : 0.5 * swMiddleShrunk]) middleY [widths.rhs.heading swMiddleShrunk Downward]
+		if (middleYExt !== nothing) : include : VBar.m df.middle middleYExt middleY swMiddleShrunk
 
 		local sfT : SerifFrame top 0 xLeftTop  xRightTop  (swRef -- swSideBot) (hSplit -- 3) (fForceSymmetric -- (form !== FORM-FLAT))
 		local sfB : SerifFrame top 0 df.leftSB df.rightSB (swRef -- swSideBot) (hSplit -- 3) (fForceSymmetric -- (form !== FORM-FLAT))

--- a/packages/font-glyphs/src/letter/latin/w.ptl
+++ b/packages/font-glyphs/src/letter/latin/w.ptl
@@ -15,11 +15,15 @@ glyph-block Letter-Latin-W : begin
 
 	define FORM-CURLY             0
 	define FORM-STRAIGHT          1
-	define FORM-ALMOST-FLAT-TOP   2
-	define FORM-FLAT-TOP          3
-	define FORM-DOUBLE-V          4
-	define FORM-ASYMMETRIC        5
+	define FORM-VERTICAL          2
+	define FORM-DOUBLE-V          3
+	define FORM-ASYMMETRIC        4
+	define FORM-CURSIVE           5
 	define FORM-CYRL-OMEGA        6
+
+	define MIDH-OTHER             0
+	define MIDH-TOP               1
+	define MIDH-ALMOST-TOP        2
 
 	define SERIFS-NONE            0
 	define SERIFS-AUTO            1
@@ -29,8 +33,8 @@ glyph-block Letter-Latin-W : begin
 	define SERIFS-CURSIVE         5
 	define SERIFS-CYRL-OMEGA      6
 	define SERIFS-ALL             7
-	define SERIFS-DOUBLE-V-ALL    8
-	define SERIFS-ASYMMETRIC-ALL  9
+	define SERIFS-ALL-OUTER       8
+	define SERIFS-ALL-ASYMMETRIC  9
 
 	define CwFineOuter            5.0
 	define CwFineInner            6.0
@@ -48,28 +52,34 @@ glyph-block Letter-Latin-W : begin
 	define PXBot1Curly            0.25
 	define PXBot1Straight         0.235
 
-	define [WDim df top bodyType slabType] : begin
+	define [WMidHeight df top bodyType midHClass] : match bodyType
+		[Just FORM-CURLY]    : top * 0.6
+		[Just FORM-VERTICAL] : top * 0.55
+		[Just FORM-STRAIGHT] : WMidHeightExt (top * 0.72) top bodyType midHClass
+		[Just FORM-CURSIVE]  : WMidHeightExt [mix [df.adviceStroke 3.25] top (11 / 16)] top bodyType midHClass
+		__                   : WMidHeightExt top top bodyType midHClass
+	define [WMidHeightExt midh top bodyType midHClass] : match midHClass
+		[Just MIDH-TOP]            top
+		[Just MIDH-ALMOST-TOP]   : top - Stroke
+		[Just MIDH-OTHER]          midh
+
+	define [WDim df top bodyType slabType midHClass] : begin
+		local CwOuterStrokeStraight : if (midHClass === MIDH-OTHER) CwOuterStrokeStraight1 CwOuterStrokeStraight2
 		local strokeOuter : match bodyType
-			[Just FORM-CURLY]             : AdviceStroke CwOuterStrokeCurly     : Math.sqrt df.adws
-			[Just FORM-STRAIGHT]          : AdviceStroke CwOuterStrokeStraight1 : Math.sqrt df.adws
-			[Just FORM-ALMOST-FLAT-TOP]   : AdviceStroke CwOuterStrokeStraight2 : Math.sqrt df.adws
-			[Just FORM-FLAT-TOP]          : AdviceStroke CwOuterStrokeStraight2 : Math.sqrt df.adws
-			[Just FORM-DOUBLE-V]          : AdviceStroke CwDoubleV              : Math.sqrt df.adws
-			[Just FORM-ASYMMETRIC]        : AdviceStroke CwDoubleV              : Math.sqrt df.adws
-			[Just FORM-CYRL-OMEGA]        : AdviceStroke CwCyrlOmega            : Math.sqrt df.adws
+			[Just FORM-CURLY]             : AdviceStroke CwOuterStrokeCurly    : Math.sqrt df.adws
+			[Just FORM-STRAIGHT]          : AdviceStroke CwOuterStrokeStraight : Math.sqrt df.adws
+			[Just FORM-DOUBLE-V]          : AdviceStroke CwDoubleV             : Math.sqrt df.adws
+			[Just FORM-ASYMMETRIC]        : AdviceStroke CwDoubleV             : Math.sqrt df.adws
+			[Just FORM-CYRL-OMEGA]        : AdviceStroke CwCyrlOmega           : Math.sqrt df.adws
 		local fineOuter : match bodyType
 			[Just FORM-CURLY]             : AdviceStroke CwFineOuter           df.adws
 			[Just FORM-STRAIGHT]          : AdviceStroke CwFineOuterStraight : Math.sqrt df.adws
-			[Just FORM-ALMOST-FLAT-TOP]   : AdviceStroke CwFineOuterStraight : Math.sqrt df.adws
-			[Just FORM-FLAT-TOP]          : AdviceStroke CwFineOuterStraight : Math.sqrt df.adws
 			[Just FORM-DOUBLE-V]          : AdviceStroke CwDoubleV           : Math.sqrt df.adws
 			[Just FORM-ASYMMETRIC]        : AdviceStroke CwDoubleV           : Math.sqrt df.adws
 			[Just FORM-CYRL-OMEGA]        : AdviceStroke CwCyrlOmega         : Math.sqrt df.adws
 		local fineInner : match bodyType
 			[Just FORM-CURLY]             : AdviceStroke CwFineInner           df.adws
 			[Just FORM-STRAIGHT]          : AdviceStroke CwFineInnerStraight : Math.sqrt df.adws
-			[Just FORM-ALMOST-FLAT-TOP]   : AdviceStroke CwFineInnerStraight : Math.sqrt df.adws
-			[Just FORM-FLAT-TOP]          : AdviceStroke CwFineInnerStraight : Math.sqrt df.adws
 			[Just FORM-DOUBLE-V]          : AdviceStroke CwFineInnerDoubleV  : Math.sqrt df.adws
 			[Just FORM-ASYMMETRIC]        : AdviceStroke CwDoubleV           : Math.sqrt df.adws
 			[Just FORM-CYRL-OMEGA]        : AdviceStroke CwCyrlOmega         : Math.sqrt df.adws
@@ -78,8 +88,6 @@ glyph-block Letter-Latin-W : begin
 		local wCo : match bodyType
 			[Just FORM-CURLY]             : AdviceStroke CwWCoCurly    df.adws
 			[Just FORM-STRAIGHT]          : AdviceStroke CwWCoStraight df.adws
-			[Just FORM-ALMOST-FLAT-TOP]   : AdviceStroke CwWCoStraight df.adws
-			[Just FORM-FLAT-TOP]          : AdviceStroke CwWCoStraight df.adws
 			[Just FORM-DOUBLE-V]          : AdviceStroke CwWCoDoubleV  df.adws
 			[Just FORM-ASYMMETRIC]        : AdviceStroke CwWCoDoubleV  df.adws
 			[Just FORM-CYRL-OMEGA]        : AdviceStroke CwWCoDoubleV  df.adws
@@ -91,8 +99,6 @@ glyph-block Letter-Latin-W : begin
 		local pxBot1 : match bodyType
 			[Just FORM-CURLY]               0.25
 			[Just FORM-STRAIGHT]            0.235
-			[Just FORM-ALMOST-FLAT-TOP]     0.235
-			[Just FORM-FLAT-TOP]            0.235
 			[Just FORM-DOUBLE-V]            0.315
 			[Just FORM-ASYMMETRIC]          0.3
 			[Just FORM-CYRL-OMEGA]          0.265
@@ -100,14 +106,8 @@ glyph-block Letter-Latin-W : begin
 		local botMixOffset : HSwToV : 0.5 * wCo2
 		local xBot1 : [if bodyType O 0] + [mix (df.leftSB + botMixOffset) (df.rightSB - botMixOffset) pxBot1]
 		local xBot2 : df.width - xBot1
-		local wMidHeight : match bodyType
-			[Just FORM-CURLY]             : top * 0.6
-			[Just FORM-STRAIGHT]          : top * 0.72
-			[Just FORM-ALMOST-FLAT-TOP]   : top - Stroke
-			[Just FORM-FLAT-TOP]            top
-			[Just FORM-DOUBLE-V]            top
-			[Just FORM-ASYMMETRIC]          top
-			[Just FORM-CYRL-OMEGA]          top
+		local wMidHeight : WMidHeight df top bodyType midHClass
+		local wMidHeightExt : WMidHeightExt wMidHeight top bodyType midHClass
 
 		local xRight1 : match bodyType
 			([Just FORM-DOUBLE-V] || [Just FORM-ASYMMETRIC] || [Just FORM-CYRL-OMEGA])
@@ -135,11 +135,37 @@ glyph-block Letter-Latin-W : begin
 			[Just FORM-CURLY]  0.25
 			__                 0.05
 
-		return : object xBot1 xBot2 strokeOuter strokeOuterCr fineOuter fineOuterCr fineInner fineInnerCr fineInnerCrTop fineHeight wMidHeight xRight1 xLeft2 wCoCr curlyStraightSegLength
+		return : object xBot1 xBot2 strokeOuter strokeOuterCr fineOuter fineOuterCr fineInner fineInnerCr fineInnerCrTop fineHeight wMidHeight wMidHeightExt xRight1 xLeft2 wCoCr curlyStraightSegLength
+
+	define [WSerifs df top bodyType slabType dim] : glyph-proc
+		local oSlabPos : match bodyType
+			[Just FORM-CURLY]      : O * 2
+			[Just FORM-VERTICAL]   : O * 2
+			[Just FORM-CYRL-OMEGA] : O * 2
+			__                       0
+
+		local sf  : SerifFrame top 0 df.leftSB df.rightSB (hSplit -- 3)
+		local sfm : SerifFrame top 0 (df.leftSB + oSlabPos) (df.rightSB - oSlabPos) (hSplit -- 3)
+
+		include : match slabType
+			[Just SERIFS-NONE]           : glyph-proc
+			[Just SERIFS-AUTO]           : NeedSlab SLAB : composite-proc sf.lt.full sf.rt.full
+			[Just SERIFS-ALL]            : composite-proc sf.lt.full sf.rt.full
+			[Just SERIFS-ALL-OUTER]      : composite-proc sfm.lt.outer sfm.rt.outer
+			[Just SERIFS-ALL-ASYMMETRIC] : composite-proc sfm.lt.outer sfm.rt.full
+			[Just SERIFS-MOTION]         : begin sfm.lt.outer
+			[Just SERIFS-DOUBLE-V]       : NeedSlab SLAB : composite-proc sfm.lt.outer sfm.rt.outer
+			[Just SERIFS-ASYMMETRIC]     : NeedSlab SLAB : composite-proc sfm.lt.outer sfm.rt.full
+			[Just SERIFS-CURSIVE]        : NeedSlab SLAB sf.lt.outer
+			[Just SERIFS-CYRL-OMEGA]     : begin
+				local jut : Math.min Jut : [HSwToV : 0.5 * dim.strokeOuter] + 0.375 * (dim.xLeft2 - df.leftSB - [HSwToV : 1.5 * dim.strokeOuter])
+				NeedSlab SLAB : composite-proc
+					HSerif.mtAsymmetric (df.leftSB + [HSwToV : 0.5 * dim.strokeOuter]) dim.wMidHeight jut jut
+					HSerif.mtAsymmetric dim.xLeft2 dim.wMidHeight jut jut
 
 	### W and w
-	define [WShapeImpl df top bodyType slabType] : glyph-proc
-		local dim : WDim df top bodyType slabType
+	define [WShapeImpl df top bodyType slabType midHClass] : glyph-proc
+		local dim : WDim df top bodyType slabType midHClass
 
 		include : tagged 'strokeDown1' : match bodyType
 			([Just FORM-CURLY] || [Just FORM-CYRL-OMEGA]) : dispiro
@@ -205,32 +231,14 @@ glyph-block Letter-Latin-W : begin
 				flat (dim.xLeft2 + shiftT) dim.wMidHeight [widths.center.heading dim.fineInnerCrTop Downward]
 				curl (dim.xBot2 - shiftB)   0             [widths.center.heading dim.fineOuterCr    Downward]
 
+		if (dim.wMidHeightExt > dim.wMidHeight) : include : tagged 'strokeExtension' : VBar.m df.middle dim.wMidHeight dim.wMidHeightExt (dim.fineInnerCrTop + [VSwToH : shiftT * 2])
 
-		local oSlabPos : if bodyType (O * 2) 0
+		include : WSerifs df top bodyType slabType dim
 
-		local sf  : SerifFrame top 0 df.leftSB df.rightSB (hSplit -- 3)
-		local sfm : SerifFrame top 0 (df.leftSB + oSlabPos) (df.rightSB - oSlabPos) (hSplit -- 3)
+	define [WHooktopShape df top bodyType slabType midHClass] : glyph-proc
+		include : WShapeImpl df top bodyType slabType midHClass
 
-		include : match slabType
-			[Just SERIFS-NONE]   : glyph-proc
-			[Just SERIFS-AUTO]   : NeedSlab SLAB : composite-proc sf.lt.full sf.rt.full
-			[Just SERIFS-ALL]    : composite-proc sf.lt.full sf.rt.full
-			[Just SERIFS-MOTION] : begin sfm.lt.outer
-			[Just SERIFS-DOUBLE-V] : NeedSlab SLAB : composite-proc sfm.lt.outer sfm.rt.outer
-			[Just SERIFS-DOUBLE-V-ALL] : composite-proc sfm.lt.outer sfm.rt.outer
-			[Just SERIFS-ASYMMETRIC] : NeedSlab SLAB : composite-proc sfm.lt.outer sfm.rt.full
-			[Just SERIFS-ASYMMETRIC-ALL] : composite-proc sfm.lt.outer sfm.rt.full
-			[Just SERIFS-CURSIVE]    : NeedSlab SLAB sf.lt.outer
-			[Just SERIFS-CYRL-OMEGA] : begin
-				local jut : Math.min Jut : [HSwToV : 0.5 * dim.strokeOuter] + 0.375 * (dim.xLeft2 - df.leftSB - [HSwToV : 1.5 * dim.strokeOuter])
-				NeedSlab SLAB : composite-proc
-					HSerif.mtAsymmetric (df.leftSB + [HSwToV : 0.5 * dim.strokeOuter]) dim.wMidHeight jut jut
-					HSerif.mtAsymmetric dim.xLeft2 dim.wMidHeight jut jut
-
-	define [WHooktopShape df top bodyType slabType] : glyph-proc
-		include : WShapeImpl df top bodyType slabType
-
-		local dim : WDim df top bodyType slabType
+		local dim : WDim df top bodyType slabType midHClass
 
 		# Eject unnecessary contours
 		eject-contour 'strokeUp2'
@@ -249,68 +257,64 @@ glyph-block Letter-Latin-W : begin
 			yDepth -- (-TailY)
 			sw -- dim.strokeOuter
 
-	define [WVertSides df top bodyType slabType] : glyph-proc
+	define [WVertSides df top bodyType slabType midHClass] : glyph-proc
+		local wMidHeight : WMidHeight df top bodyType midHClass
+		local wMidHeightExt : WMidHeightExt wMidHeight top bodyType midHClass
+
 		include : new-glyph : glyph-proc
-			include : MShape top df (form -- 2) (slabType -- 0)
+			include : MShape top df (form -- 2) (slabType -- 0) (middleYExt -- (top - wMidHeightExt))
 			include : FlipAround (df.width / 2) (top / 2)
 
-		local sf : SerifFrame top 0 df.leftSB df.rightSB
-		include : match slabType
-			[Just SERIFS-AUTO]   : NeedSlab SLAB : composite-proc sf.lt.full sf.rt.full
-			[Just SERIFS-ALL]    : composite-proc sf.lt.full sf.rt.full
-			[Just SERIFS-MOTION] : begin sf.lt.outer
-			___                  : glyph-proc
+		include : WSerifs df top bodyType slabType
 
-	define [WVSHookTopShape df top bodyType slabType] : glyph-proc
-		include : WVertSides df top bodyType slabType
+	define [WVSHookTopShape df top bodyType slabType midHClass] : glyph-proc
+		include : WVertSides df top bodyType slabType midHClass
 
 		# Eject unnecessary contours
 		eject-contour 'strokeLeftBar'
 		eject-contour 'serifRT'
 
+		define sideSw : df.adviceStroke 3
 		include : dispiro
-			widths.rhs
+			widths.rhs sideSw
 			flat df.rightSB (top - TailY - HalfStroke - O) [heading Downward]
 			curl df.rightSB [Math.min (0.8 * top) (top - TailY - HalfStroke - TINY)] [heading Downward]
-			straight.down.end df.rightSB 0 [widths.rhs.heading [AdviceStroke 4 df.adws] Downward]
+			straight.down.end df.rightSB 0 [widths.rhs.heading [df.adviceStroke 4] Downward]
 
-		include : VerticalHook.r df.rightSB (top - TailY - HalfStroke - O) TailX (-TailY)
+		include : VerticalHook.r df.rightSB (top - TailY - HalfStroke - O) TailX (-TailY) sideSw
 
-	define [WRounded df top bodyType slabType] : glyph-proc
+	define [WRounded df top bodyType slabType midHClass] : glyph-proc
+		local wMidHeight : WMidHeight df top bodyType midHClass
+		local wMidHeightExt : WMidHeightExt wMidHeight top bodyType midHClass
+
 		include : new-glyph : glyph-proc
-			include : EarlessRoundedDoubleArchSmallMShape df top 0 (top * 0.4) 0
+			include : EarlessRoundedDoubleArchSmallMShape df top 0 (top - wMidHeightExt) 0
 			include : FlipAround (df.width / 2) (top / 2)
 
-		local sf : SerifFrame top 0 df.leftSB df.rightSB
-		include : match slabType
-			[Just SERIFS-AUTO]   : NeedSlab SLAB : composite-proc sf.lt.full sf.rt.full
-			[Just SERIFS-ALL]    : composite-proc sf.lt.full sf.rt.full
-			[Just SERIFS-MOTION] : begin sf.lt.outer
-			___                  : glyph-proc
+		include : WSerifs df top bodyType slabType
 
-	define [WHookTopRounded df top bodyType slabType] : glyph-proc
+	define [WHookTopRounded df top bodyType slabType midHClass] : glyph-proc
+		local wMidHeight : WMidHeight df top bodyType midHClass
+		local wMidHeightExt : WMidHeightExt wMidHeight top bodyType midHClass
+
 		include : new-glyph : glyph-proc
-			include : EarlessRoundedDoubleArchSmallMShape df top (TailY + HalfStroke + O) (top * 0.4) 0
+			include : EarlessRoundedDoubleArchSmallMShape df top (TailY + HalfStroke + O) (top - wMidHeightExt) 0
 			include : FlipAround (df.width / 2) (top / 2)
 
-		local sf : SerifFrame top 0 df.leftSB df.rightSB
-		include : match slabType
-			[Just SERIFS-AUTO]   : NeedSlab SLAB sf.lt.full
-			[Just SERIFS-ALL]    : begin sf.lt.full
-			[Just SERIFS-MOTION] : begin sf.lt.outer
-			___                  : glyph-proc
+		include : WSerifs df top bodyType slabType
+		eject-contour 'serifRT'
 
 		include : VerticalHook.r df.rightSB (top - TailY - HalfStroke - O) TailX (-TailY) (sw -- df.mvs)
 
-	define [WCursiveImplImpl fHookTop df top bodyType slabType] : glyph-proc
-		define fine : AdviceStroke 3.25 df.adws
+	define [WCursiveImplImpl fHookTop df top bodyType slabType midHClass] : glyph-proc
+		define fine : df.adviceStroke 3.25
 		define mfine : fine * CThin
 		define x0 : mix df.leftSB df.rightSB 0.1
 		define y0 : top - O
 		define y1 : mix 0 top 0.8
 		define x1 : df.leftSB + 0 * OX
 		define y3 : mix fine top 0.375
-		define y4 : mix y3 top 0.5
+		define y4 : WMidHeight df top bodyType midHClass
 		define rInY : 1 * [DiagTail.DefaultInnerRadius]
 
 		include : dispiro
@@ -348,22 +352,25 @@ glyph-block Letter-Latin-W : begin
 			[Just SERIFS-MOTION]  : begin sf.lt.outer
 			___                   : glyph-proc
 
-	define [WCursiveImpl    df top bodyType slabType] : WCursiveImplImpl false df top bodyType slabType
-	define [WHookTopCursive df top bodyType slabType] : WCursiveImplImpl true  df top bodyType slabType
+	define [WCursiveImpl    df top bodyType slabType midHClass] : WCursiveImplImpl false df top bodyType slabType midHClass
+	define [WHookTopCursive df top bodyType slabType midHClass] : WCursiveImplImpl true  df top bodyType slabType midHClass
 
 	define WConfig : SuffixCfg.weave
 		# Body
 		object
-			straight                           { WShapeImpl   WHooktopShape   FORM-STRAIGHT          para.advanceScaleM  para.advanceScaleM }
-			straightAsymmetric                 { WShapeImpl   WHooktopShape   FORM-ASYMMETRIC        para.advanceScaleM  para.advanceScaleM }
-			straightDoubleV                    { WShapeImpl   WHooktopShape   FORM-DOUBLE-V          para.advanceScaleM  para.advanceScaleM }
-			straightAlmostFlatTop              { WShapeImpl   WHooktopShape   FORM-ALMOST-FLAT-TOP   para.advanceScaleMM para.advanceScaleM }
-			straightFlatTop                    { WShapeImpl   WHooktopShape   FORM-FLAT-TOP          para.advanceScaleMM para.advanceScaleM }
-			straightVerticalSides              { WVertSides   WVSHookTopShape FORM-STRAIGHT          para.advanceScaleM  para.advanceScaleT }
-			roundedVerticalSides               { WRounded     WHookTopRounded FORM-CURLY             para.advanceScaleMM para.advanceScaleM }
-			curly                              { WShapeImpl   WHooktopShape   FORM-CURLY             para.advanceScaleM  para.advanceScaleM }
-			cursive                            { WCursiveImpl WHookTopCursive FORM-CURLY             para.advanceScaleM  para.advanceScaleM }
-			cyrlOmega                          { WShapeImpl   WHooktopShape   FORM-CYRL-OMEGA        para.advanceScaleMM para.advanceScaleM }
+			straight                           { WShapeImpl   WHooktopShape   FORM-STRAIGHT   MIDH-OTHER      para.advanceScaleM  para.advanceScaleM }
+			straightAsymmetric                 { WShapeImpl   WHooktopShape   FORM-ASYMMETRIC MIDH-TOP        para.advanceScaleM  para.advanceScaleM }
+			straightDoubleV                    { WShapeImpl   WHooktopShape   FORM-DOUBLE-V   MIDH-TOP        para.advanceScaleM  para.advanceScaleM }
+			straightAlmostFlatTop              { WShapeImpl   WHooktopShape   FORM-STRAIGHT   MIDH-ALMOST-TOP para.advanceScaleMM para.advanceScaleM }
+			straightFlatTop                    { WShapeImpl   WHooktopShape   FORM-STRAIGHT   MIDH-TOP        para.advanceScaleMM para.advanceScaleM }
+			straightVerticalSides              { WVertSides   WVSHookTopShape FORM-VERTICAL   MIDH-OTHER      para.advanceScaleM  para.advanceScaleT }
+			straightVerticalSidesFlatTop       { WVertSides   WVSHookTopShape FORM-VERTICAL   MIDH-TOP        para.advanceScaleM  para.advanceScaleT }
+			roundedVerticalSides               { WRounded     WHookTopRounded FORM-CURLY      MIDH-OTHER      para.advanceScaleMM para.advanceScaleM }
+			roundedVerticalSidesFlatTop        { WRounded     WHookTopRounded FORM-CURLY      MIDH-TOP        para.advanceScaleMM para.advanceScaleM }
+			curly                              { WShapeImpl   WHooktopShape   FORM-CURLY      MIDH-OTHER      para.advanceScaleM  para.advanceScaleM }
+			curlyFlatTop                       { WShapeImpl   WHooktopShape   FORM-CURLY      MIDH-TOP        para.advanceScaleM  para.advanceScaleM }
+			cursive                            { WCursiveImpl WHookTopCursive FORM-CURSIVE    MIDH-OTHER      para.advanceScaleM  para.advanceScaleM }
+			cyrlOmega                          { WShapeImpl   WHooktopShape   FORM-CYRL-OMEGA MIDH-OTHER      para.advanceScaleMM para.advanceScaleM }
 
 		# Serifs
 		function [body] : if (body == 'cyrlOmega')
@@ -372,40 +379,44 @@ glyph-block Letter-Latin-W : begin
 				serifless     SERIFS-NONE
 				motionSerifed SERIFS-MOTION
 				serifed     : match body
-					[Just 'straightAsymmetric']  SERIFS-ASYMMETRIC-ALL
-					[Just 'straightDoubleV']     SERIFS-DOUBLE-V-ALL
-					[Just 'cursive']             SERIFS-MOTION
-					__                           SERIFS-ALL
+					[Just 'straightAsymmetric']           SERIFS-ALL-ASYMMETRIC
+					[Just 'straightDoubleV']              SERIFS-ALL-OUTER
+					[Just 'straightFlatTop']              SERIFS-ALL-OUTER
+					[Just 'straightVerticalSidesFlatTop'] SERIFS-ALL-OUTER
+					[Just 'roundedVerticalSidesFlatTop']  SERIFS-ALL-OUTER
+					[Just 'curlyFlatTop']                 SERIFS-ALL-OUTER
+					[Just 'cursive']                      SERIFS-MOTION
+					__                                    SERIFS-ALL
 
-	foreach { suffix { {implT hookTopImplT bodyType Udiv Ldiv} slabType } } [pairs-of WConfig] : do
+	foreach { suffix { {implT hookTopImplT bodyType midHClass Udiv Ldiv} slabType } } [pairs-of WConfig] : do
 		create-glyph "W.\(suffix)" : glyph-proc
 			local df : include : DivFrame Udiv 3
 			include : df.markSet.capital
-			include : implT df CAP bodyType slabType
+			include : implT df CAP bodyType slabType midHClass
 
 		create-glyph "w.\(suffix)" : glyph-proc
 			local df : include : DivFrame Ldiv 3
 			include : df.markSet.e
-			include : implT df XH bodyType slabType
+			include : implT df XH bodyType slabType midHClass
 
 		create-glyph "ww.\(suffix)": glyph-proc
 			local df : include : DivFrame [if (Ldiv < para.advanceScaleM) para.advanceScaleF 1] 3
 			include : df.markSet.capital
 
 			local gap : CAP * 0.05
-			include : implT df (CAP / 2 - gap / 2) bodyType slabType
+			include : implT df (CAP / 2 - gap / 2) bodyType slabType midHClass
 			include : ApparentTranslate 0 (CAP / 2 + gap)
-			include : implT df (CAP / 2 - gap / 2) bodyType slabType
+			include : implT df (CAP / 2 - gap / 2) bodyType slabType midHClass
 
 		if hookTopImplT : create-glyph "WHookTop.\(suffix)" : glyph-proc
 			local df : include : DivFrame Udiv 3
 			include : df.markSet.capital
-			include : hookTopImplT df CAP bodyType slabType
+			include : hookTopImplT df CAP bodyType slabType midHClass
 
 		if hookTopImplT : create-glyph "wHookTop.\(suffix)" : glyph-proc
 			local df : include : DivFrame Ldiv 3
 			include : df.markSet.e
-			include : hookTopImplT df XH bodyType slabType
+			include : hookTopImplT df XH bodyType slabType midHClass
 
 		create-glyph "currency/wonSign.\(suffix)" : glyph-proc
 			local df : DivFrame Udiv 3

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1885,6 +1885,7 @@ selectorAffix.WHookTop = "straightVerticalSides"
 [prime.capital-w.variants-buildup.stages.body.straight-vertical-sides-flat-top]
 rank = 7
 groupRank = 3
+nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "straight body shape with vertical sides, and a middle stem aligned to the top"
 selectorAffix.W = "straightVerticalSidesFlatTop"
 selectorAffix."W/sansSerif" = "straightVerticalSidesFlatTop"
@@ -1901,6 +1902,7 @@ selectorAffix.WHookTop = "roundedVerticalSides"
 [prime.capital-w.variants-buildup.stages.body.rounded-vertical-sides-flat-top]
 rank = 9
 groupRank = 3
+nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "rounded body shape with vertical sides, and a middle stem aligned to the top"
 selectorAffix.W = "roundedVerticalSidesFlatTop"
 selectorAffix."W/sansSerif" = "roundedVerticalSidesFlatTop"
@@ -1917,6 +1919,7 @@ selectorAffix.WHookTop = "curly"
 [prime.capital-w.variants-buildup.stages.body.curly-flat-top]
 rank = 11
 groupRank = 3
+nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "curly body with a middle stem aligned to the top"
 selectorAffix.W = "curlyFlatTop"
 selectorAffix."W/sansSerif" = "curlyFlatTop"
@@ -4882,6 +4885,7 @@ selectorAffix.wHookTop = "straightVerticalSides"
 [prime.w.variants-buildup.stages.body.straight-vertical-sides-flat-top]
 rank = 7
 groupRank = 3
+nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "straight body shape with vertical sides, and a middle stem aligned to the top"
 selectorAffix.w = "straightVerticalSidesFlatTop"
 selectorAffix."w/sansSerif" = "straightVerticalSidesFlatTop"
@@ -4898,6 +4902,7 @@ selectorAffix.wHookTop = "roundedVerticalSides"
 [prime.w.variants-buildup.stages.body.rounded-vertical-sides-flat-top]
 rank = 9
 groupRank = 3
+nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "rounded body shape with vertical sides, and a middle stem aligned to the top"
 selectorAffix.w = "roundedVerticalSidesFlatTop"
 selectorAffix."w/sansSerif" = "roundedVerticalSidesFlatTop"
@@ -4914,6 +4919,7 @@ selectorAffix.wHookTop = "curly"
 [prime.w.variants-buildup.stages.body.curly-flat-top]
 rank = 11
 groupRank = 3
+nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "curly body with a middle stem aligned to the top"
 selectorAffix.w = "curlyFlatTop"
 selectorAffix."w/sansSerif" = "curlyFlatTop"

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1845,7 +1845,7 @@ selectorAffix.WHookTop = "straight"
 [prime.capital-w.variants-buildup.stages.body.straight-almost-flat-top]
 rank = 2
 groupRank = 1
-descriptionAffix = "straight body shape that the middle is forced to be aligned the top"
+descriptionAffix = "straight body shape that the middle is almost aligned the top"
 selectorAffix.W = "straightAlmostFlatTop"
 selectorAffix."W/sansSerif" = "straightAlmostFlatTop"
 selectorAffix.WHookTop = "straightAlmostFlatTop"
@@ -1874,7 +1874,6 @@ selectorAffix.W = "straightAsymmetric"
 selectorAffix."W/sansSerif" = "straightAsymmetric"
 selectorAffix.WHookTop = "straightAsymmetric"
 
-
 [prime.capital-w.variants-buildup.stages.body.straight-vertical-sides]
 rank = 6
 groupRank = 3
@@ -1883,21 +1882,45 @@ selectorAffix.W = "straightVerticalSides"
 selectorAffix."W/sansSerif" = "straightVerticalSides"
 selectorAffix.WHookTop = "straightVerticalSides"
 
-[prime.capital-w.variants-buildup.stages.body.rounded-vertical-sides]
+[prime.capital-w.variants-buildup.stages.body.straight-vertical-sides-flat-top]
 rank = 7
+groupRank = 3
+descriptionAffix = "straight body shape with vertical sides, and a middle stem aligned to the top"
+selectorAffix.W = "straightVerticalSidesFlatTop"
+selectorAffix."W/sansSerif" = "straightVerticalSidesFlatTop"
+selectorAffix.WHookTop = "straightVerticalSidesFlatTop"
+
+[prime.capital-w.variants-buildup.stages.body.rounded-vertical-sides]
+rank = 8
 groupRank = 3
 descriptionAffix = "rounded body shape with vertical sides"
 selectorAffix.W = "roundedVerticalSides"
 selectorAffix."W/sansSerif" = "roundedVerticalSides"
 selectorAffix.WHookTop = "roundedVerticalSides"
 
+[prime.capital-w.variants-buildup.stages.body.rounded-vertical-sides-flat-top]
+rank = 9
+groupRank = 3
+descriptionAffix = "rounded body shape with vertical sides, and a middle stem aligned to the top"
+selectorAffix.W = "roundedVerticalSidesFlatTop"
+selectorAffix."W/sansSerif" = "roundedVerticalSidesFlatTop"
+selectorAffix.WHookTop = "roundedVerticalSidesFlatTop"
+
 [prime.capital-w.variants-buildup.stages.body.curly]
-rank = 8
+rank = 10
 groupRank = 3
 descriptionAffix = "curly body"
 selectorAffix.W = "curly"
 selectorAffix."W/sansSerif" = "curly"
 selectorAffix.WHookTop = "curly"
+
+[prime.capital-w.variants-buildup.stages.body.curly-flat-top]
+rank = 11
+groupRank = 3
+descriptionAffix = "curly body with a middle stem aligned to the top"
+selectorAffix.W = "curlyFlatTop"
+selectorAffix."W/sansSerif" = "curlyFlatTop"
+selectorAffix.WHookTop = "curlyFlatTop"
 
 [prime.capital-w.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -4856,24 +4879,48 @@ selectorAffix.w = "straightVerticalSides"
 selectorAffix."w/sansSerif" = "straightVerticalSides"
 selectorAffix.wHookTop = "straightVerticalSides"
 
-[prime.w.variants-buildup.stages.body.rounded-vertical-sides]
+[prime.w.variants-buildup.stages.body.straight-vertical-sides-flat-top]
 rank = 7
+groupRank = 3
+descriptionAffix = "straight body shape with vertical sides, and a middle stem aligned to the top"
+selectorAffix.w = "straightVerticalSidesFlatTop"
+selectorAffix."w/sansSerif" = "straightVerticalSidesFlatTop"
+selectorAffix.wHookTop = "straightVerticalSidesFlatTop"
+
+[prime.w.variants-buildup.stages.body.rounded-vertical-sides]
+rank = 8
 groupRank = 3
 descriptionAffix = "rounded body shape with vertical sides"
 selectorAffix.w = "roundedVerticalSides"
 selectorAffix."w/sansSerif" = "roundedVerticalSides"
 selectorAffix.wHookTop = "roundedVerticalSides"
 
+[prime.w.variants-buildup.stages.body.rounded-vertical-sides-flat-top]
+rank = 9
+groupRank = 3
+descriptionAffix = "rounded body shape with vertical sides, and a middle stem aligned to the top"
+selectorAffix.w = "roundedVerticalSidesFlatTop"
+selectorAffix."w/sansSerif" = "roundedVerticalSidesFlatTop"
+selectorAffix.wHookTop = "roundedVerticalSidesFlatTop"
+
 [prime.w.variants-buildup.stages.body.curly]
-rank = 8
-groupRank = 4
+rank = 10
+groupRank = 3
 descriptionAffix = "curly body"
 selectorAffix.w = "curly"
 selectorAffix."w/sansSerif" = "curly"
 selectorAffix.wHookTop = "curly"
 
+[prime.w.variants-buildup.stages.body.curly-flat-top]
+rank = 11
+groupRank = 3
+descriptionAffix = "curly body with a middle stem aligned to the top"
+selectorAffix.w = "curlyFlatTop"
+selectorAffix."w/sansSerif" = "curlyFlatTop"
+selectorAffix.wHookTop = "curlyFlatTop"
+
 [prime.w.variants-buildup.stages.body.cursive]
-rank = 9
+rank = 12
 groupRank = 4
 descriptionAffix = "cursive shape"
 selectorAffix.w = "cursive"


### PR DESCRIPTION
Closes #2146. This is separated from #2707 due to some problems found last minute.

<details> <summary> <code>wWⱳⱲ</code> with <code>cv57/cv32 = 3, 6, ..., 33</code>  </summary>

![image](https://github.com/user-attachments/assets/d18180bf-7dd8-4a4e-ad02-724f2acd5e20)

</details>

- Added a separate enumeration(?) `midHClass` for middle stroke height.
	- It _might_ be possible to make this a separate variant dimension, but I'll let you decide first.
- The implementation is a bit messy -- initially I misunderstood the variant to be moving the middle connection up to the top, instead of having an extra middle stem.
	- A new variable/dimension `wMiddleHeightExt` is added for the distinction between the connection and terminal y-position (needed for Curly and VerticalSides)
	- The logic behind the 2 height functions:
		- For `FORM-CURLY` and `FORM-VERTICAL`, `wMiddleHeight` has its specific values.
		- For the other forms, `wMiddleHeight` references `wMiddleHeightExt` for possible override, but defaults to:
			- Some specific values for `FORM-STRAIGHT` and `FORM-CURSIVE`
			- `top` for the rest.
		- `wMiddleHeightExt` depends on `midHClass` (and `wMiddleHeight` as a fallback)
	- Might need some cleanup/refactoring if possible.
- The full-serif top-aligned forms now all use outward serifs like the double-v forms. This is to prevent stroke overlaps.
	- Might not be needed for QP/wide forms? This is not handled in this PR.
- These variants are in theory implementable but are not included as there are no existing requests:
	- `CURSIVE` forms with extended middle stem
	- `ALMOST-TOP` forms for all of the above
	- `VERTICAL` forms with the middle connection aligned to the top instead of a stem extension, like the corresponding `M` variants.
- Other changelog changes:
	- Bumped to `33.2.0` because of new variant.
	- I accidentally used <code>`'</code> in the previous changelog. Might be too late to change it because 33.1.0 is already released, but i'll fix it anyway
		- (There's actually a much older mistake in `22.1.1.md` where I wrote "little" in place of "small" letter. I would like to fix that too if that's allowed.)
	- Since v33.1.0 didn't include #2708, the variant assignment fix is noted as well.
