### PR TITLE
Make `w.roundedVerticalSides`/`w.roundedVerticalSidesFlatTop` slightly wider under Quasi-Proportional.

### DIFF
--- a/packages/font-glyphs/src/letter/latin/w.ptl
+++ b/packages/font-glyphs/src/letter/latin/w.ptl
@@ -358,20 +358,20 @@ glyph-block Letter-Latin-W : begin
 	define WConfig : SuffixCfg.weave
 		# Body
 		object
-			straight                           { WShapeImpl   WHooktopShape   FORM-STRAIGHT   MIDH-OTHER      para.advanceScaleM  para.advanceScaleM }
-			straightAsymmetric                 { WShapeImpl   WHooktopShape   FORM-ASYMMETRIC MIDH-TOP        para.advanceScaleM  para.advanceScaleM }
-			straightDoubleV                    { WShapeImpl   WHooktopShape   FORM-DOUBLE-V   MIDH-TOP        para.advanceScaleM  para.advanceScaleM }
-			straightAlmostFlatTop              { WShapeImpl   WHooktopShape   FORM-STRAIGHT   MIDH-ALMOST-TOP para.advanceScaleMM para.advanceScaleM }
-			straightFlatTop                    { WShapeImpl   WHooktopShape   FORM-STRAIGHT   MIDH-TOP        para.advanceScaleMM para.advanceScaleM }
-			straightVerticalSides              { WVertSides   WVSHookTopShape FORM-VERTICAL   MIDH-OTHER      para.advanceScaleM  para.advanceScaleT }
-			straightVerticalSidesFlatTop       { WVertSides   WVSHookTopShape FORM-VERTICAL   MIDH-TOP        para.advanceScaleM  para.advanceScaleT }
-			roundedVerticalSides               { WRounded     WHookTopRounded FORM-CURLY      MIDH-OTHER      para.advanceScaleMM para.advanceScaleM }
-			roundedVerticalSidesFlatTop        { WRounded     WHookTopRounded FORM-CURLY      MIDH-TOP        para.advanceScaleMM para.advanceScaleM }
-			curly                              { WShapeImpl   WHooktopShape   FORM-CURLY      MIDH-OTHER      para.advanceScaleM  para.advanceScaleM }
-			curlyAlmostFlatTop                 { WShapeImpl   WHooktopShape   FORM-CURLY      MIDH-ALMOST-TOP para.advanceScaleMM para.advanceScaleM }
-			curlyFlatTop                       { WShapeImpl   WHooktopShape   FORM-CURLY      MIDH-TOP        para.advanceScaleMM para.advanceScaleM }
-			cursive                            { WCursiveImpl WHookTopCursive FORM-CURSIVE    MIDH-OTHER      para.advanceScaleM  para.advanceScaleM }
-			cyrlOmega                          { WShapeImpl   WHooktopShape   FORM-CYRL-OMEGA MIDH-OTHER      para.advanceScaleMM para.advanceScaleM }
+			straight                           { WShapeImpl   WHooktopShape   FORM-STRAIGHT   MIDH-OTHER      para.advanceScaleM  para.advanceScaleM  }
+			straightAsymmetric                 { WShapeImpl   WHooktopShape   FORM-ASYMMETRIC MIDH-TOP        para.advanceScaleM  para.advanceScaleM  }
+			straightDoubleV                    { WShapeImpl   WHooktopShape   FORM-DOUBLE-V   MIDH-TOP        para.advanceScaleM  para.advanceScaleM  }
+			straightAlmostFlatTop              { WShapeImpl   WHooktopShape   FORM-STRAIGHT   MIDH-ALMOST-TOP para.advanceScaleMM para.advanceScaleM  }
+			straightFlatTop                    { WShapeImpl   WHooktopShape   FORM-STRAIGHT   MIDH-TOP        para.advanceScaleMM para.advanceScaleM  }
+			straightVerticalSides              { WVertSides   WVSHookTopShape FORM-VERTICAL   MIDH-OTHER      para.advanceScaleM  para.advanceScaleT  }
+			straightVerticalSidesFlatTop       { WVertSides   WVSHookTopShape FORM-VERTICAL   MIDH-TOP        para.advanceScaleM  para.advanceScaleT  }
+			roundedVerticalSides               { WRounded     WHookTopRounded FORM-CURLY      MIDH-OTHER      para.advanceScaleMM para.advanceScaleMM }
+			roundedVerticalSidesFlatTop        { WRounded     WHookTopRounded FORM-CURLY      MIDH-TOP        para.advanceScaleMM para.advanceScaleMM }
+			curly                              { WShapeImpl   WHooktopShape   FORM-CURLY      MIDH-OTHER      para.advanceScaleM  para.advanceScaleM  }
+			curlyAlmostFlatTop                 { WShapeImpl   WHooktopShape   FORM-CURLY      MIDH-ALMOST-TOP para.advanceScaleMM para.advanceScaleM  }
+			curlyFlatTop                       { WShapeImpl   WHooktopShape   FORM-CURLY      MIDH-TOP        para.advanceScaleMM para.advanceScaleM  }
+			cursive                            { WCursiveImpl WHookTopCursive FORM-CURSIVE    MIDH-OTHER      para.advanceScaleMM para.advanceScaleM  }
+			cyrlOmega                          { WShapeImpl   WHooktopShape   FORM-CYRL-OMEGA MIDH-OTHER      para.advanceScaleMM para.advanceScaleM  }
 
 		# Serifs
 		function [body] : if (body == 'cyrlOmega')
@@ -394,6 +394,11 @@ glyph-block Letter-Latin-W : begin
 			local df : include : DivFrame Udiv 3
 			include : df.markSet.capital
 			include : implT df CAP bodyType slabType midHClass
+
+		create-glyph "smcpW.\(suffix)" : glyph-proc
+			local df : include : DivFrame [if (Udiv < para.advanceScaleMM) para.advanceScaleT para.advanceScaleM] 3
+			include : df.markSet.e
+			include : implT df XH bodyType slabType midHClass
 
 		create-glyph "w.\(suffix)" : glyph-proc
 			local df : include : DivFrame Ldiv 3
@@ -430,7 +435,7 @@ glyph-block Letter-Latin-W : begin
 	select-variant 'WHookTop' 0x2C72
 	select-variant 'w' 'w'
 	link-reduced-variant 'w/sansSerif' 'w' MathSansSerif
-	select-variant 'smcpW' 0x1D21 (shapeFrom -- 'w') (follow -- 'W')
+	select-variant 'smcpW' 0x1D21 (follow -- 'W')
 	select-variant 'ww' 0x2AC (follow -- 'w')
 	select-variant 'wHookTop' 0x2C73
 	select-variant 'currency/wonSign' 0x20A9 (follow -- 'W')


### PR DESCRIPTION
This basically makes the lowercase match the width of lowercase `m` under `roundedVerticalSides`, acting as a true "turned lowercase `m`" equivalent to the "turned capital `M`" analogy used by `W.straightVerticalSides`.

Capital `W` is already this width under this variant, so it is unchanged.


```
<span style="font-feature-settings:'cv32'28,'cv57'30;">
UƜVW𝖶Ⱳᴜꟺᴠᴡ<br>uɯvw𝗐ⱳʬ
</span>
```

Aile under `'cv32'28`/`'cv57'30`:
![image](https://github.com/user-attachments/assets/5547ca44-fce2-45b4-86dd-df1694955398)

```
ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ
abc.def.ghi.jkl.mno.pqrs.tuv.wxyz
!iIlL17|¦ ¢coO08BDQ $5SZ2zs ∂96µm
float il1[]={1-2/3.4,5+6=7/8%90};
1234567890 ,._-+= >< «¯-¬_» ~–÷+×
{*}[]()<>`+-=$/#_%^@\&|~?'" !,.;:
g9q¶ Þẞðþſß ΓΔΛαβγδηθικλμνξπτυφχψ
ЖЗКНРУЭЯавжзклмнруфчьыэя <= != ==
```

Aile under `ss10`:
![image](https://github.com/user-attachments/assets/359a6e91-864a-4d03-967a-2b763c728cc4)
