### PR TITLE
Make Armenian Capital/Lower To (`Թ`/`թ`) slightly wider under Quasi-Proportional.

### DIFF
--- a/changes/33.2.0.md
+++ b/changes/33.2.0.md
@@ -3,11 +3,14 @@
 * Refine shape of the following characters:
   - GREEK CAPITAL LETTER HETA (`U+0370`).
   - GREEK SMALL LETTER HETA (`U+0371`).
-  - ARMENIAN SMALL LIGATURE ECH YIWN (`U+0587`).
   - LATIN CAPITAL LETTER HALF H (`U+2C75`).
   - LATIN SMALL LETTER HALF H (`U+2C76`).
   - LATIN CAPITAL LETTER AU (`U+A736`).
   - LATIN CAPITAL LETTER REVERSED HALF H (`U+A7F5`).
   - LATIN SMALL LETTER REVERSED HALF H (`U+A7F6`).
   - LATIN SMALL LIGATURE FFI (`U+FB03`).
+* Make certain characters slightly wider under Quasi-Proportional. Affected characters:
+  - ARMENIAN CAPITAL LETTER TO (`U+0539`).
+  - ARMENIAN SMALL LETTER TO (`U+0569`).
+  - ARMENIAN SMALL LIGATURE ECH YIWN (`U+0587`).
 * Fix variant application of `cv38` on `U+1DF0F`.

--- a/packages/font-glyphs/src/letter/armenian/to.ptl
+++ b/packages/font-glyphs/src/letter/armenian/to.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Letter-Armenian-To : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : nShoulder SerifFrame
+	glyph-block-import Letter-Shared-Shapes : SerifFrame
 
 	# Common Params
 	define barPos : XH / 2
@@ -17,16 +17,15 @@ glyph-block Letter-Armenian-To : begin
 
 	do "T'o"
 		create-glyph 'armn/To' 0x539 : glyph-proc
-			local df : include : DivFrame 1
+			local df : include : DivFrame para.advanceScaleT
 			local fine : df.adviceStroke2 6 3 CAP
 			local barPosT : barPos + df.mvs / 2
 			include : dispiro
 				widths.rhs df.mvs
 				flat df.leftSB 0 [heading Upward]
-				curl df.leftSB (CAP - ArchDepthA)
+				curl df.leftSB [if (df.archDepthA + df.archDepthB < CAP) (CAP - df.archDepthA) : mix CAP 0 (df.archDepthA / (df.archDepthA + df.archDepthB))]
 				arch.rhs CAP (sw -- df.mvs)
-				flat df.rightSB (CAP - ArchDepthB)
-				curl df.rightSB (0 + ArchDepthA)
+				flatside.rd df.rightSB 0 CAP df.archDepthA df.archDepthB 0
 				arch.rhs 0 (sw -- df.mvs) (swAfter -- fine)
 				g4 (df.middle - [HSwToV : 0.5 * fine]) [mix 0 barPosT 0.5] [widths.rhs fine]
 				arcvh
@@ -37,18 +36,16 @@ glyph-block Letter-Armenian-To : begin
 				include sf.lb.full
 
 		create-glyph 'armn/to' 0x569 : glyph-proc
-			local df : include : DivFrame 1
+			local df : include : DivFrame para.advanceScaleT
 			local fine : df.adviceStroke2 6 3 XH
 			include : df.markSet.p
 			include : VBar.l df.leftSB Descender XH df.mvs
 			local barPosT : barPos + df.mvs / 2
 			include : dispiro
-				nShoulder.knots
-					left -- (df.leftSB + [HSwToV df.mvs])
-					right -- df.rightSB
-					top -- XH
-					bottom -- (0 + ArchDepthA)
-					stroke -- df.mvs
+				flat (df.leftSB + [HSwToV : df.mvs - df.shoulderFine]) (XH - df.smallArchDepthA - TINY) [widths.rhs df.shoulderFine]
+				curl (df.leftSB + [HSwToV : df.mvs - df.shoulderFine]) (XH - df.smallArchDepthA)
+				arch.rhs XH (sw -- df.mvs) (swBefore -- df.shoulderFine)
+				flatside.rd df.rightSB 0 XH df.smallArchDepthA df.smallArchDepthB 0 (af -- [widths.rhs df.mvs])
 				arch.rhs 0 (sw -- df.mvs) (swAfter -- fine)
 				g4 (df.middle - [HSwToV : 0.5 * fine]) [mix 0 barPosT 0.5] [widths.rhs fine]
 				arcvh


### PR DESCRIPTION
Basically giving more room to the curl as it is sort of like a composite character.

Shown below are comparisons to six fonts I have installed on my machine (three sans and three serif), which show it as slightly wider than the other U/u-like characters.

```
 ԱԲԳԴԵԶԷԸԹԺԻԼԽԾԿ
ՀՁՂՃՄՅՆՇՈՉՊՋՌՍՎՏ
ՐՑՒՓՔՕՖ  ՙ՚՛՜՝՞◌՟
ՠաբգդեզէըթժիլխծկ
հձղճմյնշոչպջռսվտ
րցւփքօֆևֈ։֊  ֍֎֏
```
Aile Thin Before:
![image](https://github.com/user-attachments/assets/141b8e3f-4fc5-4b71-a6ec-9cd25a4631c6)
Aile Thin After:
![image](https://github.com/user-attachments/assets/4eb4174e-a241-4451-ad62-2aa22f7c1689)
Aile Regular Before:
![image](https://github.com/user-attachments/assets/204f8299-27dc-41dd-b183-6c879c0fad20)
Aile Regular After:
![image](https://github.com/user-attachments/assets/ae44688f-0148-4e5f-9fcf-cd4028f6180b)
Aile Heavy Before:
![image](https://github.com/user-attachments/assets/18e7f812-1d23-4dfe-8af8-e0f4d4a0b464)
Aile Heavy After:
![image](https://github.com/user-attachments/assets/b5d2aea9-23b3-472a-b612-dfcd8408b407)
Compared to Arial:
![image](https://github.com/user-attachments/assets/5e1dbd16-844c-4bff-9b35-b640912761f7)
Compared to DejaVu Sans:
![image](https://github.com/user-attachments/assets/010a5db1-535b-4a07-b110-f4bdf7036f40)
Compared to Noto Sans Armenian:
![image](https://github.com/user-attachments/assets/3c7818e7-c41c-4bb1-bbe2-1e07c26dceed)
Etoile Thin Before:
![image](https://github.com/user-attachments/assets/3c62092d-1c5d-4cad-a373-1584c708c4e5)
Etoile Thin After:
![image](https://github.com/user-attachments/assets/3a3fe506-0583-4251-abb0-4aa6ca307d85)
Etoile Regular Before:
![image](https://github.com/user-attachments/assets/1615fc09-02c8-434f-9f4a-cd20715f1444)
Etoile Regular After:
![image](https://github.com/user-attachments/assets/f88bd262-ff5f-4135-b115-a00f9f14964d)
Etoile Heavy Before:
![image](https://github.com/user-attachments/assets/a5a2c082-8039-4297-bf96-493ba0f09463)
Etoile Heavy After:
![image](https://github.com/user-attachments/assets/c8afbd4a-a43f-4efb-a01a-34a0e1575620)
Compared to Times New Roman:
![image](https://github.com/user-attachments/assets/724cb644-4605-4020-a23a-535ca4ec1e68)
Compared to DejaVu Serif:
![image](https://github.com/user-attachments/assets/29a22aef-c0b3-4a72-a8b8-1e125ba07312)
Compared to Noto Serif Armenian:
![image](https://github.com/user-attachments/assets/1ed0bd5b-2bbb-4ce9-b05c-d0660801ed88)
