### PR TITLE
Cleanup of instances of `flatside` using `af` argument.

### DIFF
--- a/packages/font-glyphs/src/common/shapes.ptl
+++ b/packages/font-glyphs/src/common/shapes.ptl
@@ -61,8 +61,8 @@ glyph-block CommonShapes : begin
 	define [MaskAboveLine x1 y1 x2 y2 _ext] : begin
 		local ext : fallback _ext 0
 		return : spiro-outline
-			corner [mix x1 x2 (-ext)]    (+VERY-FAR)
-			corner [mix x1 x2 (-ext)]    [mix y1 y2 (-ext)]
+			corner [mix x1 x2 (0 - ext)] (+VERY-FAR)
+			corner [mix x1 x2 (0 - ext)] [mix y1 y2 (0 - ext)]
 			corner [mix x1 x2 (1 + ext)] [mix y1 y2 (1 + ext)]
 			corner [mix x1 x2 (1 + ext)] (+VERY-FAR)
 
@@ -70,26 +70,26 @@ glyph-block CommonShapes : begin
 	define [MaskBelowLine x1 y1 x2 y2 _ext] : begin
 		local ext : fallback _ext 0
 		return : spiro-outline
-			corner [mix x1 x2 (-ext)]    (-VERY-FAR)
-			corner [mix x1 x2 (-ext)]    [mix y1 y2 (-ext)]
+			corner [mix x1 x2 (0 - ext)] (-VERY-FAR)
+			corner [mix x1 x2 (0 - ext)] [mix y1 y2 (0 - ext)]
 			corner [mix x1 x2 (1 + ext)] [mix y1 y2 (1 + ext)]
 			corner [mix x1 x2 (1 + ext)] (-VERY-FAR)
 
 	glyph-block-export MaskLeftLine
 	define [MaskLeftLine  x1 y1 x2 y2 _ext] : begin
 		local ext : fallback _ext 0
-		spiro-outline
-			corner (-VERY-FAR)           [mix y1 y2 (-ext)]
-			corner [mix x1 x2 (-ext)]    [mix y1 y2 (-ext)]
+		return : spiro-outline
+			corner (-VERY-FAR)           [mix y1 y2 (0 - ext)]
+			corner [mix x1 x2 (0 - ext)] [mix y1 y2 (0 - ext)]
 			corner [mix x1 x2 (1 + ext)] [mix y1 y2 (1 + ext)]
 			corner (-VERY-FAR)           [mix y1 y2 (1 + ext)]
 
 	glyph-block-export MaskRightLine
 	define [MaskRightLine x1 y1 x2 y2 _ext] : begin
 		local ext : fallback _ext 0
-		spiro-outline
-			corner (+VERY-FAR)           [mix y1 y2 (-ext)]
-			corner [mix x1 x2 (-ext)]    [mix y1 y2 (-ext)]
+		return : spiro-outline
+			corner (+VERY-FAR)           [mix y1 y2 (0 - ext)]
+			corner [mix x1 x2 (0 - ext)] [mix y1 y2 (0 - ext)]
 			corner [mix x1 x2 (1 + ext)] [mix y1 y2 (1 + ext)]
 			corner (+VERY-FAR)           [mix y1 y2 (1 + ext)]
 
@@ -505,14 +505,14 @@ glyph-block CommonShapes : begin
 			local-parameter : u              # Y-position of the ring's top
 			local-parameter : ada -- ArchDepthA
 			local-parameter : adb -- ArchDepthB
-			local-parameter : overshoot -- OX
+			local-parameter : ox  -- OX
 			local-parameter : af  -- nothing # Additional function for the control knots
 
 			return : if (u - d > ada + adb)
 				list
-					flat (x + overshoot) (u - ada) af
-					curl (x + overshoot) (d + adb)
-				g4 (x + overshoot) [mix d u (adb / (ada + adb))] af
+					flat (x + ox) (u - ada) af
+					curl (x + ox) (d + adb)
+				g4 (x + ox) [mix d u (adb / (ada + adb))] af
 
 		export : define flex-params [lu]: begin
 			local-parameter : x              # X-position of the stroke, without overshoot
@@ -520,14 +520,14 @@ glyph-block CommonShapes : begin
 			local-parameter : u              # Y-position of the ring's top
 			local-parameter : ada -- ArchDepthA
 			local-parameter : adb -- ArchDepthB
-			local-parameter : overshoot -- OX
+			local-parameter : ox  -- OX
 			local-parameter : af  -- nothing # Additional function for the control knots
 
 			return : if (u - d > ada + adb)
 				list
-					flat (x + overshoot) (d + adb) af
-					curl (x + overshoot) (u - ada)
-				g4 (x + overshoot) [mix d u (adb / (ada + adb))] af
+					flat (x + ox) (d + adb) af
+					curl (x + ox) (u - ada)
+				g4 (x + ox) [mix d u (adb / (ada + adb))] af
 
 		export : define flex-params [rd]: begin
 			local-parameter : x              # X-position of the stroke, without overshoot
@@ -535,14 +535,14 @@ glyph-block CommonShapes : begin
 			local-parameter : u              # Y-position of the ring's top
 			local-parameter : ada -- ArchDepthA
 			local-parameter : adb -- ArchDepthB
-			local-parameter : overshoot -- OX
+			local-parameter : ox  -- OX
 			local-parameter : af  -- nothing # Additional function for the control knots
 
 			return : if (u - d > ada + adb)
 				list
-					flat (x - overshoot) (u - adb) af
-					curl (x - overshoot) (d + ada)
-				g4 (x - overshoot) [mix d u (ada / (ada + adb))] af
+					flat (x - ox) (u - adb) af
+					curl (x - ox) (d + ada)
+				g4 (x - ox) [mix d u (ada / (ada + adb))] af
 
 		export : define flex-params [ru]: begin
 			local-parameter : x              # X-position of the stroke, without overshoot
@@ -550,14 +550,14 @@ glyph-block CommonShapes : begin
 			local-parameter : u              # Y-position of the ring's top
 			local-parameter : ada -- ArchDepthA
 			local-parameter : adb -- ArchDepthB
-			local-parameter : overshoot -- OX
+			local-parameter : ox  -- OX
 			local-parameter : af  -- nothing # Additional function for the control knots
 
 			return : if (u - d > ada + adb)
 				list
-					flat (x - overshoot) (d + ada) af
-					curl (x - overshoot) (u - adb)
-				g4 (x - overshoot) [mix d u (ada / (ada + adb))] af
+					flat (x - ox) (d + ada) af
+					curl (x - ox) (u - adb)
+				g4 (x - ox) [mix d u (ada / (ada + adb))] af
 
 	glyph-block-export arch
 	define arch : namespace
@@ -772,19 +772,19 @@ glyph-block CommonShapes : begin
 	glyph-block-export ExtLineCenter
 	define [ExtLineCenter k sw x1 y1 x2 y2] : dispiro
 		widths.center sw
-		corner [mix x1 x2 (-k)]  [mix y1 y2 (-k)]
+		corner [mix x1 x2 (0-k)] [mix y1 y2 (0-k)]
 		corner [mix x1 x2 (1+k)] [mix y1 y2 (1+k)]
 
 	glyph-block-export ExtLineLhs
 	define [ExtLineLhs k sw x1 y1 x2 y2] : dispiro
 		widths.lhs sw
-		corner [mix x1 x2 (-k)]  [mix y1 y2 (-k)]
+		corner [mix x1 x2 (0-k)] [mix y1 y2 (0-k)]
 		corner [mix x1 x2 (1+k)] [mix y1 y2 (1+k)]
 
 	glyph-block-export ExtLineRhs
 	define [ExtLineRhs k sw x1 y1 x2 y2] : dispiro
 		widths.rhs sw
-		corner [mix x1 x2 (-k)]  [mix y1 y2 (-k)]
+		corner [mix x1 x2 (0-k)] [mix y1 y2 (0-k)]
 		corner [mix x1 x2 (1+k)] [mix y1 y2 (1+k)]
 
 	# Dot variant constructor

--- a/packages/font-glyphs/src/letter/armenian/to.ptl
+++ b/packages/font-glyphs/src/letter/armenian/to.ptl
@@ -45,7 +45,7 @@ glyph-block Letter-Armenian-To : begin
 				flat (df.leftSB + [HSwToV : df.mvs - df.shoulderFine]) (XH - df.smallArchDepthA - TINY) [widths.rhs df.shoulderFine]
 				curl (df.leftSB + [HSwToV : df.mvs - df.shoulderFine]) (XH - df.smallArchDepthA)
 				arch.rhs XH (sw -- df.mvs) (swBefore -- df.shoulderFine)
-				flatside.rd df.rightSB 0 XH df.smallArchDepthA df.smallArchDepthB 0 (af -- [widths.rhs df.mvs])
+				flatside.rd df.rightSB 0 XH df.smallArchDepthA df.smallArchDepthB 0 [widths.rhs df.mvs]
 				arch.rhs 0 (sw -- df.mvs) (swAfter -- fine)
 				g4 (df.middle - [HSwToV : 0.5 * fine]) [mix 0 barPosT 0.5] [widths.rhs fine]
 				arcvh

--- a/packages/font-glyphs/src/letter/latin/upper-q.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-q.ptl
@@ -22,7 +22,7 @@ glyph-block Letter-Latin-Upper-Q : begin
 		return : dispiro
 			g4.right.mid [arch.adjust-x.bot df.middle fine] (sw - fine) [widths.lhs fine]
 			archv
-			flatside.ru df.rightSB 0 top ArchDepthA ArchDepthB (af -- [widths.lhs sw])
+			flatside.ru df.rightSB 0 top ArchDepthA ArchDepthB nothing [widths.lhs sw]
 			arch.lhs top
 			flatside.ld df.leftSB  0 top ArchDepthA ArchDepthB
 			arcvh
@@ -48,7 +48,7 @@ glyph-block Letter-Latin-Upper-Q : begin
 				flat df.width (yRingStart + O) [widths.rhs.heading fine Leftward]
 				curl [arch.adjust-x.bot df.middle] (yRingStart + O)
 				archv
-				flatside.lu df.leftSB yRingStart top ArchDepthA ArchDepthB (af -- [widths.rhs Stroke])
+				flatside.lu df.leftSB yRingStart top ArchDepthA ArchDepthB nothing [widths.rhs Stroke]
 				arch.rhs top
 				flatside.rd df.rightSB 0 top ArchDepthA ArchDepthB
 			MaskBelowLine

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -342,7 +342,7 @@ glyph-block Letter-Shared-Shapes : begin
 				arch.lhs bot (sw -- sw) (swBefore -- fine)
 				flatside.ru right bot top ada adb
 				arch.lhs top (sw -- sw) (swAfter -- fine)
-				flatside.ld (left + [HSwToV : sw - fine]) bot top ada adb 0 (af -- [widths.lhs fine])
+				flatside.ld (left + [HSwToV : sw - fine]) bot top ada adb 0 [widths.lhs fine]
 
 		export : define [toothless] : with-params [
 				[top XH] [bot 0] [left SB] [right RightSB] [rise SHook] [sw Stroke] [fine ShoulderFine]
@@ -428,14 +428,14 @@ glyph-block Letter-Shared-Shapes : begin
 				[ada SmallArchDepthA] [adb SmallArchDepthB]
 			] : new-glyph : glyph-proc
 			include : OBarLeft.shape
-				top -- top
-				bot -- bot
-				left -- left
+				top   -- top
+				bot   -- bot
+				left  -- left
 				right -- right
-				sw -- sw
-				fine -- fine
-				ada -- ada
-				adb -- adb
+				sw    -- sw
+				fine  -- fine
+				ada   -- ada
+				adb   -- adb
 			include : FlipAround [mix left right 0.5] [mix bot top 0.5]
 
 		export : define [toothless] : with-params [
@@ -443,16 +443,16 @@ glyph-block Letter-Shared-Shapes : begin
 				[mBlend Math.SQRT1_2] [ada SmallArchDepthA] [adb SmallArchDepthB]
 			] : new-glyph : glyph-proc
 			include : OBarLeft.toothlessTop
-				top -- top
-				bot -- bot
-				left -- left
-				right -- right
-				rise -- rise
-				sw -- sw
-				fine -- fine
+				top    -- top
+				bot    -- bot
+				left   -- left
+				right  -- right
+				rise   -- rise
+				sw     -- sw
+				fine   -- fine
 				mBlend -- mBlend
-				ada -- ada
-				adb -- adb
+				ada    -- ada
+				adb    -- adb
 			include : FlipAround [mix left right 0.5] [mix bot top 0.5]
 
 		export : define [rounded] : with-params [
@@ -460,15 +460,15 @@ glyph-block Letter-Shared-Shapes : begin
 				[yTerminal CAP] [ada SmallArchDepthA] [adb SmallArchDepthB]
 			] : new-glyph : glyph-proc
 			include : OBarLeft.roundedTop
-				top -- top
-				bot -- bot
-				left -- left
-				right -- right
-				sw -- sw
-				fine -- fine
+				top       -- top
+				bot       -- bot
+				left      -- left
+				right     -- right
+				sw        -- sw
+				fine      -- fine
 				yTerminal -- (top - yTerminal)
-				ada -- ada
-				adb -- adb
+				ada       -- ada
+				adb       -- adb
 			include : FlipAround [mix left right 0.5] [mix bot top 0.5]
 
 	glyph-block-export FlatHookDepth
@@ -621,7 +621,7 @@ glyph-block Letter-Shared-Shapes : begin
 		export : define [DefaultInnerRadius] : Math.max (XH / 32) (0.5 * [AdviceStroke2 24 32 XH])
 
 		define [FineSw sw] : begin
-			define mocFine : [AdviceStroke 3] / Stroke * sw
+			define mocFine : [AdviceStroke 3] * (sw / Stroke)
 			return : mocFine / [mix 1 HVContrast 0.375]
 
 		define DiagTailSuperness DesignParameters.superness
@@ -644,7 +644,7 @@ glyph-block Letter-Shared-Shapes : begin
 					cy + O + 0.5 * fine
 					widths.center fine
 				alsoThruThem : FArc tailAngle 4
-				flat (cx + sign * dxTailStart)             (cy + O + dyTailStart) [widths.center fine]
+				flat (cx + sign *  dxTailStart)            (cy + O + dyTailStart) [widths.center fine]
 				curl (cx + sign * (dxTailStart + dxDepth)) (cy + O + dyTailStart + dyDepth)
 
 		define [superEllipse theta] : list
@@ -652,8 +652,8 @@ glyph-block Letter-Shared-Shapes : begin
 			[Math.sin theta] ** (2 / DiagTailSuperness)
 
 		define [superEllipseDerivative theta] : begin
-			local dc : (-2 / DiagTailSuperness) * [Math.sin theta] * ([Math.cos theta] ** (2 / DiagTailSuperness - 1))
-			local ds : (+2 / DiagTailSuperness) * [Math.cos theta] * ([Math.sin theta] ** (2 / DiagTailSuperness - 1))
+			local dc : (2 / DiagTailSuperness) * [Math.sin (-theta)] * ([Math.cos theta] ** (2 / DiagTailSuperness - 1))
+			local ds : (2 / DiagTailSuperness) * [Math.cos (-theta)] * ([Math.sin theta] ** (2 / DiagTailSuperness - 1))
 			local h : Math.hypot dc ds
 			return : list (dc / h) (ds / h)
 
@@ -693,7 +693,7 @@ glyph-block Letter-Shared-Shapes : begin
 			set this.right           right
 			set this.swRef           swRef
 			set this.swSerif         swSerif
-			set this.adws             adws
+			set this.adws            adws
 			set this.hSplit          hSplit
 			set this.fForceSymmetric fForceSymmetric
 
@@ -771,18 +771,18 @@ glyph-block Letter-Shared-Shapes : begin
 		local-parameter : bot
 		local-parameter : left
 		local-parameter : right
-		local-parameter : swRef -- Stroke
+		local-parameter : swRef   -- Stroke
 		local-parameter : swSerif -- swRef
-		local-parameter : adws -- 1
-		local-parameter : hSplit -- 2
+		local-parameter : adws    -- 1
+		local-parameter : hSplit  -- 2
 		local-parameter : fForceSymmetric -- false
 		return : new CSerifFrame top bot left right swRef swSerif adws hSplit fForceSymmetric
 
 	define SerifFrame.fromDf : function [] : with-params [df top bot [swSerif df.mvs] [fForceSymmetric false]] : begin
 		return : SerifFrame top bot df.leftSB df.rightSB
-			swRef -- df.mvs
-			adws -- df.adws
-			hSplit -- [Math.max 2 df.hPack]
+			swRef   -- df.mvs
+			adws    -- df.adws
+			hSplit  -- [Math.max 2 df.hPack]
 			swSerif -- swSerif
 			fForceSymmetric -- fForceSymmetric
 
@@ -824,7 +824,7 @@ glyph-block Letter-Shared-Shapes : begin
 		local mid : mix left right 0.5
 		include : dispiro
 			widths.rhs sw
-			g2 (left - [HSwToV : 0.5 * sw]) (y)
+			g2 (left - [HSwToV : 0.5 * sw]) (y + 0)
 			g2 (mid  - [HSwToV : 0.5 * sw]) (y + rise)
 		include : dispiro
 			widths.center sw
@@ -858,27 +858,27 @@ glyph-block Letter-Shared-Shapes : begin
 
 		export : define [l] : with-params [x y xDepth yDepth [sw Stroke] [yExtension 0]]
 			m
-				x -- (x + [HSwToV : 0.5 * sw])
-				y -- y
+				x      -- (x + [HSwToV : 0.5 * sw])
+				y      -- y
 				xDepth -- xDepth
 				yDepth -- yDepth
-				sw -- sw
+				sw     -- sw
 				yExtension -- yExtension
 
 		export : define [r] : with-params [x y xDepth yDepth [sw Stroke] [yExtension 0]]
 			m
-				x -- (x - [HSwToV : 0.5 * sw])
-				y -- y
+				x      -- (x - [HSwToV : 0.5 * sw])
+				y      -- y
 				xDepth -- xDepth
 				yDepth -- yDepth
-				sw -- sw
+				sw     -- sw
 				yExtension -- yExtension
 
 	do "Descender shapes"
 		define [xLinkStroke xLink x yAttach sw]
 			if (xLink == nothing) [no-shape] : HBar.b
-				Math.min xLink (x - [HSwToV : 0.5 * sw])
-				Math.max xLink (x + [HSwToV : 0.5 * sw])
+				Math.min xLink : x - [HSwToV : 0.5 * sw]
+				Math.max xLink : x + [HSwToV : 0.5 * sw]
 				begin yAttach
 
 		define [Descenders Impl] : namespace
@@ -945,11 +945,11 @@ glyph-block Letter-Shared-Shapes : begin
 				union
 					xLinkStroke xLink x yAttach sw
 					VerticalHook.m
-						x -- x
-						y -- (y - (fullDepth - TailY))
+						x      -- x
+						y      -- (y - (fullDepth - TailY))
 						xDepth -- (-TailX)
 						yDepth -- TailY
-						sw -- sw
+						sw     -- sw
 						yExtension -- [Math.max 0 : yAttach + yOverflow - y + (fullDepth - TailY)]
 				if maskOut maskOut [no-shape]
 
@@ -961,11 +961,11 @@ glyph-block Letter-Shared-Shapes : begin
 			include : union
 				xLinkStroke xLink x yAttach sw
 				VerticalHook.m
-					x -- x
-					y -- (y - (fullDepth - TailY))
+					x      -- x
+					y      -- (y - (fullDepth - TailY))
 					xDepth -- TailX
 					yDepth -- TailY
-					sw -- sw
+					sw     -- sw
 					yExtension -- [Math.max 0 : yAttach + yOverflow - y + (fullDepth - TailY)]
 
 		# Cyrillic "Middle Hook" Characters
@@ -973,12 +973,12 @@ glyph-block Letter-Shared-Shapes : begin
 		define MidHook : namespace
 			export : define [general] : with-params [left right top [bottom 0] ada adb [sw Stroke] [xDepth (-HookX)]] : composite-proc
 				nShoulder.shape
-					left -- left
-					right -- right
-					top -- top
+					left   -- left
+					right  -- right
+					top    -- top
 					bottom -- bottom
-					ada -- ada
-					adb -- adb
+					ada    -- ada
+					adb    -- adb
 					stroke -- sw
 				VerticalHook.r right bottom xDepth Hook sw
 
@@ -992,7 +992,7 @@ glyph-block Letter-Shared-Shapes : begin
 					ada    -- ArchDepthA
 					adb    -- ArchDepthB
 					sw     -- df.mvs
-					xDepth -- (-[Math.max [HSwToV df.mvs] : Math.min HookX : 0.5 * (df.rightSB - df.leftSB) - [HSwToV df.mvs]])
+					xDepth -- (0 - [Math.max [HSwToV df.mvs] : Math.min HookX : 0.5 * (df.rightSB - df.leftSB) - [HSwToV df.mvs]])
 
 		# Hook for Eng shape
 		glyph-block-export EngHook

--- a/packages/font-glyphs/src/meta/macros.ptl
+++ b/packages/font-glyphs/src/meta/macros.ptl
@@ -13,7 +13,7 @@ define-operator prefix "~~~"  : syntax-rules
 
 ### Exponentiation operator
 define-operator "**" 150 "right" : syntax-rules
-    `(@l ** @r) `[Math.pow @l @r]
+	`(@l ** @r) `[Math.pow @l @r]
 
 ### Macro for identity match
 define-macro Just : begin


### PR DESCRIPTION
Nothing behaviorally/visually is changed. This is just code cleanup for consistency.

This makes all instances of `flatside` which use the `af` argument at the end (only three total) write everything in the same line of code so it's laid out similarly to if it was an un-obfuscated `g2`/`g4`/`flat`/`curl`/etc.

This also shortens the name of the `overshoot` argument to just `ox`, but that doesn't affect anything either as everything that uses it also writes it in the same line, much like what this PR does with `af`.