### PR TITLE
Optimize glyph shape/metrics of Armenian Capital/Lower To (`Թ`/`թ`).

### DIFF
--- a/changes/33.2.1.md
+++ b/changes/33.2.1.md
@@ -1,3 +1,4 @@
 * Refine shape of the following characters:
   - ARMENIAN CAPITAL LETTER TO (`U+0539`).
   - ARMENIAN SMALL LETTER TO (`U+0569`).
+  - MATHEMATICAL DOUBLE-STRUCK DIGIT TWO (`U+1D7DA`) (#2728).

--- a/changes/33.2.1.md
+++ b/changes/33.2.1.md
@@ -1,0 +1,3 @@
+* Refine shape of the following characters:
+  - ARMENIAN CAPITAL LETTER TO (`U+0539`).
+  - ARMENIAN SMALL LETTER TO (`U+0569`).

--- a/packages/font-glyphs/src/letter/armenian/to.ptl
+++ b/packages/font-glyphs/src/letter/armenian/to.ptl
@@ -20,6 +20,7 @@ glyph-block Letter-Armenian-To : begin
 			local df : include : DivFrame para.advanceScaleT
 			include : df.markSet.capital
 			local fine : df.adviceStroke2 3 3 XH
+			local cofine : Math.min fine : VSwToH : (df.rightSB - df.leftSB) / 2 - [HSwToV df.mvs]
 			local barPosT : barPos + fine / 2
 			include : dispiro
 				widths.rhs df.mvs
@@ -27,10 +28,10 @@ glyph-block Letter-Armenian-To : begin
 				curl df.leftSB [if (df.archDepthA + df.archDepthB < CAP) (CAP - df.archDepthA) : mix CAP 0 (df.archDepthA / (df.archDepthA + df.archDepthB))]
 				arch.rhs CAP (sw -- df.mvs)
 				flatside.rd df.rightSB 0 CAP df.archDepthA df.archDepthB 0
-				arch.rhs 0 (sw -- df.mvs) (swAfter -- fine)
-				g4 (df.middle - [HSwToV : 0.5 * fine]) [mix 0 barPosT (df.archDepthB / (df.archDepthA + df.archDepthB))] [widths.rhs fine]
+				arch.rhs 0 (sw -- df.mvs) (swAfter -- cofine)
+				g4 (df.middle - [HSwToV : 0.5 * cofine]) [mix 0 barPosT (df.archDepthB / (df.archDepthA + df.archDepthB))] [widths.rhs cofine]
 				arcvh
-				flat [mix (df.middle - [HSwToV : 0.5 * fine]) df.rightSB 0.5] barPosT
+				flat [mix (df.middle - [HSwToV : 0.5 * cofine]) df.rightSB 0.5] barPosT [widths.rhs fine]
 				curl (df.rightSB + jut * [if SLAB 1.5 1] - [HSwToV : 0.5 * df.mvs]) barPosT [heading Rightward]
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df CAP 0
@@ -40,6 +41,7 @@ glyph-block Letter-Armenian-To : begin
 			local df : include : DivFrame para.advanceScaleT
 			include : df.markSet.p
 			local fine : df.adviceStroke2 3 3 XH
+			local cofine : Math.min fine : VSwToH : (df.rightSB - df.leftSB) / 2 - [HSwToV df.mvs]
 			local barPosT : barPos + fine / 2
 			include : VBar.l df.leftSB Descender XH df.mvs
 			include : dispiro
@@ -47,10 +49,10 @@ glyph-block Letter-Armenian-To : begin
 				straight.up.start (df.leftSB + [HSwToV : df.mvs - df.shoulderFine]) [if (df.smallArchDepthA + df.smallArchDepthB < XH) (XH - df.smallArchDepthA) : mix XH 0 (df.smallArchDepthA / (df.smallArchDepthA + df.smallArchDepthB))] [heading Upward]
 				arch.rhs XH (sw -- df.mvs) (swBefore -- df.shoulderFine)
 				flatside.rd df.rightSB 0 XH df.smallArchDepthA df.smallArchDepthB 0 [widths.rhs df.mvs]
-				arch.rhs 0 (sw -- df.mvs) (swAfter -- fine)
-				g4 (df.middle - [HSwToV : 0.5 * fine]) [mix 0 barPosT (df.smallArchDepthB / (df.smallArchDepthA + df.smallArchDepthB))] [widths.rhs fine]
+				arch.rhs 0 (sw -- df.mvs) (swAfter -- cofine)
+				g4 (df.middle - [HSwToV : 0.5 * cofine]) [mix 0 barPosT (df.smallArchDepthB / (df.smallArchDepthA + df.smallArchDepthB))] [widths.rhs cofine]
 				arcvh
-				flat [mix (df.middle - [HSwToV : 0.5 * fine]) df.rightSB 0.5] barPosT
+				flat [mix (df.middle - [HSwToV : 0.5 * cofine]) df.rightSB 0.5] barPosT [widths.rhs fine]
 				curl (df.rightSB + jut * [if SLAB 1.5 1] - [HSwToV : 0.5 * df.mvs]) barPosT [heading Rightward]
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH Descender

--- a/packages/font-glyphs/src/letter/armenian/to.ptl
+++ b/packages/font-glyphs/src/letter/armenian/to.ptl
@@ -18,8 +18,9 @@ glyph-block Letter-Armenian-To : begin
 	do "T'o"
 		create-glyph 'armn/To' 0x539 : glyph-proc
 			local df : include : DivFrame para.advanceScaleT
-			local fine : df.adviceStroke2 6 3 CAP
-			local barPosT : barPos + df.mvs / 2
+			include : df.markSet.capital
+			local fine : df.adviceStroke2 3 3 XH
+			local barPosT : barPos + fine / 2
 			include : dispiro
 				widths.rhs df.mvs
 				flat df.leftSB 0 [heading Upward]
@@ -27,30 +28,30 @@ glyph-block Letter-Armenian-To : begin
 				arch.rhs CAP (sw -- df.mvs)
 				flatside.rd df.rightSB 0 CAP df.archDepthA df.archDepthB 0
 				arch.rhs 0 (sw -- df.mvs) (swAfter -- fine)
-				g4 (df.middle - [HSwToV : 0.5 * fine]) [mix 0 barPosT 0.5] [widths.rhs fine]
+				g4 (df.middle - [HSwToV : 0.5 * fine]) [mix 0 barPosT (df.archDepthB / (df.archDepthA + df.archDepthB))] [widths.rhs fine]
 				arcvh
-				flat [mix df.leftSB df.rightSB 0.7] barPosT [widths.rhs df.mvs]
-				curl (df.rightSB + jut - [HSwToV : 0.5 * df.mvs]) barPosT
+				flat [mix (df.middle - [HSwToV : 0.5 * fine]) df.rightSB 0.5] barPosT
+				curl (df.rightSB + jut * [if SLAB 1.5 1] - [HSwToV : 0.5 * df.mvs]) barPosT [heading Rightward]
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df CAP 0
 				include sf.lb.full
 
 		create-glyph 'armn/to' 0x569 : glyph-proc
 			local df : include : DivFrame para.advanceScaleT
-			local fine : df.adviceStroke2 6 3 XH
 			include : df.markSet.p
+			local fine : df.adviceStroke2 3 3 XH
+			local barPosT : barPos + fine / 2
 			include : VBar.l df.leftSB Descender XH df.mvs
-			local barPosT : barPos + df.mvs / 2
 			include : dispiro
-				flat (df.leftSB + [HSwToV : df.mvs - df.shoulderFine]) (XH - df.smallArchDepthA - TINY) [widths.rhs df.shoulderFine]
-				curl (df.leftSB + [HSwToV : df.mvs - df.shoulderFine]) (XH - df.smallArchDepthA)
+				widths.rhs df.shoulderFine
+				straight.up.start (df.leftSB + [HSwToV : df.mvs - df.shoulderFine]) [if (df.smallArchDepthA + df.smallArchDepthB < XH) (XH - df.smallArchDepthA) : mix XH 0 (df.smallArchDepthA / (df.smallArchDepthA + df.smallArchDepthB))] [heading Upward]
 				arch.rhs XH (sw -- df.mvs) (swBefore -- df.shoulderFine)
 				flatside.rd df.rightSB 0 XH df.smallArchDepthA df.smallArchDepthB 0 [widths.rhs df.mvs]
 				arch.rhs 0 (sw -- df.mvs) (swAfter -- fine)
-				g4 (df.middle - [HSwToV : 0.5 * fine]) [mix 0 barPosT 0.5] [widths.rhs fine]
+				g4 (df.middle - [HSwToV : 0.5 * fine]) [mix 0 barPosT (df.smallArchDepthB / (df.smallArchDepthA + df.smallArchDepthB))] [widths.rhs fine]
 				arcvh
-				flat [mix df.leftSB df.rightSB 0.7] barPosT [widths.rhs df.mvs]
-				curl (df.rightSB + jut - [HSwToV : 0.5 * df.mvs]) barPosT
+				flat [mix (df.middle - [HSwToV : 0.5 * fine]) df.rightSB 0.5] barPosT
+				curl (df.rightSB + jut * [if SLAB 1.5 1] - [HSwToV : 0.5 * df.mvs]) barPosT [heading Rightward]
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH Descender
 				include : composite-proc sf.lt.outer sf.lb.fullSide

--- a/packages/font-glyphs/src/letter/armenian/upper-gim-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/upper-gim-group.ptl
@@ -28,7 +28,7 @@ glyph-block Letter-Armenian-Upper-Gim-Group : begin
 				flatside.ld df.leftSB barPosB CAP ArchDepthA ArchDepthB
 				arcvh
 				flat df.middle barPosB
-				curl (df.rightSB + jut * [if SLAB 1.5 1] - [HSwToV : 0.5 * df.mvs]) barPosB
+				curl (df.rightSB + jut * [if SLAB 1.5 1] - [HSwToV : 0.5 * df.mvs]) barPosB [heading Rightward]
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df CAP 0
 				include sf.rb.full
@@ -44,7 +44,7 @@ glyph-block Letter-Armenian-Upper-Gim-Group : begin
 				flatside.lu df.leftSB 0 highBarPos ArchDepthA ArchDepthB
 				arcvh
 				flat df.middle highBarPos
-				curl (df.rightSB + jut * [if SLAB 1.5 1] - [HSwToV : 0.5 * df.mvs]) highBarPos
+				curl (df.rightSB + jut * [if SLAB 1.5 1] - [HSwToV : 0.5 * df.mvs]) highBarPos [heading Rightward]
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df CAP 0
 				include sf.rt.full
@@ -60,7 +60,7 @@ glyph-block Letter-Armenian-Upper-Gim-Group : begin
 				flatside.lu df.leftSB 0 highBarPos SmallArchDepthA SmallArchDepthB
 				arcvh
 				flat df.middle highBarPos
-				curl (df.rightSB + jut * [if SLAB 1.5 1] - [HSwToV : 0.5 * df.mvs]) highBarPos
+				curl (df.rightSB + jut * [if SLAB 1.5 1] - [HSwToV : 0.5 * df.mvs]) highBarPos [heading Rightward]
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df Ascender 0
 				include sf.rt.inner


### PR DESCRIPTION
Basically making it so the loop in `armn/Gim` derived letters, including the bottom-right loop in T'o, is treated as terminating in an an Armenian bar at half x-height, effectively harmonizing it with other letters.

```
 ԱԲԳԴԵԶԷԸԹԺԻԼԽԾԿ
ՀՁՂՃՄՅՆՇՈՉՊՋՌՍՎՏ
ՐՑՒՓՔՕՖ  ՙ՚՛՜՝՞◌՟
ՠաբգդեզէըթժիլխծկ
հձղճմյնշոչպջռսվտ
րցւփքօֆևֈ։֊  ֍֎֏
```

Sans Monospace Thin Upright Before:
![image](https://github.com/user-attachments/assets/c27c97b7-9752-4920-9ce3-03929bf74b46)
Sans Monospace Thin Upright After:
![image](https://github.com/user-attachments/assets/035e3df3-667c-4436-9ae7-6aa914d6093c)
Sans Monospace Regular Upright Before:
![image](https://github.com/user-attachments/assets/b3df019b-2027-45b7-91ae-0d71d00ba950)
Sans Monospace Regular Upright After:
![image](https://github.com/user-attachments/assets/2db321d0-07e0-48e0-8cdd-717ed2e4461d)
Sans Monospace Heavy Upright Before:
![image](https://github.com/user-attachments/assets/094295ca-5aa8-492a-b655-5ac8f3f02aa6)
Sans Monospace Heavy Upright After:
![image](https://github.com/user-attachments/assets/e11613fd-af86-4630-b8ce-f2f7fc8c2fdf)
Sans Monospace Thin Italic Before:
![image](https://github.com/user-attachments/assets/91809658-7b87-4f0c-a09e-1d1af19ee1db)
Sans Monospace Thin Italic After:
![image](https://github.com/user-attachments/assets/d759f11a-df79-46b8-9852-6873565af5db)
Sans Monospace Regular Italic Before:
![image](https://github.com/user-attachments/assets/d18e7b40-17c3-4457-9881-89aa73bdbe5c)
Sans Monospace Regular Italic After:
![image](https://github.com/user-attachments/assets/4e4aa93b-5b41-41bd-9962-cc9edea5b118)
Sans Monospace Heavy Italic Before:
![image](https://github.com/user-attachments/assets/07c5c11f-3496-49dd-9d52-0b2ab815f817)
Sans Monospace Heavy Italic After:
![image](https://github.com/user-attachments/assets/efd9a957-69d3-4aef-b290-d415a7025e44)

-----

Slab Monospace Thin Upright Before:
![image](https://github.com/user-attachments/assets/a47c9062-d35b-4c2d-8c8e-e05bcf8f6a1b)
Slab Monospace Thin Upright After:
![image](https://github.com/user-attachments/assets/2a766077-91f8-4330-8566-64ce5377945a)
Slab Monospace Regular Upright Before:
![image](https://github.com/user-attachments/assets/98298e28-c70a-4a51-ac12-fc713b6f84cd)
Slab Monospace Regular Upright After:
![image](https://github.com/user-attachments/assets/4df79c33-fbc4-4339-8dab-c8cee2e418a4)
Slab Monospace Heavy Upright Before:
![image](https://github.com/user-attachments/assets/21a34abf-9f48-414f-81e7-52cc64210800)
Slab Monospace Heavy Upright After:
![image](https://github.com/user-attachments/assets/83bc0c40-c043-4fff-b6f4-5980b1ce1e39)
Slab Monospace Thin Italic Before:
![image](https://github.com/user-attachments/assets/9a42c687-9e35-462f-8b89-ef1df78b439b)
Slab Monospace Thin Italic After:
![image](https://github.com/user-attachments/assets/b65814d3-a7ca-4a93-a5dc-e2bb67af5dfe)
Slab Monospace Regular Italic Before:
![image](https://github.com/user-attachments/assets/1ad7935e-2137-43f5-b607-17741a3aeb65)
Slab Monospace Regular Italic After:
![image](https://github.com/user-attachments/assets/24ed7a64-b6ae-48d2-b6e5-046e93510c81)
Slab Monospace Heavy Italic Before:
![image](https://github.com/user-attachments/assets/0fa65af9-3392-43b6-ae5c-6b32794b1291)
Slab Monospace Heavy Italic After:
![image](https://github.com/user-attachments/assets/7f5848c6-ae76-445b-9963-c908d1d74126)

-----

Aile Thin Upright Before:
![image](https://github.com/user-attachments/assets/ec8e2ff3-3d2d-458d-a9f1-ad47742657b7)
Aile Thin Upright After:
![image](https://github.com/user-attachments/assets/6264ae90-fead-4510-81e9-7bdb4762b3fd)
Aile Regular Upright Before:
![image](https://github.com/user-attachments/assets/0a095657-da29-4075-8681-3669ff9c4464)
Aile Regular Upright After:
![image](https://github.com/user-attachments/assets/4f5abc7b-45ec-4862-a9f2-c9850e6a93d4)
Aile Heavy Upright Before:
![image](https://github.com/user-attachments/assets/061d7f52-6422-4b21-8e9c-4f37b523a0ed)
Aile Heavy Upright After:
![image](https://github.com/user-attachments/assets/dfdff3ef-8a79-4654-a962-ab4e0d20902e)
Aile Thin Italic Before:
![image](https://github.com/user-attachments/assets/2f239805-3053-4572-9211-e99ba5c258db)
Aile Thin Italic After:
![image](https://github.com/user-attachments/assets/4bd88afb-83e3-442a-970f-a9d68211bba7)
Aile Regular Italic Before:
![image](https://github.com/user-attachments/assets/5094db0c-a948-4b28-b6e5-7a8b7613c7a6)
Aile Regular Italic After:
![image](https://github.com/user-attachments/assets/27d73d6e-0e2a-449f-94e9-71d51958fa2d)
Aile Heavy Italic Before:
![image](https://github.com/user-attachments/assets/9f167b6e-a7ec-4ac9-9910-6b86205804d2)
Aile Heavy Italic After:
![image](https://github.com/user-attachments/assets/015ab4ba-abb6-4bc8-9bea-6f557fe3bfde)

-----

Etoile Thin Upright Before:
![image](https://github.com/user-attachments/assets/6d08a120-8440-4dca-8b54-9358f615528a)
Etoile Thin Upright After:
![image](https://github.com/user-attachments/assets/630f5704-38ef-41bb-b9df-100082feb420)
Etoile Regular Upright Before:
![image](https://github.com/user-attachments/assets/61269a63-2cad-4246-84a2-67e37d83dafa)
Etoile Regular Upright After:
![image](https://github.com/user-attachments/assets/7743c836-c65a-49fa-8c7a-afce41a4cf15)
Etoile Heavy Upright Before:
![image](https://github.com/user-attachments/assets/03137a98-b6db-48ff-b546-ceec1c95fe5e)
Etoile Heavy Upright After:
![image](https://github.com/user-attachments/assets/0afe9e0c-ce10-40cf-b6fb-1c211d4e59e3)
Etoile Thin Italic Before:
![image](https://github.com/user-attachments/assets/f9badbe5-a420-4625-a5ce-a9071105bffb)
Etoile Thin Italic After:
![image](https://github.com/user-attachments/assets/236ce24e-ae8c-458d-af37-fab1d4509480)
Etoile Regular Italic Before:
![image](https://github.com/user-attachments/assets/0688f28b-278d-4ad2-9fe6-6af4cd3b2f95)
Etoile Regular Italic After:
![image](https://github.com/user-attachments/assets/1d97c4c2-af2b-4587-b8bc-59dd20ffa51d)
Etoile Heavy Italic Before:
![image](https://github.com/user-attachments/assets/a5bf026d-6d23-417f-9ae8-8ffa851276e9)
Etoile Heavy Italic After:
![image](https://github.com/user-attachments/assets/7860374b-8860-4082-bda1-2e923ae02e4e)


