### PR TITLE
Website specimen: Treat Nabla and Partial Differential in Mathematical Alphanumeric Symbols block as letter.

### DIFF
--- a/pages/specimen.tsx
+++ b/pages/specimen.tsx
@@ -499,7 +499,7 @@ function charHasVariants(atlas: Coverage.Atlas, props: SpecimenCharacterProps) {
 }
 
 function charIsSpecial(lch: number) {
-	return lch < 0x0020 || (lch >= 0xfff0 && lch <= 0xffff) || lch === 0x034f;
+	return lch < 0x0020 || (lch >= 0xfff0 && lch <= 0xffff) || lch === 0x034f || lch === 0xfeff;
 }
 
 function SpecimenCharacterVariantsMarker(props: SpecimenCharacterProps) {
@@ -616,7 +616,8 @@ function SpecimenCharacterImpl(props: SpecimenCharacterImplProps) {
 			gc === "Lowercase_Letter" ||
 			gc === "Titlecase_Letter" ||
 			gc === "Other_Letter" ||
-			props.blockName === "Currency Symbols");
+			props.blockName === "Currency Symbols" ||
+			props.blockName === "Mathematical Alphanumeric Symbols");
 	return (
 		<div
 			className={joinCls(


### PR DESCRIPTION
This makes it so that all characters in the Mathematical Alphanumeric Symbols block are treated as letters and thus have the baseline markings of letters when viewed on the website.
The original characters in the Mathematical Operators block, however, are unaffected.

This also treats the ZWNBSP/BOM character as a special.