### PR TITLE
Optimize vertical position of Latin Letter Sinological Dot (`U+A78F`).

### DIFF
--- a/changes/33.2.3.md
+++ b/changes/33.2.3.md
@@ -1,0 +1,3 @@
+* Refine shape of the following characters:
+  - LATIN LETTER SINOLOGICAL DOT (`U+A78F`).
+  - MATHEMATICAL DOUBLE-STRUCK CAPITAL B (`U+1D539`).

--- a/packages/font-glyphs/src/symbol/punctuation/interpuncts.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/interpuncts.ptl
@@ -17,7 +17,6 @@ glyph-block Symbol-Punctuation-Interpuncts : begin
 
 	select-variant 'interpunct' 0xB7 (follow -- 'punctuationDot')
 	alias 'period/mid' null 'interpunct'
-	alias 'greekbullet' 0x387 'interpunct'
+	alias 'grek/semicolon' 0x387 'interpunct'
 	alias 'hyphenpoint' 0x2027 'interpunct'
 	alias 'wordseparatormiddledot' 0x2E31 'interpunct'
-	alias 'sinologicaldot' 0xA78F 'interpunct'

--- a/packages/font-glyphs/src/symbol/punctuation/small.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/small.ptl
@@ -148,10 +148,12 @@ glyph-block Symbol-Punctuation-Small : begin
 
 	derive-composites 'raisedPeriod.round'  null 'period.round'  [ApparentTranslate 0 (XH / 2 - PeriodRadius)]
 	derive-composites 'raisedPeriod.square' null 'period.square' [ApparentTranslate 0 (XH / 2 - PeriodRadius * DesignParameters.squareDotScalar)]
-	derive-composites 'raisedComma.round'  null 'comma.round'  [ApparentTranslate 0 (XH / 2 - PeriodRadius)]
-	derive-composites 'raisedComma.square' null 'comma.square' [ApparentTranslate 0 (XH / 2 - PeriodRadius * DesignParameters.squareDotScalar)]
+	derive-composites 'raisedComma.round'   null 'comma.round'   [ApparentTranslate 0 (XH / 2 - PeriodRadius)]
+	derive-composites 'raisedComma.square'  null 'comma.square'  [ApparentTranslate 0 (XH / 2 - PeriodRadius * DesignParameters.squareDotScalar)]
 	select-variant 'raisedPeriod' 0x2E33 (follow -- 'punctuationDot')
 	select-variant 'raisedComma'  0x2E34 (follow -- 'punctuationDot')
+
+	alias 'sinologicalDot' 0xA78F 'raisedPeriod'
 
 	foreach { suffix { DrawAt kDotRadius overshoot } } [Object.entries DotVariants] : do
 		create-glyph "colon.\(suffix)" : glyph-proc


### PR DESCRIPTION
It should be half x-height, as if it were a modifier letter equivalent to a combining dot (e.g. `◌̇`/`◌̣`) which matches with other modifier letter analogues of combining marks.

```
a꞉ e꞉ i꞉ o꞉ u꞉
aꞏ eꞏ iꞏ oꞏ uꞏ
```
Before:
![image](https://github.com/user-attachments/assets/a7f3f1c8-b1a6-4c5c-9f4e-02679a7e1bd6)
After:
![image](https://github.com/user-attachments/assets/3382e0f0-9086-4bd5-91f8-8bd7429f90c0)
Compared to Gentium Plus:
![image](https://github.com/user-attachments/assets/26157e4b-6486-4ea5-ab9c-8800bd701ae7)
Compared to Doulos SIL:
![image](https://github.com/user-attachments/assets/63e17721-46e2-4baf-98d4-210ba1743c8d)

