### PR TITLE
Move `[UnicodeWeightGrade n s]` to `meta/aesthetics.ptl`.

### DIFF
--- a/packages/font-glyphs/src/meta/aesthetics.ptl
+++ b/packages/font-glyphs/src/meta/aesthetics.ptl
@@ -190,6 +190,13 @@ export : define [calculateMetrics para] : begin
 	define GeometryStroke : AdviceStroke 4
 	define ShoulderFine : Math.min (Stroke * para.shoulderFineMin) : AdviceStroke 24
 
+	define [UnicodeWeightGrade n s] : begin
+		define kw : 10 - s - n / 2
+		define [mulPow ss] : (0.25 + ss / 8) * [StrokeWidthBlend 2 1]
+		define kMul : [Math.pow n : mulPow s] / [Math.pow 4 : mulPow 2]
+		define kAdj : GeometryStroke / [AdviceStroke 6]
+		return : kMul * kAdj * [AdviceStroke kw]
+
 	define [AdviceGlottalStopArchDepth y sign] : begin
 		return : ((y - Stroke) * 0.24 + Stroke * 0.625) + sign * TanSlope * SmoothAdjust
 
@@ -208,10 +215,10 @@ export : define [calculateMetrics para] : begin
 		WideWidth2 WideWidth3 WideWidth4 EssUpper EssLower EssQuestion RightSB Middle DotRadius
 		PeriodRadius ArchDepthA ArchDepthB SmallArchDepthA SmallArchDepthB CorrectionOMidX
 		CorrectionOMidS compositeBaseAnchors AdviceStroke AdviceStroke2 AdviceStrokeInSpace
-		OverlayStroke OperatorStroke GeometryStroke ShoulderFine AdviceGlottalStopArchDepth
-		StrokeWidthBlend ArchDepthAOf ArchDepthBOf SmoothAdjust SideJut MidJutSide MidJutCenter
-		YSmoothMidR YSmoothMidL DToothlessRise DMBlend HSwToV VSwToH NarrowUnicodeT WideUnicodeT
-		VERY-FAR TINY]
+		OverlayStroke OperatorStroke GeometryStroke ShoulderFine UnicodeWeightGrade
+		AdviceGlottalStopArchDepth StrokeWidthBlend ArchDepthAOf ArchDepthBOf SmoothAdjust SideJut
+		MidJutSide MidJutCenter YSmoothMidR YSmoothMidL DToothlessRise DMBlend HSwToV VSwToH
+		NarrowUnicodeT WideUnicodeT VERY-FAR TINY]
 
 export : define [setFontMetrics para metrics fm] : begin
 	define [object CAP Descender XH Width SymbolMid] metrics

--- a/packages/font-glyphs/src/meta/macros.ptl
+++ b/packages/font-glyphs/src/meta/macros.ptl
@@ -387,10 +387,10 @@ define-macro glyph-block : syntax-rules
 			WideWidth3 WideWidth4 EssUpper EssLower EssQuestion RightSB Middle DotRadius
 			PeriodRadius ArchDepthA ArchDepthB SmallArchDepthA SmallArchDepthB CorrectionOMidX
 			CorrectionOMidS compositeBaseAnchors AdviceStroke AdviceStroke2 AdviceStrokeInSpace
-			OverlayStroke OperatorStroke GeometryStroke ShoulderFine AdviceGlottalStopArchDepth
-			StrokeWidthBlend ArchDepthAOf ArchDepthBOf SmoothAdjust SideJut MidJutSide
-			MidJutCenter YSmoothMidR YSmoothMidL DToothlessRise DMBlend HSwToV VSwToH
-			NarrowUnicodeT WideUnicodeT VERY-FAR TINY]
+			OverlayStroke OperatorStroke GeometryStroke ShoulderFine UnicodeWeightGrade
+			AdviceGlottalStopArchDepth StrokeWidthBlend ArchDepthAOf ArchDepthBOf SmoothAdjust
+			SideJut MidJutSide MidJutCenter YSmoothMidR YSmoothMidL DToothlessRise DMBlend HSwToV
+			VSwToH NarrowUnicodeT WideUnicodeT VERY-FAR TINY]
 
 		define spiroFnImports `[g4 g2 corner flat curl virt close end straight g2c cg2 flatc ccurl
 			widths disable-contrast heading unimportant important alsoThru alsoThruThem bezControls

--- a/packages/font-glyphs/src/symbol/arrow.ptl
+++ b/packages/font-glyphs/src/symbol/arrow.ptl
@@ -7,7 +7,7 @@ glyph-module
 glyph-block Symbol-Arrow : for-width-kinds WideWidth1
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade GeometricSizes
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim GeometricSizes
 
 	define arrowHeight : para.arrowHeight * (Width - SB / 2) * [Math.cbrt MosaicWidthScalar]
 	define arrowWidth  : Math.min (MosaicWidth - SB / 2) arrowHeight

--- a/packages/font-glyphs/src/symbol/geometric/ballot-box.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/ballot-box.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Symbol-Geometric-Ballot-Box : for-width-kinds WideWidth1
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade GeometricSizes
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim GeometricSizes
 
 	define Geom : GeometricDim MosaicUnitWidth MosaicWidth
 

--- a/packages/font-glyphs/src/symbol/geometric/dotted.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/dotted.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Symbol-Geometric-Dice : for-width-kinds WideWidth1
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade GeometricSizes
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim GeometricSizes
 
 	define Geom : GeometricDim MosaicUnitWidth MosaicWidth
 
@@ -48,7 +48,7 @@ glyph-block Symbol-Geometric-Dice : for-width-kinds WideWidth1
 glyph-block Symbol-Geometric-Dotted : for-width-kinds WideWidth4
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade GeometricSizes
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim GeometricSizes
 
 	define Geom : GeometricDim MosaicUnitWidth MosaicWidth
 	define Size : GeometricSizes Geom

--- a/packages/font-glyphs/src/symbol/geometric/masked.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/masked.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Symbol-Geometric-Masked : for-width-kinds WideWidth1
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade GeometricSizes
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim GeometricSizes
 
 	define Geom : GeometricDim MosaicUnitWidth MosaicWidth
 	define Size : GeometricSizes Geom

--- a/packages/font-glyphs/src/symbol/geometric/plain.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/plain.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Symbol-Geometric-Plain : for-width-kinds WideWidth1
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade GeometricSizes ConvexPolygonOutline
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim GeometricSizes ConvexPolygonOutline
 
 	define Geom : GeometricDim MosaicUnitWidth MosaicWidth
 	define Size : GeometricSizes Geom

--- a/packages/font-glyphs/src/symbol/geometric/rotational.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/rotational.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Symbol-Geometric-Rotational : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade GeometricSizes
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim GeometricSizes
 
 	define [OpenRadius sw sides] : sw / 2 / [Math.tan : Math.PI / sides]
 

--- a/packages/font-glyphs/src/symbol/geometric/rounded.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/rounded.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Symbol-Geometric-Rounded : for-width-kinds WideWidth1
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade GeometricSizes
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim GeometricSizes
 
 	define Geom : GeometricDim MosaicUnitWidth MosaicWidth
 	define Size : GeometricSizes Geom

--- a/packages/font-glyphs/src/symbol/geometric/shaded.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/shaded.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Symbol-Geometric-Shaded : for-width-kinds WideWidth1
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade GeometricSizes
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim GeometricSizes
 
 	define Geom : GeometricDim MosaicUnitWidth MosaicWidth
 	define Size : GeometricSizes Geom
@@ -135,7 +135,7 @@ glyph-block Symbol-Geometric-Shaded : for-width-kinds WideWidth1
 glyph-block Symbol-Geometric-Shaded-Narrow : for-width-kinds WideWidth4
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim
 
 	define Geom : GeometricDim MosaicUnitWidth MosaicWidth
 

--- a/packages/font-glyphs/src/symbol/geometric/shared.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/shared.ptl
@@ -26,16 +26,6 @@ glyph-block Symbol-Geometric-Shared : begin
 			MidY      SymbolMid
 			Bot     : SymbolMid       - size
 
-	glyph-block-export UnicodeWeightGrade
-	define [UnicodeWeightGrade n s] : begin
-		define kwPow 1
-		define kkw : 2 / (4 ** kwPow)
-		define kw : 10 - s - kkw * (n ** kwPow)
-		define [mulPow ss pm] : (1 / 4 + ss / 8) * [StrokeWidthBlend 2 1]
-		define kMul : (n ** [mulPow s]) / (4 ** [mulPow 2])
-		define kAdj : GeometryStroke / [AdviceStroke 6]
-		return : kMul * kAdj * [AdviceStroke kw]
-
 	glyph-block-export GeometricSizes
 	define [GeometricSizes Geom] : object
 		Large         {.size [DesignParameters.GeometricLargeX Geom.Width Geom.UnitWidth]}

--- a/packages/font-glyphs/src/symbol/geometric/square-corners.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/square-corners.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Symbol-Geometric-Square-Corners : for-width-kinds WideWidth1
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade GeometricSizes
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim GeometricSizes
 
 	define Geom : GeometricDim MosaicUnitWidth MosaicWidth
 

--- a/packages/font-glyphs/src/symbol/geometric/stars.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/stars.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Symbol-Geometric-Stars : for-width-kinds WideWidth1
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade GeometricSizes
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim GeometricSizes
 
 	define Geom : GeometricDim MosaicUnitWidth MosaicWidth
 

--- a/packages/font-glyphs/src/symbol/geometric/sun-and-gear.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/sun-and-gear.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Symbol-Geometric-Sun-And-Gear : for-width-kinds WideWidth1
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade GeometricSizes
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim GeometricSizes
 
 	define Geom : GeometricDim MosaicUnitWidth MosaicWidth
 	define Size : GeometricSizes Geom

--- a/packages/font-glyphs/src/symbol/geometric/technical.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/technical.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Symbol-Geometric-Technical : for-width-kinds WideWidth1
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade GeometricSizes
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim GeometricSizes
 	glyph-block-import Shared-Symbol-Shapes : TriangleShape Polyline
 	glyph-block-import Symbol-Arrow : ArrowShape ArrowHead TrigArrowShape
 

--- a/packages/font-glyphs/src/symbol/letter.ptl
+++ b/packages/font-glyphs/src/symbol/letter.ptl
@@ -199,7 +199,6 @@ glyph-block Symbol-Letter : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Latin-X : XStrand
-	glyph-block-import Symbol-Geometric-Shared : UnicodeWeightGrade
 	glyph-block-import Letter-Shared-Shapes : FlatHookDepth
 
 	alias 'eulerConst' 0x2107 'latn/Epsilon'

--- a/packages/font-glyphs/src/symbol/mosaic/dentistry.ptl
+++ b/packages/font-glyphs/src/symbol/mosaic/dentistry.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Symbol-Mosaic-Dentistry : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim
 	glyph-block-import Mark-Above : TildeShape
 
 	define boxDrawingStroke : AdviceStroke 3.5

--- a/packages/font-glyphs/src/symbol/pictograph/checking-marks.ptl
+++ b/packages/font-glyphs/src/symbol/pictograph/checking-marks.ptl
@@ -7,7 +7,7 @@ glyph-module
 glyph-block Symbol-Pictograph-Checking-Marks : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim
 
 	for-width-kinds WideWidth1 : do
 		define Geom : GeometricDim MosaicUnitWidth MosaicWidth

--- a/packages/font-glyphs/src/symbol/pictograph/clock.ptl
+++ b/packages/font-glyphs/src/symbol/pictograph/clock.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Symbol-Geometric-Clock : for-width-kinds WideWidth1
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade GeometricSizes
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim GeometricSizes
 
 	define Geom : GeometricDim MosaicUnitWidth MosaicWidth
 

--- a/packages/font-glyphs/src/symbol/pictograph/cross.ptl
+++ b/packages/font-glyphs/src/symbol/pictograph/cross.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Symbol-Cross : for-width-kinds WideWidth1
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade GeometricSizes
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim GeometricSizes
 
 	define Geom : GeometricDim MosaicUnitWidth MosaicWidth
 	define Size : GeometricSizes Geom

--- a/packages/font-glyphs/src/symbol/pictograph/iec-power-and-playback.ptl
+++ b/packages/font-glyphs/src/symbol/pictograph/iec-power-and-playback.ptl
@@ -7,7 +7,7 @@ glyph-module
 glyph-block Symbol-Pictograph-IEC-Power-And-Playback : for-width-kinds WideWidth1 : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade GeometricSizes
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim GeometricSizes
 
 	define Geom : GeometricDim MosaicUnitWidth MosaicWidth
 	define Size : GeometricSizes Geom

--- a/packages/font-glyphs/src/symbol/pictograph/telephone-recorder.ptl
+++ b/packages/font-glyphs/src/symbol/pictograph/telephone-recorder.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Symbol-Telephone-Recorder : for-width-kinds WideWidth1
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Symbol-Geometric-Shared : GeometricDim UnicodeWeightGrade GeometricSizes
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim GeometricSizes
 
 	define Geom : GeometricDim MosaicUnitWidth MosaicWidth
 


### PR DESCRIPTION
Basically this sets up potential future PR's for character additions/etc. with Unicode-prescribed weights — based on existing characters defined in files which might currently be compiled/executed chronologically _before_ `symbol/geometric/shared.ptl`.