### PR TITLE
Make `[UnicodeWeightGrade n s]` take CSS `font-weight` values for `n`.

### DIFF
--- a/packages/font-glyphs/src/meta/aesthetics.ptl
+++ b/packages/font-glyphs/src/meta/aesthetics.ptl
@@ -120,7 +120,7 @@ export : define [calculateMetrics para] : begin
 	define SLAB para.slab
 
 	define [IBalance  df] : df.adws * df.adws * [fallback para.ibalance (LongJut * 0.04)] # Serifed
-	define [IBalance2 df] : df.adws * [fallback para.ibalance2 (LongJut * 0.14)]         # Hooky, Tailed
+	define [IBalance2 df] : df.adws * [fallback para.ibalance2 (LongJut * 0.14)]          # Hooky, Tailed
 	define JBalance  : fallback para.jbalance 0
 	define JBalance2 : fallback para.jbalance2 (QuarterStroke + LongJut * 0.04)
 	define TBalance  : fallback para.tbalance JBalance
@@ -191,9 +191,9 @@ export : define [calculateMetrics para] : begin
 	define ShoulderFine : Math.min (Stroke * para.shoulderFineMin) : AdviceStroke 24
 
 	define [UnicodeWeightGrade n s] : begin
-		define kw : 10 - s - n / 2
+		define kw : 10 - s - n / 200
 		define [mulPow ss] : (0.25 + ss / 8) * [StrokeWidthBlend 2 1]
-		define kMul : [Math.pow n : mulPow s] / [Math.pow 4 : mulPow 2]
+		define kMul : [Math.pow (n / 100) : mulPow s] / [Math.pow 4 : mulPow 2]
 		define kAdj : GeometryStroke / [AdviceStroke 6]
 		return : kMul * kAdj * [AdviceStroke kw]
 

--- a/packages/font-glyphs/src/symbol/arrow.ptl
+++ b/packages/font-glyphs/src/symbol/arrow.ptl
@@ -1062,7 +1062,7 @@ glyph-block Symbol-Arrow : for-width-kinds WideWidth1
 		MkArrow [ThickArrowShape 'blackSemiHookR'] [MangleName 'uni27A6'] [MangleUnicode 0x27A6] arrowSB SymbolMid arrowRSB SymbolMid
 
 	do "Barb arrows"
-		define BarbHeavyWideHeaded : BarbArrowShape 0.25 : UnicodeWeightGrade 9 MosaicWidthScalar
+		define BarbHeavyWideHeaded : BarbArrowShape 0.25 : UnicodeWeightGrade 900 MosaicWidthScalar
 		MkArrow BarbHeavyWideHeaded [MangleName 'uni2794'] [MangleUnicode 0x2794] arrowSB SymbolMid arrowRSB SymbolMid
 
 		define [BarbGroup prefix b k w] : begin
@@ -1076,11 +1076,11 @@ glyph-block Symbol-Arrow : for-width-kinds WideWidth1
 			MkArrow BarbLight [MangleName "\(prefix)RB"]    [MangleUnicode : b + 6] arrowDiagSB arrowDiagTop arrowDiagRSB arrowDiagBot
 			MkArrow BarbLight [MangleName "\(prefix)LB"]    [MangleUnicode : b + 7] arrowDiagRSB arrowDiagTop arrowDiagSB arrowDiagBot
 
-		BarbGroup 'barbArrowLight'     0x1F860 0.375 3
-		BarbGroup 'barbArrow'          0x1F868 0.375 5
-		BarbGroup 'barbArrowMedium'    0x1F870 0.375 7
-		BarbGroup 'barbArrowHeavy'     0x1F878 0.375 9
-		BarbGroup 'barbArrowVeryHeavy' 0x1F880 0.375 10
+		BarbGroup 'barbArrowLight'     0x1F860 0.375 300
+		BarbGroup 'barbArrow'          0x1F868 0.375 500
+		BarbGroup 'barbArrowMedium'    0x1F870 0.375 700
+		BarbGroup 'barbArrowHeavy'     0x1F878 0.375 900
+		BarbGroup 'barbArrowVeryHeavy' 0x1F880 0.375 1000
 
 	do "Weighted Trig Arrows"
 		define Geom : GeometricDim MosaicUnitWidth MosaicWidth
@@ -1105,18 +1105,18 @@ glyph-block Symbol-Arrow : for-width-kinds WideWidth1
 			MkArrow [WeightedTrigArrowShape sw w h] [MangleName "\(prefix)Right"] [MangleUnicode : b + 2] arrowSB SymbolMid arrowRSB SymbolMid
 			MkArrow [WeightedTrigArrowShape sw w h] [MangleName "\(prefix)Down"]  [MangleUnicode : b + 3] arrowMidX arrowTop arrowMidX arrowBot
 
-		TrigGroup 'trigArrowSmallHead'         0x1F800 [UnicodeWeightGrade 3 MosaicWidthScalar] Size.Small.size
-		TrigGroup 'trigArrowMediumHead'        0x1F804 [UnicodeWeightGrade 5 MosaicWidthScalar] Size.Medium.size
-		TrigGroup 'trigArrowLargeHead'         0x1F808 [UnicodeWeightGrade 7 MosaicWidthScalar] Size.Large.size
-		TrigGroup 'trigArrowSmallEqHead'       0x1F810 [UnicodeWeightGrade 3 MosaicWidthScalar] Size.Small.size (Size.Small.size * eqHeight)
-		TrigGroup 'trigArrowEqHead'            0x1F814 [UnicodeWeightGrade 4 MosaicWidthScalar] 1 eqHeight
-		TrigGroup 'trigArrowEqHeadHeavy'       0x1F818 [UnicodeWeightGrade 5 MosaicWidthScalar] 1 eqHeight
-		TrigGroup 'trigArrowLargeEqHeadHeavy'  0x1F81C [UnicodeWeightGrade 7 MosaicWidthScalar] Size.Large.size (Size.Large.size * eqHeight)
-		TrigGroup 'trigArrowNarrowShaft'       0x1F820 [UnicodeWeightGrade 3 MosaicWidthScalar] 1
-		TrigGroup 'trigArrowMediumShaft'       0x1F824 [UnicodeWeightGrade 5 MosaicWidthScalar] 1
-		TrigGroup 'trigArrowBoldShaft'         0x1F828 [UnicodeWeightGrade 7 MosaicWidthScalar] 1
-		TrigGroup 'trigArrowHeavyShaft'        0x1F82C [UnicodeWeightGrade 9 MosaicWidthScalar] 1
-		TrigGroup 'trigArrowVeryHeavyShaft'    0x1F830 [UnicodeWeightGrade 10 MosaicWidthScalar] 1
+		TrigGroup 'trigArrowSmallHead'         0x1F800 [UnicodeWeightGrade 300 MosaicWidthScalar] Size.Small.size
+		TrigGroup 'trigArrowMediumHead'        0x1F804 [UnicodeWeightGrade 500 MosaicWidthScalar] Size.Medium.size
+		TrigGroup 'trigArrowLargeHead'         0x1F808 [UnicodeWeightGrade 700 MosaicWidthScalar] Size.Large.size
+		TrigGroup 'trigArrowSmallEqHead'       0x1F810 [UnicodeWeightGrade 300 MosaicWidthScalar] Size.Small.size (Size.Small.size * eqHeight)
+		TrigGroup 'trigArrowEqHead'            0x1F814 [UnicodeWeightGrade 400 MosaicWidthScalar] 1 eqHeight
+		TrigGroup 'trigArrowEqHeadHeavy'       0x1F818 [UnicodeWeightGrade 500 MosaicWidthScalar] 1 eqHeight
+		TrigGroup 'trigArrowLargeEqHeadHeavy'  0x1F81C [UnicodeWeightGrade 700 MosaicWidthScalar] Size.Large.size (Size.Large.size * eqHeight)
+		TrigGroup 'trigArrowNarrowShaft'       0x1F820 [UnicodeWeightGrade 300 MosaicWidthScalar] 1
+		TrigGroup 'trigArrowMediumShaft'       0x1F824 [UnicodeWeightGrade 500 MosaicWidthScalar] 1
+		TrigGroup 'trigArrowBoldShaft'         0x1F828 [UnicodeWeightGrade 700 MosaicWidthScalar] 1
+		TrigGroup 'trigArrowHeavyShaft'        0x1F82C [UnicodeWeightGrade 900 MosaicWidthScalar] 1
+		TrigGroup 'trigArrowVeryHeavyShaft'    0x1F830 [UnicodeWeightGrade 1000 MosaicWidthScalar] 1
 		TrigGroup 'fingerPost'                 0x1F834 (2 * (trigArrowSize - o)) 1
 		TrigGroup 'trigArrowHeavy'             0x1F844 (2 * (trigArrowSize - o)) kMedium
 
@@ -1124,12 +1124,12 @@ glyph-block Symbol-Arrow : for-width-kinds WideWidth1
 		TrigGroupSquat 'trigArrowCompressed'      0x1F83C (2 * Geom.Size * Size.Small.size) kMedium kSmall
 		TrigGroupSquat 'trigArrowCompressedHeavy' 0x1F840 (2 * Geom.Size * Size.MediumSmall.size) kMedium kSmall
 
-		MkArrow [WeightedTrigArrowShape [UnicodeWeightGrade 3 MosaicWidthScalar] 1] [MangleName "uni279D"] [MangleUnicode 0x279D] arrowSB SymbolMid arrowRSB SymbolMid
-		MkArrow [WeightedTrigArrowShape [UnicodeWeightGrade 7 MosaicWidthScalar] 1] [MangleName "uni279E"] [MangleUnicode 0x279E] arrowSB SymbolMid arrowRSB SymbolMid
+		MkArrow [WeightedTrigArrowShape [UnicodeWeightGrade 300 MosaicWidthScalar] 1] [MangleName "uni279D"] [MangleUnicode 0x279D] arrowSB SymbolMid arrowRSB SymbolMid
+		MkArrow [WeightedTrigArrowShape [UnicodeWeightGrade 700 MosaicWidthScalar] 1] [MangleName "uni279E"] [MangleUnicode 0x279E] arrowSB SymbolMid arrowRSB SymbolMid
 		MkArrow [WeightedTrigArrowShape (2 * Geom.Size * Size.Medium.size) kMedium kSmall] [MangleName "trigArrowSquatBlackRight"] [MangleUnicode 0x27A7] (arrowMidX - squatRange) SymbolMid (arrowMidX + squatRange) SymbolMid
 
 	do "Round-stroke arrows"
-		define sw : UnicodeWeightGrade 9 MosaicWidthScalar
+		define sw : UnicodeWeightGrade 900 MosaicWidthScalar
 		MkArrow [RoundArrow.Shape sw] [MangleName 'heavyRoundArrowRight'] [MangleUnicode 0x279C] arrowSB SymbolMid arrowRSB SymbolMid
 
 	do "Sans-serif Arrows"

--- a/packages/font-glyphs/src/symbol/geometric/ballot-box.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/ballot-box.ptl
@@ -37,8 +37,8 @@ glyph-block Symbol-Geometric-Ballot-Box : for-width-kinds WideWidth1
 
 	define bbGap : Math.max (Geom.Size / 6) [AdviceStroke 5 Geom.Scalar]
 	define swMark : Math.min GeometryStroke : AdviceStroke 5 Geom.Scalar
-	define lightSwMark : UnicodeWeightGrade 3 Geom.Scalar
-	define boldSwMark  : UnicodeWeightGrade 7 Geom.Scalar
+	define lightSwMark : UnicodeWeightGrade 300 Geom.Scalar
+	define boldSwMark  : UnicodeWeightGrade 700 Geom.Scalar
 	define bbSize : Geom.Size - bbGap - swMark * 0.75
 	define circXSize : (Geom.Size - bbGap) * Math.SQRT1_2 - swMark * 0.75
 

--- a/packages/font-glyphs/src/symbol/geometric/masked.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/masked.ptl
@@ -237,7 +237,7 @@ glyph-block Symbol-Geometric-Masked : for-width-kinds WideWidth1
 	do "Diamond minus white X"
 		create-glyph [MangleName "blackDiamondMinusWhiteX"] [MangleUnicode 0x2756] : glyph-proc
 			set-width Geom.Width
-			local gap : Math.max (0.2 * Geom.Size) [UnicodeWeightGrade 4 Geom.Scalar]
+			local gap : Math.max (0.2 * Geom.Size) [UnicodeWeightGrade 400 Geom.Scalar]
 			include : difference
 				refer-glyph : MangleName "blackDiamond"
 				dispiro

--- a/packages/font-glyphs/src/symbol/geometric/plain.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/plain.ptl
@@ -136,12 +136,12 @@ glyph-block Symbol-Geometric-Plain : for-width-kinds WideWidth1
 		StdBlackShape SquareShape 'blackSquare' 0x25A0
 		StdWhiteShape SquareShape 'whiteSquare' 0x25A1
 
-		StdWhiteShape SquareShape 'lightWhiteSquare'     0x1F78E {.sw [UnicodeWeightGrade 3 Geom.Scalar]}
-		StdWhiteShape SquareShape 'mediumWhiteSquare'    0x1F78F {.sw [UnicodeWeightGrade 5 Geom.Scalar]}
-		StdWhiteShape SquareShape 'boldWhiteSquare'      0x1F790 {.sw [UnicodeWeightGrade 7 Geom.Scalar]}
-		StdWhiteShape SquareShape 'heavyWhiteSquare'     0x1F791 {.sw [UnicodeWeightGrade 9 Geom.Scalar]}
-		StdWhiteShape SquareShape 'veryHeavyWhiteSquare' 0x1F792 {.sw [UnicodeWeightGrade 10 Geom.Scalar]}
-		StdWhiteShape SquareShape 'exHeavyWhiteSquare'   0x1F793 {.sw [UnicodeWeightGrade 11 Geom.Scalar]}
+		StdWhiteShape SquareShape 'lightWhiteSquare'     0x1F78E {.sw [UnicodeWeightGrade 300  Geom.Scalar]}
+		StdWhiteShape SquareShape 'mediumWhiteSquare'    0x1F78F {.sw [UnicodeWeightGrade 500  Geom.Scalar]}
+		StdWhiteShape SquareShape 'boldWhiteSquare'      0x1F790 {.sw [UnicodeWeightGrade 700  Geom.Scalar]}
+		StdWhiteShape SquareShape 'heavyWhiteSquare'     0x1F791 {.sw [UnicodeWeightGrade 900  Geom.Scalar]}
+		StdWhiteShape SquareShape 'veryHeavyWhiteSquare' 0x1F792 {.sw [UnicodeWeightGrade 1000 Geom.Scalar]}
+		StdWhiteShape SquareShape 'exHeavyWhiteSquare'   0x1F793 {.sw [UnicodeWeightGrade 1100 Geom.Scalar]}
 
 		StdBlackShape SquareShape 'blackLargeSquare' 0x2B1B Size.Large
 		StdBlackShape SquareShape 'blackMediumSquare' 0x25FC Size.Medium
@@ -161,7 +161,7 @@ glyph-block Symbol-Geometric-Plain : for-width-kinds WideWidth1
 		StdWhiteContainingBlackShape SquareShape 'whiteSquareWithCenter' 0x25A3
 		StdWhiteContainingBlackShape SquareShape 'whiteSquareContainingBlackVerySmallSquare' 0x1F794 Size.TinyInner
 		StdWhiteContainingBlackShape SquareShape 'whiteSquareContainingBlackMediumSquare' 0x1F795 Size.MediumInner
-		StdWhiteContainingBlackShape SquareShape 'heavyWhiteSquareContainingBlackMediumSquare' 0x1CE05 : Object.assign Size.TinyInner {.sw [UnicodeWeightGrade 9 Geom.Scalar]}
+		StdWhiteContainingBlackShape SquareShape 'heavyWhiteSquareContainingBlackMediumSquare' 0x1CE05 : Object.assign Size.TinyInner {.sw [UnicodeWeightGrade 900 Geom.Scalar]}
 
 		StdGeomTargetShape SquareShape 'squareTarget' 0x1F796
 
@@ -447,7 +447,7 @@ glyph-block Symbol-Geometric-Plain : for-width-kinds WideWidth1
 				g4     [mix cx [mix cx (cx - size) 0.5] p] [mix cy [mix (cy + size) cy 0.5] p]
 				close
 
-		StdWhiteShape DiamondLazongeShape 'whiteConcaveSidedDiamond'  0x27E1 [Object.assign {.} Size.Oblique {.sw (Math.SQRT2 * [UnicodeWeightGrade 6 Geom.Scalar])}]
+		StdWhiteShape DiamondLazongeShape 'whiteConcaveSidedDiamond'  0x27E1 [Object.assign {.} Size.Oblique {.sw (Math.SQRT2 * [UnicodeWeightGrade 600 Geom.Scalar])}]
 		StdBlackShape DiamondLazongeShape 'lightFourPointedBlackCusp' 0x2BCC Size.Oblique
 		StdWhiteShape DiamondLazongeShape 'whiteFourPointedBlackCusp' 0x2BCE Size.ObliqueSA
 
@@ -472,12 +472,12 @@ glyph-block Symbol-Geometric-Plain : for-width-kinds WideWidth1
 		StdBlackShape CircleShape 'blackCircle' 0x25CF
 
 		StdWhiteShape CircleShape 'whiteCircle' 0x25CB
-		StdWhiteShape CircleShape 'mediumWhiteCircle'    0x1F785 {.sw [UnicodeWeightGrade 6 Geom.Scalar]}
-		StdWhiteShape CircleShape 'boldWhiteCircle'      0x1F786 {.sw [UnicodeWeightGrade 7 Geom.Scalar]}
-		StdWhiteShape CircleShape 'heavyWhiteCircle'     0x1F787 {.sw [UnicodeWeightGrade 9 Geom.Scalar]}
-		StdWhiteShape CircleShape 'veryHeavyWhiteCircle' 0x1F788 {.sw [UnicodeWeightGrade 10 Geom.Scalar]}
-		StdWhiteShape CircleShape 'exHeavyWhiteCircle'   0x1F789 {.sw [UnicodeWeightGrade 11 Geom.Scalar]}
-		StdWhiteShape CircleShape 'heavyLargeCircle'     0x2B55  [Object.assign {.sw [UnicodeWeightGrade 9 Geom.Scalar]} Size.Large]
+		StdWhiteShape CircleShape 'mediumWhiteCircle'    0x1F785 {.sw [UnicodeWeightGrade 600 Geom.Scalar]}
+		StdWhiteShape CircleShape 'boldWhiteCircle'      0x1F786 {.sw [UnicodeWeightGrade 700 Geom.Scalar]}
+		StdWhiteShape CircleShape 'heavyWhiteCircle'     0x1F787 {.sw [UnicodeWeightGrade 900 Geom.Scalar]}
+		StdWhiteShape CircleShape 'veryHeavyWhiteCircle' 0x1F788 {.sw [UnicodeWeightGrade 1000 Geom.Scalar]}
+		StdWhiteShape CircleShape 'exHeavyWhiteCircle'   0x1F789 {.sw [UnicodeWeightGrade 1100 Geom.Scalar]}
+		StdWhiteShape CircleShape 'heavyLargeCircle'     0x2B55  [Object.assign {.sw [UnicodeWeightGrade 900 Geom.Scalar]} Size.Large]
 
 		StdBlackShape CircleShape 'blackVerySmallCircle' null Size.VerySmall
 		StdBlackShape CircleShape 'blackSmallCircle' null Size.Small
@@ -572,7 +572,7 @@ glyph-block Symbol-Geometric-Plain : for-width-kinds WideWidth1
 		define [PentagramSw c] {.sw ([AdviceStroke c : Math.sqrt Geom.Scalar] * [Math.sqrt 5])}
 		StdBlackShape [RegularPolygonFill 5  2  1.1  0] 'blackStar' 0x2605
 		StdWhiteShape [RegularPolygonFill 5  2  1.1  0] 'whiteStar' 0x2606 [PentagramSw 5.5]
-		StdWhiteShape [RegularPolygonFill 5  2  1.1  0] 'lightWhiteStar' null {.sw ([UnicodeWeightGrade 3 : Math.sqrt Geom.Scalar] * [Math.sqrt 5])}
+		StdWhiteShape [RegularPolygonFill 5  2  1.1  0] 'lightWhiteStar' null {.sw ([UnicodeWeightGrade 300 : Math.sqrt Geom.Scalar] * [Math.sqrt 5])}
 		StdWhiteShape [RegularPolygonFill 5  2  1.1  0] 'whiteMediumStar' 0x2B50 [Object.assign [PentagramSw 7] Size.Medium]
 		StdBlackShape [RegularPolygonFill 5  2  1.1  0] 'blackSmallStar' 0x2B51 Size.Small
 		StdWhiteShape [RegularPolygonFill 5  2  1.1  0] 'whiteSmallStar' 0x2B52 [Object.assign [PentagramSw 3] Size.Small]

--- a/packages/font-glyphs/src/symbol/geometric/rotational.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/rotational.ptl
@@ -97,11 +97,11 @@ glyph-block Symbol-Geometric-Rotational : begin
 	for-width-kinds WideWidth1 : begin
 		define Geom : GeometricDim MosaicUnitWidth MosaicWidth
 
-		define lightSw      : UnicodeWeightGrade 3    Geom.Scalar
-		define normalSw     : UnicodeWeightGrade 4    Geom.Scalar
-		define semiBoldSw   : UnicodeWeightGrade 6    Geom.Scalar
-		define boldSw       : UnicodeWeightGrade 7    Geom.Scalar
-		define heavySw      : UnicodeWeightGrade 9    Geom.Scalar
+		define lightSw      : UnicodeWeightGrade 300  Geom.Scalar
+		define normalSw     : UnicodeWeightGrade 400  Geom.Scalar
+		define semiBoldSw   : UnicodeWeightGrade 600  Geom.Scalar
+		define boldSw       : UnicodeWeightGrade 700  Geom.Scalar
+		define heavySw      : UnicodeWeightGrade 900  Geom.Scalar
 
 		define [for-rotational-pointing sides phase mag gap fn] : begin
 			local shapes {}

--- a/packages/font-glyphs/src/symbol/geometric/shaded.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/shaded.ptl
@@ -140,7 +140,7 @@ glyph-block Symbol-Geometric-Shaded-Narrow : for-width-kinds WideWidth4
 	define Geom : GeometricDim MosaicUnitWidth MosaicWidth
 
 	create-glyph [MangleName 'symbolForDeleteFormTwo'] [MangleUnicode 0x2425] : glyph-proc
-		local sw : UnicodeWeightGrade 3 Geom.Scalar
+		local sw : UnicodeWeightGrade 300 Geom.Scalar
 		local gap : 0.75 * sw + [Math.max (Geom.Size * 0.125) (sw / 2)]
 		set-width Geom.Width
 		include : intersection

--- a/packages/font-glyphs/src/symbol/geometric/stars.ptl
+++ b/packages/font-glyphs/src/symbol/geometric/stars.ptl
@@ -32,18 +32,18 @@ glyph-block Symbol-Geometric-Stars : for-width-kinds WideWidth1
 					Geom.MidY + Geom.Size * mag * [Math.cos angle]
 			include : spiro-outline corners
 
-	define extThinSw    : UnicodeWeightGrade 1    Geom.Scalar
-	define extLightSw   : UnicodeWeightGrade 2    Geom.Scalar
-	define lightSw      : UnicodeWeightGrade 3    Geom.Scalar
-	define semiLightSw  : UnicodeWeightGrade 3.5  Geom.Scalar
-	define normalSw     : UnicodeWeightGrade 4    Geom.Scalar
-	define mediumSw     : UnicodeWeightGrade 5    Geom.Scalar
-	define semiBoldSw   : UnicodeWeightGrade 6    Geom.Scalar
-	define boldSw       : UnicodeWeightGrade 7    Geom.Scalar
-	define exBoldSw     : UnicodeWeightGrade 8    Geom.Scalar
-	define heavySw      : UnicodeWeightGrade 9    Geom.Scalar
-	define veryHeavySw  : UnicodeWeightGrade 10   Geom.Scalar
-	define exHeavySw    : UnicodeWeightGrade 11   Geom.Scalar
+	define extThinSw    : UnicodeWeightGrade 100  Geom.Scalar
+	define extLightSw   : UnicodeWeightGrade 200  Geom.Scalar
+	define lightSw      : UnicodeWeightGrade 300  Geom.Scalar
+	define semiLightSw  : UnicodeWeightGrade 350  Geom.Scalar
+	define normalSw     : UnicodeWeightGrade 400  Geom.Scalar
+	define mediumSw     : UnicodeWeightGrade 500  Geom.Scalar
+	define semiBoldSw   : UnicodeWeightGrade 600  Geom.Scalar
+	define boldSw       : UnicodeWeightGrade 700  Geom.Scalar
+	define exBoldSw     : UnicodeWeightGrade 800  Geom.Scalar
+	define heavySw      : UnicodeWeightGrade 900  Geom.Scalar
+	define veryHeavySw  : UnicodeWeightGrade 1000 Geom.Scalar
+	define exHeavySw    : UnicodeWeightGrade 1100 Geom.Scalar
 
 	define AsteriskCfg : list
 		* { .name 'saltire'               .unicode 0x2613  .sides  4 .phase (1/8) .sw normalSw                }

--- a/packages/font-glyphs/src/symbol/letter.ptl
+++ b/packages/font-glyphs/src/symbol/letter.ptl
@@ -334,7 +334,7 @@ glyph-block Symbol-Letter : begin
 
 	create-glyph 'informationSource' 0x2139 : glyph-proc
 		include : MarkSet.b
-		local sw : UnicodeWeightGrade 9 1
+		local sw : UnicodeWeightGrade 900 1
 		include : VBar.m Middle 0 XH sw
 		include : HSerif.lt (Middle - [HSwToV : 0.5 * sw]) XH (LongJut / 2)
 		include : HSerif.lb (Middle - [HSwToV : 0.5 * sw]) 0  (LongJut / 2)

--- a/packages/font-glyphs/src/symbol/pictograph/checking-marks.ptl
+++ b/packages/font-glyphs/src/symbol/pictograph/checking-marks.ptl
@@ -11,9 +11,9 @@ glyph-block Symbol-Pictograph-Checking-Marks : begin
 
 	for-width-kinds WideWidth1 : do
 		define Geom : GeometricDim MosaicUnitWidth MosaicWidth
-		define lightSw  : UnicodeWeightGrade 3    Geom.Scalar
-		# define mediumSw : UnicodeWeightGrade 5    Geom.Scalar
-		define heavySw  : UnicodeWeightGrade 9    Geom.Scalar
+		define lightSw  : UnicodeWeightGrade 300    Geom.Scalar
+		# define mediumSw : UnicodeWeightGrade 500    Geom.Scalar
+		define heavySw  : UnicodeWeightGrade 900    Geom.Scalar
 
 		define ptMaxWidth : MosaicWidth - SB
 		define ptHeight0 : 1.5 * (Width - SB / 2) * ((MosaicWidth / MosaicUnitWidth) ** (1 / 4))
@@ -70,9 +70,9 @@ glyph-block Symbol-Pictograph-Checking-Marks : begin
 
 	do "Decorative angular brackets"
 		define Geom : GeometricDim Width Width
-		define mediumSw : UnicodeWeightGrade 5    Geom.Scalar
-		define heavySw  : UnicodeWeightGrade 9    Geom.Scalar
-		define xHeavySw : UnicodeWeightGrade 11   Geom.Scalar
+		define mediumSw : UnicodeWeightGrade 500  Geom.Scalar
+		define heavySw  : UnicodeWeightGrade 900  Geom.Scalar
+		define xHeavySw : UnicodeWeightGrade 1100 Geom.Scalar
 
 		define HeightConfig : object
 			# suffix    width scale   height scale

--- a/packages/font-glyphs/src/symbol/pictograph/clock.ptl
+++ b/packages/font-glyphs/src/symbol/pictograph/clock.ptl
@@ -16,9 +16,9 @@ glyph-block Symbol-Geometric-Clock : for-width-kinds WideWidth1
 	define pMin 0.8
 	define pSec 0.9
 
-	define extLightSw   : UnicodeWeightGrade 2    Geom.Scalar
-	define lightSw      : UnicodeWeightGrade 3    Geom.Scalar
-	define mediumSw     : UnicodeWeightGrade 5    Geom.Scalar
+	define extLightSw   : UnicodeWeightGrade 200  Geom.Scalar
+	define lightSw      : UnicodeWeightGrade 300  Geom.Scalar
+	define mediumSw     : UnicodeWeightGrade 500  Geom.Scalar
 	
 	define dotSize : Math.max (0.6 * mediumSw) (0.1 * Geom.Size)
 

--- a/packages/font-glyphs/src/symbol/pictograph/cross.ptl
+++ b/packages/font-glyphs/src/symbol/pictograph/cross.ptl
@@ -13,9 +13,9 @@ glyph-block Symbol-Cross : for-width-kinds WideWidth1
 	define Geom : GeometricDim MosaicUnitWidth MosaicWidth
 	define Size : GeometricSizes Geom
 
-	define normalSw     : UnicodeWeightGrade 4    Geom.Scalar
-	define mediumSw     : UnicodeWeightGrade 5    Geom.Scalar
-	define heavySw      : UnicodeWeightGrade 9    Geom.Scalar
+	define normalSw     : UnicodeWeightGrade 400  Geom.Scalar
+	define mediumSw     : UnicodeWeightGrade 500  Geom.Scalar
+	define heavySw      : UnicodeWeightGrade 900  Geom.Scalar
 
 	define pBottom 2
 	define pShortBar 0.6


### PR DESCRIPTION
This is just to make it more intuitive to use. It does not affect the end behavior otherwise.

Basically instead of using `1`, `2`, (...) `9` etc., it uses `100`, `200`, (...) `900` etc. like in CSS.