### PR TITLE
Refine shape of Italic Cyrillic Lower Schwa (`ә`).

### DIFF
--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -16,7 +16,7 @@ glyph-block Letter-Latin-Lower-E : begin
 	glyph-block-import Mark-Adjustment : ExtendBelowBaseAnchors
 	glyph-block-import Letter-Latin-C : CConfig
 
-	define [HookHeightFull top stroke noSwash] : Math.min Hook : AHook / XH * top
+	define [HookHeightFull top stroke noSwash] : Math.min Hook : AHook * (top / XH)
 
 	define [HookHeight top stroke noSwash] : Math.min [HookHeightFull top stroke noSwash]
 		if (para.isItalic && !noSwash) top : stroke + 0.277 * (top - stroke * 3)
@@ -88,7 +88,7 @@ glyph-block Letter-Latin-Lower-E : begin
 			widths.lhs stroke
 			[if para.isItalic g2 flat] xStart (barBottom + (2/3) * extraCurliness)
 			[if para.isItalic g2.right.mid curl] [mix xStart df.rightSB (0.475 + 0.1 * TanSlope)] (barBottom - (1/3) * extraCurliness)
-			if para.isItalic {} [archv]
+			if (para.isItalic && !noSwash) {} [archv]
 			g4 (df.rightSB - OX) [YSmoothMidR top barBottom (0.5 * SmallArchDepthA) (0.5 * SmallArchDepthB)]
 			arch.lhs top (sw -- stroke)
 			flatside.ld df.leftSB 0 top ada adb
@@ -111,7 +111,7 @@ glyph-block Letter-Latin-Lower-E : begin
 			widths.rhs stroke
 			[if para.isItalic g2 flat] xStart (barBottom + (2/3) * extraCurliness)
 			[if para.isItalic g2.left.mid curl] [mix xStart df.leftSB (0.475 + 0.1 * TanSlope)] (barBottom - (1/3) * extraCurliness)
-			archv # Keeping this looks better
+			archv
 			g4 (df.leftSB + OX) [YSmoothMidL top barBottom (0.5 * SmallArchDepthA) (0.5 * SmallArchDepthB)]
 			arch.rhs top (sw -- stroke)
 			flatside.rd df.rightSB 0 top ada adb
@@ -382,4 +382,3 @@ glyph-block Letter-Latin-Lower-E : begin
 			union
 				VBar.l (SB + BBD + OX) 0 XH BBS
 				VBar.r (RightSB - BBD - OX) (XH * DesignParameters.eBarPos) XH BBS
-


### PR DESCRIPTION
I'm pretty sure the reason `archv` looks better for rounded reversed e (`ɘ`) is due to the lack of swash behavior via `noSwash`.

```
ƏəӘәЭэ
EeƎɘ
œꭀᴔæꬱᴂ
```

Thin:
![image](https://github.com/user-attachments/assets/e4c6c603-3da3-4bb6-bf96-57aa61cb309e)
Thin Italic:
![image](https://github.com/user-attachments/assets/ef1be621-b91e-4f08-b07e-d3f2ad7b5f33)
Regular:
![image](https://github.com/user-attachments/assets/bcd275a6-ebe9-4e73-b3d5-55025ee0898d)
Regular Italic:
![image](https://github.com/user-attachments/assets/397aafb9-7bfb-4074-b57f-87fc10ef5b11)
Heavy:
![image](https://github.com/user-attachments/assets/1ac995cf-f939-4d56-96c9-77d6a120bb82)
Heavy Italic:
![image](https://github.com/user-attachments/assets/539dd6c9-db2d-44da-8dc3-f446e3b68cb8)
