### PR TITLE
Move `[UShape]` to `common/shapes.ptl`.

### DIFF
--- a/packages/font-glyphs/src/common/shapes.ptl
+++ b/packages/font-glyphs/src/common/shapes.ptl
@@ -233,6 +233,26 @@ glyph-block CommonShapes : begin
 			arch.lhs.centerAt.rtl.t (middle + gap / 2) u (sw -- width) (knot-ty -- flat)
 			arch.lhs.centerAt.rtl.t middle u (sw -- width) (knot-ty -- curl)
 
+	glyph-block-export UShapeT
+	define [UShapeT] : with-params [sink df top bottom [stroke Stroke] [ada ArchDepthA] [adb ArchDepthB] [offset 0]] : sink
+		widths.lhs stroke
+		[if (sink == spiro-outline) corner flat] (df.leftSB + offset) top [heading Downward]
+		curl (df.leftSB + offset) (bottom + adb + offset)
+		arch.lhs (bottom + offset) (sw -- stroke)
+		flat (df.rightSB - offset) (bottom + ada + offset)
+		[if (sink == spiro-outline) corner curl] (df.rightSB - offset) top [heading Upward]
+
+	glyph-block-export UShape
+	define [UShape] : with-params [df top bottom [stroke Stroke] [ada ArchDepthA] [adb ArchDepthB] [offset 0]] : glyph-proc
+		include : UShapeT dispiro
+			df     -- df
+			top    -- top
+			bottom -- bottom
+			stroke -- stroke
+			ada    -- ada
+			adb    -- adb
+			offset -- offset
+
 	glyph-block-export HSerif
 	define HSerif : namespace
 		export : define [lt x y length _sw _swRef] : glyph-proc

--- a/packages/font-glyphs/src/letter/armenian/upper-u-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/upper-u-group.ptl
@@ -9,7 +9,6 @@ glyph-block Letter-Armenian-Upper-U-Group : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Shapes : SerifFrame
-	glyph-block-import Letter-Latin-U : USerifs
 	glyph-block-import Letter-Armenian-Shared-Shapes : ArmHBar
 
 	do "Ayb"
@@ -19,7 +18,9 @@ glyph-block Letter-Armenian-Upper-U-Group : begin
 			include : df.markSet.capital
 			include : UShape df CAP 1 df.mvs
 			include : QCrossing df CAP QInnerDiagSw
-			if SLAB : include : USerifs.Toothless df CAP df.mvs
+			if SLAB : begin
+				local sf : SerifFrame.fromDf df CAP 0
+				include : composite-proc sf.lt.full sf.rt.full
 
 	do "Men"
 		create-glyph 'armn/Men' 0x544 : glyph-proc
@@ -28,7 +29,8 @@ glyph-block Letter-Armenian-Upper-U-Group : begin
 			include : UShape df CAP 0 df.mvs
 			include : [ArmHBar.right df].cap
 			if SLAB : begin
-				include : USerifs.Toothless df CAP df.mvs
+				local sf : SerifFrame.fromDf df CAP 0
+				include : composite-proc sf.lt.full sf.rt.full
 
 	do "Vo"
 		create-glyph 'armn/Vo' 0x548 : glyph-proc
@@ -57,4 +59,5 @@ glyph-block Letter-Armenian-Upper-U-Group : begin
 			include : df.markSet.capital
 			include : UShape df CAP 1 df.mvs
 			if SLAB : begin
-				include : USerifs.Toothless df CAP df.mvs
+				local sf : SerifFrame.fromDf df CAP 0
+				include : composite-proc sf.lt.full sf.rt.full

--- a/packages/font-glyphs/src/letter/armenian/upper-u-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/upper-u-group.ptl
@@ -9,7 +9,7 @@ glyph-block Letter-Armenian-Upper-U-Group : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Shapes : SerifFrame
-	glyph-block-import Letter-Latin-U : UShape USerifs
+	glyph-block-import Letter-Latin-U : USerifs
 	glyph-block-import Letter-Armenian-Shared-Shapes : ArmHBar
 
 	do "Ayb"

--- a/packages/font-glyphs/src/letter/armenian/upper-xeh.ptl
+++ b/packages/font-glyphs/src/letter/armenian/upper-xeh.ptl
@@ -10,7 +10,6 @@ glyph-block Letter-Armenian-Upper-Xeh : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Shapes : SerifFrame
 	glyph-block-import Letter-Latin-Lower-AE-OE : SubDfAndShift
-	glyph-block-import Letter-Latin-U : UShape
 
 	do "Xeh"
 		create-glyph 'armn/Xeh' 0x53D : glyph-proc

--- a/packages/font-glyphs/src/letter/cyrillic/djerv.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/djerv.ptl
@@ -8,43 +8,38 @@ glyph-block Letter-Cyrillic-Djerv : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Shapes : LetterBarOverlay SerifFrame
-	glyph-block-import Letter-Latin-U : UShape
 
-	define [DjervBar df top py fSlab] : begin
-		local stroke : AdviceStroke2 2 3 top
-		return : LetterBarOverlay.m.in
-			x   -- df.middle
-			bot -- top * py
-			top -- top - [if fSlab Stroke 0]
-
-	define [DjervShape df top py fSmall fSlab] : glyph-proc
-		local uBot : top * (1 - py)
+	define [RStirrupShape df top py ada adb] : glyph-proc
+		local uBot : mix top 0 py
 		include : VBar.m df.middle 0 uBot
-		include : if fSmall
-			UShape df top uBot (ada -- SmallArchDepthA) (adb -- SmallArchDepthB)
-			UShape df top uBot
-
+		include : UShape df top uBot nothing ada adb
 		include : FlipAround df.middle (top / 2)
 
-		if fSlab : begin
+	define [DjervShape df top py ada adb] : glyph-proc
+		include : RStirrupShape df top py ada adb
+
+		if SLAB : begin
 			local sf : SerifFrame.fromDf df top 0
 			include sf.lb.full
 			include sf.rb.full
 			include sf.mt.full
 
+		include : LetterBarOverlay.m.in
+			x   -- df.middle
+			bot -- (top * py)
+			top -- (top - [if SLAB Stroke 0])
+
 	create-glyph 'cyrl/Djerv' 0xA648 : glyph-proc
 		define df : include : DivFrame 1
 		include : df.markSet.capital
-		include : DjervShape df CAP 0.6 false SLAB
-		include : DjervBar df CAP 0.6 SLAB
+		include : DjervShape df CAP 0.6 ArchDepthA ArchDepthB
 
 	create-glyph 'cyrl/djerv' 0xA649 : glyph-proc
 		define df : include : DivFrame 1
 		include : df.markSet.e
-		include : DjervShape df XH 0.6 true SLAB
-		include : DjervBar df XH 0.6 SLAB
+		include : DjervShape df XH 0.6 SmallArchDepthA SmallArchDepthB
 
 	create-glyph 'rStirrup' 0xAB45 : glyph-proc
 		define df : include : DivFrame 1
 		include : df.markSet.e
-		include : DjervShape df XH 0.6 false false
+		include : RStirrupShape df XH 0.6 ArchDepthA ArchDepthB

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -13,25 +13,6 @@ glyph-block Letter-Latin-U : begin
 	glyph-block-import Letter-Shared-Shapes : uBowl RightwardTailedBar SerifFrame
 	glyph-block-import Letter-Shared-Shapes : CyrDescender CyrTailDescender RetroflexHook TopHook
 
-	define [UArcT] : with-params [sink df top bottom [stroke Stroke] [ada ArchDepthA] [adb ArchDepthB] [offset 0]] : sink
-		widths.lhs stroke
-		[if (sink == spiro-outline) corner flat] (df.leftSB + offset) top [heading Downward]
-		curl (df.leftSB + offset) (bottom + adb + offset)
-		arch.lhs (bottom + offset) (sw -- stroke)
-		flat (df.rightSB - offset) (bottom + ada + offset)
-		[if (sink == spiro-outline) corner curl] (df.rightSB - offset) top [heading Upward]
-
-	glyph-block-export UShape
-	define [UShape] : with-params [df top bottom [stroke Stroke] [ada ArchDepthA] [adb ArchDepthB] [offset 0]] : glyph-proc
-		include : UArcT dispiro
-			df     -- df
-			top    -- top
-			bottom -- bottom
-			stroke -- stroke
-			ada    -- ada
-			adb    -- adb
-			offset -- offset
-
 	glyph-block-export UShapeGroup
 	define [UShapeGroup ada adb] : namespace
 		export : define [Toothed df top sw fHookLeft fShortLeg] : glyph-proc
@@ -406,7 +387,7 @@ glyph-block Letter-Latin-U : begin
 			stroke -- BBS
 		include : intersection
 			VBar.l (SB + BBD) 0 CAP BBS
-			UArcT spiro-outline [DivFrame 1] CAP 0
+			UShapeT spiro-outline [DivFrame 1] CAP 0
 				stroke -- BBS
 				oper   -- true
 				offset -- 1

--- a/packages/font-glyphs/src/meta/macros.ptl
+++ b/packages/font-glyphs/src/meta/macros.ptl
@@ -305,8 +305,8 @@ define-macro glyph-block-import : syntax-rules
 			derive-glyphs derive-composites link-reduced-variant alias-reduced-variant HalfAdvance
 			derive-multi-part-glyphs DeriveMeshT link-gr]
 
-			CommonShapes `[no-shape tagged Rect SquareAt Ring RingAt DotAt RingStroke
-			RingStrokeAt DotStrokeAt Circle Ellipse OShapeT OShape OShapeOutline OShapeFlatTB HSerif
+			CommonShapes `[no-shape tagged Rect SquareAt Ring RingAt DotAt RingStroke RingStrokeAt
+			DotStrokeAt Circle Ellipse OShapeT OShape OShapeOutline OShapeFlatTB UShapeT UShape HSerif
 			VSerif NeedSlab NeedNotItalic HBar HOverlayBar HOverlayObliqueBar VBar FlatSlashShape
 			hookstart hookend flatside arch Ungizmo Regizmo FlipAround ScaleAround Realign ForceUpright
 			DiagCor NameUni PointingTo with-transform with-outlined remove-holes radicalize clear-geometry

--- a/packages/font-glyphs/src/symbol/math/apl.ptl
+++ b/packages/font-glyphs/src/symbol/math/apl.ptl
@@ -10,7 +10,6 @@ glyph-module
 glyph-block Symbol-Math-APL : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Latin-U : UShape
 
 	# Dimensions
 	define aplBoxInnerTop BgOpTop

--- a/packages/font-glyphs/src/symbol/math/large-operators.ptl
+++ b/packages/font-glyphs/src/symbol/math/large-operators.ptl
@@ -9,7 +9,6 @@ glyph-block Symbol-Math-Large-Operators : for-width-kinds WideWidth1
 	glyph-block-import Common-Derivatives
 	glyph-block-import Shared-Symbol-Shapes : TriangleShape
 	glyph-block-import Letter-Latin-Long-S : LongSShape
-	glyph-block-import Letter-Latin-U : UShape
 	glyph-block-import Letter-Greek-Upper-Sigma : SigmaShape
 	glyph-block-import Letter-Greek-Pi : PiShape
 	glyph-block-import Letter-Blackboard : BBS BBD

--- a/packages/font-glyphs/src/symbol/math/v-and-cup.ptl
+++ b/packages/font-glyphs/src/symbol/math/v-and-cup.ptl
@@ -7,7 +7,7 @@ glyph-module
 glyph-block Symbol-Math-VAndCup : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Latin-U : UShape USerifs
+	glyph-block-import Letter-Latin-U : USerifs
 	glyph-block-import Letter-Greek-Pi : PiShape
 	glyph-block-import Letter-Cyrillic-Sha : CyrShaShape
 	glyph-block-import Symbol-Arrow-Shared : ArrowShape

--- a/packages/font-glyphs/src/symbol/math/v-and-cup.ptl
+++ b/packages/font-glyphs/src/symbol/math/v-and-cup.ptl
@@ -7,7 +7,7 @@ glyph-module
 glyph-block Symbol-Math-VAndCup : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Latin-U : USerifs
+	glyph-block-import Letter-Shared-Shapes : SerifFrame
 	glyph-block-import Letter-Greek-Pi : PiShape
 	glyph-block-import Letter-Cyrillic-Sha : CyrShaShape
 	glyph-block-import Symbol-Arrow-Shared : ArrowShape
@@ -258,7 +258,8 @@ glyph-block Symbol-Math-VAndCup : begin
 	create-glyph 'cupClosedSerifed' 0x2A4C : glyph-proc
 		include : UShape [DivFrame 1] OperTop OperBot (stroke -- OperatorStroke)
 		include : HBar.t SB RightSB OperTop OperatorStroke
-		include : USerifs.Toothless [DivFrame 1] OperTop OperatorStroke
+		local sf : SerifFrame.fromDf [DivFrame 1] OperTop OperBot (swSerif -- OperatorStroke)
+		include : composite-proc sf.lt.full sf.rt.full
 
 	turned 'capClosedSerifed' 0x2A4D 'cupClosedSerifed' Middle SymbolMid
 


### PR DESCRIPTION
I've noticed a lot of files (example: `letter/latin/upper-a.ptl`) tended to have to essentially "recreate" the `[UShape]` function from scratch if they happen to be compiled chronologically _before_ `letter/latin/u.ptl`.

This basically moves the basic U function(s) to `common/shapes.ptl` right next to `OShape`/`OShapeT` for easy access.

This might facilitate future PR's.