### PR TITLE
Refine glyph shapes of three currency symbols.

### DIFF
--- a/changes/33.2.4.md
+++ b/changes/33.2.4.md
@@ -1,2 +1,5 @@
 * Refine shape of the following characters:
+  - TENGE SIGN (`U+20B8`).
+  - TURKISH LIRA SIGN (`U+20BA`).
+  - MANAT SIGN (`U+20BC`).
   - LATIN CAPITAL LETTER LAMBDA WITH STROKE (`U+A7DC`).

--- a/packages/font-glyphs/src/letter/latin/upper-t.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-t.ptl
@@ -137,9 +137,9 @@ glyph-block Letter-Latin-Upper-T : begin
 		create-glyph "currency/tengeSign.\(suffix)" : glyph-proc
 			local df : include : DivFrame adws
 			include : df.markSet.capital
-			local gap : Math.max (CAP * 0.1) : AdviceStroke2 2 6 CAP
+			local gap : Math.max (CAP * 0.1) HalfStroke
 			include : HBar.t [TLeftX df] [TRightX df] CAP OverlayStroke
-			include : TShape df (CAP - gap - OverlayStroke) doST doSB
+			include : TShape df (CAP - OverlayStroke - gap) doST doSB
 
 		create-glyph "cyrl/teDescender.upright.\(suffix)" : glyph-proc
 			local df : include : DivFrame adws

--- a/packages/font-glyphs/src/symbol/letter.ptl
+++ b/packages/font-glyphs/src/symbol/letter.ptl
@@ -66,19 +66,22 @@ glyph-block Symbol-Currency : begin
 		create-glyph "currency/turkishLiraSign.\(suffix)" : glyph-proc
 			set-width Width
 			include : MarkSet.capital
+			local xBarLeft : SB * 1.5
+			local xRight : RightSB - 0.75 * OX
 			include : union
 				dispiro
 					widths.lhs Stroke
-					flat SB 0 [heading Rightward]
-					curl Middle 0
+					flat xBarLeft 0 [heading Rightward]
+					curl [mix xBarLeft xRight 0.5] 0
 					archv
-					straight.up.end RightSB Hook [heading Upward]
-				VBar.l SB 0 CAP
-			include : LetterObliqueBarOverlay.l SB (CAP * 0.37)
-			include : LetterObliqueBarOverlay.l SB (CAP * 0.60 - OverlayStroke * 0.25)
+					straight.up.end (xRight - OX) Hook [heading Upward]
+				VBar.l xBarLeft 0 CAP
+			include : LetterObliqueBarOverlay.l xBarLeft (CAP * 0.37)
+			include : LetterObliqueBarOverlay.l xBarLeft (CAP * 0.60 - OverlayStroke * 0.25)
 			if serifGrade : begin
-				local sf : SerifFrame.fromDf [DivFrame 1] CAP 0
-				include : composite-proc sf.lt.fullSide sf.lb.outer
+				include : HSerif.lb (xBarLeft + [HSwToV HalfStroke]) 0   Jut
+				include : HSerif.lt (xBarLeft + [HSwToV HalfStroke]) CAP Jut
+				include : HSerif.rt (xBarLeft + [HSwToV HalfStroke]) CAP MidJutSide
 
 	select-variant 'currency/turkishLiraSign' 0x20BA
 
@@ -110,27 +113,18 @@ glyph-block Symbol-Currency : begin
 
 	create-glyph 'currency/manatSign' 0x20BC : glyph-proc
 		local df : include : DivFrame para.advanceScaleT 3
-		include : df.markSet.e
 
-		define pY 0.8
-		local archTop : mix 0 XH pY
-
-		local sw : Math.min df.mvs : AdviceStroke2 3 2 archTop df.adws
-
-		local ada : df.archDepthAOf SmallArchDepth sw
-		local adb : df.archDepthBOf SmallArchDepth sw
-
-		include : VBar.m df.middle [if SLAB sw 0] XH sw
+		include : VBar.m df.middle [if SLAB df.mvs 0] (XH + LongVJut - QuarterStroke) df.mvs
 		include : dispiro
-			widths.rhs sw
+			widths.rhs df.mvs
 			flat df.leftSB  0 [heading Upward]
-			curl df.leftSB  [if (ada + adb < archTop) (archTop - ada) : mix archTop 0 (ada / (ada + adb))]
-			arch.rhs archTop (sw -- sw)
-			flat df.rightSB [if (ada + adb < archTop) (archTop - adb) : mix archTop 0 (adb / (ada + adb))]
+			curl df.leftSB  [if (df.smallArchDepthA + df.smallArchDepthB < XH) (XH - df.smallArchDepthA) : mix XH 0 (df.smallArchDepthA / (df.smallArchDepthA + df.smallArchDepthB))]
+			arch.rhs XH (sw -- df.mvs)
+			flat df.rightSB [if (df.smallArchDepthA + df.smallArchDepthB < XH) (XH - df.smallArchDepthB) : mix XH 0 (df.smallArchDepthB / (df.smallArchDepthA + df.smallArchDepthB))]
 			curl df.rightSB 0 [heading Downward]
 
 		if SLAB : begin
-			local sf : SerifFrame.fromDf df XH 0 (swSerif -- sw)
+			local sf : SerifFrame.fromDf df XH 0 (swSerif -- df.mvs)
 			include : composite-proc sf.lb.full sf.rb.full
 
 	create-glyph 'currency/lariSign' 0x20BE : glyph-proc
@@ -412,17 +406,18 @@ glyph-block Symbol-Letter-Phonetic : begin
 			g4.up.end (RightSB - OX) XH [heading Upward]
 
 	create-glyph 'cyrlInvLowKavykaWithKavyka' 0x2E46 : glyph-proc
-		include : MarkSet.e
+		local df : include : DivFrame para.advanceScaleSp
+		include : df.markSet.e
 
 		include : BreveShape
-			xMiddle -- Middle
+			xMiddle -- df.middle
 			width   -- (3 * markExtend)
 			top     -- XH
 			bottom  -- (XH - AccentHeight)
 			hs      -- markHalfStroke
 
 		include : InvBreveShape
-			xMiddle -- Middle
+			xMiddle -- df.middle
 			width   -- (3 * markExtend)
 			top     -- AccentHeight
 			bottom  -- 0


### PR DESCRIPTION
* Unify side bearings of Turkish Lira with ordinary `L`.
* Make Azerbaijani Manat sign slightly taller, making the bowl part the actual x-height part.
* Optimize top bar gap of Tenge sign under heavy.

In the screenshots below, top row is before, bottom row is after.

`m₪₺L₼ᴪ₸T`

Sans Monospace Thin Upright:
![image](https://github.com/user-attachments/assets/f0d4f6d2-4deb-4930-8647-a693125de56f)
Sans Monospace Thin Italic:
![image](https://github.com/user-attachments/assets/0eb971ee-7335-4075-8906-745a1f479cff)
Sans Monospace Regular Upright:
![image](https://github.com/user-attachments/assets/889d1335-d2ab-454a-bbb3-80f7750b0af9)
Sans Monospace Regular Italic:
![image](https://github.com/user-attachments/assets/32bf3fba-9249-4fa2-9db0-ca2e42fb8fa3)
Sans Monospace Heavy Upright:
![image](https://github.com/user-attachments/assets/a037b3ec-9200-4f38-a647-37865069839c)
Sans Monospace Heavy Italic:
![image](https://github.com/user-attachments/assets/f7c692c7-16bb-47fb-aa87-1beb20a7ea4e)
Slab Monospace Thin Upright:
![image](https://github.com/user-attachments/assets/e6cc739a-ac7f-47f0-8cd5-8ee7486c535b)
Slab Monospace Thin Italic:
![image](https://github.com/user-attachments/assets/e82711e3-f801-4aae-b567-ed5cbafff4db)
Slab Monospace Regular Upright:
![image](https://github.com/user-attachments/assets/156834b2-2625-4981-8412-8b37051155f1)
Slab Monospace Regular Italic:
![image](https://github.com/user-attachments/assets/f9aadf55-a90b-48f9-90a6-93c739c301ba)
Slab Monospace Heavy Upright:
![image](https://github.com/user-attachments/assets/adb1fb7a-23aa-4093-9ebf-6303fa6e8df5)
Slab Monospace Heavy Italic:
![image](https://github.com/user-attachments/assets/1a0bfe99-f9da-45d7-9d7a-8d54b28fca4f)
Aile Thin Upright:
![image](https://github.com/user-attachments/assets/0ee38eca-790c-4497-b388-4d6fbc9d6d1c)
Aile Thin Italic:
![image](https://github.com/user-attachments/assets/7f151ef1-1ac4-4962-85ca-f8234513bfd9)
Aile Regular Upright:
![image](https://github.com/user-attachments/assets/39a19cd8-3744-466f-ae1f-4f5c0e8f30dd)
Aile Regular Italic:
![image](https://github.com/user-attachments/assets/b30a6e59-e3a5-45b0-9cf1-fd60371dbae4)
Aile Heavy Upright:
![image](https://github.com/user-attachments/assets/14d04e01-3582-4b79-bb19-0e85b4bb1b7a)
Aile Heavy Italic:
![image](https://github.com/user-attachments/assets/2d18c4ea-15c2-4576-a78d-623c2dda6e15)
Etoile Thin Upright:
![image](https://github.com/user-attachments/assets/706411f2-878f-453f-8708-d21bfefa3762)
Etoile Thin Italic:
![image](https://github.com/user-attachments/assets/363ae483-5494-4dd0-b3fb-38c46b1bd842)
Etoile Regular Upright:
![image](https://github.com/user-attachments/assets/7e2a4a4c-76e1-4fdd-bc7c-c070e82a0eba)
Etoile Regular Italic:
![image](https://github.com/user-attachments/assets/f5bee240-8b1b-4294-9cf5-adf66db589ca)
Etoile Heavy Upright:
![image](https://github.com/user-attachments/assets/7f8a746b-23be-4b2f-8bae-60be49030808)
Etoile Heavy Italic:
![image](https://github.com/user-attachments/assets/ee9c21c8-d2be-4afc-bc46-26f23aee01fe)
