### PR TITLE
Optimize `full-serifed` variants for three `k`-derived letters.

### DIFF
--- a/packages/font-glyphs/src/letter/latin/k.ptl
+++ b/packages/font-glyphs/src/letter/latin/k.ptl
@@ -24,8 +24,9 @@ glyph-block Letter-Latin-K : begin
 	# F: Whether the serif is full
 	# B: Bottom serif type
 	# T: Top serif type
-	define [HasRtSerif mode] : maskBit mode 1
-	define [HasRbSerif mode] : maskBit mode 0
+	define [HasRtSerif   mode] : maskBit mode 1
+	define [HasRbSerif   mode] : maskBit mode 0
+	define [HasFullSerif mode] : maskBit mode 2
 
 	define flex-params [KLegSlabs] : glyph-proc
 		local-parameter : mode          -- 0
@@ -43,7 +44,7 @@ glyph-block Letter-Latin-K : begin
 		local sideJutAdj     : Ok + [HSwToV stroke]
 		local symJutExtraAdj : HSwToV (0.5 * stroke)
 
-		local slabIsFull : maskBit mode 2
+		local slabIsFull : HasFullSerif mode
 
 		if [HasRtSerif mode] : include : tagged 'serifRT' : if slabIsFull
 			then : union
@@ -419,7 +420,6 @@ glyph-block Letter-Latin-K : begin
 			topRightAndBottomRightSerifed      { 0 0 3 }
 			triSerifed                         { 2 0 3 }
 			serifedKappa                       { 2 1 3 }
-			fullSerifedKappa                   { 2 1 7 }
 			serifed : match body
 				[Just 'symmetricConnectedKH']  { 1 1 2 }
 				__                             { 1 1 3 }
@@ -616,7 +616,8 @@ glyph-block Letter-Latin-K : begin
 			if slabLT : include : tagged 'serifLT' : union
 				HSerif.lt (xBarLeft + [HSwToV HalfStroke]) Ascender Jut
 				HSerif.rt (xBarLeft + [HSwToV HalfStroke]) Ascender MidJutSide
-			if slabLB : include : tagged 'serifLB'
+			if slabLB : include : tagged 'serifLB' : if [HasFullSerif slabLegs]
+				HSerif.mb (xBarLeft + [HSwToV HalfStroke]) 0 Jut
 				HSerif.lb xBarLeft 0 SideJut
 			include : FlipAround Middle (XH / 2)
 			include : MarkSet.p
@@ -663,7 +664,7 @@ glyph-block Letter-Latin-K : begin
 	derive-composites 'kStrokeLegStroke' 0xA745 'kStroke' 'legSlashOver'
 
 	CreateTurnedLetter 'turnK'     0xA7B0  'K'     HalfAdvance (CAP / 2)
-	CreateTurnedLetter 'smcpTurnK' 0x1DF10 'smcpK' HalfAdvance (XH / 2)
+	CreateTurnedLetter 'turnSmcpK' 0x1DF10 'smcpK' HalfAdvance (XH / 2)
 
 	select-variant 'turnk' 0x29E (follow -- 'k')
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -3442,7 +3442,7 @@ disableIf = [ { body = "diagonal-tailed-cursive" } ]
 descriptionAffix = "full serifs at legs"
 selectorAffix.k = "fullSerifed"
 selectorAffix."k/sansSerif" = "serifless"
-selectorAffix."latn/kappa" = "fullSerifedKappa"
+selectorAffix."latn/kappa" = "fullSerifed"
 selectorAffix.kHookTop = "fullSerifed"
 selectorAffix.kDescender = "fullSerifed"
 
@@ -6142,7 +6142,7 @@ selectorAffix."grek/kappa/sansSerif" = "serifless"
 [prime.lower-kappa.variants-buildup.stages.serifs.full-serifed]
 rank = 8
 descriptionAffix = "full serifs at legs"
-selectorAffix."grek/kappa" = "fullSerifedKappa"
+selectorAffix."grek/kappa" = "fullSerifed"
 selectorAffix."grek/kappa/sansSerif" = "serifless"
 
 
@@ -10573,6 +10573,7 @@ cyrl-a = "double-storey-toothless-corner"
 cyrl-u = "straight-serifless"
 one = "base-flat-top-serif"
 four = "closed-serifless"
+five = "upright-flat-serifless"
 six = "straight-bar"
 seven = "straight-serifless"
 eight = "two-circles"
@@ -10632,6 +10633,7 @@ cyrl-ka = "symmetric-connected-serifed"
 cyrl-capital-u = "straight-serifed"
 cyrl-u = "straight-serifed"
 four = "closed-serifed"
+five = "upright-flat-serifed"
 seven = "straight-serifed"
 micro-sign = "toothless-rounded-serifed"
 


### PR DESCRIPTION
Basically making the top-left serif also extend to both sides, appearing more balanced against the full leg serifs.

The original `serifed` variant (distinct from `full-serifed`) is unchanged.

For each screenshot below, left is before, right is after.

`ʞĸ`

CV features off for reference (unchanged):

Slab Thin:
![image](https://github.com/user-attachments/assets/12d8bbed-8fb5-4199-89b8-1d32172577d0)

Slab Regular:
![image](https://github.com/user-attachments/assets/c54c9cf7-4676-47e4-8885-df16e7e449fc)

Slab Heavy:
![image](https://github.com/user-attachments/assets/ababe397-48c3-4c26-a750-3b94136a2776)

Under `'cv46'30` (Again, left is before, right is after):

Slab Thin:
![image](https://github.com/user-attachments/assets/124abafc-a1b0-4f2b-ac80-b0f8a7b8ad48)

Slab Regular:
![image](https://github.com/user-attachments/assets/5b251895-a4ea-40d4-954e-5e56e13050b7)

Slab Heavy:
![image](https://github.com/user-attachments/assets/7535c017-2f9f-4015-8973-752bfdf16661)
