### PR TITLE
Use `MidJutSide` for bottom serifs of four characters, including Digit Four (`4`).

### DIFF
--- a/packages/font-glyphs/src/letter/latin-ext/gha.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/gha.ptl
@@ -8,7 +8,7 @@ glyph-module
 glyph-block Letter-Latin-Gha : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : SerifFrame RightwardTailedBar
+	glyph-block-import Letter-Shared-Shapes : RightwardTailedBar
 	glyph-block-import Letter-Latin-Lower-Q : RDiagTailedBar
 	glyph-block-import Mark-Adjustment : LeaningAnchor
 
@@ -36,8 +36,8 @@ glyph-block Letter-Latin-Gha : begin
 			g4   (df.rightSB - O - [HSwToV df.mvs]) top [widths 0 df.mvs]
 
 		if slab : begin
-			local sf : SerifFrame.fromDf df top bot
-			include sf.rb.full
+			include : HSerif.rb (df.rightSB - O - [HSwToV : 0.5 * df.mvs]) bot Jut
+			include : HSerif.lb (df.rightSB - O - [HSwToV : 0.5 * df.mvs]) bot MidJutSide
 
 	define GhaConfig : object
 		straightSerifless       { TERMINAL-NORMAL false }

--- a/packages/font-glyphs/src/letter/latin/c.ptl
+++ b/packages/font-glyphs/src/letter/latin/c.ptl
@@ -286,7 +286,7 @@ glyph-block Letter-Latin-C : begin
 			local lf : CLetterForm [DivFrame 1] sty styBot CAP 0
 			include : union [lf.descBase] [lf.topSerif]
 			include : VBar.r RightSB Descender [ArcStartSerifDepth Hook] [ArcStartSerifWidth Stroke]
-			if styBot : let [sf : SerifFrame.fromDf [DivFrame 1] CAP Descender] : include sf.rb.full
+			if styBot : let [sf : SerifFrame.fromDf [DivFrame 1] CAP Descender] : include sf.rb.fullSide
 
 	select-variant 'C' 'C'
 	link-reduced-variant 'C/sansSerif' 'C' MathSansSerif

--- a/packages/font-glyphs/src/letter/latin/c.ptl
+++ b/packages/font-glyphs/src/letter/latin/c.ptl
@@ -10,7 +10,7 @@ glyph-block Letter-Latin-C : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors ExtendBelowBaseAnchors LeaningAnchor
 	glyph-block-import Letter-Shared : CreateAccentedComposition CreateDependentComposite CreateTurnedLetter
-	glyph-block-import Letter-Shared-Shapes : SerifFrame CurlyTail SerifedArcStart SerifedArcEnd
+	glyph-block-import Letter-Shared-Shapes : CurlyTail SerifedArcStart SerifedArcEnd
 	glyph-block-import Letter-Shared-Shapes : InwardSlabArcStart InwardSlabArcEnd
 	glyph-block-import Letter-Shared-Shapes : ArcStartSerif ArcEndSerif
 	glyph-block-import Letter-Shared-Shapes : LetterBarOverlay PalatalHook RetroflexHook TopHook

--- a/packages/font-glyphs/src/letter/latin/c.ptl
+++ b/packages/font-glyphs/src/letter/latin/c.ptl
@@ -286,7 +286,9 @@ glyph-block Letter-Latin-C : begin
 			local lf : CLetterForm [DivFrame 1] sty styBot CAP 0
 			include : union [lf.descBase] [lf.topSerif]
 			include : VBar.r RightSB Descender [ArcStartSerifDepth Hook] [ArcStartSerifWidth Stroke]
-			if styBot : let [sf : SerifFrame.fromDf [DivFrame 1] CAP Descender] : include sf.rb.fullSide
+			if styBot : begin
+				include : HSerif.rb (RightSB - [HSwToV : 0.5 * [ArcStartSerifWidth Stroke]]) Descender Jut
+				include : HSerif.lb (RightSB - [HSwToV : 0.5 * [ArcStartSerifWidth Stroke]]) Descender MidJutSide
 
 	select-variant 'C' 'C'
 	link-reduced-variant 'C/sansSerif' 'C' MathSansSerif

--- a/packages/font-glyphs/src/number/4.ptl
+++ b/packages/font-glyphs/src/number/4.ptl
@@ -37,7 +37,8 @@ glyph-block Digits-Four : begin
 			include : HBar.t xVertBar (xVertBar + bbd) CAP sw
 			include : HBar.b xVertBar (xVertBar + bbd) 0 sw
 		if (!bbd && slab) : begin
-			include : HSerif.mb (xVertBar - [HSwToV HalfStroke]) 0 Jut
+			include : HSerif.rb (xVertBar - [HSwToV HalfStroke]) 0 Jut
+			include : HSerif.lb (xVertBar - [HSwToV HalfStroke]) 0 MidJutSide
 
 	define [FourClosedShape top crossing slab] : begin
 		return : FourStdShape top false crossing (slab -- slab)
@@ -56,7 +57,8 @@ glyph-block Digits-Four : begin
 		include : VBar.r xVertBar 0 [mix (yBar - Stroke) top 0.75]
 		include : VBar.l SB yBar top
 		if slab : begin
-			include : HSerif.mb (xVertBar - [HSwToV HalfStroke]) 0 Jut
+			include : HSerif.rb (xVertBar - [HSwToV HalfStroke]) 0 Jut
+			include : HSerif.lb (xVertBar - [HSwToV HalfStroke]) 0 MidJutSide
 
 	define FourConfig : SuffixCfg.weave
 		object # body


### PR DESCRIPTION
Basically a more visually balanced jut behavior when it's off to one side.

For each screenshot below, left is before, right is after.

`4ↅƢƣ`

Slab Monospace Thin Upright:
![image](https://github.com/user-attachments/assets/9fca25af-4428-44e5-96ba-5f6aa8b7be56)
Slab Monospace Thin Italic:
![image](https://github.com/user-attachments/assets/f7c797a2-f2d4-4df1-a66b-1a0a5acb5394)
Slab Monospace Regular Upright:
![image](https://github.com/user-attachments/assets/612009cc-f6c0-4c9d-9682-e965a84ea65d)
Slab Monospace Regular Italic:
![image](https://github.com/user-attachments/assets/319e876d-9b66-4b0d-a4b9-c5b15d84ca81)
Slab Monospace Heavy Upright:
![image](https://github.com/user-attachments/assets/58deb6c2-3746-4862-a259-32ad8ad70119)
Slab Monospace Heavy Italic:
![image](https://github.com/user-attachments/assets/55174ae2-280b-41d6-9ea5-805616f7c94e)
Etoile Thin Upright:
![image](https://github.com/user-attachments/assets/22f1c15f-b731-48c9-943e-788efbe3fbf3)
Etoile Thin Italic:
![image](https://github.com/user-attachments/assets/d65f7ee7-f451-4159-aa03-8d2a18f71ae6)
Etoile Regular Upright:
![image](https://github.com/user-attachments/assets/5d27c821-5d8e-465c-96b7-c770bed1762f)
Etoile Regular Italic:
![image](https://github.com/user-attachments/assets/32c89d2b-94b7-4e95-972a-f82002b16553)
Etoile Heavy Upright:
![image](https://github.com/user-attachments/assets/b1a2f68c-ee79-48a6-8dbf-3c29d6c5be29)
Etoile Heavy Italic:
![image](https://github.com/user-attachments/assets/b6c7b3e8-d0ca-450f-a3ff-7feb46bc36cb)
