### PR TITLE
Use `MidJutCenter` for top/bottom serif of ten more characters, including Cyrillic Lower Ef (`ф`).

### DIFF
--- a/packages/font-glyphs/src/letter/armenian/ca.ptl
+++ b/packages/font-glyphs/src/letter/armenian/ca.ptl
@@ -8,7 +8,6 @@ glyph-module
 glyph-block Letter-Armenian-Ca : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : SerifFrame
 
 	# Common Params
 	define barPos : XH / 2

--- a/packages/font-glyphs/src/letter/armenian/feh.ptl
+++ b/packages/font-glyphs/src/letter/armenian/feh.ptl
@@ -25,9 +25,9 @@ glyph-block Letter-Armenian-Feh : begin
 			widths.rhs sw
 			straight.right.start df.middle midyTop [heading Rightward]
 			archv
-			g4 (df.rightSB - OX) [mix midyTop 0 (adb / (ada + adb))]
-			hookend 0 (sw -- sw)
-			g4 (df.leftSB + OX) (0 + hook)
+			g4 (df.rightSB - OX) [mix midyTop bot (adb / (ada + adb))]
+			hookend bot (sw -- sw)
+			g4 (df.leftSB + OX) (bot + hook)
 
 	create-glyph 'armn/Feh' 0x556 : glyph-proc
 		local df : include : DivFrame para.advanceScaleM 3
@@ -51,4 +51,4 @@ glyph-block Letter-Armenian-Feh : begin
 		include : VBar.m df.middle Descender Ascender sw
 		if SLAB : begin
 			local sf : SerifFrame.fromDf df Ascender Descender (swSerif -- sw)
-			include sf.mb.full
+			include sf.mb.fullCenter

--- a/packages/font-glyphs/src/letter/armenian/lower-sha-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/lower-sha-group.ptl
@@ -8,7 +8,6 @@ glyph-module
 glyph-block Letter-Armenian-Lower-Sha-Group : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : SerifFrame
 	glyph-block-import Letter-Armenian-Shared-Shapes : ArmHBar TwoNeck
 
 	# Common Params

--- a/packages/font-glyphs/src/letter/armenian/lower-u-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/lower-u-group.ptl
@@ -419,7 +419,7 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 				include : if ([not para.isItalic] && sf.enoughSpaceForFullSerifs)
 					composite-proc sf.lt.outer sf.rb.full
 					composite-proc sf.lt.outer sf.rb.outer
-				include : composite-proc sf2.mt.left sf2.mb.full
+				include : composite-proc sf2.mt.left sf2.mb.fullCenter
 
 	do "Ew"
 		create-glyph 'armn/ew' 0x587 : glyph-proc

--- a/packages/font-glyphs/src/letter/armenian/shared.ptl
+++ b/packages/font-glyphs/src/letter/armenian/shared.ptl
@@ -8,7 +8,6 @@ glyph-module
 glyph-block Letter-Armenian-Shared-Shapes : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : SerifFrame
 
 	define barPos : XH / 2
 	define highBarPos XH

--- a/packages/font-glyphs/src/letter/armenian/upper-co.ptl
+++ b/packages/font-glyphs/src/letter/armenian/upper-co.ptl
@@ -8,7 +8,6 @@ glyph-module
 glyph-block Letter-Armenian-Upper-Co : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : SerifFrame
 
 	# Common Params
 	define barPos : XH / 2

--- a/packages/font-glyphs/src/letter/armenian/upper-dza-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/upper-dza-group.ptl
@@ -9,7 +9,6 @@ glyph-block Letter-Armenian-Upper-Dza : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Shapes : CurlyTail
-	glyph-block-import Letter-Shared-Shapes : SerifFrame
 
 	# Common Params
 	define barPos : XH / 2

--- a/packages/font-glyphs/src/letter/armenian/upper-yi.ptl
+++ b/packages/font-glyphs/src/letter/armenian/upper-yi.ptl
@@ -8,7 +8,6 @@ glyph-module
 glyph-block Letter-Armenian-Upper-Yi : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : SerifFrame
 	glyph-block-import Letter-Cyrillic-Ze : CyrZe
 
 	do "Yi"

--- a/packages/font-glyphs/src/letter/armenian/upper-za-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/upper-za-group.ptl
@@ -8,7 +8,6 @@ glyph-module
 glyph-block Letter-Armenian-Upper-Za-Group : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : SerifFrame
 	glyph-block-import Letter-Armenian-Shared-Shapes : ArmHBar
 
 	do "Za"

--- a/packages/font-glyphs/src/letter/cyrillic/djerv.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/djerv.ptl
@@ -22,7 +22,7 @@ glyph-block Letter-Cyrillic-Djerv : begin
 			local sf : SerifFrame.fromDf df top 0
 			include sf.lb.full
 			include sf.rb.full
-			include sf.mt.full
+			include sf.mt.fullCenter
 
 		include : LetterBarOverlay.m.in
 			x   -- df.middle

--- a/packages/font-glyphs/src/letter/greek/phi.ptl
+++ b/packages/font-glyphs/src/letter/greek/phi.ptl
@@ -106,7 +106,7 @@ glyph-block Letter-Greek-Phi : begin
 			DiagTail.L df.middle y1 [DiagTail.StdDepth dfHook sw] sw
 
 	define [MtSerif df y sw] : tagged 'serifMT' : HSerif.lt df.middle y Jut sw
-	define [MbSerif df y sw] : tagged 'serifMB' : HSerif.mb df.middle y Jut sw
+	define [MbSerif df y sw] : tagged 'serifMB' : HSerif.mb df.middle y MidJutCenter sw
 
 	glyph-block-export yCapitalPhiBowlBot yCapitalPhiBowlTop
 	define [yCapitalPhiBowlBot top slab] : mix [if slab Stroke 0] [if slab (top - Stroke) top] 0.125
@@ -182,8 +182,8 @@ glyph-block Letter-Greek-Phi : begin
 		include [refer-glyph 'grek/varphi'] AS_BASE ALSO_METRICS
 
 		if SLAB : begin
-			include : tagged 'serifMT' : HSerif.mt df.middle Ascender  Jut
-			include : tagged 'serifMB' : HSerif.mb df.middle Descender Jut
+			include : tagged 'serifMT' : HSerif.mt df.middle Ascender  MidJutCenter
+			include : tagged 'serifMB' : HSerif.mb df.middle Descender MidJutCenter
 
 	define CyrlLowerEfConfig : SuffixCfg.weave
 		object # bowl

--- a/packages/font-glyphs/src/letter/latin-ext/glottal-stop.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/glottal-stop.ptl
@@ -8,7 +8,6 @@ glyph-module
 glyph-block Letter-Latin-Glottal-Stop : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Mark-Shared-Metrics : markHalfStroke
 	glyph-block-import Letter-Shared : CreateTurnedLetter
 	glyph-block-import Letter-Shared-Shapes : LetterBarOverlay CurlyTail
 
@@ -23,9 +22,20 @@ glyph-block Letter-Latin-Glottal-Stop : begin
 			flat (Middle + [HSwToV HalfStroke]) (XH * 0.3)
 			curl (Middle + [HSwToV HalfStroke]) 0 [heading Downward]
 		if SLAB : begin
-			include : HSerif.mb Middle 0 Jut
+			include : HSerif.mb Middle 0 MidJutCenter
 
-	alias 'capGlottalStop' 0x241 'glottalStop'
+	create-glyph 'capGlottalStop' 0x241 : glyph-proc
+		include : MarkSet.capital
+		include : dispiro
+			widths.rhs
+			g4 SB (CAP - Hook)
+			hookstart CAP
+			g4 RightSB (CAP - [AdviceGlottalStopArchDepth CAP 1])
+			alsoThru.g2 0.5 0.5 important
+			flat (Middle + [HSwToV HalfStroke]) (XH * 0.3)
+			curl (Middle + [HSwToV HalfStroke]) 0 [heading Downward]
+		if SLAB : begin
+			include : HSerif.mb Middle 0 MidJutCenter
 
 	create-glyph 'revGlottalStop' 0x295 : glyph-proc
 		include : MarkSet.b
@@ -38,7 +48,7 @@ glyph-block Letter-Latin-Glottal-Stop : begin
 			flat (Middle - [HSwToV HalfStroke]) (XH * 0.3)
 			curl (Middle - [HSwToV HalfStroke]) 0 [heading Downward]
 		if SLAB : begin
-			include : HSerif.mb Middle 0 Jut
+			include : HSerif.mb Middle 0 MidJutCenter
 
 	create-glyph 'smallGlottalStop' 0x242 : glyph-proc
 		include : MarkSet.e
@@ -51,7 +61,7 @@ glyph-block Letter-Latin-Glottal-Stop : begin
 			flat (Middle + [HSwToV HalfStroke]) (XH * 0.15)
 			curl (Middle + [HSwToV HalfStroke]) 0 [heading Downward]
 		if SLAB : begin
-			include : HSerif.mb Middle 0 Jut
+			include : HSerif.mb Middle 0 MidJutCenter
 
 	create-glyph 'smallRevGlottalStop' : glyph-proc
 		include : MarkSet.e
@@ -64,7 +74,7 @@ glyph-block Letter-Latin-Glottal-Stop : begin
 			flat (Middle - [HSwToV HalfStroke]) (XH * 0.15)
 			curl (Middle - [HSwToV HalfStroke]) 0 [heading Downward]
 		if SLAB : begin
-			include : HSerif.mb Middle 0 Jut
+			include : HSerif.mb Middle 0 MidJutCenter
 
 	CreateTurnedLetter 'invGlottalStop' 0x296 'revGlottalStop' HalfAdvance (Ascender / 2)
 
@@ -83,7 +93,7 @@ glyph-block Letter-Latin-Glottal-Stop : begin
 			CurlyTail.n fine 0 SB RightSB 0 yMid
 
 		if SLAB : begin
-			include : HSerif.mt Middle Ascender Jut
+			include : HSerif.mt Middle Ascender MidJutCenter
 
 
 	create-glyph 'glottalStopBar' 0x2A1 : glyph-proc

--- a/packages/font-glyphs/src/letter/latin-ext/lower-db-qp.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/lower-db-qp.ptl
@@ -42,4 +42,4 @@ glyph-block Letter-Latin-Lower-DB-QP : begin
 		include : FlipAround df.middle (XH / 2)
 		include : VBar.m df.middle Descender 0 df.mvs
 		if SLAB : begin
-			include : HSerif.mb df.middle Descender Jut
+			include : HSerif.mb df.middle Descender MidJutCenter

--- a/packages/font-glyphs/src/letter/latin/upper-y.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-y.ptl
@@ -43,7 +43,7 @@ glyph-block Letter-Latin-Upper-Y : begin
 		include : tagged 'strokeVMid' : VBar.m Middle bot (cross + HalfStroke)
 		set-base-anchor 'overlay' Middle cross
 		set-base-anchor 'overlayOnExtension' Middle
-			[mix (bot + [if (slabType === SLAB-NONE || slabType === SLAB-BASE) 0 Stroke]) cross 0.5] + (Stroke - OverlayStroke) / 2
+			[mix (bot + [if (slabType === SLAB-ALL || slabType === SLAB-BASE) Stroke 0]) cross 0.5] + (Stroke - OverlayStroke) / 2
 
 	define [YenOverlayShape slabType] : glyph-proc
 		define { ks bot } : match slabType

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -702,6 +702,7 @@ glyph-block Letter-Shared-Shapes : begin
 
 
 			local jutFS   MidJutSide
+			local jutFC   MidJutCenter
 			local jut     : mix [HSwToV : 0.5 * swRef] Jut : Math.min 1 : adws * 2.25 / hSplit
 			local sideJut : jut - 0.5 * ink
 
@@ -746,6 +747,8 @@ glyph-block Letter-Shared-Shapes : begin
 			set this.mb : object
 				full : tagged 'serifMB' : HSerif.mbAsymmetric [mix lBarCenter rBarCenter 0.5] bot jutIn jutIn swSerif
 				[fullAt x] : tagged 'serifMB' : HSerif.mbAsymmetric x bot jutIn jutIn swSerif
+				fullCenter : tagged 'serifMB' : HSerif.mbAsymmetric [mix lBarCenter rBarCenter 0.5] bot jutFC jutFC swSerif
+				[fullCenterAt x] : tagged 'serifMB' : HSerif.mbAsymmetric x bot jutFC jutFC swSerif
 				left : tagged 'serifMB' : HSerif.mbAsymmetric [mix lBarCenter rBarCenter 0.5] bot jutIn 0 swSerif
 				[leftAt x] : tagged 'serifMB' : HSerif.mbAsymmetric x bot jutIn 0 swSerif
 				right : tagged 'serifMB' : HSerif.mbAsymmetric [mix lBarCenter rBarCenter 0.5] bot 0 jutIn swSerif
@@ -753,6 +756,8 @@ glyph-block Letter-Shared-Shapes : begin
 			set this.mt : object
 				full : tagged 'serifMT' : HSerif.mtAsymmetric [mix lBarCenter rBarCenter 0.5] top jutIn jutIn swSerif
 				[fullAt x] : tagged 'serifMT' : HSerif.mtAsymmetric x top jutIn jutIn swSerif
+				fullCenter : tagged 'serifMT' : HSerif.mtAsymmetric [mix lBarCenter rBarCenter 0.5] top jutFC jutFC swSerif
+				[fullCenterAt x] : tagged 'serifMT' : HSerif.mtAsymmetric x top jutFC jutFC swSerif
 				left : tagged 'serifMT' : HSerif.mtAsymmetric [mix lBarCenter rBarCenter 0.5] top jutIn 0 swSerif
 				[leftAt x] : tagged 'serifMT' : HSerif.mtAsymmetric x top jutIn 0 swSerif
 				right : tagged 'serifMT' : HSerif.mtAsymmetric [mix lBarCenter rBarCenter 0.5] top 0 jutIn swSerif


### PR DESCRIPTION
Continuation of #2788 , this time focusing on characters which weren't already using `MidJutSide` for their top/bottom serifs.

This also newly defines `[SerifFrame].`{`mt`|`mb`}`.fullCenter` as a centered analogue of `[SerifFrame].`{`mt`|`mb`}`.fullSide`.

`ȸȹɸʔʕʖфփֆꙈꙉ`

Slab Monospace Thin:
![image](https://github.com/user-attachments/assets/c84209f7-7df1-4926-9600-fcc699b5f80d)
Slab Monospace Regular:
![image](https://github.com/user-attachments/assets/ef99539e-c6a2-49d6-a5c0-832b51f3e6cc)
Slab Monospace Heavy:
![image](https://github.com/user-attachments/assets/d680e8b6-8fa5-4d01-a39e-208564218634)
Etoile Thin:
![image](https://github.com/user-attachments/assets/b0f4309d-e1eb-471d-b7f5-ee4463b01ac2)
Etoile Regular:
![image](https://github.com/user-attachments/assets/1e64c4c2-69a4-418b-b9e7-d4d354fdd659)
Etoile Heavy:
![image](https://github.com/user-attachments/assets/bcf3598d-5b1c-4e25-a6fe-9d6e38617a32)
