### PR TITLE
Optimize jut length of serifs of Latin Upper I (`I`) under Quasi-Proportional.

### DIFF
--- a/packages/font-glyphs/src/letter/latin/upper-i.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-i.ptl
@@ -11,28 +11,31 @@ glyph-block Letter-Latin-Upper-I : begin
 	glyph-block-import Letter-Shared : SetGrekUpperTonos CreateAccentedComposition
 	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors
 
-	define [ISeriflessShape df top bot jut] : glyph-proc
-		include : VBar.m df.middle bot top
+	define [ISeriflessShape df top] : glyph-proc
+		include : VBar.m df.middle 0 top
 
-	define [ISerifShapeImpl df top bot jut] : glyph-proc
-		include : VBar.m df.middle bot top
-		include : HSerif.mb df.middle bot jut
-		include : HSerif.mt df.middle top jut
-		set-base-anchor 'trailing' (df.middle + jut) bot
+	define ISerifs : namespace
+		export : define [Impl df top jut] : glyph-proc
+			include : HSerif.mb df.middle 0   jut
+			include : HSerif.mt df.middle top jut
+			set-base-anchor 'trailing' (df.middle + jut) 0
 
-	define [ISerifShape df top bot jut] : ISerifShapeImpl df top bot (jut * df.adws)
+		export : define [None  df top] : no-shape
+		export : define [Long  df top] : Impl df top : Math.max MidJutCenter (LongJut * df.adws)
+		export : define [Short df top] : Impl df top : Math.max Jut     (MidJutCenter * df.adws)
 
 	define UpperIConfig : object
-		'straight'     { para.advanceScaleI  ISeriflessShape LongJut      }
-		'serifless'    { para.advanceScaleII ISeriflessShape LongJut      }
-		'serifed'      { para.advanceScaleI  ISerifShape     LongJut      }
-		'shortSerifed' { para.advanceScaleI  ISerifShape     MidJutCenter }
+		'straight'     { para.advanceScaleI  ISerifs.None  }
+		'serifless'    { para.advanceScaleII ISerifs.None  }
+		'serifed'      { para.advanceScaleI  ISerifs.Long  }
+		'shortSerifed' { para.advanceScaleI  ISerifs.Short }
 
-	foreach { suffix { adws Body jut } } [Object.entries UpperIConfig] : do
+	foreach { suffix { adws Serifs } } [Object.entries UpperIConfig] : do
 		create-glyph "I.\(suffix)" : glyph-proc
 			local df : include : DivFrame adws
 			include : df.markSet.capital
-			include : Body df CAP 0 jut
+			include : ISeriflessShape df CAP
+			include : Serifs df CAP
 
 		create-glyph "grek/Iota.\(suffix)" : glyph-proc
 			include [refer-glyph "I.\(suffix)"] AS_BASE ALSO_METRICS
@@ -41,15 +44,17 @@ glyph-block Letter-Latin-Upper-I : begin
 		create-glyph "ISideways.\(suffix)" : glyph-proc
 			local df : DivFrame (XH / Width) 2 (XH * 0.1 / SB)
 			include : PointingTo Width XH Width 0 : function [] : glyph-proc
-				include : Body df (Width - SB) 0 jut
+				include : ISeriflessShape df RightSB
+				include : Serifs df RightSB
 				include : ApparentTranslate 0 (0.5 * SB)
 
 		create-glyph "ILonga.\(suffix)" : glyph-proc
 			local df : include : DivFrame adws
 			include : df.markSet.capital
-			local top : CAP + Ascender - XH
+			local top : CAP + (Ascender - XH)
 			include : ExtendAboveBaseAnchors top
-			include : Body df top 0 jut
+			include : ISeriflessShape df top
+			include : Serifs df top
 
 	select-variant 'I' 'I'
 	link-reduced-variant 'I/sansSerif' 'I' MathSansSerif
@@ -67,7 +72,8 @@ glyph-block Letter-Latin-Upper-I : begin
 	create-glyph 'smcpI' 0x26A : glyph-proc
 		local df : include : DivFrame para.advanceScaleI
 		include : df.markSet.e
-		include : ISerifShapeImpl df XH 0 MidJutCenter
+		include : ISeriflessShape df XH
+		include : ISerifs.Impl df XH MidJutCenter
 
 	CreateAccentedComposition 'smcpIBarOver' 0x1D7B 'smcpI' 'barOver'
 
@@ -75,5 +81,5 @@ glyph-block Letter-Latin-Upper-I : begin
 	create-glyph 'mathbb/I' 0x1D540 : glyph-proc
 		include : MarkSet.capital
 		include : BBBarCenter Middle 0 CAP
-		include : HBar.t    (Middle - BBD / 2 - Jut) (Middle + BBD / 2 + Jut) CAP BBS
+		include : HBar.t (Middle - BBD / 2 - Jut) (Middle + BBD / 2 + Jut) CAP BBS
 		include : HBar.b (Middle - BBD / 2 - Jut) (Middle + BBD / 2 + Jut) 0   BBS


### PR DESCRIPTION
Basically, `MidJutCenter` tends to be slightly wider than `LongJut * para.advanceScaleI`, and `Jut` tends to be slightly wider than `MidJutCenter * para.advanceScaleI`. This basically makes _all_ variants of `I` match other characters' jut lengths under Quasi-Proportional, shown here under Etoile in particular.

Monospace is unchanged.

For each screenshot below, top row is before, bottom row is after.

With `'ss19'2`:

`ꟚꞱITY`

Etoile Thin:
![image](https://github.com/user-attachments/assets/23962c7f-6cde-4f58-afaf-4e89bb4f9487)
Etoile Regular:
![image](https://github.com/user-attachments/assets/8166b2c7-5b97-4a4e-bfe7-78596288cbe2)
Etoile Heavy:
![image](https://github.com/user-attachments/assets/15d585eb-7821-4feb-a9ae-d392356fb924)

With `'ss19'3`:

`HIH`

Etoile Thin:
![image](https://github.com/user-attachments/assets/ae405e54-6db2-4d07-8628-358b00851dbe)
Etoile Regular:
![image](https://github.com/user-attachments/assets/44b8b37e-9577-4167-99e8-c3f7c1de1341)
Etoile Heavy:
![image](https://github.com/user-attachments/assets/b469a896-1a58-4b67-913e-4ac343ae6e24)
