### PR TITLE
Optimize arch depth of Greek Lower Psi (`ψ`).

### DIFF
--- a/changes/33.2.5.md
+++ b/changes/33.2.5.md
@@ -1,5 +1,7 @@
 * Refine shape of the following characters:
   - LATIN SMALL LETTER RAMS HORN (`U+0264`).
+  - GREEK SMALL LETTER PSI (`U+03C8`).
+  - CYRILLIC SMALL LETTER PSI (`U+0471`).
   - LATIN LETTER AIN (`U+1D25`).
   - MODIFIER LETTER SMALL AIN (`U+1D5C`).
   - TURKISH LIRA SIGN (`U+20BA`).

--- a/packages/font-glyphs/src/letter/greek/psi.ptl
+++ b/packages/font-glyphs/src/letter/greek/psi.ptl
@@ -10,8 +10,8 @@ glyph-block Letter-Greek-Psi : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 
-	define [PsiBaseShape df y1 y2 y3 y4 doBotSerif doTopSerif doSideSerifL doSideSerifR] : glyph-proc
-		include : UShape df y3 y2 df.mvs (ArchDepthA * df.adws) (ArchDepthB * df.adws)
+	define [PsiShape df y1 y2 y3 y4 ada adb doBotSerif doTopSerif doSideSerifL doSideSerifR] : glyph-proc
+		include : UShape df y3 y2 df.mvs ada adb
 		include : VBar.m df.middle y2 y4 df.mvs
 		include : VBar.m df.middle y1 (y2 + HalfStroke)
 
@@ -23,14 +23,14 @@ glyph-block Letter-Greek-Psi : begin
 	create-glyph 'grek/Psi' 0x3A8 : glyph-proc
 		local df : include : DivFrame para.advanceScaleM 3
 		include : df.markSet.capital
-		include : PsiBaseShape df 0 (CAP * 0.3) CAP CAP SLAB (SLAB && (df.width > para.refJut * 7)) SLAB SLAB
+		include : PsiShape df 0 (CAP * 0.3) CAP CAP df.archDepthA df.archDepthB SLAB (SLAB && (df.width > para.refJut * 7)) SLAB SLAB
 
 	alias 'cyrl/Psi' 0x470 'grek/Psi'
 
 	create-glyph 'smcpPsi' 0x1D2A : glyph-proc
 		local df : include : DivFrame para.advanceScaleT 3
 		include : df.markSet.e
-		include : PsiBaseShape df 0 (XH * 0.3) XH XH SLAB false SLAB SLAB
+		include : PsiShape df 0 (XH * 0.3) XH XH df.archDepthA df.archDepthB SLAB false SLAB SLAB
 
 	define GrekLowerPsiConfig : SuffixCfg.weave
 		object # top
@@ -44,7 +44,7 @@ glyph-block Letter-Greek-Psi : begin
 		create-glyph "grek/psi.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleM 3
 			include : df.markSet.[if (top > XH) 'bp' 'p']
-			include : PsiBaseShape df Descender 0 XH top false false slab false
+			include : PsiShape df Descender 0 XH top df.smallArchDepthA df.smallArchDepthB false false slab false
 
 	select-variant 'grek/psi' 0x3C8
 	link-reduced-variant 'grek/psi/sansSerif' 'grek/psi' MathSansSerif


### PR DESCRIPTION
Basically this makes Lower Psi use `[DivFrame].smallArchDepth`{`A`|`B`} instead of `ArchDepth`{`A`|`B`}` * [DivFrame].adws` to match that of other lowercase letters such as Lower Phi Symbol (`ϕ`) which was itself changed to use its own `[DivFrame].smallArchDepth`{`A`|`B`} a while back.

For each screenshot below, left is before, right is after.

`Ψψ`

Monospace Thin Upright:
![image](https://github.com/user-attachments/assets/d0a5c14a-7286-48e3-ba18-c00fe8a9ca41)
Monospace Thin Italic:
![image](https://github.com/user-attachments/assets/2739f73b-b964-457b-8f64-6d6d9eeb1b30)
Monospace Regular Upright:
![image](https://github.com/user-attachments/assets/28bcfa08-d7a3-462a-bbd2-c5eba5802956)
Monospace Regular Italic:
![image](https://github.com/user-attachments/assets/f4143a84-afd8-4007-b55b-4aaac7d1a69c)
Monospace Heavy Upright:
![image](https://github.com/user-attachments/assets/a97c81bf-8d0a-4b3b-8faa-675c99dd9547)
Monospace Heavy Italic:
![image](https://github.com/user-attachments/assets/35d83b92-09ad-42fe-aa67-cb3df076a00e)
Aile Thin Upright:
![image](https://github.com/user-attachments/assets/79819552-62d7-452c-8d9c-e38b7ea42406)
Aile Thin Italic:
![image](https://github.com/user-attachments/assets/f9312c61-5b4e-4957-83c9-d87e613c0e2e)
Aile Regular Upright:
![image](https://github.com/user-attachments/assets/b099b3b8-d666-48fa-b679-763286bbe858)
Aile Regular Italic:
![image](https://github.com/user-attachments/assets/51319f0b-4545-4e8d-bfd5-4708668ada88)
Aile Heavy Upright:
![image](https://github.com/user-attachments/assets/08055adf-9827-4a47-adbf-51993c555454)
Aile Heavy Italic:
![image](https://github.com/user-attachments/assets/081402fa-de4f-468b-9ca7-b9a9ad786d5b)
