### PR TITLE
Make four characters with serifs of jut length `Jut` slightly narrower under Etoile.

### DIFF
--- a/packages/font-glyphs/src/letter/armenian/eh-liun-hiun.ptl
+++ b/packages/font-glyphs/src/letter/armenian/eh-liun-hiun.ptl
@@ -49,7 +49,7 @@ glyph-block Letter-Armenian-Eh-Liun-Hiun : begin
 				include : composite-proc sf.lt.full sf.lb.outer
 
 		create-glyph 'armn/liun' 0x56C : glyph-proc
-			local df : include : DivFrame : if SLAB para.advanceScaleI para.advanceScaleII
+			local df : include : DivFrame para.advanceScaleII
 			include : df.markSet.p
 			local xMiddle : df.middle - [IBalance2 df]
 			local longJut : if (df.adws < 1) (jut * [if SLAB 1.5 1]) LongJut

--- a/packages/font-glyphs/src/letter/latin/lower-j.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-j.ptl
@@ -43,7 +43,7 @@ glyph-block Letter-Latin-Lower-J : begin
 
 	define Body : namespace
 		export : define [BentHook df top xMiddle] : glyph-proc
-			local hookx : Math.min (xMiddle - (Width * 0.5) - [HSwToV HalfStroke] + OXHook) (xMiddle - 1.5 * [HSwToV Stroke] + OXHook)
+			local hookx : Math.min (xMiddle - (Width * 0.5) - [HSwToV HalfStroke] + OXHook) (xMiddle - [HSwToV : 1.5 * Stroke] + OXHook)
 			set-base-anchor "below" [mix hookx xMiddle 0.5] Descender
 			include : dispiro
 				widths.rhs
@@ -96,17 +96,17 @@ glyph-block Letter-Latin-Lower-J : begin
 
 	define JConfig : object
 		'bentHookSerifless'          { "BentHook"        Serifs.None   XMiddle.BentHook           Marks.Serifless  Div.BentHook          }
+		'bentHookShortSerifed'       { "BentHook"        Serifs.Short  XMiddle.BentHook           Marks.Serifless  Div.BentHook          }
 		'bentHookSerifed'            { "BentHook"        Serifs.Long   XMiddle.BentHook           Marks.Serifed    Div.BentHook          }
-		'bentHookShortSerifed'       { "BentHook"        Serifs.Short  XMiddle.BentHook           Marks.Serifed    Div.BentHook          }
 		'straightSerifless'          { "Straight"        Serifs.None   XMiddle.StraightSerifless  Marks.Serifless  Div.StraightSerifless }
+		'straightShortSerifed'       { "Straight"        Serifs.Short  XMiddle.StraightSerifless  Marks.Serifless  Div.StraightSerifless }
 		'straightSerifed'            { "Straight"        Serifs.Long   XMiddle.StraightSerifed    Marks.Serifed    Div.StraightSerifed   }
-		'straightShortSerifed'       { "Straight"        Serifs.Short  XMiddle.StraightSerifed    Marks.Serifed    Div.StraightSerifed   }
 		'flatHookSerifless'          { "FlatHook"        Serifs.None   XMiddle.FlatHookSerifless  Marks.Serifless  Div.FlatHookSerifless }
+		'flatHookShortSerifed'       { "FlatHook"        Serifs.Short  XMiddle.FlatHookSerifless  Marks.Serifless  Div.FlatHookSerifless }
 		'flatHookSerifed'            { "FlatHook"        Serifs.Long   XMiddle.FlatHookSerifed    Marks.Serifed    Div.FlatHookSerifed   }
-		'flatHookShortSerifed'       { "FlatHook"        Serifs.Short  XMiddle.FlatHookSerifed    Marks.Serifed    Div.FlatHookSerifed   }
 		'diagonalTailedSerifless'    { "DiagonalTailed"  Serifs.None   XMiddle.FlatHookSerifless  Marks.Serifless  Div.FlatHookSerifless }
+		'diagonalTailedShortSerifed' { "DiagonalTailed"  Serifs.Short  XMiddle.FlatHookSerifless  Marks.Serifless  Div.FlatHookSerifless }
 		'diagonalTailedSerifed'      { "DiagonalTailed"  Serifs.Long   XMiddle.FlatHookSerifed    Marks.Serifed    Div.FlatHookSerifed   }
-		'diagonalTailedShortSerifed' { "DiagonalTailed"  Serifs.Short  XMiddle.FlatHookSerifed    Marks.Serifed    Div.FlatHookSerifed   }
 
 	foreach { suffix { shapeId Serif xMiddleT Marks adws } } [Object.entries JConfig] : do
 		local df : DivFrame adws
@@ -152,8 +152,8 @@ glyph-block Letter-Latin-Lower-J : begin
 			flat m1 XH [heading Downward]
 			curl m1 (Descender + fine + rinner * 2)
 			CurlyTail.n fine Descender (m1 - LongJut - [HSwToV Stroke])
-				x2 -- RightSB + [HSwToV : 0.5 * fine]
-				y2 -- Descender + 0.5 * fine
+				x2 -- (RightSB + [HSwToV : 0.5 * fine])
+				y2 -- (Descender + 0.5 * fine)
 
 	create-glyph 'dotlessjCurlyTail.bentHookSerifed' : glyph-proc
 		include [refer-glyph 'dotlessjCurlyTail.bentHookSerifless'] AS_BASE ALSO_METRICS

--- a/packages/font-glyphs/src/letter/latin/upper-i.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-i.ptl
@@ -11,7 +11,7 @@ glyph-block Letter-Latin-Upper-I : begin
 	glyph-block-import Letter-Shared : SetGrekUpperTonos CreateAccentedComposition
 	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors
 
-	define [ISeriflessShape df top] : glyph-proc
+	define [IShape df top] : glyph-proc
 		include : VBar.m df.middle 0 top
 
 	define ISerifs : namespace
@@ -28,23 +28,24 @@ glyph-block Letter-Latin-Upper-I : begin
 		'straight'     { para.advanceScaleI  ISerifs.None  }
 		'serifless'    { para.advanceScaleII ISerifs.None  }
 		'serifed'      { para.advanceScaleI  ISerifs.Long  }
-		'shortSerifed' { para.advanceScaleI  ISerifs.Short }
+		'shortSerifed' { para.advanceScaleII ISerifs.Short }
 
 	foreach { suffix { adws Serifs } } [Object.entries UpperIConfig] : do
 		create-glyph "I.\(suffix)" : glyph-proc
 			local df : include : DivFrame adws
 			include : df.markSet.capital
-			include : ISeriflessShape df CAP
+			include : IShape df CAP
 			include : Serifs df CAP
 
 		create-glyph "grek/Iota.\(suffix)" : glyph-proc
+			local df : DivFrame adws
 			include [refer-glyph "I.\(suffix)"] AS_BASE ALSO_METRICS
-			include : SetGrekUpperTonos 0
+			include : SetGrekUpperTonos [Math.min 0 : df.middle - [if (Serifs != no-shape) Jut : HSwToV HalfStroke] - SB]
 
 		create-glyph "ISideways.\(suffix)" : glyph-proc
 			local df : DivFrame (XH / Width) 2 (XH * 0.1 / SB)
 			include : PointingTo Width XH Width 0 : function [] : glyph-proc
-				include : ISeriflessShape df RightSB
+				include : IShape df RightSB
 				include : Serifs df RightSB
 				include : ApparentTranslate 0 (0.5 * SB)
 
@@ -53,7 +54,7 @@ glyph-block Letter-Latin-Upper-I : begin
 			include : df.markSet.capital
 			local top : CAP + (Ascender - XH)
 			include : ExtendAboveBaseAnchors top
-			include : ISeriflessShape df top
+			include : IShape df top
 			include : Serifs df top
 
 	select-variant 'I' 'I'
@@ -72,7 +73,7 @@ glyph-block Letter-Latin-Upper-I : begin
 	create-glyph 'smcpI' 0x26A : glyph-proc
 		local df : include : DivFrame para.advanceScaleI
 		include : df.markSet.e
-		include : ISeriflessShape df XH
+		include : IShape df XH
 		include : ISerifs.Impl df XH MidJutCenter
 
 	CreateAccentedComposition 'smcpIBarOver' 0x1D7B 'smcpI' 'barOver'


### PR DESCRIPTION
Basically making it so that certain serifed variants with minimum change in jut length doesn't expand the advance width scale over serifless.

In the case of `I.shortSerifed`, keeping it at `para.advanceScaleII` makes it have almost identical side bearings to that of `H`, while still remaining larger than those of `H`.

**That being said**, `I.serifed` **(still default for Etoile, not shown here) is unchanged.**

In the case of `j`, it only impacts characters which use `j.shortSerifed`, namely `յ`/`ֈ` (Armenian).

For each screenshot below, top row is before, bottom row is after.

`HIIH`

Etoile `'cv19'3` Thin:
![image](https://github.com/user-attachments/assets/af627505-7ea7-4d26-bd29-894a020413b7)
Etoile `'cv19'3` Regular:
![image](https://github.com/user-attachments/assets/8baf6cf9-073d-4b20-86bd-e162432b2744)
Etoile `'cv19'3` Heavy:
![image](https://github.com/user-attachments/assets/ccea6a7d-fc3d-4463-9ead-14a30db89750)
