### PR TITLE
Make (non-`descending`) `flat-hook` variants of Upper J (`J`) slightly narrower under Quasi-Proportional.

### DIFF
--- a/packages/font-glyphs/src/letter/latin/upper-j.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-j.ptl
@@ -112,11 +112,11 @@ glyph-block Letter-Latin-Upper-J : begin
 
 	define JConfig : SuffixCfg.weave
 		object # height and hook
-			bentHook                    { JBentHookBase                    [DivFrame 1]                [DivFrame 1]               }
-			flatHook                    { JFlatHookBase                    [DivFrame 1]                [DivFrame 1]               }
-			descendingBentHook          { JDescendingBentHookBase          [DivFrame 1]                [DivFrame 1]               }
-			descendingFlatHookSerifless { JDescendingFlatHookSeriflessBase [DivFrame para.advanceScaleI]  [DivFrame para.advanceScaleI] }
-			descendingFlatHookSerifed   { JDescendingFlatHookSerifedBase   [DivFrame para.advanceScaleI]  [DivFrame para.advanceScaleI] }
+			bentHook                    { JBentHookBase                    [DivFrame 1]                  [DivFrame 1]                  }
+			flatHook                    { JFlatHookBase                    [DivFrame para.advanceScaleF] [DivFrame para.advanceScaleF] }
+			descendingBentHook          { JDescendingBentHookBase          [DivFrame 1]                  [DivFrame 1]                  }
+			descendingFlatHookSerifless { JDescendingFlatHookSeriflessBase [DivFrame para.advanceScaleI] [DivFrame para.advanceScaleI] }
+			descendingFlatHookSerifed   { JDescendingFlatHookSerifedBase   [DivFrame para.advanceScaleI] [DivFrame para.advanceScaleI] }
 		function [body] : if (body == 'descendingFlatHookSerifless' || body == 'descendingFlatHookSerifed') {."" null} : object
 			serifless         null
 			serifed           JLeftwardSerif


### PR DESCRIPTION
Basically it looked rather wide under an advance width of `1`, especially considering how the `descending` variants and the lowercase are both slightly narrower under `flat-hook`; However, I felt that it would be too extreme to shrink it all the way down to `para.advanceScaleI` just to match those, so this instead uses `para.advanceScaleF`, both as a compromise and also to match e.g. long-S (`ſ`) etc.

For each screenshot below, top row is before, bottom row is after.

**Disclaimer: Default variants for** `J` **used by Aile/Etoile are unchanged.**

`John Jonah Jameson Junior`

Aile `'cv20'5` Thin:
![image](https://github.com/user-attachments/assets/b4fac866-6d9d-49d3-9044-43d0048e0a5b)
Aile `'cv20'5` Regular:
![image](https://github.com/user-attachments/assets/7a6bd90d-fc24-47fa-ae69-085e4eeb2d69)
Aile `'cv20'5` Heavy:
![image](https://github.com/user-attachments/assets/a47f7a65-ea74-41b3-8934-664dca9a2d05)
Etoile `'cv20'8` Thin:
![image](https://github.com/user-attachments/assets/ae8daccc-43bf-4d07-9f85-c73681dc5a3f)
Etoile `'cv20'8` Regular:
![image](https://github.com/user-attachments/assets/fdcf71d3-0df3-43f4-9c01-9903f7924827)
Etoile `'cv20'8` Heavy:
![image](https://github.com/user-attachments/assets/c576c127-d549-4d18-ba71-3e6811f34809)
