### PR TITLE
Optimize jut length of serifs of `J.serifedSymmetric`.

### DIFF
--- a/packages/font-glyphs/src/letter/latin/upper-j.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-j.ptl
@@ -19,11 +19,11 @@ glyph-block Letter-Latin-Upper-J : begin
 
 		local xBarRight : df.rightSB - JBalance2
 
-		set-base-anchor 'above' (xBarRight - [HSwToV : 0.75 * Stroke]) top
+		set-base-anchor 'above'   (xBarRight - [HSwToV : 0.75 * Stroke])  top
 		set-base-anchor 'overlay' (xBarRight - [HSwToV : 0.75 * Stroke]) (top * OverlayPos)
 		set-base-anchor 'jTopSerifAttach' (xBarRight - [HSwToV HalfStroke]) top
 
-		local sw : Math.min (0.4 * (xBarRight - df.leftSB)) Stroke
+		local sw : Math.min Stroke : 0.4 * (xBarRight - df.leftSB)
 		local hookx : 0.75 * df.leftSB
 
 		include : dispiro
@@ -36,19 +36,22 @@ glyph-block Letter-Latin-Upper-J : begin
 	define [JFlatHookBase df dfHook top] : glyph-proc
 		set-width df.width
 		include : df.markSet.[if (top > XH) 'capital' 'e']
-		set-base-anchor 'above' (df.rightSB - [HSwToV : 0.75 * Stroke] - JBalance2) top
-		set-base-anchor 'overlay' (df.rightSB - [HSwToV : 0.75 * Stroke] - JBalance2) (top * OverlayPos)
-		set-base-anchor 'jTopSerifAttach' (df.rightSB - JBalance2 - [HSwToV HalfStroke]) top
 
-		local sw : Math.min (0.4 * (df.rightSB - JBalance2 - df.leftSB)) Stroke
+		local xBarRight : df.rightSB - JBalance2
+
+		set-base-anchor 'above'   (xBarRight - [HSwToV : 0.75 * Stroke])  top
+		set-base-anchor 'overlay' (xBarRight - [HSwToV : 0.75 * Stroke]) (top * OverlayPos)
+		set-base-anchor 'jTopSerifAttach' (xBarRight - [HSwToV HalfStroke]) top
+
+		local sw : Math.min Stroke : 0.4 * (xBarRight - df.leftSB)
 		local hookx : 0.75 * df.leftSB
 		local hd : FlatHookDepth dfHook
 
 		include : dispiro
-			flat (df.rightSB - JBalance2) top [widths.rhs.heading sw Downward]
-			curl (df.rightSB - JBalance2) (HalfStroke + 1.375 * hd.y)
+			flat xBarRight top [widths.rhs.heading sw Downward]
+			curl xBarRight (HalfStroke + 1.375 * hd.y)
 			arcvh.superness DesignParameters.tightHookSuperness
-			flat (df.rightSB - JBalance2 - [Math.min (0.625 * (df.rightSB - df.leftSB)) (1.375 * hd.x)]) 0 [widths.rhs Stroke]
+			flat (xBarRight - [Math.min (0.625 * (df.rightSB - df.leftSB)) (1.375 * hd.x)]) 0 [widths.rhs Stroke]
 			curl df.leftSB 0
 
 	define [JDescendingBentHookBase df dfHook top] : glyph-proc
@@ -56,7 +59,7 @@ glyph-block Letter-Latin-Upper-J : begin
 		include : df.markSet.[if (top > XH) 'capDesc' 'p']
 
 		local center : df.middle + JBalance + [HSwToV HalfStroke]
-		set-base-anchor 'above' (center - [HSwToV HalfStroke]) top
+		set-base-anchor 'above'   (center - [HSwToV HalfStroke])  top
 		set-base-anchor 'overlay' (center - [HSwToV HalfStroke]) (top / 2)
 		set-base-anchor 'jTopSerifAttach' (center - [HSwToV HalfStroke]) top
 
@@ -75,7 +78,7 @@ glyph-block Letter-Latin-Upper-J : begin
 		set-width df.width
 		include : df.markSet.(markClass)
 
-		set-base-anchor 'above' xc top
+		set-base-anchor 'above'   xc  top
 		set-base-anchor 'overlay' xc (top / 2)
 		set-base-anchor 'jTopSerifAttach' xc top
 
@@ -87,8 +90,8 @@ glyph-block Letter-Latin-Upper-J : begin
 			curl (xc + [HSwToV HalfStroke]) (bottom + fine + rinner * 2)
 			CurlyTail.n fine bottom xCo
 				x2 -- df.width
-				y2 -- bottom + 0.5 * fine
-				yLoopTop -- bottom + 2 * fine + 2 * rinner
+				y2 -- (bottom + 0.5 * fine)
+				yLoopTop -- (bottom + 2 * fine + 2 * rinner)
 
 	define [JDescendingFlatHookSeriflessBase df dfHook top] : glyph-proc
 		set-width df.width
@@ -106,9 +109,9 @@ glyph-block Letter-Latin-Upper-J : begin
 			barCenter -- (df.middle + JBalance * df.adws)
 			serif -- true
 
-	define [JLeftwardSerif df x top] : HSerif.lt x top LongJut
+	define [JLeftwardSerif  df x top] : HSerif.lt x top LongJut
 	define [JBothSidesSerif df x top] : union [HSerif.lt x top LongJut] [HSerif.rt x top Jut]
-	define [JSymmetricSerif df x top] : HSerif.mt (x + O) top (Jut + JBalance2)
+	define [JSymmetricSerif df x top] : HSerif.mt (x + OX) top MidJutCenter
 
 	define JConfig : SuffixCfg.weave
 		object # height and hook
@@ -153,10 +156,10 @@ glyph-block Letter-Latin-Upper-J : begin
 	CreateAccentedComposition 'JAcute' null 'J' 'acuteAbove'
 
 	create-glyph 'mathbb/J' 0x1D541 : glyph-proc
-		local hookx (0.75 * SB)
+		local hookx : 0.75 * SB
 
 		include : MarkSet.capital
-		set-base-anchor 'above' (RightSB - [HSwToV : 0.75 * BBD] - JBalance2) CAP
+		set-base-anchor 'above'   (RightSB - [HSwToV : 0.75 * BBD] - JBalance2)  CAP
 		set-base-anchor 'overlay' (RightSB - [HSwToV : 0.75 * BBD] - JBalance2) (CAP * OverlayPos)
 
 		include : dispiro


### PR DESCRIPTION
This basically completes the unification between serifed `I` and symmetric-serifed `J`.
Under the extreme weight conditions, the jut length is in fact not that extreme when compared to before; Under _all_ conditions, however, `J.serifedSymmetric` is unified with `I.shortSerifed` (under Monospace) or with `I.serifed` (under Quasi-Proportional).

**Note that the default variants for** `J` **under sans/slab/Aile/Etoile are all completely unchanged**.

For each screenshot below, top row is before, bottom row is after.

`IntellIJ JIT`

Slab Monospace `'cv19'3,'cv20'4` Thin:
![image](https://github.com/user-attachments/assets/c0ce1d61-67f0-45b5-b302-2922c1dc2353)
Slab Monospace `'cv19'3,'cv20'4` Regular:
![image](https://github.com/user-attachments/assets/29600a03-9a19-4c9d-a4bf-14f668f00cb2)
Slab Monospace `'cv19'3,'cv20'4` Heavy:
![image](https://github.com/user-attachments/assets/e36c3c99-7838-441d-9626-4f48958e7581)
Etoile `'cv19'2,'cv20'4` Thin:
![image](https://github.com/user-attachments/assets/ac198f72-c796-40f4-b00a-85f60196dba9)
Etoile `'cv19'2,'cv20'4` Regular:
![image](https://github.com/user-attachments/assets/e638d4b4-b609-4daf-9a37-8bf0ce018322)
Etoile `'cv19'2,'cv20'4` Heavy:
![image](https://github.com/user-attachments/assets/ccb95da0-704b-4576-b8f3-8f1fbfc7fd24)
