### PR TITLE
Make `straightDoubleV` and `straightAsymmetric` variants of Lower W (`w`) slightly narrower under Quasi-Proportional.

### DIFF
--- a/packages/font-glyphs/src/letter/latin/w.ptl
+++ b/packages/font-glyphs/src/letter/latin/w.ptl
@@ -359,8 +359,8 @@ glyph-block Letter-Latin-W : begin
 		# Body
 		object
 			straight                           { WShapeImpl   WHooktopShape   FORM-STRAIGHT   MIDH-OTHER      para.advanceScaleM  para.advanceScaleM  }
-			straightAsymmetric                 { WShapeImpl   WHooktopShape   FORM-ASYMMETRIC MIDH-TOP        para.advanceScaleM  para.advanceScaleM  }
-			straightDoubleV                    { WShapeImpl   WHooktopShape   FORM-DOUBLE-V   MIDH-TOP        para.advanceScaleM  para.advanceScaleM  }
+			straightAsymmetric                 { WShapeImpl   WHooktopShape   FORM-ASYMMETRIC MIDH-TOP        para.advanceScaleM  para.advanceScaleT  }
+			straightDoubleV                    { WShapeImpl   WHooktopShape   FORM-DOUBLE-V   MIDH-TOP        para.advanceScaleM  para.advanceScaleT  }
 			straightAlmostFlatTop              { WShapeImpl   WHooktopShape   FORM-STRAIGHT   MIDH-ALMOST-TOP para.advanceScaleMM para.advanceScaleM  }
 			straightFlatTop                    { WShapeImpl   WHooktopShape   FORM-STRAIGHT   MIDH-TOP        para.advanceScaleMM para.advanceScaleM  }
 			straightVerticalSides              { WVertSides   WVSHookTopShape FORM-VERTICAL   MIDH-OTHER      para.advanceScaleM  para.advanceScaleT  }
@@ -427,7 +427,7 @@ glyph-block Letter-Latin-W : begin
 		create-glyph "currency/wonSign.\(suffix)" : glyph-proc
 			local df : DivFrame Udiv 3
 			include [refer-glyph "W.\(suffix)"] AS_BASE ALSO_METRICS
-			include : HOverlayBar [mix df.leftSB 0 0.7] [mix df.rightSB df.width 0.7] (CAP * 0.6)
+			include : HOverlayBar [mix df.leftSB 0 0.7] [mix df.rightSB df.width 0.7] (CAP * 0.60)
 			include : HOverlayBar [mix df.leftSB 0 0.7] [mix df.rightSB df.width 0.7] (CAP * 0.35)
 
 	select-variant 'W' 'W'
@@ -453,7 +453,7 @@ glyph-block Letter-Latin-W : begin
 	define [BBWShape top] : begin
 		local offset : BBD * 2
 		local ksW : [AdviceStroke2 8 2 top] / BBS
-		local kdW : Math.min ksW (3 / 4)
+		local kdW : Math.min ksW 0.75
 		return : union
 			difference
 				BBVShape SB (RightSB - offset) kdW ksW top


### PR DESCRIPTION
Basically more resembling the width of something akin to e.g. `straight-flat-top` but where the two halves have been essentially "pushed together" slightly.

The capital form (`W`) already looks correct by this logic and is therefore unchanged. It is, however, still shown below for comparison.

```
UƜVW𝖶Ⱳᴜꟺᴠᴡ
uɯvw𝗐ⱳʬ
```

-----

For each screenshot below, top is default, bottom is under `'cv32'10,'cv57'10`.

Aile Thin:
![image](https://github.com/user-attachments/assets/7bd40114-6c84-4e8c-a234-235091a1eba4)
Aile Regular:
![image](https://github.com/user-attachments/assets/b82ada57-3ce6-4565-9923-3a174b4e9230)
Aile Heavy:
![image](https://github.com/user-attachments/assets/59340fbe-85b5-40f3-963b-461a43f2f605)

-----

For each screenshot below, top is default, bottom is under `'cv32'12,'cv57'12`.

Etoile Thin:
![image](https://github.com/user-attachments/assets/6b69d76d-4647-46a0-a173-1fcd08011e10)
Etoile Regular:
![image](https://github.com/user-attachments/assets/d9166bc7-6be0-471a-8d06-19ecfd7f7273)
Etoile Heavy:
![image](https://github.com/user-attachments/assets/a4c82e36-adf0-425c-8fa6-892a5f1f442b)
