### PR TITLE
Better align advance width gears

### DIFF
--- a/packages/font-glyphs/src/auto-build/composite.ptl
+++ b/packages/font-glyphs/src/auto-build/composite.ptl
@@ -1618,7 +1618,7 @@ glyph-block Autobuild-Pnonetic-Ligatures : begin
 	define [ToLetter] : glyph-proc
 
 	define stdShrink : clamp 0.625 0.9 : StrokeWidthBlend 0.625 0.9
-	createPhoneticLigatures ToLetter 'phonetic1' [Math.max 1 : para.advanceScaleF * para.advanceScaleMM] 2 stdShrink 1 : list
+	createPhoneticLigatures ToLetter 'phonetic1' para.advanceScaleM 2 stdShrink 1 : list
 		list 0xFB00  { 'f'               'f'                     } null
 		list 0xFB01  { 'f/compLigLeft1'  'dotlessi/compLigRight' } null
 		list 0xFB02  { 'f/compLigLeft3'  'l/compLigRight'        } null
@@ -1642,11 +1642,11 @@ glyph-block Autobuild-Pnonetic-Ligatures : begin
 		list 0xFB05  { 'longs/compLigLeft' 't/compLigRight'                 } null
 		list 0xFB06  { 's/compLigLeft'     't/compLigRight'                 } null
 
-	createPhoneticLigatures ToLetter 'phonetic3' [Math.max para.advanceScaleMM : para.advanceScaleF * [mix 1 para.advanceScaleMM 2]] 3 stdShrink 1 : list
+	createPhoneticLigatures ToLetter 'phonetic3' para.advanceScaleUl 3 stdShrink 1 : list
 		list 0xFB03  { 'f/compLigLeft2' 'f/compLigLeft1' 'dotlessi/compLigRight' } null
 		list 0xFB04  { 'f/compLigLeft4' 'f/compLigLeft3' 'l/compLigRight'        } null
 
-	createPhoneticLigatures ToLetter 'phoneticSmcp' (para.advanceScaleM * para.advanceScaleMM) 3 1 0.5 : list
+	createPhoneticLigatures ToLetter 'phoneticSmcp' para.advanceScaleUl 3 1 0.5 : list
 		list 0x2121  { 'smcpT' 'smcpE' 'smcpL' } 'e'
 		list 0x213B  { 'smcpF' 'smcpA' 'smcpX' } 'e'
 

--- a/packages/font-glyphs/src/auto-build/recursive-build.ptl
+++ b/packages/font-glyphs/src/auto-build/recursive-build.ptl
@@ -23,6 +23,8 @@ glyph-block Recursive-Build : begin
 		if forceUpright : begin
 			forkedPara.slopeAngle  = 0
 		if mono : begin
+			forkedPara.advanceScaleUu = 1
+			forkedPara.advanceScaleUl = 1
 			forkedPara.advanceScaleMM = 1
 			forkedPara.advanceScaleM  = 1
 			forkedPara.advanceScaleT  = 1
@@ -49,6 +51,8 @@ glyph-block Recursive-Build : begin
 		forkedPara.accentWidth = AccentWidth * p
 		forkedPara.jut = Jut * p
 		forkedPara.longjut = LongJut * p
+		forkedPara.advanceScaleUu = 1
+		forkedPara.advanceScaleUl = 1
 		forkedPara.advanceScaleMM = 1
 		forkedPara.advanceScaleM  = 1
 		forkedPara.advanceScaleT  = 1

--- a/packages/font-glyphs/src/auto-build/transformed.ptl
+++ b/packages/font-glyphs/src/auto-build/transformed.ptl
@@ -295,6 +295,8 @@ glyph-block Autobuild-Transformed-Texture : begin
 		local forkedPara : Object.assign {.} para
 		if (extL + extR > 0)
 		: then : begin
+			forkedPara.advanceScaleUu = 1 + extL + extR
+			forkedPara.advanceScaleUl = 1 + extL + extR
 			forkedPara.advanceScaleMM = 1 + extL + extR
 			forkedPara.advanceScaleM  = 1 + extL + extR
 			forkedPara.advanceScaleT  = 1 + extL + extR

--- a/packages/font-glyphs/src/letter/cyrillic/big-yus.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/big-yus.ptl
@@ -108,7 +108,7 @@ glyph-block Letter-Cyrillic-BigYus : begin
 			fCapital  -- fCapital
 
 	create-glyph 'cyrl/BigYusIotified' 0x46C : glyph-proc
-		local df : include : DivFrame (para.advanceScaleM ** 2) 4.25
+		local df : include : DivFrame para.advanceScaleUl 4.25
 		include : df.markSet.capital
 		include : CyrIotifiedBigYusShape true df CAP 0.575
 

--- a/packages/font-glyphs/src/letter/cyrillic/dzzhe-zhwe.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/dzzhe-zhwe.ptl
@@ -31,21 +31,21 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 			include : CyrDeItalicShapeT dispiro subDf sw
 
 		create-glyph "cyrl/Dzzhe/left" : glyph-proc
-			define df : include : DivFrame (para.advanceScaleMM * para.advanceScaleM) 3.5
+			define df : include : DivFrame para.advanceScaleUu 3.5
 			include : df.markSet.capital
 			include : ExtendBelowBaseAnchors ((-LongVJut) + QuarterStroke)
 			set-base-anchor 'cvDecompose' 0 0
 			include : CyrDzzheDeShape df CAP
 
 		create-glyph "cyrl/dzzhe.upright/left" : glyph-proc
-			define df : include : DivFrame (para.advanceScaleM * para.advanceScaleM) 3.5
+			define df : include : DivFrame para.advanceScaleUl 3.5
 			include : df.markSet.e
 			include : ExtendBelowBaseAnchors ((-LongVJut) + QuarterStroke)
 			set-base-anchor 'cvDecompose' 0 0
 			include : CyrDzzheDeShape df XH
 
 		create-glyph "cyrl/dzzhe.italic/left" : glyph-proc
-			define df : include : DivFrame (para.advanceScaleM * para.advanceScaleM) 3.5
+			define df : include : DivFrame para.advanceScaleUl 3.5
 			include : df.markSet.b
 			set-base-anchor 'cvDecompose' 0 0
 			include : CyrDzzheDeItalicShape df
@@ -65,13 +65,13 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 
 		foreach { suffix { slabTop slabBot } } [Object.entries ZeConfig] : do
 			create-glyph "cyrl/Zhwe/left.\(suffix)" : glyph-proc
-				define df : include : DivFrame (para.advanceScaleMM * para.advanceScaleM) 3.5
+				define df : include : DivFrame para.advanceScaleUu 3.5
 				include : df.markSet.capital
 				set-base-anchor 'cvDecompose' 0 0
 				include : CyrZhweZeShape slabTop slabBot df CAP Hook
 
 			create-glyph "cyrl/zhwe/left.\(suffix)" : glyph-proc
-				define df : include : DivFrame (para.advanceScaleM * para.advanceScaleM) 3.5
+				define df : include : DivFrame para.advanceScaleUl 3.5
 				include : df.markSet.e
 				set-base-anchor 'cvDecompose' 0 0
 				include : CyrZhweZeShape slabTop slabBot df XH SHook
@@ -115,28 +115,28 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 
 		foreach { suffix { legShape fSlab fMidSlab } } [Object.entries ZheConfig] : do
 			create-glyph "cyrl/Dzzhe/right.\(suffix)" : glyph-proc
-				define df : include : DivFrame (para.advanceScaleMM * para.advanceScaleM) 3.5
+				define df : include : DivFrame para.advanceScaleUu 3.5
 				include : df.markSet.capital
 				include : CyrRightZheShape legShape fSlab fMidSlab df CAP : DzzheLeft df
 
 			create-glyph "cyrl/dzzhe.upright/right.\(suffix)" : glyph-proc
-				define df : include : DivFrame (para.advanceScaleM * para.advanceScaleM) 3.5
+				define df : include : DivFrame para.advanceScaleUl 3.5
 				include : df.markSet.e
 				include : CyrRightZheShape legShape fSlab fMidSlab df XH : DzzheLeft df
 
 			create-glyph "cyrl/dzzhe.italic/right.\(suffix)" : glyph-proc
-				define df : include : DivFrame (para.advanceScaleM * para.advanceScaleM) 3.5
+				define df : include : DivFrame para.advanceScaleUl 3.5
 				include : df.markSet.e
 				include : DzzheZheItalicShape legShape fSlab fMidSlab df XH
 
 			create-glyph "cyrl/Zhwe/right.\(suffix)" : glyph-proc
-				define df : include : DivFrame (para.advanceScaleMM * para.advanceScaleM) 3.5
+				define df : include : DivFrame para.advanceScaleUu 3.5
 				include : df.markSet.capital
 				set-base-anchor 'cvDecompose' 0 0
 				include : ZhweZheShape legShape fSlab fMidSlab df CAP Hook
 
 			create-glyph "cyrl/zhwe/right.\(suffix)" : glyph-proc
-				define df : include : DivFrame (para.advanceScaleM * para.advanceScaleM) 3.5
+				define df : include : DivFrame para.advanceScaleUl 3.5
 				include : df.markSet.e
 				set-base-anchor 'cvDecompose' 0 0
 				include : ZhweZheShape legShape fSlab fMidSlab df XH SHook

--- a/packages/font-glyphs/src/letter/cyrillic/small-yus.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/small-yus.ptl
@@ -92,14 +92,14 @@ glyph-block Letter-Cyrillic-SmallYus : begin
 				CyrSmallYusShape dfSub top straightBar df.mvs
 			intersection [MaskBelow df.mvs]
 				MaskLeft : mix xIotifiedBarRight [Math.min (dfSub.leftSB + shift) (xIotifiedBarRight + botGap)] 0.5
-		
+
 		include : Iotified.A df top
 			hBarRight -- [mix df.leftSB df.rightSB (2 / 3)]
 			hBarY     -- (top / 2 - df.mvs * 0.5)
 			fCapital  -- fCapital
 
 	create-glyph : glyph-proc
-		local df : include : DivFrame (para.advanceScaleM ** 2) 4.25
+		local df : include : DivFrame para.advanceScaleUl 4.25
 		include : df.markSet.capital
 		create-forked-glyph 'cyrl/SmallYusIotified.straight'
 			CyrIotifiedSmallYusShape false true df CAP true

--- a/packages/font-glyphs/src/letter/latin/upper-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-m.ptl
@@ -156,8 +156,8 @@ glyph-block Letter-Latin-Upper-M : begin
 			include : LeaningAnchor.Below.VBar.l df.leftSB
 			include : MShape XH df form slab slanted
 
-		define cyrSoftEmDf : DivFrame (para.advanceScaleM * para.advanceScaleM) 4
-		define cyrSoftemDf : DivFrame (para.advanceScaleT * para.advanceScaleM) 4
+		define cyrSoftEmDf : DivFrame para.advanceScaleUl 4
+		define cyrSoftemDf : DivFrame para.advanceScaleMM 4
 
 		DefineSelectorGlyph "cyrl/EmSoft" suffix cyrSoftEmDf 'capital'
 		DefineSelectorGlyph "cyrl/emSoft" suffix cyrSoftemDf 'e'

--- a/packages/font-glyphs/src/symbol/punctuation/percentages.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/percentages.ptl
@@ -53,7 +53,7 @@ glyph-block Symbol-Punctuation-Percentages : begin
 
 	create-glyph 'basepoint.NWID.dots' : glyph-proc
 		define df : include : DivFrame para.advanceScaleM
-		define slopeDf : DivFrame : Math.min 1 : para.advanceScaleM * 0.8
+		define slopeDf : DivFrame para.advanceScaleT
 
 		define refSw : AdviceStroke 5 df.adws
 

--- a/params/parameters.toml
+++ b/params/parameters.toml
@@ -78,6 +78,8 @@ slab = 0
 onumZeroHeightRatio = 1.145
 
 # Diversed advance width scale factors, used in quasi-proportional families
+advanceScaleUu = 1 # Ultra-wide uppercase
+advanceScaleUl = 1 # Ultra-wide lowercase
 advanceScaleMM = 1 # Extra-wide letters
 advanceScaleM  = 1 # M-like letters
 advanceScaleT  = 1 # T-like letters
@@ -134,17 +136,21 @@ forceMonospace = true
 [spacing-quasi-proportional]
 spacing = 3
 isQuasiProportional = true
-advanceScaleMM = 1.5             # 9/6
-advanceScaleM  = 1.3333333333333 # 8/6
-advanceScaleT  = 1.1666666666666 # 7/6
-advanceScaleF  = 0.8333333333333 # 5/6
-advanceScaleI  = 0.6666666666666 # 4/6
-advanceScaleII = 0.5             # 3/6
+advanceScaleUu = 2               # 12/6
+advanceScaleUl = 1.6666666666666 # 10/6
+advanceScaleMM = 1.5             #  9/6
+advanceScaleM  = 1.3333333333333 #  8/6
+advanceScaleT  = 1.1666666666666 #  7/6
+advanceScaleF  = 0.8333333333333 #  5/6
+advanceScaleI  = 0.6666666666666 #  4/6
+advanceScaleII = 0.5             #  3/6
 advanceScaleSp = 0.5833333333333 # 7/12
 
 [spacing-quasi-proportional-extension-only]
 spacing = 3
 isQuasiProportional = true
+advanceScaleUu = 2.00            # 12/6
+advanceScaleUl = 1.6666666666666 # 10/6
 advanceScaleMM = 1.50            # 9/6
 advanceScaleM  = 1.3333333333333 # 8/6
 advanceScaleT  = 1.1666666666666 # 7/6


### PR DESCRIPTION
This change eliminates multiplication around advance gears so the resulting width will better align the QP charistics.