### PR TITLE
Better align advance width gears of `armn/ew`.

### DIFF
--- a/packages/font-glyphs/src/letter/armenian/lower-u-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/lower-u-group.ptl
@@ -423,8 +423,7 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 
 	do "Ew"
 		create-glyph 'armn/ew' 0x587 : glyph-proc
-			local df : include : DivFrame : Math.max para.advanceScaleM
-				[mix 1 para.advanceScaleF 0.5] * para.advanceScaleMM
+			local df : include : DivFrame para.advanceScaleM
 			include : df.markSet.b
 			local subDf : DivFrame (0.75 * para.advanceScaleM) 2
 			include : uBowl.shape


### PR DESCRIPTION
I would have filed this PR shortly after #2806 or after its follow up bugfix but I've been recovering from surgery since June 19th, and I'm still recovering even right now.

Basically the trailing Armenian bar part of the `ւ` part in the `և` ligature would've theoretically made the whole character's advanceScale to be `1.375` when the whole expression was evaluated.

However, I fully respect the decision to move away from multiplying two advanceScale values together for individual characters since the resulting fractional values makes the ability for text to line back up basically impossible without other characters like it being typed later in the same line.

The nearest familiar value for this character happens to be `para.advanceScaleM`. Conveniently, simply replacing the two-line expression with just `para.advanceScaleM` only makes the trailing Armenian bar part slightly shorter and does not compress the other `ե` part.

I'd like to add image examples but I am in incredible pain right now from sitting at my desk long enough to file this PR and type all this out. Future PR's I may file within the next three weeks, if any, will of course become gradually easier.