### PR TITLE
Better align advance width gears of two characters which had been using ambiguous quarter-increment values.

### DIFF
--- a/packages/font-glyphs/src/letter/latin-ext/archaic-m.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/archaic-m.ptl
@@ -10,10 +10,10 @@ glyph-block Letter-Latin-Archaic-M : begin
 	glyph-block-import Letter-Shared-Shapes : SerifFrame
 
 	define [ExtLineJct ke ks sw x1 y1 kl1 kr1 x2 y2 kl2 kr2] : dispiro
-		flat [mix x1 x2 (-ke)]  [mix y1 y2 (-ke)]  [widths (sw * kl1) (sw * kr1)]
+		flat [mix x1 x2 (0-ke)] [mix y1 y2 (0-ke)] [widths (sw * kl1) (sw * kr1)]
 		curl [mix x1 x2 0]      [mix y1 y2 0]      [widths (sw * kl1) (sw * kr1)]
-		flat [mix x1 x2 ks]	    [mix y1 y2 ks]     [widths.center sw]
-		curl [mix x1 x2 (1-ks)]	[mix y1 y2 (1-ks)] [widths.center sw]
+		flat [mix x1 x2 (0+ks)] [mix y1 y2 ks]     [widths.center sw]
+		curl [mix x1 x2 (1-ks)] [mix y1 y2 (1-ks)] [widths.center sw]
 		flat [mix x1 x2 1]      [mix y1 y2 1]      [widths (sw * kl2) (sw * kr2)]
 		curl [mix x1 x2 (1+ke)] [mix y1 y2 (1+ke)] [widths (sw * kl2) (sw * kr2)]
 
@@ -37,6 +37,6 @@ glyph-block Letter-Latin-Archaic-M : begin
 			include : difference sf.rt.full [MaskLeft  : mix cl cr 0.7]
 
 	create-glyph "ArchaicM" 0xA7FF : glyph-proc
-		local df : include : DivFrame [mix 1 para.advanceScaleMM 1.5] 4.5
+		local df : include : DivFrame para.advanceScaleUl 4.5
 		include : df.markSet.capital
 		include : ArchaicMShape df CAP 0

--- a/packages/font-glyphs/src/symbol/letter.ptl
+++ b/packages/font-glyphs/src/symbol/letter.ptl
@@ -86,7 +86,7 @@ glyph-block Symbol-Currency : begin
 	select-variant 'currency/turkishLiraSign' 0x20BA
 
 	create-glyph 'currency/sheqelSign' 0x20AA : glyph-proc
-		local df : include : DivFrame [mix 1 para.advanceScaleMM 0.5] 4
+		local df : include : DivFrame para.advanceScaleT 4
 		include : df.markSet.e
 
 		define pX 0.7


### PR DESCRIPTION
There didn't seem like there had been any precedent at whether to defer to the lower or higher familiar advanceScale value if the existing value was exactly halfway between two applicable values. Cases like `ﬁ`/`ﬃ` seemed make sense for those characters in particular more so than it does here.

I think in these two cases case I tend to prefer rounding _down_ than _up_ since the individual sub-glyphs would look stretched out if it went the other way. Plus, there isn't even a preexisting value of 11/6 for Archaic M to go to if it even had been preferable anyway.

Also to anyone concerned since my previous PR: This PR was written entirely while standing up, and there are now 2 weeks remaining in my recovery as of today.

For each screenshot below, top row is before, bottom row is after.

```
₪ꟿ
₪ꟿ
```

Aile Thin:
![image](https://github.com/user-attachments/assets/5ba9db8c-cb66-4f16-b98f-df6d3600a056)
Aile Regular:
![image](https://github.com/user-attachments/assets/1666d656-621d-4a03-938c-4ac3a61ff6ca)
Aile Heavy:
![image](https://github.com/user-attachments/assets/59b2c88e-ddd8-4bcf-851b-fa3025583b04)

