### PR TITLE
Cleanup of #2806 .

### DIFF
--- a/packages/font-glyphs/src/auto-build/composite.ptl
+++ b/packages/font-glyphs/src/auto-build/composite.ptl
@@ -196,7 +196,7 @@ glyph-block AutoBuild-Enclosure : begin
 		define { gn unicode parts w bal baly }      job
 		define [object width] dimens
 		local jobFirstHalf  { gn unicode [parts.slice 0 (parts.length / 2)] w bal baly }
-		local jobSecondHalf { gn unicode [parts.slice (parts.length / 2)  ] w bal baly }
+		local jobSecondHalf { gn unicode [parts.slice   (parts.length / 2)] w bal baly }
 		local finalPartsFirstHalf  : EnsureInnerSubGlyphSeq inners "enclosureInnerFirstHalf"  miniatureFont jobFirstHalf  dimens 0.55 (+0.55)
 		local finalPartsSecondHalf : EnsureInnerSubGlyphSeq inners "enclosureInnerSecondHalf" miniatureFont jobSecondHalf dimens 0.55 (-0.10)
 
@@ -206,7 +206,7 @@ glyph-block AutoBuild-Enclosure : begin
 		define { gn unicode parts w bal baly }      job
 		define [object width] dimens
 		local jobFirstHalf  { gn unicode [parts.slice 0 (parts.length / 2)] w bal baly }
-		local jobSecondHalf { gn unicode [parts.slice (parts.length / 2)  ] w bal baly }
+		local jobSecondHalf { gn unicode [parts.slice   (parts.length / 2)] w bal baly }
 
 		local finalPartsFirstHalf  : EnsureInnerSubGlyphSeq inners "enclosureInnerFirstHalf"  miniatureFont jobFirstHalf  dimens 0.6 (+0.55)
 		local finalPartsSecondHalf : EnsureInnerSubGlyphSeq inners "enclosureInnerSecondHalf" miniatureFont jobSecondHalf dimens 0.6 (-0.15)
@@ -280,7 +280,7 @@ glyph-block AutoBuild-Enclosure : begin
 		addAnchors      StandardInners.addAnchors
 		getXScalar      StandardInners.getXScalar
 		buildInnerShape : function [subGlyph] : difference
-			Rect (1.05 * CAP - O) (-0.05 * CAP + O) O (Width - O)
+			Rect ((+1.05) * CAP - O) ((-0.05) * CAP + O) O (Width - O)
 			begin subGlyph
 		getPara : function [pp digits rows width] : MiniatureParaT pp
 			crowd      -- [CircCrowd (digits / rows) width]
@@ -491,7 +491,7 @@ glyph-block AutoBuild-Enclosure : begin
 		define [TwoRowMarks dimens] : glyph-proc
 			local [object left right sw] dimens
 			local gap : Gap dimens
-			set-base-anchor 'enclosureInnerFirstHalf'  (left + sw + gap)  0
+			set-base-anchor 'enclosureInnerFirstHalf'  (left  + sw + gap) 0
 			set-base-anchor 'enclosureInnerSecondHalf' (right - sw - gap) 0
 
 		export : define [Shape digits ww] : glyph-proc
@@ -669,7 +669,7 @@ glyph-block AutoBuild-Enclosure : begin
 	define [BraceShape digits ww] : glyph-proc
 		define [object width pscale sw l r] : bracedDottedDimens digits ww
 		local s : TanSlope * SymbolMid / 2
-		local p : 0.1 * [Math.sqrt : Math.min 1 (width / (digits * Width))]
+		local p : [Math.sqrt : Math.min 1 (width / (digits * Width))] / 10
 		set-width width
 		include : dispiro
 			widths.lhs sw
@@ -692,7 +692,7 @@ glyph-block AutoBuild-Enclosure : begin
 	define [HexBracedShape digits ww] : glyph-proc
 		define [object width pscale sw l r] : bracedDottedDimens digits ww
 		local s : TanSlope * SymbolMid / 2
-		local p : (1 / 6) * [Math.sqrt : Math.min 1 (width / (digits * Width))]
+		local p : [Math.sqrt : Math.min 1 (width / (digits * Width))] / 6
 		set-width width
 
 		include : dispiro
@@ -858,7 +858,7 @@ glyph-block AutoBuild-Enclosure : begin
 	do "Double-digit inset circled"
 		local compositions : list
 			list 0x2793 { "one/sansSerif.lnum" "zero.lnum" } WideWidth1
-		foreach [j : range 10 till 10] : compositions.push : list (0x2776 + j - 1) [digitGlyphNames j] WideWidth1
+		foreach [j : range 10 till 10] : compositions.push : list (0x2776 + j - 1)  [digitGlyphNames j] WideWidth1
 		foreach [j : range 11 till 20] : compositions.push : list (0x24EB + j - 11) [digitGlyphNames j] WideWidth1
 		createDecomposableInsetCircledGlyphs 2 compositions
 
@@ -1045,7 +1045,7 @@ glyph-block AutoBuild-Enclosure : begin
 	do "Single-digit braced"
 		local compositions {}
 		foreach [j : range 1 till 9] : compositions.push : list (0x2474 + j - 1) [digitGlyphNames j] WideWidth1
-		foreach [j : range 0 26] : compositions.push {(0x249C + j) {[glyphStore.queryNameByUnicode (['a'.charCodeAt 0] + j)]} WideWidth1 0.5 (XH/2)}
+		foreach [j : range 0 26] : compositions.push {(0x249C  + j) {[glyphStore.queryNameByUnicode (['a'.charCodeAt 0] + j)]} WideWidth1 0.5 (XH/2)}
 		foreach [j : range 0 26] : compositions.push {(0x1F110 + j) {[glyphStore.queryNameByUnicode (['A'.charCodeAt 0] + j)]} WideWidth1}
 		createBracedGlyphs 1 compositions
 
@@ -1143,7 +1143,7 @@ glyph-block Autobuild-Fractions : begin
 
 				if jobDecomposable : CvDecompose.set currentGlyph decomposition
 
-		foreach job [items-of jobs.nonDecomposable] : createFractionImpl job false
+		foreach job [items-of jobs.nonDecomposable]  : createFractionImpl job false
 		foreach job [items-of jobs.decomposableJobs] : createFractionImpl job true
 
 		applyRelations jobs.relApplications
@@ -1162,7 +1162,7 @@ glyph-block Autobuild-Fractions : begin
 				if fine : include : HBar.m SB RightSB SymbolMid (fine * 0.75)
 				set-base-anchor 'fracBuildUp' (Middle - firstRowWidth * scaleFactor / 2) (SymbolMid + dist / 2)
 			shiftShape   : function [iRow nRows numWidth denWidth] : glyph-proc
-				local offset : -(numWidth / 2 + denWidth / 2) * scaleFactor
+				local offset : (numWidth / 2 + denWidth / 2) * (-scaleFactor)
 				set-width 0
 				set-mark-anchor 'fracBuildUp' 0 0 offset (-partOffsetY)
 
@@ -1182,10 +1182,10 @@ glyph-block Autobuild-Fractions : begin
 				local offset : [startPos denWidth iRow] - [startPos numWidth (iRow - 1)] - numWidth * scaleFactor
 
 				set-width 0
-				set-mark-anchor 'fracBuildUp' 0 0 offset (-(CAP * scaleFactor + gap))
+				set-mark-anchor 'fracBuildUp' 0 0 offset (CAP * (-scaleFactor) - gap)
 
 	define [createFractions records]        : createFracImpl 'frac'      records : FractionLayout CAP [AdviceStroke 3] 0.55 0.05
-	define [createFractionsSmall records]   : createFracImpl 'fracSmall' records : FractionLayout XH [AdviceStroke 3] 0.55 0.05
+	define [createFractionsSmall records]   : createFracImpl 'fracSmall' records : FractionLayout XH  [AdviceStroke 3] 0.55 0.05
 	define [createControlPictures2 records] : createFracImpl 'ctrlPict2' records : ControlPictureLayout 3.75 0.55  0.2
 	define [createControlPictures3 records] : createFracImpl 'ctrlPict3' records : ControlPictureLayout 5    0.375 0.1
 
@@ -1283,7 +1283,7 @@ glyph-block AutoBuild-Accented-Equal : begin
 				set-mark-anchor 'compositeInner' 0 0
 				include : dFont.queryByNameEnsured gidPart
 				include : Ungizmo
-				include : Translate (-totalWidth / 2 + offset) 0
+				include : Translate (totalWidth * (-0.5) + offset) 0
 				include : Scale scale
 				include : Translate (Middle + shiftX - Width) shiftY
 				include : Regizmo
@@ -1326,7 +1326,7 @@ glyph-block AutoBuild-Accented-Equal : begin
 		list 0x225b {"blackStar.NWID"}
 		list 0x225c {"whiteTriangleUp.NWID"}
 		list 0x2a6e {"opAsterisk"}
-	createAccentedOp 'sqrt' 5 0.5 (-Width / 4) [mix OperBot OperTop 0.6] : list
+	createAccentedOp 'sqrt' 5 0.5 (Width * (-0.25)) [mix OperBot OperTop 0.6] : list
 		list 0x221b {"three.lnum"}
 		list 0x221c {"four.lnum"}
 	createAccentedOp 'equal' 8 0.3 0 aboveMarkBot : list
@@ -1642,11 +1642,11 @@ glyph-block Autobuild-Pnonetic-Ligatures : begin
 		list 0xFB05  { 'longs/compLigLeft' 't/compLigRight'                 } null
 		list 0xFB06  { 's/compLigLeft'     't/compLigRight'                 } null
 
-	createPhoneticLigatures ToLetter 'phonetic3' para.advanceScaleUl 3 stdShrink 1 : list
+	createPhoneticLigatures ToLetter 'phonetic3' [mix 1 para.advanceScaleM 2] 3 stdShrink 1 : list
 		list 0xFB03  { 'f/compLigLeft2' 'f/compLigLeft1' 'dotlessi/compLigRight' } null
 		list 0xFB04  { 'f/compLigLeft4' 'f/compLigLeft3' 'l/compLigRight'        } null
 
-	createPhoneticLigatures ToLetter 'phoneticSmcp' para.advanceScaleUl 3 1 0.5 : list
+	createPhoneticLigatures ToLetter 'phoneticSmcp' [mix 1 para.advanceScaleM 2] 3 1 0.5 : list
 		list 0x2121  { 'smcpT' 'smcpE' 'smcpL' } 'e'
 		list 0x213B  { 'smcpF' 'smcpA' 'smcpX' } 'e'
 
@@ -1699,9 +1699,9 @@ glyph-block Autobuild-Double-Emotions : begin
 				include : Translate (dfg1.advanceWidth * wadj1 - kern) 0
 				include : union dfg1 [with-transform [Translate (dfg1.advanceWidth) 0] dfm1]
 				include : Ungizmo
-				include : Translate ((-refW) / 2) 0
+				include : Translate (refW   * (-0.5)) 0
 				include : Scale [clamp 0 1 ((CWidth - SB * 1.25) / (CWidth - SB * 2) * CWidth / refW)] 1
-				include : Translate (CWidth / 2) 0
+				include : Translate (CWidth * (+0.5)) 0
 				include : Regizmo
 
 		applyRelations jobs.relApplications
@@ -1725,7 +1725,7 @@ glyph-block Autobuild-Grouped-Digits : begin
 				HBar.b 0 Width (Descender * 0.75) [AdviceStroke 4]
 				glyph-proc
 					include : refer-glyph "denseShade.WWID"
-					include : Translate ((-Width) / 2) 0
+					include : Translate (Width * (-0.5)) 0
 			include : Translate (-Width) 0
 
 		foreach [gid : items-of numberGlyphIDs] : foreach [nd : items-of {0 1 2 3 4 5 6}]

--- a/packages/font-glyphs/src/auto-build/recursive-build.ptl
+++ b/packages/font-glyphs/src/auto-build/recursive-build.ptl
@@ -23,8 +23,6 @@ glyph-block Recursive-Build : begin
 		if forceUpright : begin
 			forkedPara.slopeAngle  = 0
 		if mono : begin
-			forkedPara.advanceScaleUu = 1
-			forkedPara.advanceScaleUl = 1
 			forkedPara.advanceScaleMM = 1
 			forkedPara.advanceScaleM  = 1
 			forkedPara.advanceScaleT  = 1
@@ -51,8 +49,6 @@ glyph-block Recursive-Build : begin
 		forkedPara.accentWidth = AccentWidth * p
 		forkedPara.jut = Jut * p
 		forkedPara.longjut = LongJut * p
-		forkedPara.advanceScaleUu = 1
-		forkedPara.advanceScaleUl = 1
 		forkedPara.advanceScaleMM = 1
 		forkedPara.advanceScaleM  = 1
 		forkedPara.advanceScaleT  = 1

--- a/packages/font-glyphs/src/auto-build/transformed.ptl
+++ b/packages/font-glyphs/src/auto-build/transformed.ptl
@@ -295,8 +295,6 @@ glyph-block Autobuild-Transformed-Texture : begin
 		local forkedPara : Object.assign {.} para
 		if (extL + extR > 0)
 		: then : begin
-			forkedPara.advanceScaleUu = 1 + extL + extR
-			forkedPara.advanceScaleUl = 1 + extL + extR
 			forkedPara.advanceScaleMM = 1 + extL + extR
 			forkedPara.advanceScaleM  = 1 + extL + extR
 			forkedPara.advanceScaleT  = 1 + extL + extR

--- a/packages/font-glyphs/src/letter/cyrillic/big-yus.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/big-yus.ptl
@@ -108,7 +108,7 @@ glyph-block Letter-Cyrillic-BigYus : begin
 			fCapital  -- fCapital
 
 	create-glyph 'cyrl/BigYusIotified' 0x46C : glyph-proc
-		local df : include : DivFrame para.advanceScaleUl 4.25
+		local df : include : DivFrame [mix 1 para.advanceScaleM 2] 4.25
 		include : df.markSet.capital
 		include : CyrIotifiedBigYusShape true df CAP 0.575
 

--- a/packages/font-glyphs/src/letter/cyrillic/dzzhe-zhwe.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/dzzhe-zhwe.ptl
@@ -31,21 +31,21 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 			include : CyrDeItalicShapeT dispiro subDf sw
 
 		create-glyph "cyrl/Dzzhe/left" : glyph-proc
-			define df : include : DivFrame para.advanceScaleUu 3.5
+			define df : include : DivFrame [mix 1 para.advanceScaleMM 2] 3.5
 			include : df.markSet.capital
 			include : ExtendBelowBaseAnchors ((-LongVJut) + QuarterStroke)
 			set-base-anchor 'cvDecompose' 0 0
 			include : CyrDzzheDeShape df CAP
 
 		create-glyph "cyrl/dzzhe.upright/left" : glyph-proc
-			define df : include : DivFrame para.advanceScaleUl 3.5
+			define df : include : DivFrame [mix 1 para.advanceScaleM 2] 3.5
 			include : df.markSet.e
 			include : ExtendBelowBaseAnchors ((-LongVJut) + QuarterStroke)
 			set-base-anchor 'cvDecompose' 0 0
 			include : CyrDzzheDeShape df XH
 
 		create-glyph "cyrl/dzzhe.italic/left" : glyph-proc
-			define df : include : DivFrame para.advanceScaleUl 3.5
+			define df : include : DivFrame [mix 1 para.advanceScaleM 2] 3.5
 			include : df.markSet.b
 			set-base-anchor 'cvDecompose' 0 0
 			include : CyrDzzheDeItalicShape df
@@ -65,13 +65,13 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 
 		foreach { suffix { slabTop slabBot } } [Object.entries ZeConfig] : do
 			create-glyph "cyrl/Zhwe/left.\(suffix)" : glyph-proc
-				define df : include : DivFrame para.advanceScaleUu 3.5
+				define df : include : DivFrame [mix 1 para.advanceScaleMM 2] 3.5
 				include : df.markSet.capital
 				set-base-anchor 'cvDecompose' 0 0
 				include : CyrZhweZeShape slabTop slabBot df CAP Hook
 
 			create-glyph "cyrl/zhwe/left.\(suffix)" : glyph-proc
-				define df : include : DivFrame para.advanceScaleUl 3.5
+				define df : include : DivFrame [mix 1 para.advanceScaleM 2] 3.5
 				include : df.markSet.e
 				set-base-anchor 'cvDecompose' 0 0
 				include : CyrZhweZeShape slabTop slabBot df XH SHook
@@ -115,28 +115,28 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 
 		foreach { suffix { legShape fSlab fMidSlab } } [Object.entries ZheConfig] : do
 			create-glyph "cyrl/Dzzhe/right.\(suffix)" : glyph-proc
-				define df : include : DivFrame para.advanceScaleUu 3.5
+				define df : include : DivFrame [mix 1 para.advanceScaleMM 2] 3.5
 				include : df.markSet.capital
 				include : CyrRightZheShape legShape fSlab fMidSlab df CAP : DzzheLeft df
 
 			create-glyph "cyrl/dzzhe.upright/right.\(suffix)" : glyph-proc
-				define df : include : DivFrame para.advanceScaleUl 3.5
+				define df : include : DivFrame [mix 1 para.advanceScaleM 2] 3.5
 				include : df.markSet.e
 				include : CyrRightZheShape legShape fSlab fMidSlab df XH : DzzheLeft df
 
 			create-glyph "cyrl/dzzhe.italic/right.\(suffix)" : glyph-proc
-				define df : include : DivFrame para.advanceScaleUl 3.5
+				define df : include : DivFrame [mix 1 para.advanceScaleM 2] 3.5
 				include : df.markSet.e
 				include : DzzheZheItalicShape legShape fSlab fMidSlab df XH
 
 			create-glyph "cyrl/Zhwe/right.\(suffix)" : glyph-proc
-				define df : include : DivFrame para.advanceScaleUu 3.5
+				define df : include : DivFrame [mix 1 para.advanceScaleMM 2] 3.5
 				include : df.markSet.capital
 				set-base-anchor 'cvDecompose' 0 0
 				include : ZhweZheShape legShape fSlab fMidSlab df CAP Hook
 
 			create-glyph "cyrl/zhwe/right.\(suffix)" : glyph-proc
-				define df : include : DivFrame para.advanceScaleUl 3.5
+				define df : include : DivFrame [mix 1 para.advanceScaleM 2] 3.5
 				include : df.markSet.e
 				set-base-anchor 'cvDecompose' 0 0
 				include : ZhweZheShape legShape fSlab fMidSlab df XH SHook

--- a/packages/font-glyphs/src/letter/cyrillic/small-yus.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/small-yus.ptl
@@ -99,7 +99,7 @@ glyph-block Letter-Cyrillic-SmallYus : begin
 			fCapital  -- fCapital
 
 	create-glyph : glyph-proc
-		local df : include : DivFrame para.advanceScaleUl 4.25
+		local df : include : DivFrame [mix 1 para.advanceScaleM 2] 4.25
 		include : df.markSet.capital
 		create-forked-glyph 'cyrl/SmallYusIotified.straight'
 			CyrIotifiedSmallYusShape false true df CAP true

--- a/packages/font-glyphs/src/letter/latin-ext/archaic-m.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/archaic-m.ptl
@@ -12,7 +12,7 @@ glyph-block Letter-Latin-Archaic-M : begin
 	define [ExtLineJct ke ks sw x1 y1 kl1 kr1 x2 y2 kl2 kr2] : dispiro
 		flat [mix x1 x2 (0-ke)] [mix y1 y2 (0-ke)] [widths (sw * kl1) (sw * kr1)]
 		curl [mix x1 x2 0]      [mix y1 y2 0]      [widths (sw * kl1) (sw * kr1)]
-		flat [mix x1 x2 (0+ks)] [mix y1 y2 ks]     [widths.center sw]
+		flat [mix x1 x2 (0+ks)] [mix y1 y2 (0+ks)] [widths.center sw]
 		curl [mix x1 x2 (1-ks)] [mix y1 y2 (1-ks)] [widths.center sw]
 		flat [mix x1 x2 1]      [mix y1 y2 1]      [widths (sw * kl2) (sw * kr2)]
 		curl [mix x1 x2 (1+ke)] [mix y1 y2 (1+ke)] [widths (sw * kl2) (sw * kr2)]
@@ -33,10 +33,10 @@ glyph-block Letter-Latin-Archaic-M : begin
 
 		if SLAB : begin
 			local sf : SerifFrame.fromDf df top bottom (fForceSymmetric -- true)
-			include : difference sf.lb.full [MaskRight : mix cl cr 0.3]
-			include : difference sf.rt.full [MaskLeft  : mix cl cr 0.7]
+			include : difference sf.lb.full : MaskRight [mix cl cr 0.3]
+			include : difference sf.rt.full : MaskLeft  [mix cl cr 0.7]
 
 	create-glyph "ArchaicM" 0xA7FF : glyph-proc
-		local df : include : DivFrame para.advanceScaleUl 4.5
+		local df : include : DivFrame [mix 1 para.advanceScaleM 2] 4.5
 		include : df.markSet.capital
 		include : ArchaicMShape df CAP 0

--- a/packages/font-glyphs/src/letter/latin/upper-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-m.ptl
@@ -156,7 +156,10 @@ glyph-block Letter-Latin-Upper-M : begin
 			include : LeaningAnchor.Below.VBar.l df.leftSB
 			include : MShape XH df form slab slanted
 
-		define cyrSoftEmDf : DivFrame para.advanceScaleUl 4
+		# This is actually wider than `para.advanceScaleMM` by itself.
+		define cyrSoftEmDf : DivFrame [mix 1 para.advanceScaleM 2] 4
+
+		# This is incidentally equivalent to `para.advanceScaleT + (para.advanceScaleM - 1)`.
 		define cyrSoftemDf : DivFrame para.advanceScaleMM 4
 
 		DefineSelectorGlyph "cyrl/EmSoft" suffix cyrSoftEmDf 'capital'

--- a/params/parameters.toml
+++ b/params/parameters.toml
@@ -78,11 +78,9 @@ slab = 0
 onumZeroHeightRatio = 1.145
 
 # Diversed advance width scale factors, used in quasi-proportional families
-advanceScaleUu = 1 # Ultra-wide uppercase
-advanceScaleUl = 1 # Ultra-wide lowercase
 advanceScaleMM = 1 # Extra-wide letters
 advanceScaleM  = 1 # M-like letters
-advanceScaleT  = 1 # T-like letters
+advanceScaleT  = 1 # T-like letters (with serifs)
 advanceScaleF  = 1 # f-like letters
 advanceScaleI  = 1 # i-like letters (with serifs/tails)
 advanceScaleII = 1 # Extra-narrow letters (like i without serifs/tails)
@@ -136,21 +134,17 @@ forceMonospace = true
 [spacing-quasi-proportional]
 spacing = 3
 isQuasiProportional = true
-advanceScaleUu = 2               # 12/6
-advanceScaleUl = 1.6666666666666 # 10/6
-advanceScaleMM = 1.5             #  9/6
-advanceScaleM  = 1.3333333333333 #  8/6
-advanceScaleT  = 1.1666666666666 #  7/6
-advanceScaleF  = 0.8333333333333 #  5/6
-advanceScaleI  = 0.6666666666666 #  4/6
-advanceScaleII = 0.5             #  3/6
+advanceScaleMM = 1.5             # 9/6
+advanceScaleM  = 1.3333333333333 # 8/6
+advanceScaleT  = 1.1666666666666 # 7/6
+advanceScaleF  = 0.8333333333333 # 5/6
+advanceScaleI  = 0.6666666666666 # 4/6
+advanceScaleII = 0.5             # 3/6
 advanceScaleSp = 0.5833333333333 # 7/12
 
 [spacing-quasi-proportional-extension-only]
 spacing = 3
 isQuasiProportional = true
-advanceScaleUu = 2.00            # 12/6
-advanceScaleUl = 1.6666666666666 # 10/6
 advanceScaleMM = 1.50            # 9/6
 advanceScaleM  = 1.3333333333333 # 8/6
 advanceScaleT  = 1.1666666666666 # 7/6


### PR DESCRIPTION
It's occurred to me that all the characters which used `para.advanceScaleUl`/`para.advanceScaleUu` were all ones with subglyphs using `para.advanceScaleM`/`para.advanceScaleMM`, but where the rest of the character also needed to have the same **flat** width augmentation applied a second time.

The word 'flat' is important in my previous sentence. I think my old habit of multiplying values together was naïve about this and made everything more complicated as well as making alignment less stable.

The same clean 1/6 numbers can be accomplished anywhere in the code via `[mix 1 para.advanceScaleM`{`M`}` 2]` etc. and it can also aid in code readability when written this way.

I will point out that the `mix` function would always need to use an integer at the end in order to guarantee everything stays locked to 1/6 increments. This is also dependent on how it's enforced.

