### PR TITLE
Make Cyrillic Multiocular O (`ꙮ`) slightly wider under Quasi-Proportional.

### DIFF
--- a/changes/33.2.7.md
+++ b/changes/33.2.7.md
@@ -1,0 +1,2 @@
+* Make certain characters slightly wider under Quasi-Proportional. Affected characters:
+  - CYRILLIC LETTER MULTIOCULAR O (`U+A66E`).

--- a/packages/font-glyphs/src/letter/cyrillic/multiocular-o.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/multiocular-o.ptl
@@ -13,20 +13,20 @@ glyph-block Letter-Cyrillic-Multiocular-O : begin
 	foreach { suffix { DrawAt kdr } } [Object.entries DotVariants] : do
 
 		create-glyph "cyrl/multiocularO.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.advanceScaleMM 6
+			local df : include : DivFrame [mix 1 para.advanceScaleM 2] 6
 			include : df.markSet.bp
 
 			local subDf : df.slice 5 2
 
-			local pMidRowBottom     0.327
-			local pMidRowSw         (-0.25)
-			local middleRowBottom : [mix Descender Ascender pMidRowBottom] + pMidRowSw * df.mvs
+			local pMidRowBottom     (+0.327)
+			local pMidRowSw         (-0.250)
+			local middleRowBottom : [mix Descender Ascender (0 + pMidRowBottom)] + pMidRowSw * df.mvs
 			local middleRowTop    : [mix Descender Ascender (1 - pMidRowBottom)] - pMidRowSw * df.mvs
 
 			local [SingleEye pX pY] : begin
 				local yBot : middleRowBottom + pY * (middleRowBottom - Descender)
-				local yTop : middleRowTop + pY * (Ascender - middleRowTop)
-				local xLeft : subDf.leftSB + (pX / 3) * (df.width - subDf.width)
+				local yTop : middleRowTop    + pY * (Ascender - middleRowTop)
+				local xLeft  : subDf.leftSB  + (pX / 3) * (df.width - subDf.width)
 				local xRight : subDf.rightSB + (pX / 3) * (df.width - subDf.width)
 
 				local dotSpace : InnerDot.spaceOfDf subDf


### PR DESCRIPTION
Using an advanceScale value of `[mix 1 para.advanceScaleM 2]` (evaluating to 5/3, or 10/6), this effectively makes the five primary vertical lines of the middle row of "eyes" worth 1/3 (or 2/6) of advance width each.

For each screenshot below, top row is before, bottom row is after.

`₪ꟿꙮև`

Aile Thin:
<img width="652" height="463" alt="image" src="https://github.com/user-attachments/assets/1a13fc83-1c69-48cc-a5dc-4cd5f9c03c57" />
Aile Regular:
<img width="633" height="441" alt="image" src="https://github.com/user-attachments/assets/0c96f222-dee8-4be1-82a3-36c6f970c19d" />
Aile Heavy:
<img width="648" height="442" alt="image" src="https://github.com/user-attachments/assets/c74b6eb8-64b7-49cc-bbe1-27a5b7064587" />
