### PR TITLE
Stabilize hook metrics of `cyrl/ef` under Quasi-Proportional.

### DIFF
--- a/packages/font-glyphs/src/letter/greek/phi.ptl
+++ b/packages/font-glyphs/src/letter/greek/phi.ptl
@@ -60,10 +60,10 @@ glyph-block Letter-Greek-Phi : begin
 		include : VBar.m df.middle (y3 - HalfStroke) y4 sw
 
 	define [CursiveBar df y1 y2 y3 y4 sw] : glyph-proc
-		local dfHook : DivFrame para.advanceScaleF
+		local dfHook : DivFrame : mix 1 (1 / df.adws) 0.5
 		local hd : FlatHookDepth dfHook
 
-		local m : mix 1 para.advanceScaleF 1.5
+		local m : mix 1 (1 / df.adws) 0.75
 
 		local xCrossLeft  : df.middle - dfHook.middle + dfHook.leftSB * m
 		local xCrossRight : df.middle + dfHook.middle - dfHook.leftSB * m
@@ -86,10 +86,10 @@ glyph-block Letter-Greek-Phi : begin
 			curl xBarRight (y2 - O)
 
 	define [DiagonalTailCursiveBar df y1 y2 y3 y4 sw] : glyph-proc
-		local dfHook : DivFrame para.advanceScaleF
+		local dfHook : DivFrame : mix 1 (1 / df.adws) 0.5
 		local hd : FlatHookDepth dfHook
 
-		local m : mix 1 para.advanceScaleF 1.5
+		local m : mix 1 (1 / df.adws) 0.75
 
 		local xCrossRight : df.middle + dfHook.middle - dfHook.leftSB * m
 		local xBarLeft    : df.middle - [HSwToV : 0.5 * sw]


### PR DESCRIPTION
This basically eliminates the need for a separate `para.advanceScaleF` for the sub-df (`dfHook`) by making the cursive bar shrink based on `[mix 1 (1 / df.adws) 0.5]` instead.

This will appear as completely unchanged under Monospace and default Aile/Etoile, as it will still reach 1/1 and 5/6 respectively;

It may, however, appear _very slightly_ different (under Quasi-Proportional only) if the non-`split` cursive variant in particular is used, but not by much (it will actually be `0.875`, which is coincidentally the old `para.diversityF` value anyway).

**Reminder that this is for a sub-df, not the DivFrame of the entire character, so the actual advance width of the character itself will not change.**