### PR TITLE
Optimize jut length of bottom serif of two Cyrillic Te-derived letters.

### DIFF
--- a/packages/font-glyphs/src/letter/cyrillic/te-midhook.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/te-midhook.ptl
@@ -35,7 +35,7 @@ glyph-block Letter-Cyrillic-Te-MidHook : begin
 		if slabBot : begin
 			include : intersection
 				MaskLeft : mix (left + [HSwToV sw]) (df.rightSB - [HSwToV sw]) 0.625
-				HSerif.mb (left + [HSwToV : 0.5 * sw]) 0 Jut
+				HSerif.mb (left + [HSwToV : 0.5 * sw]) 0 ([Math.max Jut : MidJutCenter * [Math.min 1 : df.adws * 0.875]] - [HSwToV : 0.5 * (Stroke - sw)])
 
 	foreach { suffix { adws doST doSB } } [Object.entries TConfig] : do
 		create-glyph "cyrl/TeMidHook.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/letter/cyrillic/tje.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/tje.ptl
@@ -30,7 +30,7 @@ glyph-block Letter-Cyrillic-Tje : begin
 			include : VSerif.dr xTopBarRight top jutTop
 
 		if slabBot : begin
-			include : HSerif.lb left 0 SideJut
+			include : HSerif.lb left 0 ([Math.max Jut : MidJutCenter * [Math.min 1 : df.adws * 0.875]] - [HSwToV HalfStroke])
 
 	define [RightHalf Yeri df top sw] : glyph-proc
 		include : Yeri top


### PR DESCRIPTION
Basically using `MidJutCenter` like ordinary ASCII `T` except multiplied by 7/8 under Monospace or by just 1 under Quasi-Proportional. This is to accommodate for the more crowded space.

Characters like `Ђ` and `Ћ` (Somewhat related Serbo-Croatian letters, not shown here) are unchanged because they're arguably more like `Һ` with a top bar, at least in handwriting. This may be subjective though.

For each screenshot below, top row is before, bottom row is after.

`ТᲉꚊтᲊꚋ`

Slab Monospace Thin:
<img width="559" height="443" alt="image" src="https://github.com/user-attachments/assets/a13c95ce-4224-4d3d-8c4e-27144f926913" />
Slab Monospace Regular:
<img width="540" height="419" alt="image" src="https://github.com/user-attachments/assets/097cc9be-a934-4500-83ea-02b65f6b3b33" />
Slab Monospace Heavy:
<img width="539" height="434" alt="image" src="https://github.com/user-attachments/assets/d5f7c152-5a21-4f5d-8107-dc230fc7b067" />
Etoile Thin:
<img width="742" height="426" alt="image" src="https://github.com/user-attachments/assets/40fa9c6e-44b7-4647-98d3-a2521e82879c" />
Etoile Regular:
<img width="754" height="434" alt="image" src="https://github.com/user-attachments/assets/c3062a18-a7ae-498b-a237-af0cb81f5e32" />
Etoile Heavy:
<img width="743" height="429" alt="image" src="https://github.com/user-attachments/assets/eeaf8443-015f-4c2e-b587-68c569eb8dae" />
