### PR TITLE
Make Cyrillic Iotified Yat (`Ꙓ`/`ꙓ`) slightly wider under Quasi-Proportional.

### DIFF
--- a/changes/33.2.7.md
+++ b/changes/33.2.7.md
@@ -1,2 +1,7 @@
 * Make certain characters slightly wider under Quasi-Proportional. Affected characters:
+  - CYRILLIC CAPITAL LETTER IOTIFIED YAT (`U+A652`).
+  - CYRILLIC SMALL LETTER IOTIFIED YAT (`U+A653`).
   - CYRILLIC LETTER MULTIOCULAR O (`U+A66E`).
+* Refine shape of the following characters:
+  - CYRILLIC SMALL LETTER TALL YAT (`U+1C87`).
+  - MATHEMATICAL DOUBLE-STRUCK SMALL A (`U+1D552`) (#2769).

--- a/packages/font-glyphs/src/letter/cyrillic/yat.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/yat.ptl
@@ -80,24 +80,24 @@ glyph-block Letter-Cyrillic-Yat : begin
 		create-glyph "cyrl/yatTall.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleT
 			include : df.markSet.b
-			local asc : Ascender + 0.5 * AccentStackOffset
+			local asc : Ascender + [Math.max (LongVJut - QuarterStroke) : if SLAB (1.375 * df.mvs) 0]
 			include : ExtendAboveBaseAnchors asc
 			include : YatShape df Lc asc
 				pBar -- (YeriBarPos * XH / asc)
 				fLowerCase -- true
-				yCrossbarOverride -- (Ascender - [if SLAB (0.25 * df.mvs) 0])
+				yCrossbarOverride -- Ascender
 
 		create-glyph "cyrl/YatIotified.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.advanceScaleM 3
+			local df : include : DivFrame para.advanceScaleMM 3
 			include : df.markSet.capital
 			include : IotifiedYatShape df Uc CAP
 				pBar -- 0.5
 
 		create-glyph "cyrl/yatIotified.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.advanceScaleM 3
+			local df : include : DivFrame para.advanceScaleMM 3
 			include : df.markSet.b
 			include : IotifiedYatShape df Lc Ascender
-				pBar -- 0.375
+				pBar -- (YeriBarPos * XH / Ascender)
 				fLowerCase -- true
 
 		# Italic Yat


### PR DESCRIPTION
Basically adding 2/6 of flat advance width to the base character when iotated (instead of 1/6 like before), which matches all other iotated letters and makes the sub-glyph of the base character look less "squished".

For each screenshot below: top row is before, bottom row is after.

`ѢꙒᲇѣꙓ`

Aile Thin:
<img width="556" height="330" alt="image" src="https://github.com/user-attachments/assets/9b3a2090-f3ec-4fb1-ab29-085e9fe1bb27" />
Aile Regular:
<img width="537" height="300" alt="image" src="https://github.com/user-attachments/assets/ed16cd13-c01e-4dcb-b280-62c7d82959d4" />
Aile Heavy:
<img width="559" height="315" alt="image" src="https://github.com/user-attachments/assets/aa4d250d-584d-452d-badc-b4804af82478" />
Etoile Thin:
<img width="532" height="304" alt="image" src="https://github.com/user-attachments/assets/e5774ff8-7ab3-4995-8a5b-4295d1d98832" />
Etoile Regular:
<img width="548" height="311" alt="image" src="https://github.com/user-attachments/assets/6bc47f7c-f401-4cc5-b99f-de4b827e907e" />
Etoile Heavy:
<img width="537" height="308" alt="image" src="https://github.com/user-attachments/assets/e1570d8c-984d-460f-ad5d-7c7bec44ea95" />
