### PR TITLE
Shrink side bearings and increase bowl size of Cyrillic Ef (`Ф`) under Quasi-Proportional.

### DIFF
--- a/packages/font-glyphs/src/letter/greek/phi.ptl
+++ b/packages/font-glyphs/src/letter/greek/phi.ptl
@@ -13,12 +13,14 @@ glyph-block Letter-Greek-Phi : begin
 
 	define [VarPhiRing fFlatTB df y2 y3 ada adb] : glyph-proc
 		include : VBar.m df.middle y2 y3 df.mvs
+		local l : mix df.leftSB 0 : if fFlatTB (0.75 * (df.adws % 0.5)) 0
+		local r : df.width - l
 		include : if fFlatTB
-			OShapeFlatTB y3 y2 df.leftSB df.rightSB df.mvs ada adb : Math.max
-				(df.rightSB - df.leftSB) - (y3 - y2)
-				(df.rightSB - df.leftSB) * 0.25
+			OShapeFlatTB y3 y2 l r df.mvs ada adb : Math.max
+				(r - l) - (y3 - y2)
+				(r - l) * 0.25
 				HSwToV df.mvs
-			OShape y3 y2 df.leftSB df.rightSB df.mvs ada adb
+			OShape y3 y2 l r df.mvs ada adb
 
 	define [CyrlEfSplitRing fFlatTB df y2 y3 ada adb] : glyph-proc
 		include : VBar.m df.middle y2 y3 df.mvs


### PR DESCRIPTION
Basically making it match the bowl width of e.g. `Р`/etc. more (which that character has a slightly expanded left SB).

I originally tried changing the advance width of the character (for `Ф`), but it looked too extreme and actually made the negative space worse as well. The solution I found was to leave the advance width alone and shrink the side bearings instead.

This only affects Quasi-Proportional; The line containing `df.adws % 0.5` makes it so that this neither affects monospace nor Bulgarian `Ф` (which uses `para.advanceScaleMM`) as they are already divisible by the number of vertical lines (i.e. multiples of `0.5`) and therefore look fine as-is.

Multiplying the resulting value (of the aforementioned expression) by `0.75` also makes the difference more mild (that is to say _less_ extreme), going from 1/3 to just 1/4 of the side bearing shaved off.

I showed the following samples to some people in a few servers and the general consensus (among those familiar with Cyrillic) seemed to be that the wider bowl looked better. It could always stand to be tweaked in the future, though, depending on taste.

For all screenshots below: Top row is before, bottom row is after.

`ΦϕϷФф РФ: Феличан наскиџтагон`

Aile Thin:
<img width="2439" height="348" alt="image" src="https://github.com/user-attachments/assets/bee13a25-693f-492d-86f9-8e4acaefefab" />
Aile Regular:
<img width="2442" height="345" alt="image" src="https://github.com/user-attachments/assets/d6a3aa80-4939-42a3-9c6d-c2ce66ebecb5" />
Aile Heavy:
<img width="2430" height="353" alt="image" src="https://github.com/user-attachments/assets/1110e33e-342d-498a-9de1-f51297db5b54" />
Etoile Thin:
<img width="2457" height="358" alt="image" src="https://github.com/user-attachments/assets/b66abeff-db3e-4a70-b3af-21d27204e123" />
Etoile Regular:
<img width="2433" height="343" alt="image" src="https://github.com/user-attachments/assets/1f7dec23-9c32-40a7-81c1-f3b01aedf9e8" />
Etoile Heavy:
<img width="2461" height="349" alt="image" src="https://github.com/user-attachments/assets/71ae238f-291e-4213-8564-947860ba4dbb" />
