### PR TITLE
Make Cyrillic Closed Small Yus (`Ꙙ`/`ꙙ`) slightly wider under Quasi-Proportional.

### DIFF
--- a/changes/33.2.8.md
+++ b/changes/33.2.8.md
@@ -1,3 +1,8 @@
+* Make certain characters slightly wider under Quasi-Proportional. Affected characters:
+  - CYRILLIC CAPITAL LETTER CLOSED LITTLE YUS (`U+A658`).
+  - CYRILLIC SMALL LETTER CLOSED LITTLE YUS (`U+A659`).
+  - CYRILLIC CAPITAL LETTER IOTIFIED CLOSED LITTLE YUS (`U+A65C`).
+  - CYRILLIC SMALL LETTER IOTIFIED CLOSED LITTLE YUS (`U+A65D`).
 * Refine shape of the following characters:
   - CYRILLIC CAPITAL LETTER EF (`U+0424`).
   - CYRILLIC SMALL LETTER EF (`U+0444`).

--- a/packages/font-glyphs/src/letter/cyrillic/small-yus.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/small-yus.ptl
@@ -53,30 +53,30 @@ glyph-block Letter-Cyrillic-SmallYus : begin
 		local df : include : DivFrame para.advanceScaleM 3
 		include : df.markSet.capital
 		create-forked-glyph 'cyrl/SmallYus.straight' : CyrSmallYusShape df CAP true
-		create-forked-glyph 'cyrl/SmallYus.curly' : CyrSmallYusShape df CAP false
+		create-forked-glyph 'cyrl/SmallYus.curly'    : CyrSmallYusShape df CAP false
 
 	create-glyph : glyph-proc
 		local df : include : DivFrame 1 3
 		include : df.markSet.e
 		create-forked-glyph 'cyrl/smallYus.straight' : CyrSmallYusShape df XH true
-		create-forked-glyph 'cyrl/smallYus.curly' : CyrSmallYusShape df XH false
+		create-forked-glyph 'cyrl/smallYus.curly'    : CyrSmallYusShape df XH false
 
 	create-glyph : glyph-proc
-		local df : include : DivFrame 1
+		local df : include : DivFrame para.advanceScaleM 2
 		include : df.markSet.capital
 		create-forked-glyph 'cyrl/SmallYusClosed.straight' : CyrClosedSmallYusShape df CAP true
-		create-forked-glyph 'cyrl/SmallYusClosed.curly' : CyrClosedSmallYusShape df CAP false
+		create-forked-glyph 'cyrl/SmallYusClosed.curly'    : CyrClosedSmallYusShape df CAP false
 
 	create-glyph : glyph-proc
-		local df : include : DivFrame 1
+		local df : include : DivFrame 1 2
 		include : df.markSet.e
 		create-forked-glyph 'cyrl/smallYusClosed.straight' : CyrClosedSmallYusShape df XH true
-		create-forked-glyph 'cyrl/smallYusClosed.curly' : CyrClosedSmallYusShape df XH false
+		create-forked-glyph 'cyrl/smallYusClosed.curly'    : CyrClosedSmallYusShape df XH false
 
 	select-variant 'cyrl/SmallYus' 0x466 (follow -- 'cyrl/Yus')
 	select-variant 'cyrl/smallYus' 0x467 (follow -- 'cyrl/Yus')
-	select-variant 'cyrl/SmallYusClosed' 0xA658 (follow -- 'grek/Delta')
-	select-variant 'cyrl/smallYusClosed' 0xA659 (follow -- 'grek/Delta')
+	select-variant 'cyrl/SmallYusClosed' 0xA658 (follow -- 'cyrl/Yus')
+	select-variant 'cyrl/smallYusClosed' 0xA659 (follow -- 'cyrl/Yus')
 
 	define [CyrIotifiedSmallYusShape fClosed fCapital df top straightBar] : glyph-proc
 		local gap : (df.width - 2 * df.leftSB - [if fClosed 3 4] * df.mvs) / 3
@@ -115,7 +115,7 @@ glyph-block Letter-Cyrillic-SmallYus : begin
 			CyrIotifiedSmallYusShape false false df XH false
 
 	create-glyph : glyph-proc
-		local df : include : DivFrame para.advanceScaleM 3.5
+		local df : include : DivFrame [mix 1 para.advanceScaleM 2] 3.5
 		include : df.markSet.capital
 		create-forked-glyph 'cyrl/SmallYusClosedIotified.straight'
 			CyrIotifiedSmallYusShape true true df CAP true
@@ -132,5 +132,5 @@ glyph-block Letter-Cyrillic-SmallYus : begin
 
 	select-variant 'cyrl/SmallYusIotified' 0x468 (follow -- 'cyrl/Yus')
 	select-variant 'cyrl/smallYusIotified' 0x469 (follow -- 'cyrl/Yus')
-	select-variant 'cyrl/SmallYusClosedIotified' 0xA65C (follow -- 'grek/Delta')
-	select-variant 'cyrl/smallYusClosedIotified' 0xA65D (follow -- 'grek/Delta')
+	select-variant 'cyrl/SmallYusClosedIotified' 0xA65C (follow -- 'cyrl/Yus')
+	select-variant 'cyrl/smallYusClosedIotified' 0xA65D (follow -- 'cyrl/Yus')


### PR DESCRIPTION
This basically makes the closed form (`Ꙙ`/`ꙙ`) match the advance width of the normal/"open" form (`Ѧ`/`ѧ`) appearing as if written by starting with the original and simply deleting the middle leg and adding an underbar.

Its resemblance to Cyrillic A (`А`) or Greek Delta (`Δ`) is arguably superficial, at least by comparison to its known direct lineage (ignoring all the convergence/divergence throughout history, tracing back to Glagolitic).

Also make the closed form follow the same CV features as the open form.

For each screenshot below: Top row is before, bottom row is after.

`ѦꙘѨꙜѧꙙѩꙝ`

Aile Thin:
<img width="695" height="243" alt="image" src="https://github.com/user-attachments/assets/e65b50d4-ed80-4462-ba84-2917f14d2203" />

Aile Regular:
<img width="703" height="254" alt="image" src="https://github.com/user-attachments/assets/abce6580-3980-4f8a-946a-ecc2b26c0d9a" />

Aile Heavy:
<img width="707" height="245" alt="image" src="https://github.com/user-attachments/assets/b3afb0ab-fe81-4982-a097-41276f6d8f7e" />

Etoile Thin:
<img width="708" height="240" alt="image" src="https://github.com/user-attachments/assets/a53cfb9d-4051-40c8-ac01-8ead19480db1" />

Etoile Regular:
<img width="703" height="244" alt="image" src="https://github.com/user-attachments/assets/64d304bc-a009-4e32-97ef-84a8b7a69a99" />

Etoile Heavy:
<img width="702" height="245" alt="image" src="https://github.com/user-attachments/assets/702e9af8-7936-40ad-9f91-a6dbc9841344" />
