### PR TITLE
Fix broken geometry for `cyrl/be` with custom build plan (#2822).

### DIFF
--- a/packages/font-glyphs/src/letter/cyrillic/lower-be.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/lower-be.ptl
@@ -9,21 +9,18 @@ glyph-block Letter-Cyrillic-Lower-Be : begin
 	glyph-block-import Common-Derivatives
 
 	create-glyph 'cyrl/be' 0x431 : glyph-proc
-		local df : include : DivFrame 1
-		include : df.markSet.b
+		include : MarkSet.b
 
 		local yRingTop : Math.min (XH + O) (XH - QuarterStroke)
-		local ada : df.archDepthAOf : SmallArchDepth * yRingTop / XH
-		local adb : df.archDepthBOf : SmallArchDepth * yRingTop / XH
+		local ada : ArchDepthAOf (SmallArchDepth * yRingTop / XH) Width
+		local adb : ArchDepthBOf (SmallArchDepth * yRingTop / XH) Width
 
 		include : dispiro
 			widths.rhs ShoulderFine
 			straight.up.start (SB + OX + [HSwToV : Stroke - ShoulderFine]) (yRingTop - ada)
 			arch.rhs yRingTop (swBefore -- ShoulderFine)
-			flat (RightSB - OX) (yRingTop - adb)
-			curl (RightSB - OX) ada
+			flatside.rd RightSB 0 yRingTop ada adb
 			arch.rhs 0
-			flat (SB + OX) adb
-			curl (SB + OX) (yRingTop - ada)
+			flatside.lu SB      0 yRingTop ada adb
 			alsoThruThem [list {0.3 0.85} {0.65 0.925}] important g4
 			g4   (RightSB - [HSwToV : Stroke / 16]) Ascender [heading Rightward]


### PR DESCRIPTION
The build config included in the issue report compiles without error after changing `flat`/`curl` to `flatside`.

The character is otherwise unchanged under default parameters (that is to say without any metric overrides).