### PR TITLE
Refactor of `letter/greek/lower-delta.ptl` (Continuation of #2823).

### DIFF
--- a/packages/font-glyphs/src/letter/greek/lower-delta.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-delta.ptl
@@ -12,9 +12,8 @@ glyph-block Letter-Greek-Lower-Delta : begin
 	create-glyph 'grek/delta.rounded' : glyph-proc
 		include : MarkSet.b
 
-		local yRingTop : QuarterStroke + Ascender * 0.619
+		local yRingTop : Ascender * 0.619 + QuarterStroke
 		local xNeck   : mix SB RightSB 0.06
-		local xOTLeft : mix SB RightSB 0.5
 
 		include : dispiro
 			g4   [mix Middle RightSB 0.85] [mix XH Ascender 0.8] [widths.lhs]
@@ -23,39 +22,32 @@ glyph-block Letter-Greek-Lower-Delta : begin
 			archv 2
 			g4   (xNeck + Stroke) [mix (Ascender - O - Stroke) yRingTop 0.5] [widths.rhs]
 			arcvh 2
-			g4   xOTLeft yRingTop [heading Rightward]
+			g4   Middle yRingTop [heading Rightward]
 			alsoThruThem : list {0.25 0.05} {0.5 0.13}
-			flat (RightSB - OX) (yRingTop - SmallArchDepthB)
-			curl (RightSB - OX) SmallArchDepthA
+			flatside.rd RightSB 0 yRingTop SmallArchDepthA SmallArchDepthB
 			arch.rhs 0
-			flat (SB + OX) SmallArchDepthB
-			curl (SB + OX) (yRingTop - SmallArchDepthA)
+			flatside.lu SB 0 yRingTop SmallArchDepthA SmallArchDepthB
 			arcvh
-			g4   xOTLeft (yRingTop - QuarterStroke) [widths.rhs HalfStroke]
+			g4   Middle (yRingTop - QuarterStroke) [widths.rhs HalfStroke]
 
 	create-glyph 'grek/delta.flatTop' : glyph-proc
 		include : MarkSet.b
 
-		local fine ShoulderFine
-		local coFine : mix fine Stroke 0.5
 		local yTop : Ascender - Stroke
-		local yMid : QuarterStroke + [mix 0 XH (7 / 8)]
-		local yMid2 : mix yMid [YSmoothMidR yMid 0 SmallArchDepthA SmallArchDepthB] 0.95
-		local yMid3 : mix yMid [YSmoothMidR yMid 0 SmallArchDepthA SmallArchDepthB] 0.5
-		local yMockBarStart : yMid3 + 2.25 * Stroke
+		local yMid : XH * 0.875 + QuarterStroke
+		local yMid2 : YSmoothMidR yMid 0 SmallArchDepthA SmallArchDepthB
+		local yMockBarStart : [mix yMid2 yMid 0.5] + 2.25 * Stroke
 		local pStraightBarStart : 0.75 - (Stroke / Ascender)
 
 		include : HBar.t SB RightSB Ascender
 		include : intersection [MaskBelow yTop] : dispiro
-			widths.lhs fine
-			flat (RightSB - OX - [HSwToV : Stroke - fine]) SmallArchDepthA
-			curl (RightSB - OX - [HSwToV : Stroke - fine]) (yMid - SmallArchDepthB)
-			arch.lhs yMid (swBefore -- fine)
-			flat (SB + OX) (yMid - SmallArchDepthA)
-			curl (SB + OX) SmallArchDepthB
+			widths.lhs ShoulderFine
+			flatside.ru (RightSB - [HSwToV : Stroke - ShoulderFine]) 0 yMid SmallArchDepthA SmallArchDepthB
+			arch.lhs yMid (swBefore -- ShoulderFine)
+			flatside.ld SB 0 yMid SmallArchDepthA SmallArchDepthB
 			arch.lhs 0
-			flat (RightSB - OX) SmallArchDepthA
-			curl (RightSB - OX) yMid2
+			flat (RightSB - OX) [Math.min SmallArchDepthA yMid2]
+			curl (RightSB - OX) [mix yMid2 yMid 0.05]
 			flat [mix Width SB pStraightBarStart] [mix yMockBarStart yTop pStraightBarStart]
 			curl [mix Width SB 1]                 [mix yMockBarStart yTop 1] [widths.rhs]
 


### PR DESCRIPTION
I noticed that `grek/delta` was also broken under the build plans included in #2822, despite not specifically throwing a compiler error, so I went ahead and fixed it too.

Even though the diff looks quite messy, nothing actually changes under the normal parameters (i.e. in builds without any metric overrides).