### PR TITLE
Stabilize certain characters when `para.xHeight` is changed via metric override.

### DIFF
--- a/packages/font-glyphs/src/letter/armenian/ca.ptl
+++ b/packages/font-glyphs/src/letter/armenian/ca.ptl
@@ -31,11 +31,9 @@ glyph-block Letter-Armenian-Ca : begin
 				flat xStart yStart
 				curl df.middle yStart
 				archv
-				flat df.rightSB (yStart - ArchDepthB)
-				curl df.rightSB (0 + ArchDepthA)
+				flatside.rd df.rightSB 0 yStart ArchDepthA ArchDepthB 0
 				arch.rhs 0 (sw -- df.mvs)
-				flat df.leftSB (0 + ArchDepthB)
-				curl df.leftSB (yStart - ArchDepthA)
+				flatside.lu df.leftSB  0 yStart ArchDepthA ArchDepthB 0
 				arcvh
 				flat df.rightSB CAP
 				curl (df.rightSB + jut - [HSwToV : 0.5 * df.mvs]) CAP
@@ -58,11 +56,9 @@ glyph-block Letter-Armenian-Ca : begin
 				flat x1 Ascender [widths.center.heading df.mvs Downward]
 				sharp-corner x2 y2
 				curl x4 XH [widths.center df.mvs]
-				flat (df.rightSB - OX) (XH - SmallArchDepthB) [widths.rhs df.mvs]
-				curl (df.rightSB - OX) (0 + SmallArchDepthA)
+				flatside.rd df.rightSB 0 XH         SmallArchDepthA SmallArchDepthB nothing [widths.rhs df.mvs]
 				arch.rhs 0 (sw -- df.mvs)
-				flat (df.leftSB + OX) (0 + SmallArchDepthB)
-				curl (df.leftSB + OX) (highBarPos - SmallArchDepthA)
+				flatside.lu df.leftSB  0 highBarPos SmallArchDepthA SmallArchDepthB
 				arcvh
 				flat df.middle highBarPos
 				curl rExt highBarPos

--- a/packages/font-glyphs/src/letter/cyrillic/ze.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/ze.ptl
@@ -15,7 +15,6 @@ glyph-block Letter-Cyrillic-Ze : begin
 	glyph-block-import Letter-Shared-Shapes : SerifedArcStart SerifedArcEnd SerifFrame
 	glyph-block-import Letter-Shared-Shapes : InwardSlabArcStart InwardSlabArcEnd
 	glyph-block-import Letter-Shared-Shapes : ArcStartSerif ArcEndSerif
-	glyph-block-import Letter-Shared-Shapes : OBarLeft OBarRight
 	glyph-block-import Letter-Shared-Shapes : RetroflexHook CyrDescender
 	glyph-block-import Letter-Shared-Shapes : UpwardHookShape RhoticHookShape
 
@@ -43,8 +42,8 @@ glyph-block Letter-Cyrillic-Ze : begin
 			local midy : mix bot top OverlayPos
 			local topHeight : top - bot
 			local midyHeight : midy - bot
-			local ada : topHeight - [mix (midyHeight + stroke / 2) (topHeight - O - stroke) (ArchDepthB / (ArchDepthA + ArchDepthB))] - [HSwToV TanSlope] * stroke
-			local adb : [mix (stroke + O) (midyHeight - stroke / 2) (ArchDepthB / (ArchDepthA + ArchDepthB))] + [HSwToV TanSlope] * stroke
+			local ada : topHeight - [mix (midyHeight + stroke / 2) (topHeight - O - stroke) (ArchDepthB / (ArchDepthA + ArchDepthB))] - [HSwToV : TanSlope * stroke]
+			local adb : [mix (stroke + O) (midyHeight - stroke / 2) (ArchDepthB / (ArchDepthA + ArchDepthB))] + [HSwToV : TanSlope * stroke]
 			local fine : stroke * CThin
 			local stemFine : ShoulderFine * (stroke / Stroke)
 			return : object stroke midx midy ada adb fine stemFine
@@ -58,9 +57,12 @@ glyph-block Letter-Cyrillic-Ze : begin
 					[Just OPEN-VERTICAL] : flat SB top [widths.lhs.heading stroke Downward]
 					([Just CLOSED-CIRCLE] || [Just CLOSED-ROUND]) : list
 						flat (RightSB - [if (slabTop === CLOSED-CIRCLE) OX 0]) midy [widths.lhs stroke]
-						curl (RightSB - [if (slabTop === CLOSED-CIRCLE) OX 0]) (top - adb2)
+						curl (RightSB - [if (slabTop === CLOSED-CIRCLE) OX 0]) [Math.max (top - adb2) (midy + TINY)]
 						arch.lhs top (sw -- stroke)
-					[Just CLOSED-STEM] : OBarRight.arcStart top SB RightSB stroke stemFine ada2 adb2 midy
+					[Just CLOSED-STEM] : list
+						flat (RightSB - [HSwToV : stroke - stemFine]) midy [widths.lhs stemFine]
+						curl (RightSB - [HSwToV : stroke - stemFine]) [Math.max (top - adb2) (midy + TINY)]
+						arch.lhs top (sw -- stroke) (swBefore -- stemFine)
 					__ : list [g4 (RightSB + O) (top - hook) [widths.lhs]] [hookstart top (sw -- stroke)]
 				[if (slabTop === OPEN-VERTICAL) curl g4] SB [YSmoothMidL top (midy - stroke / 2)]
 				arcvh
@@ -80,9 +82,12 @@ glyph-block Letter-Cyrillic-Ze : begin
 					[Just OPEN-VERTICAL] : curl (SB + OX * 2) bot [heading Downward]
 					([Just CLOSED-CIRCLE] || [Just CLOSED-ROUND]) : list
 						arch.lhs bot (sw -- stroke)
-						flat (RightSB - [if (slabBot === CLOSED-CIRCLE) OX 0]) (bot + adb2)
+						flat (RightSB - [if (slabBot === CLOSED-CIRCLE) OX 0]) [Math.min (bot + ada2) (midy - TINY)]
 						curl (RightSB - [if (slabBot === CLOSED-CIRCLE) OX 0]) midy
-					[Just CLOSED-STEM] : OBarRight.arcEnd bot SB RightSB stroke stemFine ada2 adb2 midy
+					[Just CLOSED-STEM] : list
+						arch.lhs bot (sw -- stroke) (swAfter -- stemFine)
+						flat (RightSB - [HSwToV : stroke - stemFine]) [Math.min (bot + ada2) (midy - TINY)] [widths.lhs stemFine]
+						curl (RightSB - [HSwToV : stroke - stemFine]) midy
 					__ : list [hookend bot (sw -- stroke)] [g4 (RightSB - O) (bot + hook)]
 
 		export : define [Shape] : union [UpperShape] [LowerShape]
@@ -113,15 +118,15 @@ glyph-block Letter-Cyrillic-Ze : begin
 			local midy : mix bot top op
 			local topHeight : top - bot
 			local midyHeight : midy - bot
-			local adb : topHeight - [mix (midyHeight + stroke / 2) (topHeight - yo - stroke) (ArchDepthA / (ArchDepthA + ArchDepthB))] + [HSwToV TanSlope] * stroke
-			local ada : [mix (stroke + yo) (midyHeight - stroke / 2) (ArchDepthA / (ArchDepthA + ArchDepthB))] - [HSwToV TanSlope] * stroke
+			local adb : topHeight - [mix (midyHeight + stroke / 2) (topHeight - yo - stroke) (ArchDepthA / (ArchDepthA + ArchDepthB))] + [HSwToV : TanSlope * stroke]
+			local ada : [mix (stroke + yo) (midyHeight - stroke / 2) (ArchDepthA / (ArchDepthA + ArchDepthB))] - [HSwToV : TanSlope * stroke]
 			local fine : stroke * CThin
 			local stemFine : ShoulderFine * (stroke / Stroke)
 			return : object stroke midx midy ada adb fine stemFine
 
 		define [UpperShapeT sink] : begin
 			define [object stroke midx midy ada adb fine stemFine] : Dim
-			local middle : (left + right) / 2
+			local middle : mix left right 0.5
 			return : sink
 				match slabTop
 					[Just SLAB-CLASSICAL] : SerifedArcStart.LtrRhs left top stroke hook
@@ -132,9 +137,12 @@ glyph-block Letter-Cyrillic-Ze : begin
 					[Just OPEN-VERTICAL] : flat right top [widths.rhs.heading stroke Downward]
 					([Just CLOSED-CIRCLE] || [Just CLOSED-ROUND]) : list
 						flat (left + [if (slabTop === CLOSED-CIRCLE) xo 0]) midy [widths.rhs stroke]
-						curl (left + [if (slabTop === CLOSED-CIRCLE) xo 0]) (top - ada2)
+						curl (left + [if (slabTop === CLOSED-CIRCLE) xo 0]) [Math.max (top - ada2) (midy + TINY)]
 						arch.rhs top (sw -- stroke)
-					[Just CLOSED-STEM] : OBarLeft.arcStart top left right stroke stemFine ada2 adb2 midy
+					[Just CLOSED-STEM] : list
+						flat (left + [HSwToV : stroke - stemFine]) midy [widths.rhs stemFine]
+						curl (left + [HSwToV : stroke - stemFine]) [Math.max (top - ada2) (midy + TINY)]
+						arch.rhs top (sw -- stroke) (swBefore -- stemFine)
 					__ : list [g4 (left - xo) (top - hook) [widths.rhs stroke]] [hookstart top (sw -- stroke)]
 				[if (slabTop === OPEN-VERTICAL) curl g4] right [YSmoothMidR top (midy - stroke / 2)]
 				arcvh
@@ -143,7 +151,7 @@ glyph-block Letter-Cyrillic-Ze : begin
 
 		define [LowerShapeT sink] : begin
 			define [object stroke midx midy ada adb fine stemFine] : Dim
-			local middle : (left + right) / 2
+			local middle : mix left right 0.5
 			return : sink
 				flat midx (midy + (fine - stroke / 2)) [widths.heading 0 fine Rightward]
 				curl middle (midy + (fine - stroke / 2)) [heading Rightward]
@@ -158,9 +166,12 @@ glyph-block Letter-Cyrillic-Ze : begin
 					[Just OPEN-VERTICAL] : curl (right - xo * 2) bot [heading Downward]
 					([Just CLOSED-CIRCLE] || [Just CLOSED-ROUND]) : list
 						arch.rhs bot (sw -- stroke)
-						flat (left + [if (slabBot === CLOSED-CIRCLE) xo 0]) (bot + adb2)
+						flat (left + [if (slabBot === CLOSED-CIRCLE) xo 0]) [Math.min (bot + adb2) (midy - TINY)]
 						curl (left + [if (slabBot === CLOSED-CIRCLE) xo 0]) midy
-					[Just CLOSED-STEM] : OBarLeft.arcEnd bot left right stroke stemFine ada2 adb2 midy
+					[Just CLOSED-STEM] : list
+						arch.rhs bot (sw -- stroke) (swAfter -- stemFine)
+						flat (left + [HSwToV : stroke - stemFine]) [Math.min (bot + adb2) (midy - TINY)] [widths.rhs stemFine]
+						curl (left + [HSwToV : stroke - stemFine]) midy
 					__ : list [hookend bot (sw -- stroke)] [g4 (left + xo) (bot + hook)]
 
 		export : define [UpperShape] : UpperShapeT dispiro
@@ -169,7 +180,7 @@ glyph-block Letter-Cyrillic-Ze : begin
 
 		define [LowerShapeTailed] : begin
 			define [object stroke midx midy ada adb fine] : Dim
-			local middle : (left + right) / 2
+			local middle : mix left right 0.5
 			return : dispiro
 				flat (TanSlope * Stroke + [Math.max (left + (Stroke - [mix Descender Stroke 0.5]) * 1.1 + 1) middle]) Descender [widths.rhs]
 				curl (TanSlope * Stroke + left + (Stroke - [mix Descender Stroke 0.5]) * 1.1) Descender

--- a/packages/font-glyphs/src/letter/greek/lower-sigma-final.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-sigma-final.ptl
@@ -10,7 +10,6 @@ glyph-block Letter-Greek-Lower-Sigma-Final : begin
 	glyph-block-import Common-Derivatives
 
 	define [SigmaFinalEndingKnots] : list
-		curl (SB + OX) SmallArchDepthB
 		arcvh
 		g4 [arch.adjust-x.bot Middle] 0
 		alsoThru 0.5 0.1353
@@ -25,7 +24,7 @@ glyph-block Letter-Greek-Lower-Sigma-Final : begin
 			widths.lhs
 			g4 RightSB (XH - Hook)
 			hookstart XH
-			flat (SB + OX) (XH - SmallArchDepthA)
+			flatside.ld SB 0 XH SmallArchDepthA SmallArchDepthB
 			SigmaFinalEndingKnots
 
 	create-glyph 'grek/stigma' 0x3DB : glyph-proc
@@ -37,7 +36,7 @@ glyph-block Letter-Greek-Lower-Sigma-Final : begin
 			g2 [mix [arch.adjust-x.top Middle] (RightSB - [HSwToV fine]) 0.5] (XH - O - Hook * [StrokeWidthBlend 0.05 0.025]) [widths.lhs.heading Stroke Leftward]
 			g4 [arch.adjust-x.top Middle] (XH - O)
 			archv 16
-			flat (SB + OX) (XH - SmallArchDepthA)
+			flatside.ld SB 0 XH SmallArchDepthA SmallArchDepthB
 			SigmaFinalEndingKnots
 
 	create-glyph 'grek/Stigma' 0x3DA : glyph-proc

--- a/packages/font-glyphs/src/letter/greek/lower-sigma.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-sigma.ptl
@@ -11,16 +11,14 @@ glyph-block Letter-Greek-Lower-Sigma : begin
 
 	create-glyph 'grek/sigma' 0x3C3 : glyph-proc
 		include : MarkSet.e
-		local fine : clamp [AdviceStroke 8] (Stroke * 0.625) (Stroke * 0.25)
+		local fine : Math.max QuarterStroke : AdviceStroke 8
 		include : dispiro
 			widths.lhs
 			flat (RightSB + SideJut + [HSwToV : 0.15 * Stroke]) XH [heading Leftward]
 			curl Middle (XH - O) [heading Leftward]
 			archv
-			flat (SB + OX) (XH - SmallArchDepthA)
-			curl (SB + OX) SmallArchDepthB
+			flatside.ld SB      0 XH SmallArchDepthA SmallArchDepthB
 			arch.lhs 0
-			flat RightSB SmallArchDepthA
-			curl RightSB (XH - SmallArchDepthB)
+			flatside.ru RightSB 0 XH SmallArchDepthA SmallArchDepthB 0
 			arcvh
-			g4.left.end Middle (XH - Stroke + fine - O) [widths.lhs.heading fine Leftward]
+			g4.left.end Middle (XH - O - (Stroke - fine)) [widths.lhs.heading fine Leftward]

--- a/packages/font-glyphs/src/letter/greek/upper-omega.ptl
+++ b/packages/font-glyphs/src/letter/greek/upper-omega.ptl
@@ -12,22 +12,20 @@ glyph-block Letter-Greek-Upper-Omega : begin
 
 	define [UpperOmegaShape top extend ada adb] : glyph-proc
 		local fine : Stroke * CThin
-		local x1 [mix SB RightSB 0.4]
-		local x2 (Width - x1)
+		local x1 : mix SB RightSB 0.4
+		local x2 : Width - x1
 		local yattach : top * extend + Stroke
 		include : dispiro
 			g4   x1 (yattach - fine) [widths.rhs.heading fine Leftward]
 			archv
-			flat SB (yattach - Stroke + adb) [widths.rhs Stroke]
-			curl SB (top - ada)
+			flatside.lu SB      (yattach - Stroke) top ada adb 0 [widths.rhs Stroke]
 			arch.rhs top
-			flat RightSB (top - adb)
-			curl RightSB (yattach - Stroke + ada)
+			flatside.rd RightSB (yattach - Stroke) top ada adb 0
 			arcvh
 			g4   x2 (yattach - fine) [widths.heading 0 fine Leftward]
-		include : VBar.r x1 0 (yattach) fine
+		include : VBar.r x1 0 yattach fine
 		include : HBar.m SB x1 HalfStroke
-		include : VBar.l x2 0 (yattach) fine
+		include : VBar.l x2 0 yattach fine
 		include : HBar.m x2 RightSB HalfStroke
 
 	create-glyph 'grek/Omega' 0x3A9 : glyph-proc

--- a/packages/font-glyphs/src/letter/latin-ext/insular-t.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/insular-t.ptl
@@ -15,8 +15,7 @@ glyph-block Letter-Latin-Insular-T : begin
 		include : dispiro
 			straight.left.start Middle (top - Stroke + fine) [widths.lhs.heading fine Leftward]
 			archv
-			flat (SB + OX) (top - ada - Stroke + fine) [widths.lhs]
-			curl (SB + OX) (bot + adb)
+			flatside.ld SB bot (top - Stroke + fine) ada adb nothing [widths.lhs]
 			hookend bot
 			g4 RightSB (bot + Hook)
 

--- a/packages/font-glyphs/src/letter/latin/k.ptl
+++ b/packages/font-glyphs/src/letter/latin/k.ptl
@@ -188,7 +188,7 @@ glyph-block Letter-Latin-K : begin
 					flat kshLeft (0.5 * top + stroke / 2) [widths.rhs.heading stroke Rightward]
 					curl [mix kshLeft right 0.5] (0.5 * top + stroke / 2)
 					archv
-					flat right (0.5 * top + stroke / 2 - ArchDepthB)
+					flat right ([Math.max (0.5 * top - ArchDepthB) (hookDepth + Hook + TINY)] + stroke / 2)
 					curl right (hookDepth + Hook + stroke / 2)
 					arcvh
 					straight.left.end (right - HookX - [HSwToV : 0.5 * stroke]) hookDepth

--- a/packages/font-glyphs/src/letter/latin/lower-a.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-a.ptl
@@ -159,8 +159,7 @@ glyph-block Letter-Latin-Lower-A : begin
 			bezControls k1 k2 k3 1 6
 			arch.rhs.centerAt.rtl.b middle 0
 			archv
-			flat (SB + OX * 2) SmallArchDepthB
-			curl (SB + OX * 2) (XH - SmallArchDepthA)
+			flatside.lu SB 0 XH SmallArchDepthA SmallArchDepthB (OX * 2)
 			arcvh
 			arch.rhs.centerAt.ltr.t middle XH
 			bezControls (1 - k3) 0 (1 - k1) (1 - k2) 6

--- a/packages/font-glyphs/src/letter/latin/upper-b.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-b.ptl
@@ -192,8 +192,8 @@ glyph-block Letter-Latin-Upper-B : begin
 		local stroke : AdviceStroke2 2 3 top
 		local fine : stroke * CThin
 		local yMiddle : top * HBarPos
-		local adb : top - [mix (yMiddle + stroke / 2) (top - O - stroke) (ArchDepthA / (ArchDepthA + ArchDepthB))] + [HSwToV TanSlope] * stroke
-		local ada : [mix (stroke + O) (yMiddle - stroke / 2) (ArchDepthA / (ArchDepthA + ArchDepthB))] - [HSwToV TanSlope] * stroke
+		local adb : top - [mix (yMiddle + stroke / 2) (top - O - stroke) (ArchDepthA / (ArchDepthA + ArchDepthB))] + [HSwToV : TanSlope * stroke]
+		local ada : [mix (stroke + O) (yMiddle - stroke / 2) (ArchDepthA / (ArchDepthA + ArchDepthB))] - [HSwToV : TanSlope * stroke]
 		local xMidLeft : mix (RightSB - [HSwToV stroke]) (SB + [HSwToV stroke]) 0.7
 		local xMidArc : Math.max [mix xMidLeft RightSB 0.1] [mix SB RightSB 0.5]
 		include : dispiro
@@ -203,10 +203,9 @@ glyph-block Letter-Latin-Upper-B : begin
 			archv
 			g4   (RightSB - (OX - O)) (top - adb) [widths.lhs stroke]
 			arch.lhs top
-			flat (SB + O) (top - SmallArchDepthA)
-			curl (SB + O) (0   + SmallArchDepthB)
+			flatside.ld SB 0 top SmallArchDepthA SmallArchDepthB O
 			arch.lhs 0
-			g4   (RightSB - (OX + O)) (0 + ada)
+			g4   (RightSB - (OX + O)) (0   + ada)
 			arcvh
 			flat xMidArc  (yMiddle + (fine - stroke / 2)) [widths.heading fine 0 Leftward]
 			curl xMidLeft (yMiddle + (fine - stroke / 2)) [widths.heading fine 0 Leftward]
@@ -281,7 +280,7 @@ glyph-block Letter-Latin-Upper-B : begin
 		local r0 : 0.2 * (RightSB - SB)
 
 		local ry : r0 + 0.25 * fine
-		local rx : r0 + 0.25 * [HSwToV fine]
+		local rx : r0 + [HSwToV : 0.25 * fine]
 
 		local cx : RightSB - rx
 		local cyt : XH - 1.375 * ry
@@ -294,8 +293,7 @@ glyph-block Letter-Latin-Upper-B : begin
 			arch.lhs (cyt - ry) (sw -- fine)
 			g4 (cx + rx - OX) [YSmoothMidR.cr cyt ry]
 			arch.lhs XH (swBefore -- fine)
-			flat SB (XH - SmallArchDepthA)
-			curl SB (0  + SmallArchDepthB)
+			flatside.ld SB 0 XH SmallArchDepthA SmallArchDepthB 0
 			arch.lhs 0 (swAfter -- fine)
 			g4 (cx + rx - OX) [YSmoothMidR.cr cyb ry] [widths.lhs fine]
 			arch.lhs (cyb + ry) (sw -- fine)

--- a/packages/font-glyphs/src/letter/latin/upper-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-g.ptl
@@ -25,7 +25,9 @@ glyph-block Letter-Latin-Upper-G : begin
 	define SLAB-LETTER        1
 	define SLAB-INWARD        2
 
-	define [GShape toothShape slabShape crossBarShape top ada adb _hook _yBar] : glyph-proc
+	define [GShape toothShape slabShape crossBarShape top _ada _adb _hook _yBar] : glyph-proc
+		local ada : fallback _ada ArchDepthA
+		local adb : fallback _adb ArchDepthB
 		local hook : fallback _hook Hook
 		local yBar : fallback _yBar (top * 0.52 + QuarterStroke)
 		local fine ShoulderFine
@@ -35,36 +37,34 @@ glyph-block Letter-Latin-Upper-G : begin
 			[Just SLAB-INWARD] : InwardSlabArcStart.RtlLhs RightSB top Stroke hook
 			__ : list [widths.lhs] [g4 RightSB (top - hook)] [hookstart top]
 
-		knots.push
-			flat (SB + OX) (top - ada)
-			curl (SB + OX) adb
+		knots.push [flatside.ld SB 0 top ada adb]
 
 		match toothShape
 			[Just TOOTHED] : knots.push
 				arch.lhs 0 (swAfter -- fine)
-				straight.up.end (RightSB - [HSwToV (Stroke - fine)]) ada [widths.lhs.heading fine Upward]
+				straight.up.end (RightSB - [HSwToV : Stroke - fine]) ada [widths.lhs.heading fine Upward]
 			[Just TOOTHLESS-CORNER] : knots.push
 				arch.lhs 0 (blendPost -- {})
 				g4   RightSB  DToothlessRise
 			[Just TOOTHLESS-ROUNDED] : knots.push
 				arch.lhs 0
-				flat RightSB ada
+				flat RightSB [Math.min ada : yBar - TINY]
 				curl RightSB yBar [heading Upward]
 
 		include : union
 			dispiro.apply null knots
-			if (slabShape === SLAB-LETTER) [ArcStartSerif.R RightSB top Stroke hook] [glyph-proc]
+			if (slabShape === SLAB-LETTER) [ArcStartSerif.R       RightSB top Stroke hook] [glyph-proc]
 			if (slabShape === SLAB-INWARD) [ArcStartSerif.InwardR RightSB top Stroke hook] [glyph-proc]
 			match crossBarShape
-				[Just CROSSBAR-NONE]   : glyph-proc
-				[Just CROSSBAR-HOOKED] : HBar.t Middle RightSB yBar
+				[Just CROSSBAR-HOOKED] : HBar.t Middle      RightSB              yBar
 				[Just CROSSBAR-CAPPED] : HBar.t Middle [mix RightSB Width 0.625] yBar
+				__ : glyph-proc
 			match toothShape
 				[Just TOOTHED] : union
-					VBar.r RightSB (ada + O) yBar
-					VBar.r RightSB ada 0 [Math.max (Stroke - fine / 2) : AdviceStroke 5]
-				[Just TOOTHLESS-CORNER]  : VBar.r RightSB DToothlessRise yBar
-				[Just TOOTHLESS-ROUNDED] : glyph-proc
+					VBar.r RightSB ([Math.min ada : yBar - TINY] + O) yBar
+					VBar.r RightSB ([Math.min ada : yBar - TINY] + 0) 0 [Math.max (Stroke - fine / 2) : AdviceStroke 5]
+				[Just TOOTHLESS-CORNER] : VBar.r RightSB DToothlessRise yBar
+				__ : glyph-proc
 
 	create-glyph 'GBarOverlay' : LetterBarOverlay.r.in
 		x     -- RightSB
@@ -89,19 +89,19 @@ glyph-block Letter-Latin-Upper-G : begin
 	foreach { suffix { shape slabType crossBarShape } } [Object.entries GConfig] : begin
 		create-glyph "G.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : GShape shape slabType crossBarShape CAP ArchDepthA ArchDepthB
+			include : GShape shape slabType crossBarShape CAP
 		create-glyph "GHookTop.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : GShape shape slabType crossBarShape CAP ArchDepthA ArchDepthB
+			include : GShape shape slabType crossBarShape CAP
 			include : TopHook.toRight.arcStart RightSB CAP Hook
 			include : ExtendAboveBaseAnchors (CAP + Ascender - XH)
 			include : LeaningAnchor.Above.VBar.r RightSB
 		create-glyph "smcpG.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			include : GShape shape slabType crossBarShape XH ArchDepthA ArchDepthB
+			include : GShape shape slabType crossBarShape XH
 		create-glyph "smcpGHookTop.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			include : GShape shape slabType crossBarShape XH ArchDepthA ArchDepthB
+			include : GShape shape slabType crossBarShape XH
 			include : TopHook.toRight.arcStart RightSB XH Hook
 			include : ExtendAboveBaseAnchors Ascender
 			include : LeaningAnchor.Above.VBar.r RightSB
@@ -147,10 +147,9 @@ glyph-block Letter-Latin-Upper-G : begin
 		widths.lhs BBS
 		g4 (RightSB - offset) (top - Hook)
 		hookstart (top - offset) (sw -- BBS)
-		flat (SB + OX + offset) (top - ada)
-		curl (SB + OX + offset) adb
+		flatside.ld (SB + offset) 0 top ada adb
 		arch.lhs offset (sw -- BBS)
-		flat (xTerm - offset) ada
+		flat (xTerm - offset) [Math.min ada : yTerm - TINY]
 		curl (xTerm - offset) yTerm [heading Upward]
 
 	create-glyph 'mathbb/G' 0x1D53E : glyph-proc

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -241,7 +241,7 @@ glyph-block Letter-Shared-Shapes : begin
 
 			return : list
 				flat (left - [HSwToV fine]) leftY0 [widths.rhs fine]
-				curl (left - [HSwToV fine]) (top - ada)
+				curl (left - [HSwToV fine]) [Math.max (top - ada) (leftY0 + TINY)]
 				arch.rhs top (sw -- stroke) (swBefore -- fine)
 				flat right [Math.max (top - adb) (bottom + TINY)] [widths.rhs stroke]
 				[if fMask corner curl] right bottom [widths.rhs.heading stroke Downward]
@@ -273,7 +273,7 @@ glyph-block Letter-Shared-Shapes : begin
 
 			return : list
 				flat (right + [HSwToV fine]) rightY0 [widths.rhs fine]
-				curl (right + [HSwToV fine]) (bottom + ada)
+				curl (right + [HSwToV fine]) [Math.min (bottom + ada) (rightY0 - TINY)]
 				arch.rhs bottom (sw -- stroke) (swBefore -- fine)
 				flat left [Math.min (bottom + adb) (top - TINY)] [widths.rhs stroke]
 				[if fMask corner curl] left top [widths.rhs.heading stroke Upward]

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -243,7 +243,7 @@ glyph-block Letter-Shared-Shapes : begin
 				flat (left - [HSwToV fine]) leftY0 [widths.rhs fine]
 				curl (left - [HSwToV fine]) (top - ada)
 				arch.rhs top (sw -- stroke) (swBefore -- fine)
-				flat right (top - adb) [widths.rhs stroke]
+				flat right [Math.max (top - adb) (bottom + TINY)] [widths.rhs stroke]
 				[if fMask corner curl] right bottom [widths.rhs.heading stroke Downward]
 				if [not fMask] {} {[corner left bottom]}
 
@@ -275,7 +275,7 @@ glyph-block Letter-Shared-Shapes : begin
 				flat (right + [HSwToV fine]) rightY0 [widths.rhs fine]
 				curl (right + [HSwToV fine]) (bottom + ada)
 				arch.rhs bottom (sw -- stroke) (swBefore -- fine)
-				flat left (bottom + adb) [widths.rhs stroke]
+				flat left [Math.min (bottom + adb) (top - TINY)] [widths.rhs stroke]
 				[if fMask corner curl] left top [widths.rhs.heading stroke Upward]
 				if fMask {[corner right top]} {}
 		export : define [shape] : begin
@@ -303,7 +303,7 @@ glyph-block Letter-Shared-Shapes : begin
 
 			return : dispiro
 				flat left top [widths.lhs.heading sw Downward]
-				curl left (bottom + adb)
+				curl left [Math.min (bottom + adb) (top - TINY)]
 				arch.lhs.centerAt.ltr.b (xMid + [HSwToV : 0.2 * sw]) bottom
 				g4 right (bottom + rise + 0.25 * sw) [widths.lhs fine]
 


### PR DESCRIPTION
These are all the characters I could find within the BMP which were broken under the build config attached in #2822 .

Assuming I did everything correctly, nothing should change under normal parameters (i.e. without metric overrides).

I did, however, deliberately change one of the `adb2` to an `ada2` in `letter/cyrillic/ze.ptl` because it appeared to be a defect. Other than that, I tried my best to preserve e.g. each character's overshoot behavior etc.