### PR TITLE
Continuation of #2826 .

### DIFF
--- a/packages/font-glyphs/src/common/shapes.ptl
+++ b/packages/font-glyphs/src/common/shapes.ptl
@@ -49,13 +49,13 @@ glyph-block CommonShapes : begin
 	define [SquareAt x y r] : Rect (y + r) (y - r) (x - r) (x + r)
 
 	glyph-block-export MaskAbove
-	define [MaskAbove y] : Rect (VERY-FAR) y (-VERY-FAR) (VERY-FAR)
+	define [MaskAbove y] : Rect (+VERY-FAR) y (-VERY-FAR) (+VERY-FAR)
 	glyph-block-export MaskBelow
-	define [MaskBelow y] : Rect y (-VERY-FAR) (-VERY-FAR) (VERY-FAR)
+	define [MaskBelow y] : Rect y (-VERY-FAR) (-VERY-FAR) (+VERY-FAR)
 	glyph-block-export MaskLeft
-	define [MaskLeft  x] : Rect VERY-FAR (-VERY-FAR) (-VERY-FAR) x
+	define [MaskLeft  x] : Rect (+VERY-FAR) (-VERY-FAR) (-VERY-FAR) x
 	glyph-block-export MaskRight
-	define [MaskRight x] : Rect VERY-FAR (-VERY-FAR) x VERY-FAR
+	define [MaskRight x] : Rect (+VERY-FAR) (-VERY-FAR) x (+VERY-FAR)
 
 	glyph-block-export MaskAboveLine
 	define [MaskAboveLine x1 y1 x2 y2 _ext] : begin
@@ -237,9 +237,9 @@ glyph-block CommonShapes : begin
 	define [UShapeT] : with-params [sink df top bottom [stroke Stroke] [ada ArchDepthA] [adb ArchDepthB] [offset 0]] : sink
 		widths.lhs stroke
 		[if (sink == spiro-outline) corner flat] (df.leftSB + offset) top [heading Downward]
-		curl (df.leftSB  + offset) (bottom + offset + adb)
+		curl (df.leftSB  + offset) [Math.min (bottom + offset + adb) (top - TINY)]
 		arch.lhs (bottom + offset) (sw -- stroke)
-		flat (df.rightSB - offset) (bottom + offset + ada)
+		flat (df.rightSB - offset) [Math.min (bottom + offset + ada) (top - TINY)]
 		[if (sink == spiro-outline) corner curl] (df.rightSB - offset) top [heading Upward]
 
 	glyph-block-export UShape
@@ -371,7 +371,7 @@ glyph-block CommonShapes : begin
 	glyph-block-export HOverlayObliqueBar
 	define [HOverlayObliqueBar xleft xright y s slant] : dispiro
 		widths.center [fallback s OverlayStroke]
-		flat xleft (y - [fallback slant : XH * 0.1])
+		flat xleft  (y - [fallback slant : XH * 0.1])
 		curl xright (y + [fallback slant : XH * 0.1])
 
 	glyph-block-export HCrossBar
@@ -420,10 +420,10 @@ glyph-block CommonShapes : begin
 		local doSwash : !noSwash && !isStart && atBottom && (para.isItalic || isTail) && [if (para.slopeAngle >= 0) ltr [not ltr]]
 		local superness DesignParameters.superness
 
-		local y : yRef + [if (yRef > toFinish.y) (-1) 1] * overshoot
+		local y : yRef + [if (yRef > toFinish.y) (-1) (+1)] * overshoot
 
 		# Adjust terminal's position if necessary
-		toFinish.x = toFinish.x + OXHook * [if ltr (-1) 1] * [if isStart (-1) 1]
+		toFinish.x = toFinish.x + OXHook * [if ltr (-1) (+1)] * [if isStart (-1) (+1)]
 		if (doSwash) : begin
 			local tailAdjX : Math.max (Hook * 0.5) (1.00 * sw)
 			local tailAdjY : Math.max (Hook * 0.5) (1.25 * sw)
@@ -435,10 +435,10 @@ glyph-block CommonShapes : begin
 		local v : Math.abs (toFinish.y - y)
 		local u : Math.abs (toFinish.x - toStraight.x)
 		local mixRatio : determineMixR w v u sw doSwash
-		local mx : [mix toStraight.x toFinish.x mixRatio] + [if atBottom 1 (-1)] * 0.75 * CorrectionOMidX * sw
+		local mx : [mix toStraight.x toFinish.x mixRatio] + [if atBottom (+1) (-1)] * 0.75 * CorrectionOMidX * sw
 		local keyKnotDirection : if ltr Rightward Leftward
-		local extraSlope : [if ltr 1 (-1)] * 0.5 * (sw - swTerminal) / sw
-		local finalTurnSlope : keyKnotDirection.x + extraSlope - [if ltr 1 (-1)] * 0.5 * TanSlope
+		local extraSlope : [if ltr (+1) (-1)] * 0.5 * (sw - swTerminal) / sw
+		local finalTurnSlope : keyKnotDirection.x + extraSlope - [if ltr (+1) (-1)] * 0.5 * TanSlope
 		local keyKnot : g4.[if ltr "right" "left"].mid
 			begin mx
 			begin y
@@ -454,10 +454,10 @@ glyph-block CommonShapes : begin
 
 			local headDirection : if doSwash
 				object
-					x (Contrast / [Math.hypot 1 skew] * [if dtu (-1) 1])
-					y (skew / [Math.hypot 1 skew] * [if ltr 1 (-1)])
+					x (Contrast / [Math.hypot 1 skew] * [if dtu (-1) (+1)])
+					y (skew / [Math.hypot 1 skew] * [if ltr (+1) (-1)])
 				object
-					x (Contrast * [if dtu (-1) 1])
+					x (Contrast * [if dtu (-1) (+1)])
 					y 0
 
 			set toFinish.af : new AfCombine toFinish.af [heading headDirection]
@@ -614,13 +614,13 @@ glyph-block CommonShapes : begin
 		define [superSin angle superness] : begin
 			if [not angle] : return 0
 			local s : Math.sin (angle * Math.PI / 180)
-			local sign : if (s < 0) (-1) 1
+			local sign : if (s < 0) (-1) (+1)
 			return : sign * ([Math.abs s] ** (2 / superness))
 
 		define [superCos angle superness] : begin
 			if [not angle] : return 1
 			local c : Math.cos (angle * Math.PI / 180)
-			local sign : if (c < 0) (-1) 1
+			local sign : if (c < 0) (-1) (+1)
 			return : sign * ([Math.abs c] ** (2 / superness))
 
 		define [mixR w angW v angV u] : begin

--- a/packages/font-glyphs/src/letter/cyrillic/abk-ha.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/abk-ha.ptl
@@ -9,17 +9,16 @@ glyph-block Letter-Cyrillic-Abkhasian-Ha : begin
 	glyph-block-import Common-Derivatives
 
 	define [CyrlAbkHaShape df top sm] : begin
-		local ada : ArchDepthAOf sm df.width
-		local adb : ArchDepthBOf sm df.width
-		local ada2 : ArchDepthAOf (0.625 * sm) df.width
-		local adb2 : ArchDepthBOf (0.625 * sm) df.width
+		local ada : df.archDepthAOf sm
+		local adb : df.archDepthBOf sm
+		local ada2 : df.archDepthAOf (0.625 * sm)
+		local adb2 : df.archDepthBOf (0.625 * sm)
 		local xm : df.middle - [HSwToV : 0.5 * df.mvs]
 		local y2 : top * 0.75
 		return : dispiro
 			arch.lhs.centerAt.rtl.t df.middle top (sw -- df.mvs) (knot-ty -- g4.left.start)
 			archv
-			flat (df.leftSB + OX) (top - ada)
-			curl (df.leftSB + OX) adb
+			flatside.ld df.leftSB 0 top ada adb
 			arch.lhs 0 (sw -- df.mvs)
 			straight.up.mid (df.rightSB - OX) [YSmoothMidR (y2 + df.mvs / 2) 0 ada2 adb2]
 			arch.lhs y2 (sw -- df.mvs)

--- a/packages/font-glyphs/src/letter/cyrillic/de.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/de.ptl
@@ -16,7 +16,7 @@ glyph-block Letter-Cyrillic-De : begin
 	glyph-block-export CyrDeBottom
 	define [CyrDeBottom left right _sw _desc] : glyph-proc
 		local descenderOverflow : if SLAB SideJut ((right - left) * 0.075)
-		local xTopLeft : mix left right : StrokeWidthBlend 0.15 0.1
+		local xTopLeft  : mix left right : StrokeWidthBlend 0.15 0.1
 		local xTopRight : mix left right : StrokeWidthBlend 0.95 0.96
 		local swOuter : fallback _sw Stroke
 		local desc : fallback _desc BottomExtension
@@ -32,7 +32,7 @@ glyph-block Letter-Cyrillic-De : begin
 	glyph-block-export CyrDeShape
 	define [CyrDeShape top left right _sw _desc fLower] : glyph-proc
 		local descenderOverflow : if SLAB SideJut ((right - left) * 0.075)
-		local xTopLeft : mix left right : StrokeWidthBlend 0.15 0.1
+		local xTopLeft  : mix left right : StrokeWidthBlend 0.15 0.1
 		local xTopRight : mix left right : StrokeWidthBlend 0.95 0.96
 		local swOuter : fallback _sw Stroke
 		local swInner : swOuter * [AdviceStroke 2.75] / Stroke
@@ -150,9 +150,6 @@ glyph-block Letter-Cyrillic-De : begin
 	## Italic
 	glyph-block-export CyrDeItalicShapeT
 	define [CyrDeItalicShapeT sink df _sw] : begin
-		local left  df.leftSB
-		local right df.rightSB
-		local middle : mix left right 0.5
 		local sw : fallback _sw df.mvs
 
 		local yRingTop : Math.min (XH + O) (XH - QuarterStroke)
@@ -161,15 +158,13 @@ glyph-block Letter-Cyrillic-De : begin
 
 		return : sink
 			widths.lhs ShoulderFine
-			straight.up.start (right - OX - [HSwToV : sw - ShoulderFine]) (yRingTop - adb)
+			straight.up.start (df.rightSB - OX - [HSwToV : sw - ShoulderFine]) (yRingTop - adb)
 			arch.lhs yRingTop (sw -- sw) (swBefore -- ShoulderFine)
-			flat (left + OX) (yRingTop - ada)
-			curl (left + OX) adb
+			flatside.ld df.leftSB  0 yRingTop ada adb
 			arch.lhs 0 (sw -- sw)
-			flat (right - OX) ada
-			curl (right - OX) (yRingTop - adb)
+			flatside.ru df.rightSB 0 yRingTop ada adb
 			quadControls 0 0.8
-			g4 (left + sw * 1.1) Ascender
+			g4 (df.leftSB + sw * 1.1) Ascender
 
 	create-glyph 'cyrl/de.italic' : glyph-proc
 		local df : include : DivFrame 1
@@ -184,7 +179,7 @@ glyph-block Letter-Cyrillic-De : begin
 			local dfLeft : df.slice 3 2 OX
 			include : CyrDeItalicShapeT dispiro dfLeft
 
-			local xZeLeft : dfLeft.leftSB + df.width - dfLeft.width + OX
+			local xZeLeft  : dfLeft.leftSB  + df.width - dfLeft.width + OX
 			local xZeRight : dfLeft.rightSB + df.width - dfLeft.width - OX
 			local ze : CyrZe 1 sb XH Descender
 				left     -- xZeLeft

--- a/packages/font-glyphs/src/letter/latin/v.ptl
+++ b/packages/font-glyphs/src/letter/latin/v.ptl
@@ -18,7 +18,7 @@ glyph-block Letter-Latin-V : begin
 	define VShapeFine : Math.max
 		Stroke * [if SLAB para.vtipfineSlab para.vtipfine]
 		VCornerHalfWidth * 1.2
-	define VShapeFineStraight : Stroke * CThin * 1.15
+	define VShapeFineStraight : 1.15 * Stroke * CThin
 	define pInktrap : 2 / 3
 	define VShapeMiddleWidth : Math.min [mix Stroke VShapeFineStraight pInktrap] [AdviceStroke 3]
 
@@ -27,7 +27,7 @@ glyph-block Letter-Latin-V : begin
 
 	glyph-block-export VShapeOutline
 	define [VShapeOutline] : with-params [df fBarStraight top [sw Stroke]] : glyph-proc
-		define cornerHW : VCornerHalfWidth * sw / Stroke
+		define cornerHW : VCornerHalfWidth * (sw / Stroke)
 		define dgCor : DiagCor top (Width / 2) 0 (sw * 2)
 		define clearance : 0 - OX
 
@@ -57,7 +57,7 @@ glyph-block Letter-Latin-V : begin
 				curl vxStartR top
 
 	define [VBottomCapShape df fBarStraight sw] : begin
-		define cornerHW : VCornerHalfWidth * sw / Stroke
+		define cornerHW : VCornerHalfWidth * (sw / Stroke)
 		return : spiro-outline
 			corner (df.middle + cornerHW) 0
 			corner (df.middle - cornerHW) 0
@@ -76,7 +76,7 @@ glyph-block Letter-Latin-V : begin
 		define vxEndR : df.middle + cornerHW
 
 		if fBarStraight : do
-			define midSW : dgCor * VShapeMiddleWidth / Stroke * sw
+			define midSW : dgCor * VShapeMiddleWidth * (sw / Stroke)
 			include : tagged 'strokeDown' : dispiro
 				widths.lhs (sw * dgCor)
 				flat [mix vxStartL vxEndL 0] [mix top 0 0] [heading Downward]
@@ -138,7 +138,7 @@ glyph-block Letter-Latin-V : begin
 			straight.left.start (df.rightSB + hookWidthOuter) (top - sw - O)
 			g4 (df.rightSB - hookWidthInner) (top - 0.5 * sw - TailY)
 			quadControls 0.4 0.75 64 unimportant
-			g4 (df.middle + VCornerHalfWidth * sw / Stroke) 0 [widths.rhs : VShapeFine * sw / Stroke]
+			g4 (df.middle + VCornerHalfWidth * (sw / Stroke)) 0 [widths.rhs : VShapeFine * (sw / Stroke)]
 
 	define [VLoopShape] : with-params [df fBarStraight top [sw Stroke]] : glyph-proc
 		include : VShape df fBarStraight top (sw -- sw)
@@ -146,7 +146,7 @@ glyph-block Letter-Latin-V : begin
 		include : VBottomCapShape df fBarStraight sw
 
 		define cornerHW : VCornerHalfWidth * (sw / Stroke)
-		define cornerSw : VShapeFine * sw / Stroke
+		define cornerSw : VShapeFine * (sw / Stroke)
 		define sbScale : if fBarStraight StraightSbShrink 1
 		define vxStartL : df.leftSB * sbScale
 		define vxEndL : df.middle - cornerHW
@@ -295,14 +295,14 @@ glyph-block Letter-Latin-V : begin
 		include : dispiro
 			widths.lhs
 			flat df.leftSB top [heading Downward]
-			curl df.leftSB adb
+			curl df.leftSB [Math.min adb : top - TINY]
 			arch.lhs 0
-			flat df.rightSB ada
+			flat df.rightSB [Math.min ada : top - Hook - HalfStroke - TINY]
 			curl df.rightSB (top - Hook - HalfStroke) [heading Upward]
 		include : VerticalHook.r
 			x -- df.rightSB
 			y -- (top - Hook - HalfStroke)
-			xDepth -- ((-RightSB) + Middle + [HSwToV HalfStroke])
+			xDepth -- ((-df.rightSB) + df.middle + [HSwToV HalfStroke])
 			yDepth -- (-Hook)
 
 	create-glyph 'VHookTop.serifless' : glyph-proc


### PR DESCRIPTION
These characters break under the build plans of #2822 when italicized and/or non-condensed.

The only character that seems to visually change here is Abkhaz Ha (`Ҩ`/`ҩ`), but only under Quasi-Proportional (monospace appears to be unchanged); However, I think it looks better this way since the larger arch depth actually makes sense for the width of the character.

For each screenshot below: left is before, right is after.

`Ҩҩ`

Aile Thin:
<img width="504" height="181" alt="image" src="https://github.com/user-attachments/assets/aab80725-e9fe-4445-bf72-caaf618ae693" />
Aile Regular:
<img width="486" height="153" alt="image" src="https://github.com/user-attachments/assets/880dacd4-d246-4d31-889e-ab080694a8d3" />
Aile Heavy:
<img width="482" height="140" alt="image" src="https://github.com/user-attachments/assets/ff1c5519-2a51-4bd4-9c8f-4b42b0cac6df" />
