### PR TITLE
Unify function arguments of `UShapeT` with `OShapeT`.

### DIFF
--- a/packages/font-glyphs/src/common/shapes.ptl
+++ b/packages/font-glyphs/src/common/shapes.ptl
@@ -33,8 +33,8 @@ glyph-block CommonShapes : begin
 	define [Rect u d l r transformShiftOnly] : glyph-proc
 		local giz currentGlyph.gizmo
 		include : new-glyph : glyph-proc
-			local my ((u + d) / 2)
-			local mx ((l + r) / 2)
+			local my : mix u d 0.5
+			local mx : mix l r 0.5
 			currentGlyph.gizmo = [if transformShiftOnly [Transform.Id] giz]
 			include : spiro-outline
 				corner l d
@@ -104,8 +104,8 @@ glyph-block CommonShapes : begin
 	define [Ring u d l r transformShiftOnly] : glyph-proc
 		local giz currentGlyph.gizmo
 		include : new-glyph : glyph-proc
-			local my ((u + d) / 2)
-			local mx ((l + r) / 2)
+			local my : mix u d 0.5
+			local mx : mix l r 0.5
 			currentGlyph.gizmo = [if transformShiftOnly [Transform.Id] giz]
 			include : spiro-outline
 				g4 mx d
@@ -129,8 +129,8 @@ glyph-block CommonShapes : begin
 	define [RingStroke u d l r s transformShiftOnly] : glyph-proc
 		local giz currentGlyph.gizmo
 		include : new-glyph : glyph-proc
-			local my ((u + d) / 2)
-			local mx ((l + r) / 2)
+			local my : mix u d 0.5
+			local mx : mix l r 0.5
 			currentGlyph.gizmo = [if transformShiftOnly [Transform.Id] giz]
 			include : dispiro
 				widths.rhs [fallback s Stroke]
@@ -163,8 +163,8 @@ glyph-block CommonShapes : begin
 			export : define [AtDimens u d l r transformShiftOnly] : glyph-proc
 				local giz currentGlyph.gizmo
 				include : new-glyph : glyph-proc
-					local my ((u + d) / 2)
-					local mx ((l + r) / 2)
+					local my : mix u d 0.5
+					local mx : mix l r 0.5
 					currentGlyph.gizmo = [if transformShiftOnly [Transform.Id] giz]
 					include : spiro-outline
 						g4 mx d
@@ -188,7 +188,7 @@ glyph-block CommonShapes : begin
 		if (l > r) : throw : new Error "OShapeT: l > r"
 		if (d > u) : throw : new Error "OShapeT: d > u"
 
-		local middle : (l + r) / 2
+		local middle : mix l r 0.5
 		local width : fallback _width Stroke
 		local ada : fallback _ada SmallArchDepthA
 		local adb : fallback _adb SmallArchDepthB
@@ -214,7 +214,7 @@ glyph-block CommonShapes : begin
 
 	glyph-block-export OShapeFlatTB
 	define [OShapeFlatTB u d l r _width _ada _adb gap] : glyph-proc
-		local middle : (l + r) / 2
+		local middle : mix l r 0.5
 		local width : fallback _width Stroke
 		local ada : fallback _ada SmallArchDepthA
 		local adb : fallback _adb SmallArchDepthB
@@ -234,24 +234,25 @@ glyph-block CommonShapes : begin
 			arch.lhs.centerAt.rtl.t  middle            u (sw -- width) (knot-ty -- curl) (o -- 0)
 
 	glyph-block-export UShapeT
-	define [UShapeT] : with-params [sink df top bottom [stroke Stroke] [ada ArchDepthA] [adb ArchDepthB] [offset 0]] : sink
-		widths.lhs stroke
-		[if (sink == spiro-outline) corner flat] (df.leftSB + offset) top [heading Downward]
-		curl (df.leftSB  + offset) [Math.min (bottom + offset + adb) (top - TINY)]
-		arch.lhs (bottom + offset) (sw -- stroke)
-		flat (df.rightSB - offset) [Math.min (bottom + offset + ada) (top - TINY)]
-		[if (sink == spiro-outline) corner curl] (df.rightSB - offset) top [heading Upward]
+	define [UShapeT sink u d l r _width _ada _adb] : begin
+		if (l > r) : throw : new Error "UShapeT: l > r"
+		if (d > u) : throw : new Error "UShapeT: d > u"
+
+		local width : fallback _width Stroke
+		local ada : fallback _ada ArchDepthA
+		local adb : fallback _adb ArchDepthB
+		return : sink
+			widths.lhs width
+			[if (sink == spiro-outline) corner flat] l u [heading Downward]
+			curl l [Math.min (d + adb) (u - TINY)]
+			arch.lhs d (sw -- width)
+			flat r [Math.min (d + ada) (u - TINY)]
+			[if (sink == spiro-outline) corner curl] r u [heading Upward]
 
 	glyph-block-export UShape
-	define [UShape] : with-params [df top bottom [stroke Stroke] [ada ArchDepthA] [adb ArchDepthB] [offset 0]] : glyph-proc
-		include : UShapeT dispiro
-			df     -- df
-			top    -- top
-			bottom -- bottom
-			stroke -- stroke
-			ada    -- ada
-			adb    -- adb
-			offset -- offset
+	define [UShape u d l r _width _ada _adb] : UShapeT dispiro u d l r _width _ada _adb
+	glyph-block-export UShapeOutline
+	define [UShapeOutline u d l r _width _ada _adb] : UShapeT spiro-outline u d l r _width _ada _adb
 
 	glyph-block-export HSerif
 	define HSerif : namespace
@@ -398,7 +399,7 @@ glyph-block CommonShapes : begin
 		local superness DesignParameters.superness
 		local r : piecewise
 			(w <= v)   0.5
-			true     : 1 / (((1 - ((1 - v / w) ** superness)) ** (1 / superness)) + 1)
+			true      (1 / (((1 - ((1 - v / w) ** superness)) ** (1 / superness)) + 1))
 		if swash : begin
 			local idepth : w - sw
 			local iwidth : u * r - sw
@@ -431,9 +432,9 @@ glyph-block CommonShapes : begin
 			toFinish.y = toFinish.y - tailAdjY * [Math.abs TanSlope]
 
 		# Compute key middle knot
-		local w : Math.abs (toStraight.y - y)
-		local v : Math.abs (toFinish.y - y)
-		local u : Math.abs (toFinish.x - toStraight.x)
+		local w : Math.abs : toStraight.y - y
+		local v : Math.abs : toFinish.y - y
+		local u : Math.abs : toFinish.x - toStraight.x
 		local mixRatio : determineMixR w v u sw doSwash
 		local mx : [mix toStraight.x toFinish.x mixRatio] + [if atBottom (+1) (-1)] * 0.75 * CorrectionOMidX * sw
 		local keyKnotDirection : if ltr Rightward Leftward
@@ -594,7 +595,7 @@ glyph-block CommonShapes : begin
 		define [impl args] : begin
 			local doAdj : not args.compact
 
-			local skew : [HSwToV : args.swAfter - args.swBefore] / (2 * args.sw)
+			local skew : [HSwToV : 0.5 * (args.swAfter - args.swBefore)] / args.sw
 			local heading : object
 				x : [boolePn args.rtl] * ([boolePn args.lhs] * skew + [boole doAdj] * TanSlope)
 				y : [boolePn args.lhs] * [boolePn args.atBot] * 1
@@ -613,15 +614,13 @@ glyph-block CommonShapes : begin
 
 		define [superSin angle superness] : begin
 			if [not angle] : return 0
-			local s : Math.sin (angle * Math.PI / 180)
-			local sign : if (s < 0) (-1) (+1)
-			return : sign * ([Math.abs s] ** (2 / superness))
+			local s : Math.sin : angle * Math.PI / 180
+			return : [Math.sign s] * ([Math.abs s] ** (2 / superness))
 
 		define [superCos angle superness] : begin
 			if [not angle] : return 1
-			local c : Math.cos (angle * Math.PI / 180)
-			local sign : if (c < 0) (-1) (+1)
-			return : sign * ([Math.abs c] ** (2 / superness))
+			local c : Math.cos : angle * Math.PI / 180
+			return : [Math.sign c] * ([Math.abs c] ** (2 / superness))
 
 		define [mixR w angW v angV u] : begin
 			if (w < v) : return : 1 - [mixR v angV w angW u]
@@ -644,9 +643,9 @@ glyph-block CommonShapes : begin
 			local before : fallback args.mockPre _before
 			local after : fallback args.mockPost _after
 
-			local u : Math.abs (after.x - before.x)
-			local v : Math.abs (after.y - args.y)
-			local w : Math.abs (before.y - args.y)
+			local u : Math.abs : after.x  - before.x
+			local v : Math.abs : after.y  - args.y
+			local w : Math.abs : before.y - args.y
 			local mixRatio : mixR w args.anglePre v args.anglePost u
 
 			set args.x : mix before.x after.x [fallback args.p mixRatio]
@@ -670,7 +669,7 @@ glyph-block CommonShapes : begin
 			local-parameter : swAfter      -- sw
 			local-parameter : mockPre      -- nothing
 			local-parameter : mockPost     -- nothing
-			local-parameter : blendPre     -- [if anglePre nothing [arcvh]]
+			local-parameter : blendPre     -- [if anglePre  nothing [arcvh]]
 			local-parameter : blendPost    -- [if anglePost nothing [archv]]
 			local args : object [lhs true] y p sw compact o swBefore swAfter mockPre mockPost blendPre blendPost anglePre anglePost
 			return : new FunctionInterpolator archBlender args
@@ -687,7 +686,7 @@ glyph-block CommonShapes : begin
 			local-parameter : swAfter      -- sw
 			local-parameter : mockPre      -- nothing
 			local-parameter : mockPost     -- nothing
-			local-parameter : blendPre     -- [if anglePre nothing [arcvh]]
+			local-parameter : blendPre     -- [if anglePre  nothing [arcvh]]
 			local-parameter : blendPost    -- [if anglePost nothing [archv]]
 			local args : object [lhs false] y p sw compact o swBefore swAfter mockPre mockPost blendPre blendPost anglePre anglePost
 			return : new FunctionInterpolator archBlender args
@@ -824,7 +823,7 @@ glyph-block CommonShapes : begin
 	define [TangentToNormal offset contrast _tanSlope] : begin
 		local r : Math.hypot offset.x offset.y
 		return : new Point Point.Type.Corner
-			contrast * (-offset.y / r)
+			(0 - offset.y * contrast) / r
 			(offset.x + offset.y * [fallback _tanSlope TanSlope]) / r
 	define [VectorDot p1 p2] : p1.x * p2.x + p1.y * p2.y
 

--- a/packages/font-glyphs/src/letter/armenian/upper-u-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/upper-u-group.ptl
@@ -16,7 +16,7 @@ glyph-block Letter-Armenian-Upper-U-Group : begin
 		create-glyph 'armn/Ayb' 0x531 : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.capital
-			include : UShape df CAP 1 df.mvs
+			include : UShape CAP 1 df.leftSB df.rightSB df.mvs
 			include : QCrossing df CAP QInnerDiagSw
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df CAP 0
@@ -26,7 +26,7 @@ glyph-block Letter-Armenian-Upper-U-Group : begin
 		create-glyph 'armn/Men' 0x544 : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.capital
-			include : UShape df CAP 0 df.mvs
+			include : UShape CAP 0 df.leftSB df.rightSB df.mvs
 			include : [ArmHBar.right df].cap
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df CAP 0
@@ -36,7 +36,7 @@ glyph-block Letter-Armenian-Upper-U-Group : begin
 		create-glyph 'armn/Vo' 0x548 : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.capital
-			include : UShape df CAP 1 df.mvs
+			include : UShape CAP 1 df.leftSB df.rightSB df.mvs
 			include : FlipAround Middle (CAP / 2)
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df CAP 0
@@ -46,7 +46,7 @@ glyph-block Letter-Armenian-Upper-U-Group : begin
 		create-glyph 'armn/Rra' 0x54C : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.capital
-			include : UShape df CAP 1 df.mvs
+			include : UShape CAP 1 df.leftSB df.rightSB df.mvs
 			include : FlipAround Middle (CAP / 2)
 			include : [ArmHBar.right df].mid
 			if SLAB : begin
@@ -57,7 +57,7 @@ glyph-block Letter-Armenian-Upper-U-Group : begin
 		create-glyph 'armn/Seh' 0x54D : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.capital
-			include : UShape df CAP 1 df.mvs
+			include : UShape CAP 1 df.leftSB df.rightSB df.mvs
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df CAP 0
 				include : composite-proc sf.lt.full sf.rt.full

--- a/packages/font-glyphs/src/letter/armenian/upper-xeh.ptl
+++ b/packages/font-glyphs/src/letter/armenian/upper-xeh.ptl
@@ -18,8 +18,7 @@ glyph-block Letter-Armenian-Upper-Xeh : begin
 			include : df.markSet.capital
 			include : VBar.l df.leftSB 0 CAP df.mvs
 			include : HBar.t df.leftSB df.middle XH df.mvs
-			include : with-transform [ApparentTranslate shift 0]
-				UShape subDf XH 0 subDf.mvs subDf.archDepthA subDf.archDepthB
+			include : UShape XH 0 (subDf.leftSB + shift) (subDf.rightSB + shift) subDf.mvs subDf.archDepthA subDf.archDepthB
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df CAP 0
 				local sf2 : SerifFrame.fromDf df XH 0

--- a/packages/font-glyphs/src/letter/cyrillic/djerv.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/djerv.ptl
@@ -12,7 +12,7 @@ glyph-block Letter-Cyrillic-Djerv : begin
 	define [RStirrupShape df top py ada adb] : glyph-proc
 		local uBot : mix top 0 py
 		include : VBar.m df.middle 0 uBot
-		include : UShape df top uBot nothing ada adb
+		include : UShape top uBot df.leftSB df.rightSB nothing ada adb
 		include : FlipAround df.middle (top / 2)
 
 	define [DjervShape df top py ada adb] : glyph-proc

--- a/packages/font-glyphs/src/letter/greek/psi.ptl
+++ b/packages/font-glyphs/src/letter/greek/psi.ptl
@@ -11,7 +11,7 @@ glyph-block Letter-Greek-Psi : begin
 	glyph-block-import Common-Derivatives
 
 	define [PsiShape df y1 y2 y3 y4 ada adb doBotSerif doTopSerif doSideSerifL doSideSerifR] : glyph-proc
-		include : UShape df y3 y2 df.mvs ada adb
+		include : UShape y3 y2 df.leftSB df.rightSB df.mvs ada adb
 		include : VBar.m df.middle y2 y4 df.mvs
 		include : VBar.m df.middle y1 (y2 + HalfStroke)
 

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -352,12 +352,7 @@ glyph-block Letter-Latin-U : begin
 				widths.lhs fine
 				corner (SB + outStand) (yTurn + outStandY)
 				corner (SB - outStand) (yTurn - outStandY)
-			spiro-outline
-				corner (SB - O) XH
-				curl   (SB - O) SmallArchDepthB
-				arch.lhs 0
-				flat   (RightSB + O) SmallArchDepthA
-				corner (RightSB + O) XH
+			UShapeOutline XH 0 (SB - O) (RightSB + O) SmallArchDepthA SmallArchDepthB
 		if SLAB : begin
 			include : HSerif.lt SB XH SideJut
 
@@ -381,14 +376,10 @@ glyph-block Letter-Latin-U : begin
 	create-glyph 'mathbb/U' 0x1D54C : glyph-proc
 		include : MarkSet.capital
 		include : HBar.t SB (SB + BBD) CAP BBS
-		include : UShape [DivFrame 1] CAP 0
-			stroke -- BBS
+		include : UShape CAP 0 SB RightSB BBS
 		include : intersection
 			VBar.l (SB + BBD) 0 CAP BBS
-			UShapeT spiro-outline [DivFrame 1] CAP 0
-				stroke -- BBS
-				oper   -- true
-				offset -- 1
+			UShapeOutline CAP 1 (SB + 1) (RightSB - 1) BBS
 
 	create-glyph 'mathbb/u' 0x1D566 : glyph-proc
 		include : MarkSet.e

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -352,7 +352,7 @@ glyph-block Letter-Latin-U : begin
 				widths.lhs fine
 				corner (SB + outStand) (yTurn + outStandY)
 				corner (SB - outStand) (yTurn - outStandY)
-			UShapeOutline XH 0 (SB - O) (RightSB + O) SmallArchDepthA SmallArchDepthB
+			UShapeOutline XH 0 (SB - O) (RightSB + O) nothing SmallArchDepthA SmallArchDepthB
 		if SLAB : begin
 			include : HSerif.lt SB XH SideJut
 

--- a/packages/font-glyphs/src/meta/macros.ptl
+++ b/packages/font-glyphs/src/meta/macros.ptl
@@ -306,12 +306,12 @@ define-macro glyph-block-import : syntax-rules
 			derive-multi-part-glyphs DeriveMeshT link-gr]
 
 			CommonShapes `[no-shape tagged Rect SquareAt Ring RingAt DotAt RingStroke RingStrokeAt
-			DotStrokeAt Circle Ellipse OShapeT OShape OShapeOutline OShapeFlatTB UShapeT UShape HSerif
-			VSerif NeedSlab NeedNotItalic HBar HOverlayBar HOverlayObliqueBar VBar FlatSlashShape
-			hookstart hookend flatside arch Ungizmo Regizmo FlipAround ScaleAround Realign ForceUpright
-			DiagCor NameUni PointingTo with-transform with-outlined remove-holes radicalize clear-geometry
-			clear-anchors ExtLineCenter ExtLineLhs ExtLineRhs DiagCorDs HCrossBar MaskAbove
-			MaskBelow MaskLeft MaskRight HalfRectTriangle MaskAboveLine MaskBelowLine
+			DotStrokeAt Circle Ellipse OShapeT OShape OShapeOutline OShapeFlatTB UShapeT UShape
+			UShapeOutline HSerif VSerif NeedSlab NeedNotItalic HBar HOverlayBar HOverlayObliqueBar VBar
+			FlatSlashShape hookstart hookend flatside arch Ungizmo Regizmo FlipAround ScaleAround Realign
+			ForceUpright DiagCor NameUni PointingTo with-transform with-outlined remove-holes radicalize
+			clear-geometry clear-anchors ExtLineCenter ExtLineLhs ExtLineRhs DiagCorDs HCrossBar
+			MaskAbove MaskBelow MaskLeft MaskRight HalfRectTriangle MaskAboveLine MaskBelowLine
 			MaskLeftLine MaskRightLine DotVariants WithDotVariants TangentToNormal VectorDot sharp-corner]
 
 		define vartiableFilter : if externEnv.$glyphBlockVariableUsage$

--- a/packages/font-glyphs/src/symbol/letter.ptl
+++ b/packages/font-glyphs/src/symbol/letter.ptl
@@ -114,7 +114,7 @@ glyph-block Symbol-Currency : begin
 	create-glyph 'currency/manatSign' 0x20BC : glyph-proc
 		local df : include : DivFrame para.advanceScaleT 3
 
-		include : UShape df XH 0 df.mvs df.smallArchDepthA df.smallArchDepthB
+		include : UShape XH 0 df.leftSB df.rightSB df.mvs df.smallArchDepthA df.smallArchDepthB
 		include : FlipAround df.middle (XH / 2)
 
 		include : VBar.m df.middle [if SLAB df.mvs 0] (XH + LongVJut - QuarterStroke) [Math.min VJutStroke df.mvs]

--- a/packages/font-glyphs/src/symbol/math/apl.ptl
+++ b/packages/font-glyphs/src/symbol/math/apl.ptl
@@ -93,10 +93,10 @@ glyph-block Symbol-Math-APL : begin
 			corner (RightSB - [HSwToV (Stroke - fine)]) (OperTop + shift)
 		include : union
 			composite-proc
-				UShape [DivFrame 1] OperTop OperBot (stroke -- OperatorStroke)
+				UShape OperTop OperBot SB RightSB OperatorStroke
 				FlipAround Middle SymbolMid
 			intersection
-				UShape [DivFrame 1] (OperTop + shift) (OperBot + shift) (stroke -- OperatorStroke)
+				UShape (OperTop + shift) (OperBot + shift) SB RightSB OperatorStroke
 				InnerCircleMask OperatorStroke
 				composite-proc [InnerCircleMask fine] [FlipAround Middle (OperTop - ArchDepth)]
 
@@ -122,7 +122,6 @@ glyph-block Symbol-Math-APL : begin
 		include : intersection [refer-glyph 'apl/quadShadow'] shape
 		include : ScaleAround Middle SymbolMid aplBoxInnerScale
 
-
 	define [centerSmallPunctuations] : glyph-proc
 		include : ApparentTranslate (Width / 2 - currentGlyph.advanceWidth / 2) 0
 		set-width Width
@@ -140,6 +139,7 @@ glyph-block Symbol-Math-APL : begin
 	# Boxed
 	define [DeriveBoxed src] : aplBoxed : aplBoxedInner src
 	derive-glyphs 'uni2338' 0x2338 'equal'                          DeriveBoxed
+	derive-glyphs 'uni2339' 0x2339 'divide'                         DeriveBoxed
 	derive-glyphs 'uni233A' 0x233A 'whiteDiamondOperator'           DeriveBoxed
 	derive-glyphs 'uni233B' 0x233B 'mathSmallCircle'                DeriveBoxed
 	derive-glyphs 'uni233C' 0x233C 'whiteCircle.NWID'               DeriveBoxed
@@ -156,27 +156,27 @@ glyph-block Symbol-Math-APL : begin
 	derive-glyphs 'uni2354' 0x2354 'nabla.aplForm'                  DeriveBoxed
 	derive-glyphs 'uni2357' 0x2357 'arrowDown.NWID'                 DeriveBoxed
 	derive-glyphs 'uni235E' 0x235E 'asciiSingleQuote/body/straight' DeriveBoxed
-	derive-glyphs 'uni236F' 0x236F 'notequal'                       DeriveBoxed
-	derive-glyphs 'uni2339' 0x2339 'divide'                         DeriveBoxed
 	derive-glyphs 'uni2360' 0x2360 'colon/mid'                      DeriveBoxed
+	derive-glyphs 'uni236F' 0x236F 'notequal'                       DeriveBoxed
 	derive-glyphs 'uni2370' 0x2370 'question'                       DeriveBoxed
 
 	# Simple Composites
-	create-glyph 0x233D : composite-proc [refer-glyph 'apl/bar'] [refer-glyph 'whiteCircle.NWID']
-	create-glyph 0x233E : composite-proc [refer-glyph 'whiteCircle.NWID'] [refer-glyph 'whiteSmallCircle.NWID']
-	create-glyph 0x233F : composite-proc [refer-glyph 'apl/minus'] [refer-glyph 'slash']
-	create-glyph 0x2340 : composite-proc [refer-glyph 'apl/minus'] [refer-glyph 'backslash']
-	create-glyph 0x2349 : composite-proc [refer-glyph 'apl/backSlash'] [refer-glyph 'whiteCircle.NWID']
-	derive-composites 'apl/deltaStile' 0x234B  'increment.aplThin' 'apl/longBar'
-	create-glyph 0x234F : composite-proc [refer-glyph 'arrowUp.NWID'] [refer-glyph 'minus']
-	derive-composites 'apl/delStile'   0x2352  'nabla.aplThin'     'apl/longBar'
-	create-glyph 0x2356 : composite-proc [refer-glyph 'arrowDown.NWID'] [refer-glyph 'minus']
-	derive-composites 'apl/deltaUnderbar' 0x2359 'increment.aplForm' 'underlineBelow'
-	create-glyph 0x2366 : composite-proc [refer-glyph 'cup'] [refer-glyph 'apl/bar']
+	create-glyph 0x233D : composite-proc [refer-glyph 'apl/bar']              [refer-glyph 'whiteCircle.NWID']
+	create-glyph 0x233E : composite-proc [refer-glyph 'whiteCircle.NWID']     [refer-glyph 'whiteSmallCircle.NWID']
+	create-glyph 0x233F : composite-proc [refer-glyph 'apl/minus']            [refer-glyph 'slash']
+	create-glyph 0x2340 : composite-proc [refer-glyph 'apl/minus']            [refer-glyph 'backslash']
+	create-glyph 0x2349 : composite-proc [refer-glyph 'apl/backSlash']        [refer-glyph 'whiteCircle.NWID']
+	create-glyph 0x234F : composite-proc [refer-glyph 'arrowUp.NWID']         [refer-glyph 'minus']
+	create-glyph 0x2356 : composite-proc [refer-glyph 'arrowDown.NWID']       [refer-glyph 'minus']
+	create-glyph 0x2366 : composite-proc [refer-glyph 'cup']                  [refer-glyph 'apl/bar']
 	create-glyph 0x236D : composite-proc [refer-glyph 'overlayTildeOperator'] [refer-glyph 'bar']
 
+	derive-composites 'apl/deltaStile'    0x234B 'increment.aplThin'        'apl/longBar'
+	derive-composites 'apl/delStile'      0x2352 'nabla.aplThin'            'apl/longBar'
+	derive-composites 'apl/deltaUnderbar' 0x2359 'increment.aplForm'        'underlineBelow'
+	derive-composites 'apl/zeroTilde'     0x236C 'zero.lnum/forceUnslashed' 'overlayTildeOperator'
+
 	derive-composites 'apl/barComma' 0x236A 'comma' [centerSmallPunctuations] 'minus'
-	derive-composites 'apl/zeroTilde' 0x236C 'zero.lnum/forceUnslashed' 'overlayTildeOperator'
 
 	# Dieresis & underscore
 	define [AplAccented u part1 part2 marks]
@@ -187,8 +187,8 @@ glyph-block Symbol-Math-APL : begin
 			refer-glyph srcs.1
 			clear-anchors
 
-	AplAccented 0x2362 'nabla.aplForm'                     'dieresisAbove'  [MarkSet.tack]
 	AplAccented 0x2361 'top'                               'dieresisAbove'  [MarkSet.tack]
+	AplAccented 0x2362 'nabla.aplForm'                     'dieresisAbove'  [MarkSet.tack]
 	AplAccented 0x2363 'asterisk.pentaSMid'                'dieresisAbove'  [MarkSet.plus]
 	AplAccented 0x2364 'mathSmallCircle'                   'dieresisAbove'  [MarkSet.plus]
 	AplAccented 0x2365 'whiteCircle.NWID'                  'dieresisAbove'  [MarkSet.plus]
@@ -209,7 +209,7 @@ glyph-block Symbol-Math-APL : begin
 	create-glyph 0x2351 : composite-proc [refer-glyph 'top'] [MarkSet.tack] [refer-glyph 'sbRsbOverlineAbove'] [clear-anchors]
 
 	# Overlay
-	create-glyph 0x2345 : composite-proc : Overlay [refer-glyph 'arrowLeft.NWID'] [refer-glyph 'apl/bar']
+	create-glyph 0x2345 : composite-proc : Overlay [refer-glyph 'arrowLeft.NWID']  [refer-glyph 'apl/bar']
 	create-glyph 0x2346 : composite-proc : Overlay [refer-glyph 'arrowRight.NWID'] [refer-glyph 'apl/bar']
 
 	# Circled
@@ -275,10 +275,10 @@ glyph-block Symbol-Math-APL : begin
 	LinkAplFormForNwidWwid 'whiteTriangleRB'
 	LinkAplFormForNwidWwid 'whiteTriangleRT'
 	LinkAplFormForNwidWwid 'arrowDownRight'
+	LinkAplFormForNwidWwid 'arrowTailFromLeft'
+	LinkAplFormForNwidWwid 'arrowTailFromRight'
 	LinkAplFormForNwidWwid 'barArrowUp'
 	LinkAplFormForNwidWwid 'barArrowDown'
-	LinkAplFormForNwidWwid 'counterArrowLeft'
-	LinkAplFormForNwidWwid 'counterArrowRight'
 	LinkAplFormForNwidWwid 'countersink'
 	LinkAplFormForNwidWwid 'cwOpenCircleArrow'
 	LinkAplFormForNwidWwid 'dashArrowUp'

--- a/packages/font-glyphs/src/symbol/math/large-operators.ptl
+++ b/packages/font-glyphs/src/symbol/math/large-operators.ptl
@@ -63,10 +63,9 @@ glyph-block Symbol-Math-Large-Operators : for-width-kinds WideWidth1
 
 	create-glyph [MangleName 'Cup'] [MangleUnicode 0x22C3] : glyph-proc
 		set-width df.width
-		include : UShape df BgOpTop BgOpBot
-			stroke -- OperatorStroke
-			ada -- [ArchDepthAOf (ArchDepth * [Math.sqrt df.adws]) (df.width)]
-			adb -- [ArchDepthBOf (ArchDepth * [Math.sqrt df.adws]) (df.width)]
+		include : UShape BgOpTop BgOpBot df.leftSB df.rightSB OperatorStroke
+			ArchDepthAOf (ArchDepth * [Math.sqrt df.adws]) df.width
+			ArchDepthBOf (ArchDepth * [Math.sqrt df.adws]) df.width
 
 	turned [MangleName 'Cap'] [MangleUnicode 0x22C2] [MangleName 'Cup'] df.middle SymbolMid
 

--- a/packages/font-glyphs/src/symbol/math/v-and-cup.ptl
+++ b/packages/font-glyphs/src/symbol/math/v-and-cup.ptl
@@ -7,7 +7,6 @@ glyph-module
 glyph-block Symbol-Math-VAndCup : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : SerifFrame
 	glyph-block-import Letter-Greek-Pi : PiShape
 	glyph-block-import Letter-Cyrillic-Sha : CyrShaShape
 	glyph-block-import Symbol-Arrow-Shared : ArrowShape
@@ -152,13 +151,13 @@ glyph-block Symbol-Math-VAndCup : begin
 	# Cup
 
 	create-glyph 'cup' 0x222A : glyph-proc
-		include : UShape [DivFrame 1] OperTop OperBot (stroke -- OperatorStroke)
+		include : UShape OperTop OperBot SB RightSB OperatorStroke
 
 	turned 'cap' 0x2229 'cup' Middle SymbolMid
 
 	define ThinCupStroke : AdviceStroke 4
 	create-glyph 'thinCup' : glyph-proc
-		include : UShape [DivFrame 1] OperTop OperBot (stroke -- ThinCupStroke)
+		include : UShape OperTop OperBot SB RightSB ThinCupStroke
 
 	WithDotVariants 'cupDot' 0x228D : function [DrawAt kdr overshoot ]: glyph-proc
 		include [refer-glyph 'thinCup'] AS_BASE ALSO_METRICS
@@ -197,12 +196,10 @@ glyph-block Symbol-Math-VAndCup : begin
 	create-glyph 'doubleCup' 0x22D3 : glyph-proc
 		local sw : AdviceStroke 6
 		local gap : Math.min ((RightSB - SB - [HSwToV : 4 * sw]) / 3) : Math.max (Width / 8) (sw / 2)
-		include : UShape [DivFrame 1] OperTop OperBot (stroke -- sw)
-		include : UShape [DivFrame 1] OperTop OperBot
-			stroke -- sw
-			offset -- (sw + gap)
-			ada -- [ArchDepthAOf (ArchDepth - sw - gap) Width]
-			adb -- [ArchDepthBOf (ArchDepth - sw - gap) Width]
+		include : UShape OperTop OperBot SB RightSB sw
+		include : UShape OperTop (OperBot + sw + gap) (SB + sw + gap) (RightSB - sw - gap) sw
+			ArchDepthAOf (ArchDepth - sw - gap) Width
+			ArchDepthBOf (ArchDepth - sw - gap) Width
 
 	turned 'doubleCap' 0x22D2 'doubleCup' Middle SymbolMid
 
@@ -210,7 +207,7 @@ glyph-block Symbol-Math-VAndCup : begin
 	define pitchForkSw  : AdviceStroke 3.25
 
 	create-glyph 'pitchFork' 0x22D4 : composite-proc
-		UShape [DivFrame 1] OperTop OperBot (stroke -- pitchForkSw)
+		UShape OperTop OperBot SB RightSB pitchForkSw
 		FlipAround Middle SymbolMid
 		VBar.m Middle OperBot pitchForkTop pitchForkSw
 
@@ -225,18 +222,18 @@ glyph-block Symbol-Math-VAndCup : begin
 		include : HBar.m (Middle - cupInnerPlusSize / 2) (Middle + cupInnerPlusSize / 2) (OperBot + ArchDepth) cupInnerPlusSw
 
 	create-glyph 'cupOverbar' 0x2A42 : let [gap : WedgeBarGap] : glyph-proc
-		include : UShape [DivFrame 1] (OperTop - OperatorStroke - gap) OperBot (stroke -- OperatorStroke)
+		include : UShape (OperTop - OperatorStroke - gap) OperBot SB RightSB OperatorStroke
 		include : HBar.t SB RightSB OperTop OperatorStroke
 
 	create-glyph 'capOverbar' 0x2A43 : let [gap : WedgeBarGap] : glyph-proc
-		include : UShape [DivFrame 1] OperTop (OperBot + OperatorStroke + gap) (stroke -- OperatorStroke)
+		include : UShape OperTop (OperBot + OperatorStroke + gap) SB RightSB OperatorStroke
 		include : FlipAround Middle SymbolMid
 		include : HBar.t SB RightSB OperTop OperatorStroke
 
 	turned 'elementDown' 0x2AD9 'elementUp' Middle SymbolMid
 
 	create-glyph 'transversalIntersection' 0x2ADB : composite-proc
-		UShape [DivFrame 1] OperTop OperBot (stroke -- pitchForkSw)
+		UShape OperTop OperBot SB RightSB pitchForkSw
 		FlipAround Middle SymbolMid
 		VBar.m Middle (OperBot + OperTop - pitchForkTop) pitchForkTop pitchForkSw
 
@@ -245,24 +242,23 @@ glyph-block Symbol-Math-VAndCup : begin
 		include : HBar.t SB RightSB pitchForkTop pitchForkSw
 
 	create-glyph 'nonForking' 0x2ADD : glyph-proc
-		include : UShape [DivFrame 1] SymbolMid OperBot (stroke -- pitchForkSw)
+		include : UShape SymbolMid OperBot SB RightSB pitchForkSw
 		include : VBar.m Middle OperBot OperTop pitchForkSw
 
 	create-glyph 'forking' 0x2ADC : glyph-proc
 		include [refer-glyph 'nonForking'] AS_BASE ALSO_METRICS
 		include : dispiro
 			widths.center NotGlyphSw
-			flat SB OperBot
+			flat SB      OperBot
 			curl RightSB OperTop
 
 	create-glyph 'cupClosedSerifed' 0x2A4C : glyph-proc
-		include : UShape [DivFrame 1] OperTop OperBot (stroke -- OperatorStroke)
+		include : UShape OperTop OperBot SB RightSB OperatorStroke
 		include : HBar.t SB RightSB OperTop OperatorStroke
-		local sf : SerifFrame.fromDf [DivFrame 1] OperTop OperBot (swSerif -- OperatorStroke)
-		include : composite-proc sf.lt.full sf.rt.full
+		include : HSerif.lt SB      OperTop SideJut OperatorStroke
+		include : HSerif.rt RightSB OperTop SideJut OperatorStroke
 
 	turned 'capClosedSerifed' 0x2A4D 'cupClosedSerifed' Middle SymbolMid
-
 
 	# Square Cup
 


### PR DESCRIPTION
Basically an excuse for more code cleanup, but also to setup possible future PR's.

Once again nothing is changed, except for how I also went ahead and fixed the APL linking for `⤙`/`⤚` (for UIUA), which was disrupted a while ago when the arrow code was refactored (with some characters getting renamed).