### PR TITLE
Add new constant `DesignParameters.aBarPos`.

### DIFF
--- a/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
@@ -60,7 +60,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 				local [left]  : AAShape DoubleStorey.ToothlessRounded hookStyle 0 df
 				local [right] : AAShape bodyR                         hookStyle 1 df
 				include : difference [right] : intersection
-					MaskAbove (XH * OverlayPos * 1.02)
+					MaskAbove (XH * DesignParameters.aBarPos)
 					union
 						with-transform [ApparentTranslate ((-0.25) * df.mvs) 0] [left]
 						with-transform [ApparentTranslate ((-0.50) * df.mvs) 0] [left]
@@ -68,7 +68,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 						with-transform [ApparentTranslate ((-1.00) * df.mvs) 0] [left]
 
 				include : difference [left] : intersection
-					MaskBelow (XH * OverlayPos * 1.02)
+					MaskBelow (XH * DesignParameters.aBarPos)
 					union
 						with-transform [ApparentTranslate ((+0.25) * df.mvs) 0] [right]
 						with-transform [ApparentTranslate ((+0.50) * df.mvs) 0] [right]

--- a/packages/font-glyphs/src/letter/latin/lower-a.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-a.ptl
@@ -48,7 +48,7 @@ glyph-block Letter-Latin-Lower-A : begin
 
 		define [ADoubleStoreyArcT df sink kind rise stroke exd] : glyph-proc
 			local isMask : sink == spiro-outline
-			local bartop : XH * OverlayPos * 1.02 + stroke * 0.425
+			local bartop : XH * DesignParameters.aBarPos + stroke * 0.425
 			local bowlArcY1 : YSmoothMidL 0 bartop SmallArchDepthA SmallArchDepthB
 			local bowlArcY2 : YSmoothMidR 0 bartop SmallArchDepthA SmallArchDepthB
 			local leftSlope : TanSlope - 0.1 * (df.width / HalfUPM)

--- a/packages/font-glyphs/src/meta/aesthetics.ptl
+++ b/packages/font-glyphs/src/meta/aesthetics.ptl
@@ -150,14 +150,14 @@ export : define [calculateMetrics para] : begin
 	define SideJut : Jut - [HSwToV HalfStroke]
 	define VJutStroke : AdviceStroke 3.5
 
-	define DToothlessRise : Hook * 0.25 + Stroke / 16
+	define DToothlessRise : Hook / 4 + Stroke / 16
 	define DMBlend          0.80
 
 	define [StrokeWidthBlend min max sw] : linreg para.canonicalStrokeWidthMin min para.canonicalStrokeWidthMax max [fallback sw Stroke]
 
 	define SmoothAdjust : StrokeWidthBlend 80 144
-	define [ArchDepthAOf archDepth width] : archDepth - TanSlope * SmoothAdjust / Width * width
-	define [ArchDepthBOf archDepth width] : archDepth + TanSlope * SmoothAdjust / Width * width
+	define [ArchDepthAOf archDepth width] : archDepth - TanSlope * SmoothAdjust * (width / Width)
+	define [ArchDepthBOf archDepth width] : archDepth + TanSlope * SmoothAdjust * (width / Width)
 	define [YSmoothMidR top bot _ada _adb] : begin
 		local ada : fallback _ada ArchDepthA
 		local adb : fallback _adb ArchDepthB
@@ -410,8 +410,9 @@ export : define DesignParameters : object
 	braceCurlyM2               0.45
 	braceOvershoot             0.02
 	# Bar position
+	aBarPos                    0.5304
 	hBarPos                    0.525
-	eBarPos                    0.5
+	eBarPos                    0.50
 	fiveBarPos                 0.64
 	overlayPos                 0.52
 	fBarPosToXH                0.875


### PR DESCRIPTION
I noticed that separate files (that is to say more than one file) had to calculate the bar position of `a` using `OverlayPos * 1.02`, so I made a constant in `DesignParameters` in `meta/aesthetics.ptl`. Its defined value is exactly equal to the existing value, which is `DesignParameters.overlayPos * 1.02` which evaluates to `0.5304`. This also makes it able to be tweaked to a more friendly-looking number in the future if you ever want to.

Nothing else is changed.