### PR TITLE
Fix `YSmoothMid`{`L`|`R`} being applied upside-down for double-storey `a`.

### DIFF
--- a/packages/font-glyphs/src/letter/latin/lower-a.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-a.ptl
@@ -49,15 +49,16 @@ glyph-block Letter-Latin-Lower-A : begin
 		define [ADoubleStoreyArcT df sink kind rise stroke exd] : glyph-proc
 			local isMask : sink == spiro-outline
 			local bartop : XH * DesignParameters.aBarPos + stroke * 0.425
-			local bowlArcY1 : YSmoothMidL 0 bartop SmallArchDepthA SmallArchDepthB
-			local bowlArcY2 : YSmoothMidR 0 bartop SmallArchDepthA SmallArchDepthB
-			local leftSlope : TanSlope - 0.1 * (df.width / HalfUPM)
+			local bowlArcY1 : YSmoothMidL bartop 0 SmallArchDepthA SmallArchDepthB
+			local bowlArcY2 : YSmoothMidR bartop 0 SmallArchDepthA SmallArchDepthB
+			local leftSlopeS : 0.1 * (df.width / HalfUPM)
+			local leftSlope  : leftSlopeS - TanSlope
 			include : sink
 				widths.lhs stroke
 				[if isMask corner flat] (df.rightSB + O) bartop [heading Leftward]
 				curl [mix df.rightSB df.middle 0.9] bartop
 				archv
-				g4 (df.leftSB + OX) (bowlArcY1 + [HSwToV : Stroke * leftSlope]) [heading {.x (+HVContrast) .y (-leftSlope)}]
+				g4 (df.leftSB + OX) (bowlArcY1 - [HSwToV : Stroke * leftSlopeS]) [heading {.x HVContrast .y leftSlope}]
 				match kind
 					0 : list
 						arch.lhs 0 (sw -- stroke) (swAfter -- df.shoulderFine)

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -41,12 +41,12 @@ glyph-block Letter-Latin-Lower-E : begin
 
 	glyph-block-export SmallEShape
 	define [SmallEShape] : with-params [
-		df top [stroke : AdviceStroke2 2 3 top] [barpos DesignParameters.eBarPos] [bbd 0]
+		df top [stroke [AdviceStroke2 2 3 top]] [barpos DesignParameters.eBarPos] [bbd 0]
 		[ada SmallArchDepthA] [adb SmallArchDepthB] [tailSlab nothing] [noSwash false]
 		] : glyph-proc
 		local barBottom : top * barpos - (stroke / 2)
 
-		include : HBar.b (df.leftSB + (stroke / 2) + OX + bbd) (df.rightSB - (stroke / 2) - OX) barBottom stroke
+		include : HBar.b ((df.leftSB + OX) + (stroke / 2) + bbd) ((df.rightSB - OX) - (stroke / 2)) barBottom stroke
 		local path : include : dispiro
 			widths.lhs stroke
 			flat (df.rightSB - OX) barBottom [heading Upward]
@@ -61,12 +61,12 @@ glyph-block Letter-Latin-Lower-E : begin
 
 	glyph-block-export RevSmallEShape
 	define [RevSmallEShape] : with-params [
-		df top [stroke : AdviceStroke2 2 3 top] [barpos DesignParameters.eBarPos]
+		df top [stroke [AdviceStroke2 2 3 top]] [barpos DesignParameters.eBarPos]
 		[ada SmallArchDepthA] [adb SmallArchDepthB]
 		] : glyph-proc
 		local barBottom : top * barpos - (stroke / 2)
 
-		include : HBar.b (df.leftSB + (stroke / 2) + OX) (df.rightSB - (stroke / 2) - OX) barBottom stroke
+		include : HBar.b ((df.leftSB + OX) + (stroke / 2)) ((df.rightSB - OX) - (stroke / 2)) barBottom stroke
 		include : dispiro
 			widths.rhs stroke
 			flat (df.leftSB + OX) barBottom [heading Upward]
@@ -78,18 +78,20 @@ glyph-block Letter-Latin-Lower-E : begin
 
 	glyph-block-export SmallERoundedShape
 	define [SmallERoundedShape] : with-params [
-		df top [stroke : AdviceStroke2 2 3 top] [barpos : if para.isItalic 0.500 0.475]
+		df top [stroke [AdviceStroke2 2 3 top]] [barpos DesignParameters.eBarPos]
 		[ada SmallArchDepthA] [adb SmallArchDepthB] [tailSlab nothing] [noSwash false]
 		] : glyph-proc
-		local barBottom : top * barpos - (stroke / 2)
+		local barBottom : top * (barpos * [if para.isItalic 1 0.95]) - (stroke / 2)
 		local xStart : df.leftSB + [HSwToV : 0.125 * stroke]
 		local extraCurliness : if para.isItalic (0.1 * (top - barBottom)) 0
+		local ada2 : ArchDepthAOf : (1 - barpos) * SmallArchDepth
+		local adb2 : ArchDepthBOf : (1 - barpos) * SmallArchDepth
 		local path : include : dispiro
 			widths.lhs stroke
 			[if para.isItalic g2 flat] xStart (barBottom + (2/3) * extraCurliness)
 			[if para.isItalic g2.right.mid curl] [mix xStart df.rightSB (0.475 + 0.1 * TanSlope)] (barBottom - (1/3) * extraCurliness)
-			if (para.isItalic && !noSwash) {} [archv]
-			g4 (df.rightSB - OX) [YSmoothMidR top barBottom (0.5 * SmallArchDepthA) (0.5 * SmallArchDepthB)]
+			if [not para.isItalic] [archv] {}
+			g4 (df.rightSB - OX) [YSmoothMidR top barBottom ada2 adb2]
 			arch.lhs top (sw -- stroke)
 			flatside.ld df.leftSB 0 top ada adb
 			SmallESerifedTerminalShape df top stroke tailSlab noSwash
@@ -100,26 +102,27 @@ glyph-block Letter-Latin-Lower-E : begin
 
 	glyph-block-export RevSmallERoundedShape
 	define [RevSmallERoundedShape] : with-params [
-		df top [stroke : AdviceStroke2 2 3 top] [barpos : if para.isItalic 0.500 0.475]
+		df top [stroke [AdviceStroke2 2 3 top]] [barpos DesignParameters.eBarPos]
 		[ada SmallArchDepthA] [adb SmallArchDepthB]
 		] : glyph-proc
-		local barBottom : top * barpos - (stroke / 2)
+		local barBottom : top * (barpos * [if para.isItalic 1 0.95]) - (stroke / 2)
 		local xStart : df.rightSB - [HSwToV : 0.125 * stroke]
-		local pfIt : if para.isItalic 1 0
 		local extraCurliness : if para.isItalic (0.1 * (top - barBottom)) 0
+		local ada2 : ArchDepthAOf : (1 - barpos) * SmallArchDepth
+		local adb2 : ArchDepthBOf : (1 - barpos) * SmallArchDepth
 		include : dispiro
 			widths.rhs stroke
 			[if para.isItalic g2 flat] xStart (barBottom + (2/3) * extraCurliness)
 			[if para.isItalic g2.left.mid curl] [mix xStart df.leftSB (0.475 + 0.1 * TanSlope)] (barBottom - (1/3) * extraCurliness)
 			archv
-			g4 (df.leftSB + OX) [YSmoothMidL top barBottom (0.5 * SmallArchDepthA) (0.5 * SmallArchDepthB)]
+			g4 (df.leftSB + OX) [YSmoothMidL top barBottom ada2 adb2]
 			arch.rhs top (sw -- stroke)
 			flatside.rd df.rightSB 0 top ada adb
 			hookend 0 (sw -- stroke)
 			g4 (df.leftSB + 0.5 * OX) [HookHeight top stroke true]
 
 	define [AbkCheShape] : with-params [
-		fDesc Body df top [stroke : Math.min df.mvs : AdviceStroke2 2 3 top] [barpos nothing]
+		fDesc Body df top [stroke [Math.min df.mvs : AdviceStroke2 2 3 top]] [barpos nothing]
 		[ada SmallArchDepthA] [adb SmallArchDepthB] [tailSlab nothing]
 		] : glyph-proc
 		local gap : 0.375 * (df.width - 2 * df.leftSB - 2.5 * stroke) - [HSwToV : 0.25 * stroke]
@@ -136,7 +139,7 @@ glyph-block Letter-Latin-Lower-E : begin
 			local desc : (-LongVJut) + QuarterStroke
 			include : ExtendBelowBaseAnchors desc
 			include : difference
-				VBar.m subDf.middle desc (stroke + O) (VJutStroke * subDf.mvs / Stroke)
+				VBar.m subDf.middle desc (O + stroke) (VJutStroke * (subDf.mvs / Stroke))
 				OShapeOutline.NoOvershoot top 0 subDf.leftSB subDf.rightSB stroke
 		include : Translate shift 0
 
@@ -188,7 +191,7 @@ glyph-block Letter-Latin-Lower-E : begin
 					alsoThruThem.computed { (1/3) (2/3) } : object
 						rx       : function [rt] rt
 						deltaX   : function [rt] 0
-						ry       : function [rt] : (1/24) + rt + ((1/2) - rt) * (3/8)
+						ry       : function [rt] : (11/48) + (5/8) * rt
 						deltaY   : function [rt] : (-0.25) * [mix fine markStroke rt]
 						modifier : function [rt] : widths.rhs [mix fine markStroke : rt ** 2]
 					g4.down.mid (RightSB - extL) ((-0.75) * depth) [widths.rhs.heading markStroke {.x HVContrast .y turnSlope}]

--- a/packages/font-glyphs/src/meta/aesthetics.ptl
+++ b/packages/font-glyphs/src/meta/aesthetics.ptl
@@ -156,8 +156,8 @@ export : define [calculateMetrics para] : begin
 	define [StrokeWidthBlend min max sw] : linreg para.canonicalStrokeWidthMin min para.canonicalStrokeWidthMax max [fallback sw Stroke]
 
 	define SmoothAdjust : StrokeWidthBlend 80 144
-	define [ArchDepthAOf archDepth width] : archDepth - TanSlope * SmoothAdjust * (width / Width)
-	define [ArchDepthBOf archDepth width] : archDepth + TanSlope * SmoothAdjust * (width / Width)
+	define [ArchDepthAOf archDepth width] : archDepth - TanSlope * SmoothAdjust * ([fallback width Width] / Width)
+	define [ArchDepthBOf archDepth width] : archDepth + TanSlope * SmoothAdjust * ([fallback width Width] / Width)
 	define [YSmoothMidR top bot _ada _adb] : begin
 		local ada : fallback _ada ArchDepthA
 		local adb : fallback _adb ArchDepthB


### PR DESCRIPTION
The `top` and `bot` arguments were swapped (for _who knows_ how long; Probably similar timescale to #2831 ), which had effectively swapped the roles of `SmallArchDepthA`/`SmallArchDepthB`.

An attempt was made in April 2024 to fix some former issues with broken geometry surrounding this code via #2274 but it appears as though this may have been at least somewhat of an underlying factor.

Also minor rewrite of rounded `e` to use `ArchDepth`{`A`|`B`}`Of (0.5 * SmallArchDepth)` instead of `0.5 * SmallArchDepth`{`A`|`B`}.

For each screenshot below: Top row is before, bottom row is after.

`aꜳæꜵꜷꙗ𝕒 uᵫꭣɯ`

Monospace Thin Upright under `'cv36'1,'cv87'1`:
<img width="1763" height="629" alt="image" src="https://github.com/user-attachments/assets/070db765-bde4-4310-a3ab-dbbf77a19360" />
Monospace Regular Upright under `'cv36'1,'cv87'1`:
<img width="1768" height="615" alt="image" src="https://github.com/user-attachments/assets/753de3cf-0744-4f90-8c12-bb125f83538b" />
Monospace Heavy Upright under `'cv36'1,'cv87'1`:
<img width="1766" height="614" alt="image" src="https://github.com/user-attachments/assets/152a4e43-bbd0-4ced-b228-ad024d89c27b" />
Monospace Thin Italic under `'cv36'1,'cv87'1`:
<img width="1779" height="597" alt="image" src="https://github.com/user-attachments/assets/c2e85763-4362-4229-be38-645847e95d69" />
Monospace Regular Italic under `'cv36'1,'cv87'1`:
<img width="1752" height="579" alt="image" src="https://github.com/user-attachments/assets/607447f9-e7ca-469a-8594-b902f58c5f78" />
Monospace Heavy Italic under `'cv36'1,'cv87'1`:
<img width="1762" height="588" alt="image" src="https://github.com/user-attachments/assets/74b3625f-c2c1-4f62-8b51-2b93f434e68f" />
Aile Thin Upright:
<img width="2365" height="519" alt="image" src="https://github.com/user-attachments/assets/640e9278-02ff-4f62-9f78-0e4b302e9a5a" />
Aile Regular Upright:
<img width="2379" height="531" alt="image" src="https://github.com/user-attachments/assets/f62dd54f-b10b-4f60-92db-51785af3c190" />
Aile Heavy Upright:
<img width="2376" height="537" alt="image" src="https://github.com/user-attachments/assets/ca437ad8-96db-4c9e-9d04-592ed45c2a01" />
Aile Thin Italic:
<img width="2384" height="521" alt="image" src="https://github.com/user-attachments/assets/52f6b11e-76fc-463b-8efc-32de8bef2d24" />
Aile Regular Italic:
<img width="2373" height="528" alt="image" src="https://github.com/user-attachments/assets/c1ad6164-ac05-4431-958f-0c2297d49235" />
Aile Heavy Italic:
<img width="2379" height="526" alt="image" src="https://github.com/user-attachments/assets/4db1b048-969d-4edb-bf26-225b749f71dc" />
