### PR TITLE
Minor refinement to double storey `a`.

### DIFF
--- a/packages/font-glyphs/src/letter/latin/lower-a.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-a.ptl
@@ -38,32 +38,34 @@ glyph-block Letter-Latin-Lower-A : begin
 
 		export : define [HookAndBar df hookStyle y0 _stroke] : glyph-proc
 			if ((hookStyle != 1) && (hookStyle != 2)) : throw : new Error "Invalid hookStyle"
-			local sw : fallback _stroke [ADoubleStoreyStroke df]
+			local sw : fallback _stroke : ADoubleStoreyStroke df
 			include : ADoubleStoreyHookAndBarT dispiro df hookStyle y0 sw
 			if (hookStyle == 2) : include : ArcStartSerif.L df.leftSB (XH - DToothlessRise) sw AHook
 
 		export : define [HookAndBarMask df hookStyle y0 _stroke] : begin
-			local sw : fallback _stroke [ADoubleStoreyStroke df]
+			local sw : fallback _stroke : ADoubleStoreyStroke df
 			return : ADoubleStoreyHookAndBarT spiro-outline df hookStyle y0 sw
 
 		define [ADoubleStoreyArcT df sink kind rise stroke exd] : glyph-proc
 			local isMask : sink == spiro-outline
-			local bartop : XH * DesignParameters.aBarPos + stroke * 0.425
-			local bowlArcY1 : YSmoothMidL bartop 0 SmallArchDepthA SmallArchDepthB
-			local bowlArcY2 : YSmoothMidR bartop 0 SmallArchDepthA SmallArchDepthB
+			local barTop : XH * DesignParameters.aBarPos + stroke * 0.425
+			local ada2 : ArchDepthAOf : SmallArchDepth * DesignParameters.aBarPos
+			local adb2 : ArchDepthBOf : SmallArchDepth * DesignParameters.aBarPos
+			local bowlArcY1 : YSmoothMidL barTop 0 ada2 adb2
+			local bowlArcY2 : YSmoothMidR barTop 0 ada2 adb2
 			local leftSlopeS : 0.1 * (df.width / HalfUPM)
 			local leftSlope  : leftSlopeS - TanSlope
 			include : sink
 				widths.lhs stroke
-				[if isMask corner flat] (df.rightSB + O) bartop [heading Leftward]
-				curl [mix df.rightSB df.middle 0.9] bartop
+				[if isMask corner flat] (df.rightSB + O) barTop [heading Leftward]
+				curl [mix df.rightSB df.middle 0.9] barTop
 				archv
-				g4 (df.leftSB + OX) (bowlArcY1 - [HSwToV : Stroke * leftSlopeS]) [heading {.x HVContrast .y leftSlope}]
+				g4 (df.leftSB + OX) (bowlArcY1 - [HSwToV : SmoothAdjust * leftSlopeS]) [heading {.x HVContrast .y leftSlope}]
 				match kind
 					0 : list
 						arch.lhs 0 (sw -- stroke) (swAfter -- df.shoulderFine)
-						straight.up.end (df.rightSB - exd - [HSwToV : stroke - df.shoulderFine]) [Math.min [df.archDepthAOf (SmallArchDepth * 0.9) stroke] (bartop - TINY)] [widths.lhs df.shoulderFine]
-						if isMask { [corner (df.rightSB - exd - [HSwToV : stroke - df.shoulderFine]) bartop] } {}
+						[if isMask flat straight.up.end] (df.rightSB - exd - [HSwToV : stroke - df.shoulderFine]) [Math.min (barTop - [if isMask TINY 0]) : df.archDepthAOf (SmallArchDepth * 0.9) stroke] [widths.lhs df.shoulderFine]
+						if isMask { [corner (df.rightSB - exd - [HSwToV : stroke - df.shoulderFine]) barTop] } {}
 					1 : list
 						arch.lhs 0 (sw -- stroke) (blendPost -- {})
 						g4   df.rightSB rise
@@ -73,11 +75,11 @@ glyph-block Letter-Latin-Lower-A : begin
 						curl df.rightSB (rise + [HSwToV : stroke * TanSlope] + TINY) [heading Upward]
 
 		export : define [Arc df kind rise _sw _exd] : ADoubleStoreyArcT df dispiro kind rise
-			fallback _sw [ADoubleStoreyStroke df]
+			fallback _sw : ADoubleStoreyStroke df
 			fallback _exd 0
 
 		export : define [ArcMask df kind rise _sw _exd] : ADoubleStoreyArcT df spiro-outline kind rise
-			fallback _sw [ADoubleStoreyStroke df]
+			fallback _sw : ADoubleStoreyStroke df
 			fallback _exd 0
 
 		export : define [Serifless df hookStyle sw] : union


### PR DESCRIPTION
I've found that, when the following section:
```
local bowlArcY1 : YSmoothMidL bartop 0 SmallArchDepthA SmallArchDepthB
local bowlArcY2 : YSmoothMidR bartop 0 SmallArchDepthA SmallArchDepthB
```
...is rewritten to this:
```
local ada2 : ArchDepthAOf : SmallArchDepth * DesignParameters.aBarPos
local adb2 : ArchDepthBOf : SmallArchDepth * DesignParameters.aBarPos
local bowlArcY1 : YSmoothMidL barTop 0 ada2 adb2
local bowlArcY2 : YSmoothMidR barTop 0 ada2 adb2
```
...then the following line:
```
g4 (df.leftSB + OX) (bowlArcY1 - [HSwToV : Stroke * leftSlopeS]) [heading {.x HVContrast .y leftSlope}]
```
is better like this:
```
g4 (df.leftSB + OX) (bowlArcY1 - [HSwToV : SmoothAdjust * leftSlopeS]) [heading {.x HVContrast .y leftSlope}]
```
...basically just with `Stroke` replaced with `SmoothAdjust`, as that's how much of `bowlArcY1` is eaten by
`[heading {.x HVContrast .y (0.1 * (df.width / HalfUPM) - TanSlope)}]`, assuming that the `TanSlope` part is already handled by `YSmoothMidL` itself, now that it has been flipped rightside-up by #2839 .

This hinges on the first change here though, because otherwise:
(`SmallArchDepthA` + `SmallArchDepthB`) > `XH * DesignParameters.aBarPos + stroke * 0.425` which would squish the `delta` variable defined in the code for `YSmoothMidL` (in `meta/aesthetics.ptl`).

-----

For each screenshot below: Top row is before (i.e. the latest release version), bottom row is after.

`aꜳæꜵꜷꙗ𝕒`

Sans Monospace Thin Upright under `'cv36'1,'cv87'1`:
<img width="1114" height="640" alt="image" src="https://github.com/user-attachments/assets/b77c2a88-1d6e-4805-b88b-8e451b86d7bc" />
Sans Monospace Regular Upright under `'cv36'1,'cv87'1`:
<img width="1114" height="634" alt="image" src="https://github.com/user-attachments/assets/e32821dc-faad-4372-996c-2be8d0a52fe7" />
Sans Monospace Heavy Upright under `'cv36'1,'cv87'1`:
<img width="1113" height="619" alt="image" src="https://github.com/user-attachments/assets/2c850119-ac94-4035-b300-29ec812690ea" />
Sans Monospace Thin Italic under `'cv36'1,'cv87'1`:
<img width="1088" height="618" alt="image" src="https://github.com/user-attachments/assets/f4717b4c-aaa4-4c9e-8d5f-324de9e13b8e" />
Sans Monospace Regular Italic under `'cv36'1,'cv87'1`:
<img width="1090" height="623" alt="image" src="https://github.com/user-attachments/assets/f9ea0670-7c70-4b8d-82d4-bc797e1abdde" />
Sans Monospace Heavy Italic under `'cv36'1,'cv87'1`:
<img width="1092" height="624" alt="image" src="https://github.com/user-attachments/assets/5cd6ae83-afe5-4fe3-a61b-0de7b15c41f5" />

