### PR TITLE
Use more sophisticated swash suppression behavior for Lower E shapes.

### DIFF
--- a/packages/font-glyphs/src/common/shapes.ptl
+++ b/packages/font-glyphs/src/common/shapes.ptl
@@ -413,12 +413,12 @@ glyph-block CommonShapes : begin
 
 	define nHookSegments 12
 	define [HookShape toStraight toFinish isStart args] : begin
-		local [object yRef sw swTerminal isTail noSwash overshoot] args
+		local [object yRef sw swTerminal isTail suppressSwash overshoot] args
 
 		local atBottom : toStraight.y > yRef
 		local ltr : if isStart (toFinish.x < toStraight.x) (toFinish.x > toStraight.x)
 		local dtu : if isStart (yRef > toFinish.y) (yRef < toFinish.y)
-		local doSwash : !noSwash && !isStart && atBottom && (para.isItalic || isTail) && [if (para.slopeAngle >= 0) ltr [not ltr]]
+		local doSwash : !suppressSwash && !isStart && atBottom && (isTail || (para.isItalic && (para.slopeAngle != 0) && [if (para.slopeAngle > 0) ltr [not ltr]]))
 		local superness DesignParameters.superness
 
 		local y : yRef + [if (yRef > toFinish.y) (-1) (+1)] * overshoot
@@ -502,9 +502,9 @@ glyph-block CommonShapes : begin
 		local-parameter : sw             -- Stroke
 		local-parameter : swTerminal     -- sw
 		local-parameter : isTail         -- false
-		local-parameter : noSwash        -- false
+		local-parameter : suppressSwash  -- false
 		local-parameter : o              -- O
-		local args : object [yRef y] sw swTerminal isTail noSwash [overshoot o]
+		local args : object [yRef y] sw swTerminal isTail suppressSwash [overshoot o]
 		return : new FunctionInterpolator hookStartBlender args
 
 	glyph-block-export hookend
@@ -513,9 +513,9 @@ glyph-block CommonShapes : begin
 		local-parameter : sw             -- Stroke
 		local-parameter : swTerminal     -- sw
 		local-parameter : isTail         -- false
-		local-parameter : noSwash        -- false
+		local-parameter : suppressSwash  -- false
 		local-parameter : o              -- O
-		local args : object [yRef y] sw swTerminal isTail noSwash [overshoot o]
+		local args : object [yRef y] sw swTerminal isTail suppressSwash [overshoot o]
 		return : new FunctionInterpolator hookEndBlender args
 
 	glyph-block-export flatside

--- a/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
@@ -124,6 +124,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 						stroke -- df.mvs
 						ada    -- subDf.smallArchDepthA
 						adb    -- subDf.smallArchDepthB
+						ccw    -- true
 
 		define Config : object
 			flatCrossbar { SmallEShape        RevSmallEShape        }

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -16,33 +16,33 @@ glyph-block Letter-Latin-Lower-E : begin
 	glyph-block-import Mark-Adjustment : ExtendBelowBaseAnchors
 	glyph-block-import Letter-Latin-C : CConfig
 
-	define [HookHeightFull top stroke noSwash] : Math.min Hook : AHook * (top / XH)
+	define [EHook top] : Math.min Hook : AHook * (top / XH)
 
-	define [HookHeight top stroke noSwash] : Math.min [HookHeightFull top stroke noSwash]
-		if (para.isItalic && !noSwash) top : stroke + 0.277 * (top - stroke * 3)
+	define [HookHeight top stroke doSwash] : Math.min [EHook top]
+		if doSwash top : stroke + 0.277 * (top - stroke * 3)
 
 	define SLAB-NONE       0
 	define SLAB-CLASSICAL  1
 	define SLAB-INWARD     2
 
-	define [SmallESerifedTerminalShape df top stroke tailSlab noSwash] : match tailSlab
+	define [SmallESerifedTerminalShape df top stroke tailSlab isStart] : match tailSlab
 		[Just SLAB-CLASSICAL] : begin
-			SerifedArcEnd.LtrLhs df.rightSB 0 stroke [HookHeightFull top stroke noSwash]
+			SerifedArcEnd.LtrLhs df.rightSB 0 stroke [EHook top]
 		[Just SLAB-INWARD] : begin
-			InwardSlabArcEnd.LtrLhs df.rightSB 0 stroke [HookHeightFull top stroke noSwash]
+			InwardSlabArcEnd.LtrLhs df.rightSB 0 stroke [EHook top]
 		__ : list
-			hookend 0 (sw -- stroke) (noSwash -- noSwash)
-			g4 (df.rightSB - [if (para.isItalic && !noSwash) 0 0.5] * OX) [HookHeight top stroke noSwash]
+			hookend 0 (sw -- stroke) (suppressSwash -- isStart)
+			g4 (df.rightSB - [if (!isStart && para.isItalic && (para.slopeAngle > 0)) 0 0.5] * OX) [HookHeight top stroke (!isStart && para.isItalic && (para.slopeAngle > 0))]
 
-	define [SmallETerminalSerif df top stroke tailSlab noSwash] : match tailSlab
-		[Just SLAB-CLASSICAL] : ArcEndSerif.R       df.rightSB 0 stroke [HookHeightFull top stroke noSwash]
-		[Just SLAB-INWARD]    : ArcEndSerif.InwardR df.rightSB 0 stroke [HookHeightFull top stroke noSwash]
+	define [SmallETerminalSerif df top stroke tailSlab isStart] : match tailSlab
+		[Just SLAB-CLASSICAL] : ArcEndSerif.R       df.rightSB 0 stroke [EHook top]
+		[Just SLAB-INWARD]    : ArcEndSerif.InwardR df.rightSB 0 stroke [EHook top]
 		__ : no-shape
 
 	glyph-block-export SmallEShape
 	define [SmallEShape] : with-params [
 		df top [stroke [AdviceStroke2 2 3 top]] [barpos DesignParameters.eBarPos] [bbd 0]
-		[ada SmallArchDepthA] [adb SmallArchDepthB] [tailSlab nothing] [noSwash false]
+		[ada SmallArchDepthA] [adb SmallArchDepthB] [tailSlab nothing] [cw false]
 		] : glyph-proc
 		local barBottom : top * barpos - (stroke / 2)
 
@@ -53,16 +53,16 @@ glyph-block Letter-Latin-Lower-E : begin
 			curl (df.rightSB - OX) (top - adb)
 			arch.lhs top (sw -- stroke)
 			flatside.ld df.leftSB 0 top ada adb
-			SmallESerifedTerminalShape df top stroke tailSlab noSwash
+			SmallESerifedTerminalShape df top stroke tailSlab cw
 
-		include : SmallETerminalSerif df top stroke tailSlab noSwash
+		include : SmallETerminalSerif df top stroke tailSlab cw
 
 		return path.rhsKnots.[path.rhsKnots.length - 1]
 
 	glyph-block-export RevSmallEShape
 	define [RevSmallEShape] : with-params [
 		df top [stroke [AdviceStroke2 2 3 top]] [barpos DesignParameters.eBarPos]
-		[ada SmallArchDepthA] [adb SmallArchDepthB]
+		[ada SmallArchDepthA] [adb SmallArchDepthB] [ccw false]
 		] : glyph-proc
 		local barBottom : top * barpos - (stroke / 2)
 
@@ -73,13 +73,13 @@ glyph-block Letter-Latin-Lower-E : begin
 			curl (df.leftSB + OX) (top - ada)
 			arch.rhs top (sw -- stroke)
 			flatside.rd df.rightSB 0 top ada adb
-			hookend 0 (sw -- stroke)
-			g4 (df.leftSB + 0.5 * OX) [HookHeight top stroke true]
+			hookend 0 (sw -- stroke) (suppressSwash -- ccw)
+			g4 (df.leftSB + [if (!ccw && para.isItalic && (para.slopeAngle < 0)) 0 0.5] * OX) [HookHeight top stroke (!ccw && para.isItalic && (para.slopeAngle < 0))]
 
 	glyph-block-export SmallERoundedShape
 	define [SmallERoundedShape] : with-params [
 		df top [stroke [AdviceStroke2 2 3 top]] [barpos DesignParameters.eBarPos]
-		[ada SmallArchDepthA] [adb SmallArchDepthB] [tailSlab nothing] [noSwash false]
+		[ada SmallArchDepthA] [adb SmallArchDepthB] [tailSlab nothing] [cw false]
 		] : glyph-proc
 		local barBottom : top * (barpos * [if para.isItalic 1 0.95]) - (stroke / 2)
 		local xStart : df.leftSB + [HSwToV : 0.125 * stroke]
@@ -89,21 +89,21 @@ glyph-block Letter-Latin-Lower-E : begin
 		local path : include : dispiro
 			widths.lhs stroke
 			[if para.isItalic g2 flat] xStart (barBottom + (2/3) * extraCurliness)
-			[if para.isItalic g2.right.mid curl] [mix xStart df.rightSB (0.475 + 0.1 * TanSlope)] (barBottom - (1/3) * extraCurliness)
-			if [not para.isItalic] [archv] {}
+			[if para.isItalic g2.right.mid curl] [mix xStart df.rightSB (0.475 + 0.1 * TanSlope)] (barBottom - (1/3) * extraCurliness) [if (para.isItalic && (para.slopeAngle > 0)) null [heading Rightward]]
+			if (para.isItalic && (para.slopeAngle > 0)) {} { [archv] }
 			g4 (df.rightSB - OX) [YSmoothMidR top barBottom ada2 adb2]
 			arch.lhs top (sw -- stroke)
 			flatside.ld df.leftSB 0 top ada adb
-			SmallESerifedTerminalShape df top stroke tailSlab noSwash
+			SmallESerifedTerminalShape df top stroke tailSlab cw
 
-		include : SmallETerminalSerif df top stroke tailSlab noSwash
+		include : SmallETerminalSerif df top stroke tailSlab cw
 
 		return path.rhsKnots.[path.rhsKnots.length - 1]
 
 	glyph-block-export RevSmallERoundedShape
 	define [RevSmallERoundedShape] : with-params [
 		df top [stroke [AdviceStroke2 2 3 top]] [barpos DesignParameters.eBarPos]
-		[ada SmallArchDepthA] [adb SmallArchDepthB]
+		[ada SmallArchDepthA] [adb SmallArchDepthB] [ccw false]
 		] : glyph-proc
 		local barBottom : top * (barpos * [if para.isItalic 1 0.95]) - (stroke / 2)
 		local xStart : df.rightSB - [HSwToV : 0.125 * stroke]
@@ -113,16 +113,16 @@ glyph-block Letter-Latin-Lower-E : begin
 		include : dispiro
 			widths.rhs stroke
 			[if para.isItalic g2 flat] xStart (barBottom + (2/3) * extraCurliness)
-			[if para.isItalic g2.left.mid curl] [mix xStart df.leftSB (0.475 + 0.1 * TanSlope)] (barBottom - (1/3) * extraCurliness)
-			archv
+			[if para.isItalic g2.left.mid curl] [mix xStart df.leftSB (0.475 - 0.1 * TanSlope)] (barBottom - (1/3) * extraCurliness) [if (para.isItalic && (para.slopeAngle < 0)) null [heading Leftward]]
+			if (para.isItalic && (para.slopeAngle < 0)) {} { [archv] }
 			g4 (df.leftSB + OX) [YSmoothMidL top barBottom ada2 adb2]
 			arch.rhs top (sw -- stroke)
 			flatside.rd df.rightSB 0 top ada adb
-			hookend 0 (sw -- stroke)
-			g4 (df.leftSB + 0.5 * OX) [HookHeight top stroke true]
+			hookend 0 (sw -- stroke) (suppressSwash -- ccw)
+			g4 (df.leftSB + [if (!ccw && para.isItalic && (para.slopeAngle < 0)) 0 0.5] * OX) [HookHeight top stroke (!ccw && para.isItalic && (para.slopeAngle < 0))]
 
 	define [AbkCheShape] : with-params [
-		fDesc Body df top [stroke [Math.min df.mvs : AdviceStroke2 2 3 top]] [barpos nothing]
+		fDesc Body df top [stroke [Math.min df.mvs : AdviceStroke2 2 3 top]] [barpos DesignParameters.eBarPos]
 		[ada SmallArchDepthA] [adb SmallArchDepthB] [tailSlab nothing]
 		] : glyph-proc
 		local gap : 0.375 * (df.width - 2 * df.leftSB - 2.5 * stroke) - [HSwToV : 0.25 * stroke]
@@ -144,13 +144,14 @@ glyph-block Letter-Latin-Lower-E : begin
 		include : Translate shift 0
 
 		local hd : FlatHookDepth df
-		local yBar : top * DesignParameters.eBarPos - 0.5 * stroke
+		local barBottom : top * barpos - (stroke / 2)
 		include : intersection [MaskLeft : subDf.leftSB + shift] : dispiro
-			flat (df.leftSB - [HSwToV : 0.25 * stroke]) (yBar + Hook) [widths.lhs.heading stroke Downward]
-			curl (df.leftSB - [HSwToV : 0.25 * stroke]) (yBar + [Math.min Hook hd.y] - 0.25 * stroke) [heading Downward]
+			widths.lhs stroke
+			flat (df.leftSB - [HSwToV : 0.25 * stroke]) (barBottom + Hook) [heading Downward]
+			curl (df.leftSB - [HSwToV : 0.25 * stroke]) (barBottom + [Math.min Hook hd.y] - 0.25 * stroke) [heading Downward]
 			arcvh
-			flat [Math.min (df.leftSB + hd.x - [HSwToV : 0.5 * stroke]) (subDf.leftSB + shift)] yBar
-			curl (subDf.middle + shift) yBar
+			flat [Math.min (df.leftSB + hd.x - [HSwToV : 0.5 * stroke]) (subDf.leftSB + shift)] barBottom
+			curl (subDf.middle + shift) barBottom
 
 	define SmallEConfig : object
 		flatCrossbar { SmallEShape        RevSmallEShape        }
@@ -196,7 +197,7 @@ glyph-block Letter-Latin-Lower-E : begin
 						modifier : function [rt] : widths.rhs [mix fine markStroke : rt ** 2]
 					g4.down.mid (RightSB - extL) ((-0.75) * depth) [widths.rhs.heading markStroke {.x HVContrast .y turnSlope}]
 					arcvh [widths.rhs markStroke]
-					g4 (RightSB + [mix (-extL) extR (11/16)]) ((-depth) + O) [heading Rightward]
+					g4 (RightSB + [mix (-extL) (+extR) (11/16)]) ((-depth) + O) [heading Rightward]
 					g4 (RightSB + extR) ((-depth) + 0.5 * O) [heading Rightward]
 
 		create-glyph "eWithNotch.\(suffix)" : glyph-proc
@@ -296,7 +297,7 @@ glyph-block Letter-Latin-Lower-E : begin
 					ada -- ArchDepthA
 					adb -- ArchDepthB
 					tailSlab -- styTop
-					noSwash -- true
+					cw -- true
 				include : FlipAround Middle (CAP / 2)
 			create-glyph "cyrl/schwa.\(suffix).\(suffixSerif)" : glyph-proc
 				set-width 0
@@ -305,7 +306,7 @@ glyph-block Letter-Latin-Lower-E : begin
 					ada -- SmallArchDepthA
 					adb -- SmallArchDepthB
 					tailSlab -- styTop
-					noSwash -- true
+					cw -- true
 				include : FlipAround Middle (XH / 2)
 
 			create-glyph "cyrl/abk/Che.\(suffix).\(suffixSerif)" : glyph-proc


### PR DESCRIPTION
Basically telling it to draw characters derived from either `e`/`ɘ` as clockwise or counterclockwise compared to how they would be drawn normally, and determining whether the `hookend` in the terminal should therefore treat itself as a "backwards `hookstart`" and suppress its swash based on that.

Also, when `para.slopeAngle` is negative, this makes the `archv` part of the existing `e.rounded` code trigger for `ɘ` instead of `e`.

Also make swashes not trigger at all when `para.SlopeAngle` is `0`, unless it uses `isTail`.
I could probably later make the `isTail` part also require `para.SlopeAngle` to not be `0`, but that would require further testing and it would also visually change some variants of `i`/`l` under upright if I did.

For each screenshot below: Left is before, right is after.

```
ƏəӘәЭэ
EeƎɘƎǝ
œꭀᴔæꬱᴂ
```

Thin Upright:
<img width="1939" height="1072" alt="image" src="https://github.com/user-attachments/assets/91acb76b-7dee-4ea2-83c1-eade37c8db8f" />
Regular Upright:
<img width="1923" height="1028" alt="image" src="https://github.com/user-attachments/assets/b54953af-a637-4c19-8557-af842d0cc5b8" />
Heavy Upright:
<img width="1902" height="1027" alt="image" src="https://github.com/user-attachments/assets/25512c01-20ef-4822-b7b1-634cd444e89e" />
Thin Italic:
<img width="1931" height="1020" alt="image" src="https://github.com/user-attachments/assets/1823b124-dbe6-4cca-b30a-2cd4dda9acf0" />
Regular Italic:
<img width="1873" height="999" alt="image" src="https://github.com/user-attachments/assets/c8101462-cef7-4b42-8d29-a61434bce7ce" />
Heavy Italic:
<img width="1899" height="990" alt="image" src="https://github.com/user-attachments/assets/20d4a02f-c438-47ed-8abe-4192b30af66b" />
