### PR TITLE
Cleanup of #2845 .

### DIFF
--- a/packages/font-glyphs/src/letter/cyrillic/iotified-a.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/iotified-a.ptl
@@ -183,6 +183,7 @@ glyph-block Letter-Cyrillic-Iotified-A : begin
 				include : with-transform [ApparentTranslate shift 0]
 					body subDf XH
 						stroke -- df.mvs
+						hook   -- AHook
 						ada    -- (SmallArchDepthA * 0.7 * df.adws)
 						adb    -- (SmallArchDepthB * 0.7 * df.adws)
 

--- a/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
@@ -113,6 +113,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 			return : with-transform [ApparentTranslate shift 0]
 				body subDf XH
 					stroke -- df.mvs
+					hook   -- AHook
 					ada    -- subDf.smallArchDepthA
 					adb    -- subDf.smallArchDepthB
 
@@ -122,6 +123,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 				with-transform [FlipAround subDf.middle (XH / 2)]
 					revbody subDf XH
 						stroke -- df.mvs
+						hook   -- AHook
 						ada    -- subDf.smallArchDepthA
 						adb    -- subDf.smallArchDepthB
 						ccw    -- true

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -16,35 +16,32 @@ glyph-block Letter-Latin-Lower-E : begin
 	glyph-block-import Mark-Adjustment : ExtendBelowBaseAnchors
 	glyph-block-import Letter-Latin-C : CConfig
 
-	define [EHook top] : Math.min Hook : AHook * (top / XH)
-
-	define [HookHeight top stroke doSwash] : Math.min [EHook top]
-		if doSwash top : stroke + 0.277 * (top - stroke * 3)
+	define [SmallEHook top stroke hook doSwash] : Math.min hook : if doSwash top : mix stroke (top * DesignParameters.eBarPos - stroke / 2) 0.554
 
 	define SLAB-NONE       0
 	define SLAB-CLASSICAL  1
 	define SLAB-INWARD     2
 
-	define [SmallESerifedTerminalShape df top stroke tailSlab isStart] : match tailSlab
+	define [SmallESerifedTerminalShape df top stroke hook tailSlab isStart] : match tailSlab
 		[Just SLAB-CLASSICAL] : begin
-			SerifedArcEnd.LtrLhs df.rightSB 0 stroke [EHook top]
+			SerifedArcEnd.LtrLhs df.rightSB 0 stroke hook
 		[Just SLAB-INWARD] : begin
-			InwardSlabArcEnd.LtrLhs df.rightSB 0 stroke [EHook top]
+			InwardSlabArcEnd.LtrLhs df.rightSB 0 stroke hook
 		__ : list
 			hookend 0 (sw -- stroke) (suppressSwash -- isStart)
-			g4 (df.rightSB - [if (!isStart && para.isItalic && (para.slopeAngle > 0)) 0 0.5] * OX) [HookHeight top stroke (!isStart && para.isItalic && (para.slopeAngle > 0))]
+			g4 (df.rightSB - [if (!isStart && para.isItalic && (para.slopeAngle > 0)) 0 0.5] * OX) [SmallEHook top stroke hook (!isStart && para.isItalic && (para.slopeAngle > 0))]
 
-	define [SmallETerminalSerif df top stroke tailSlab isStart] : match tailSlab
-		[Just SLAB-CLASSICAL] : ArcEndSerif.R       df.rightSB 0 stroke [EHook top]
-		[Just SLAB-INWARD]    : ArcEndSerif.InwardR df.rightSB 0 stroke [EHook top]
+	define [SmallETerminalSerif df top stroke hook tailSlab isStart] : match tailSlab
+		[Just SLAB-CLASSICAL] : ArcEndSerif.R       df.rightSB 0 stroke hook
+		[Just SLAB-INWARD]    : ArcEndSerif.InwardR df.rightSB 0 stroke hook
 		__ : no-shape
 
 	glyph-block-export SmallEShape
 	define [SmallEShape] : with-params [
-		df top [stroke [AdviceStroke2 2 3 top]] [barpos DesignParameters.eBarPos] [bbd 0]
+		df top [stroke [AdviceStroke2 2 3 top]] [hook AHook] [bbd 0]
 		[ada SmallArchDepthA] [adb SmallArchDepthB] [tailSlab nothing] [cw false]
 		] : glyph-proc
-		local barBottom : top * barpos - (stroke / 2)
+		local barBottom : top * DesignParameters.eBarPos - (stroke / 2)
 
 		include : HBar.b ((df.leftSB + OX) + (stroke / 2) + bbd) ((df.rightSB - OX) - (stroke / 2)) barBottom stroke
 		local path : include : dispiro
@@ -53,18 +50,18 @@ glyph-block Letter-Latin-Lower-E : begin
 			curl (df.rightSB - OX) (top - adb)
 			arch.lhs top (sw -- stroke)
 			flatside.ld df.leftSB 0 top ada adb
-			SmallESerifedTerminalShape df top stroke tailSlab cw
+			SmallESerifedTerminalShape df top stroke hook tailSlab cw
 
-		include : SmallETerminalSerif df top stroke tailSlab cw
+		include : SmallETerminalSerif df top stroke hook tailSlab cw
 
 		return path.rhsKnots.[path.rhsKnots.length - 1]
 
 	glyph-block-export RevSmallEShape
 	define [RevSmallEShape] : with-params [
-		df top [stroke [AdviceStroke2 2 3 top]] [barpos DesignParameters.eBarPos]
+		df top [stroke [AdviceStroke2 2 3 top]] [hook AHook]
 		[ada SmallArchDepthA] [adb SmallArchDepthB] [ccw false]
 		] : glyph-proc
-		local barBottom : top * barpos - (stroke / 2)
+		local barBottom : top * DesignParameters.eBarPos - (stroke / 2)
 
 		include : HBar.b ((df.leftSB + OX) + (stroke / 2)) ((df.rightSB - OX) - (stroke / 2)) barBottom stroke
 		include : dispiro
@@ -74,18 +71,18 @@ glyph-block Letter-Latin-Lower-E : begin
 			arch.rhs top (sw -- stroke)
 			flatside.rd df.rightSB 0 top ada adb
 			hookend 0 (sw -- stroke) (suppressSwash -- ccw)
-			g4 (df.leftSB + [if (!ccw && para.isItalic && (para.slopeAngle < 0)) 0 0.5] * OX) [HookHeight top stroke (!ccw && para.isItalic && (para.slopeAngle < 0))]
+			g4 (df.leftSB + [if (!ccw && para.isItalic && (para.slopeAngle < 0)) 0 0.5] * OX) [SmallEHook top stroke hook (!ccw && para.isItalic && (para.slopeAngle < 0))]
 
 	glyph-block-export SmallERoundedShape
 	define [SmallERoundedShape] : with-params [
-		df top [stroke [AdviceStroke2 2 3 top]] [barpos DesignParameters.eBarPos]
+		df top [stroke [AdviceStroke2 2 3 top]] [hook AHook]
 		[ada SmallArchDepthA] [adb SmallArchDepthB] [tailSlab nothing] [cw false]
 		] : glyph-proc
-		local barBottom : top * (barpos * [if para.isItalic 1 0.95]) - (stroke / 2)
+		local barBottom : top * (DesignParameters.eBarPos * [if para.isItalic 1 0.95]) - (stroke / 2)
 		local xStart : df.leftSB + [HSwToV : 0.125 * stroke]
 		local extraCurliness : if para.isItalic (0.1 * (top - barBottom)) 0
-		local ada2 : ArchDepthAOf : (1 - barpos) * SmallArchDepth
-		local adb2 : ArchDepthBOf : (1 - barpos) * SmallArchDepth
+		local ada2 : ArchDepthAOf : (1 - DesignParameters.eBarPos) * SmallArchDepth
+		local adb2 : ArchDepthBOf : (1 - DesignParameters.eBarPos) * SmallArchDepth
 		local path : include : dispiro
 			widths.lhs stroke
 			[if para.isItalic g2 flat] xStart (barBottom + (2/3) * extraCurliness)
@@ -94,22 +91,22 @@ glyph-block Letter-Latin-Lower-E : begin
 			g4 (df.rightSB - OX) [YSmoothMidR top barBottom ada2 adb2]
 			arch.lhs top (sw -- stroke)
 			flatside.ld df.leftSB 0 top ada adb
-			SmallESerifedTerminalShape df top stroke tailSlab cw
+			SmallESerifedTerminalShape df top stroke hook tailSlab cw
 
-		include : SmallETerminalSerif df top stroke tailSlab cw
+		include : SmallETerminalSerif df top stroke hook tailSlab cw
 
 		return path.rhsKnots.[path.rhsKnots.length - 1]
 
 	glyph-block-export RevSmallERoundedShape
 	define [RevSmallERoundedShape] : with-params [
-		df top [stroke [AdviceStroke2 2 3 top]] [barpos DesignParameters.eBarPos]
+		df top [stroke [AdviceStroke2 2 3 top]] [hook AHook]
 		[ada SmallArchDepthA] [adb SmallArchDepthB] [ccw false]
 		] : glyph-proc
-		local barBottom : top * (barpos * [if para.isItalic 1 0.95]) - (stroke / 2)
+		local barBottom : top * (DesignParameters.eBarPos * [if para.isItalic 1 0.95]) - (stroke / 2)
 		local xStart : df.rightSB - [HSwToV : 0.125 * stroke]
 		local extraCurliness : if para.isItalic (0.1 * (top - barBottom)) 0
-		local ada2 : ArchDepthAOf : (1 - barpos) * SmallArchDepth
-		local adb2 : ArchDepthBOf : (1 - barpos) * SmallArchDepth
+		local ada2 : ArchDepthAOf : (1 - DesignParameters.eBarPos) * SmallArchDepth
+		local adb2 : ArchDepthBOf : (1 - DesignParameters.eBarPos) * SmallArchDepth
 		include : dispiro
 			widths.rhs stroke
 			[if para.isItalic g2 flat] xStart (barBottom + (2/3) * extraCurliness)
@@ -119,10 +116,10 @@ glyph-block Letter-Latin-Lower-E : begin
 			arch.rhs top (sw -- stroke)
 			flatside.rd df.rightSB 0 top ada adb
 			hookend 0 (sw -- stroke) (suppressSwash -- ccw)
-			g4 (df.leftSB + [if (!ccw && para.isItalic && (para.slopeAngle < 0)) 0 0.5] * OX) [HookHeight top stroke (!ccw && para.isItalic && (para.slopeAngle < 0))]
+			g4 (df.leftSB + [if (!ccw && para.isItalic && (para.slopeAngle < 0)) 0 0.5] * OX) [SmallEHook top stroke hook (!ccw && para.isItalic && (para.slopeAngle < 0))]
 
 	define [AbkCheShape] : with-params [
-		fDesc Body df top [stroke [Math.min df.mvs : AdviceStroke2 2 3 top]] [barpos DesignParameters.eBarPos]
+		fDesc Body df top [stroke [Math.min df.mvs : AdviceStroke2 2 3 top]] [hook AHook]
 		[ada SmallArchDepthA] [adb SmallArchDepthB] [tailSlab nothing]
 		] : glyph-proc
 		local gap : 0.375 * (df.width - 2 * df.leftSB - 2.5 * stroke) - [HSwToV : 0.25 * stroke]
@@ -130,7 +127,7 @@ glyph-block Letter-Latin-Lower-E : begin
 		define subDf : DivFrame divSub 2
 		include : Body subDf top
 			stroke -- stroke
-			barpos -- barpos
+			hook -- hook
 			ada -- (ada * 0.7 * df.adws)
 			adb -- (adb * 0.7 * df.adws)
 			tailSlab -- tailSlab
@@ -144,7 +141,7 @@ glyph-block Letter-Latin-Lower-E : begin
 		include : Translate shift 0
 
 		local hd : FlatHookDepth df
-		local barBottom : top * barpos - (stroke / 2)
+		local barBottom : top * DesignParameters.eBarPos - (stroke / 2)
 		include : intersection [MaskLeft : subDf.leftSB + shift] : dispiro
 			widths.lhs stroke
 			flat (df.leftSB - [HSwToV : 0.25 * stroke]) (barBottom + Hook) [heading Downward]
@@ -161,12 +158,14 @@ glyph-block Letter-Latin-Lower-E : begin
 		create-glyph "e.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : Body [DivFrame 1] XH
+				hook -- AHook
 				ada -- SmallArchDepthA
 				adb -- SmallArchDepthB
 
 		create-glyph "eOgonek.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			local lastKnot : include : Body [DivFrame 1] XH
+				hook -- AHook
 				ada -- SmallArchDepthA
 				adb -- SmallArchDepthB
 			include : refer-glyph 'ogonekTR/spacer'
@@ -175,7 +174,7 @@ glyph-block Letter-Latin-Lower-E : begin
 			local fine : AdviceStroke 8
 			local depth : (-Descender) - markStroke
 			local extL : (7 / 16) * depth + 0.25 * markStress
-			local extR : Math.max (0.0625 * markExtend) (1.5 * TanSlope * markStroke)
+			local extR : Math.max (0.0625 * markExtend) (TanSlope * (1.5 * markStroke))
 			local beginCoSlope : if para.isItalic 0.2 0
 
 			set-base-anchor 'trailing' (RightSB + extR) ((-depth) + 0.5 * O - markStroke)
@@ -203,6 +202,7 @@ glyph-block Letter-Latin-Lower-E : begin
 		create-glyph "eWithNotch.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			local lastKnot : include : Body [DivFrame 1] XH
+				hook -- AHook
 				ada -- SmallArchDepthA
 				adb -- SmallArchDepthB
 			local sw : AdviceStroke 4
@@ -218,6 +218,7 @@ glyph-block Letter-Latin-Lower-E : begin
 		create-glyph "eRetroflexHook.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : Body [DivFrame 1] XH
+				hook -- AHook
 				ada -- SmallArchDepthA
 				adb -- SmallArchDepthB
 				tailSlab -- SLAB-CLASSICAL
@@ -229,6 +230,7 @@ glyph-block Letter-Latin-Lower-E : begin
 		create-glyph "Schwa.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : Body [DivFrame 1] CAP
+				hook -- Hook
 				ada -- ArchDepthA
 				adb -- ArchDepthB
 			include : FlipAround Middle (CAP / 2)
@@ -240,44 +242,45 @@ glyph-block Letter-Latin-Lower-E : begin
 		create-glyph "schwaRhoticHook.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleM 1
 			include : df.markSet.e
-			local divSub : Math.min 1 : 0.85 * para.advanceScaleM
-			local dfSub : DivFrame divSub 2
-			local stroke : AdviceStroke2 2 3 XH divSub
+			local dfSub : DivFrame [Math.min 1 : 0.85 * para.advanceScaleM] 2
+			local stroke : dfSub.adviceStroke2 2 3 XH
 			include : Body dfSub XH
 				stroke -- stroke
+				hook -- AHook
 				ada -- [dfSub.archDepthAOf SmallArchDepth stroke]
 				adb -- [dfSub.archDepthBOf SmallArchDepth stroke]
 			include : FlipAround dfSub.middle (XH / 2)
-			include : RhoticHookShape (dfSub.rightSB - [HSwToV : 1.25 * markFine]) df.width (XH * 0.5) (XH * 0.2)
+			include : RhoticHookShape (dfSub.rightSB - [HSwToV : 1.25 * markFine]) df.width (XH * DesignParameters.eBarPos) (0.4 * (XH * DesignParameters.eBarPos))
 
 		create-glyph "schwaRetroflexHook.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleM 1
 			include : df.markSet.e
-			local divSub : Math.min 1 : 0.85 * para.advanceScaleM
-			local dfSub : DivFrame divSub 2
-			local stroke : AdviceStroke2 2 3 XH divSub
+			local dfSub : DivFrame [Math.min 1 : 0.85 * para.advanceScaleM] 2
+			local stroke : dfSub.adviceStroke2 2 3 XH
 			include : Body dfSub XH
 				stroke -- stroke
+				hook -- AHook
 				ada -- [dfSub.archDepthAOf SmallArchDepth stroke]
 				adb -- [dfSub.archDepthBOf SmallArchDepth stroke]
 			include : FlipAround dfSub.middle (XH / 2)
 			include : RetroflexHook.r
 				x -- [mix RightSB df.width 0.5]
 				y -- 0
-				yAttach -- (XH / 2 - HalfStroke)
+				yAttach -- (XH * DesignParameters.eBarPos - HalfStroke)
 				xLink -- (dfSub.rightSB - [HSwToV : 0.5 * stroke])
 				refSw -- [AdviceStroke 4]
 
 		create-glyph "eRev.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : RevBody [DivFrame 1] XH
+				hook -- AHook
 				ada -- SmallArchDepthA
 				adb -- SmallArchDepthB
 
 		create-glyph "eBar.\(suffix)" : glyph-proc
 			include [refer-glyph "e.\(suffix)"] AS_BASE ALSO_METRICS
-			include : HBar.m [mix SB 0 0.7] [mix RightSB Width 0.7] (XH * 0.25 + QuarterStroke)
-				Math.min (0.25 * (XH - 3 * Stroke)) : AdviceStroke 5
+			local yBar : mix Stroke (XH * DesignParameters.eBarPos - HalfStroke) 0.5
+			include : HBar.m [mix SB 0 0.7] [mix RightSB Width 0.7] yBar [Math.min (yBar - Stroke) : AdviceStroke 5]
 
 		DefineSelectorGlyph "cyrl/Schwa" suffix [DivFrame 1] 'capital'
 		DefineSelectorGlyph "cyrl/schwa" suffix [DivFrame 1] 'e'
@@ -294,6 +297,7 @@ glyph-block Letter-Latin-Lower-E : begin
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
 				include : Body [DivFrame 1] CAP
+					hook -- Hook
 					ada -- ArchDepthA
 					adb -- ArchDepthB
 					tailSlab -- styTop
@@ -303,6 +307,7 @@ glyph-block Letter-Latin-Lower-E : begin
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
 				include : Body [DivFrame 1] XH
+					hook -- AHook
 					ada -- SmallArchDepthA
 					adb -- SmallArchDepthB
 					tailSlab -- styTop
@@ -313,6 +318,7 @@ glyph-block Letter-Latin-Lower-E : begin
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
 				include : AbkCheShape false Body abkCheDf CAP
+					hook -- Hook
 					ada -- ArchDepthA
 					adb -- ArchDepthB
 					tailSlab -- styBot
@@ -320,6 +326,7 @@ glyph-block Letter-Latin-Lower-E : begin
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
 				include : AbkCheShape false Body abkCheDf XH
+					hook -- AHook
 					ada -- SmallArchDepthA
 					adb -- SmallArchDepthB
 					tailSlab -- styBot
@@ -327,6 +334,7 @@ glyph-block Letter-Latin-Lower-E : begin
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
 				include : AbkCheShape true Body abkCheDf CAP
+					hook -- Hook
 					ada -- ArchDepthA
 					adb -- ArchDepthB
 					tailSlab -- styBot
@@ -334,6 +342,7 @@ glyph-block Letter-Latin-Lower-E : begin
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
 				include : AbkCheShape true Body abkCheDf XH
+					hook -- AHook
 					ada -- SmallArchDepthA
 					adb -- SmallArchDepthB
 					tailSlab -- styBot
@@ -378,6 +387,7 @@ glyph-block Letter-Latin-Lower-E : begin
 		include : MarkSet.e
 		include : SmallEShape [DivFrame 1] XH
 			stroke -- BBS
+			hook -- AHook
 			bbd -- BBD
 			ada -- SmallArchDepthA
 			adb -- SmallArchDepthB


### PR DESCRIPTION
Code cleanup:

Cleanup some heavily obfuscated expressions in `letter/latin/e.ptl`. Example:
`mix stroke (top * 0.5 - stroke / 2) 0.554` from the previous `stroke + 0.277 * (top - stroke * 3)` etc.

I was tempted to substitute `0.277` for `(5 / 18)` (or 0.2777(...)) in the above expression, which would have yielded `(5 / 9)` (or 0.5555(...)), but I didn't want to change any more than I already have so far.

Also drop `barpos` argument in {`Rev`}`SmallE`{`Rounded`}`Shape` — which currently doesn't get taken advantage of — In favor of `hook` — Which _does_ get taken advantage of. Example: in `Ə` etc.

Also rewrite certain `e`-derived characters to be aware of `DesignParameters.eBarPos` instead of just assuming `/ 2` or `* 0.5`, even if they are currently equivalent.

Otherwise, nothing is visually changed, hence no screenshots.