### PR TITLE
Finishing touches for double-storey `a`.

### DIFF
--- a/packages/font-glyphs/src/letter/latin/lower-a.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-a.ptl
@@ -60,7 +60,7 @@ glyph-block Letter-Latin-Lower-A : begin
 				[if isMask corner flat] (df.rightSB + O) barTop [heading Leftward]
 				curl [mix df.rightSB df.middle 0.9] barTop
 				archv
-				g4 (df.leftSB + OX) (bowlArcY1 - [HSwToV : SmoothAdjust * leftSlopeS]) [heading {.x HVContrast .y leftSlope}]
+				g4 (df.leftSB + OX) (bowlArcY1 - SmoothAdjust * leftSlopeS) [heading {.x HVContrast .y leftSlope}]
 				match kind
 					0 : list
 						arch.lhs 0 (sw -- stroke) (swAfter -- df.shoulderFine)
@@ -72,7 +72,7 @@ glyph-block Letter-Latin-Lower-A : begin
 					2 : list
 						arch.lhs 0 (sw -- stroke)
 						flat df.rightSB [Math.min bowlArcY2 rise]
-						curl df.rightSB (rise + [HSwToV : stroke * TanSlope] + TINY) [heading Upward]
+						curl df.rightSB (rise + stroke * TanSlope + TINY) [heading Upward]
 
 		export : define [Arc df kind rise _sw _exd] : ADoubleStoreyArcT df dispiro kind rise
 			fallback _sw : ADoubleStoreyStroke df

--- a/packages/font-glyphs/src/letter/latin/lower-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-m.ptl
@@ -15,13 +15,13 @@ glyph-block Letter-Latin-Lower-M : begin
 
 	define [SmallMSmooth df] : df.adws * (0.5 * SmallArchDepth + 0.375 * Stroke)
 	define [SmallMShoulderSpiro] : with-params [left right top bottom width fine df coBottom] : glyph-proc
-		local fix : TanSlope * [HSwToV Stroke] * width / Stroke
+		local fix : TanSlope * SmoothAdjust * (width / Stroke)
 		local sm : [SmallMSmooth df] + fix / 2
 		include : spiro-outline
-			corner (right - [HSwToV width]) [Math.min (top - sm - TINY) bottom]
+			corner (right - [HSwToV width]) [Math.min bottom : top - sm - TINY]
 			curl   (right - [HSwToV width]) (top - sm + fix)
 			arcvh 8
-			g2     [mix left (right - [HSwToV width]) 0.5] (top - O - width)
+			g2     [mix (right - [HSwToV width]) left 0.5] (top - O - width)
 			archv 8
 			flat   left (top - sm - fix)
 			corner left (top - sm - fix - 1)
@@ -34,17 +34,17 @@ glyph-block Letter-Latin-Lower-M : begin
 			g2     [mix (left - [HSwToV fine]) right 0.5] (top - O)
 			archv 8
 			flat   right (top - sm)
-			corner right [Math.min (top - sm - TINY) bottom]
+			corner right [Math.min bottom : top - sm - TINY]
 			close
 
 	define [RevSmallMShoulderSpiro] : with-params [left right top bottom width fine df coBottom] : glyph-proc
-		local fix : TanSlope * [HSwToV Stroke] * width / Stroke
+		local fix : TanSlope * SmoothAdjust * (width / Stroke)
 		local sm : [SmallMSmooth df] - fix / 2
 		include : spiro-outline
-			corner (left + [HSwToV width]) [Math.min (top - sm - TINY) bottom]
+			corner (left + [HSwToV width]) [Math.min bottom : top - sm - TINY]
 			curl   (left + [HSwToV width]) (top - sm - fix)
 			arcvh 8
-			g2     [mix right (left + [HSwToV width]) 0.5] (top - O - width)
+			g2     [mix (left + [HSwToV width]) right 0.5] (top - O - width)
 			archv 8
 			flat   right (top - sm - fix)
 			corner right (top - sm - fix - 1)
@@ -57,7 +57,7 @@ glyph-block Letter-Latin-Lower-M : begin
 			g2     [mix (right + [HSwToV fine]) left 0.5] (top - O)
 			archv 8
 			flat   left (top - sm)
-			corner left [Math.min (top - sm - TINY) bottom]
+			corner left [Math.min bottom : top - sm - TINY]
 			close
 
 	define [SmallMTopLeftSerif df top lbot fFull] : begin


### PR DESCRIPTION
As it turns out, the _entire expression_ `[HSwToV Stroke]` seemed to have been what was serving as the stand-in for `SmoothAdjust`.
Previously, removing `HSwToV` would break the geometry, but now that `YSmoothMidL` has been flipped right­side-up via #2839 , it is no longer needed.

For each screenshot below: Top row is before, bottom row is after.

`aꜳæꜵꜷꙗ𝕒`

Monospace Thin Upright:
<img width="959" height="548" alt="image" src="https://github.com/user-attachments/assets/be9fab2e-daa6-4a63-ab4c-8f93fa8ce859" />
Monospace Regular Upright:
<img width="950" height="534" alt="image" src="https://github.com/user-attachments/assets/8f9fcd3e-ba58-4b20-abf0-d6bf97647d98" />
Monospace Heavy Upright:
<img width="972" height="538" alt="image" src="https://github.com/user-attachments/assets/fe35f05a-a2dc-4630-9317-34e4be8e5e16" />
Monospace Thin Italic under `'cv36'3,'cv87'3`:
<img width="973" height="549" alt="image" src="https://github.com/user-attachments/assets/1184d4b4-0f70-4079-bb14-a11a9c7eb5c3" />
Monospace Regular Italic under `'cv36'3,'cv87'3`:
<img width="950" height="541" alt="image" src="https://github.com/user-attachments/assets/0eb67dc9-51b0-4d9f-898f-e368e87dbc36" />
Monospace Heavy Italic under `'cv36'3,'cv87'3`:
<img width="964" height="538" alt="image" src="https://github.com/user-attachments/assets/2c0e514c-611e-4fb4-bc0a-560085ed440f" />
Aile Thin Upright:
<img width="1544" height="581" alt="image" src="https://github.com/user-attachments/assets/0232140c-b693-4e93-8a08-307b36da6cf7" />
Aile Regular Upright:
<img width="1519" height="550" alt="image" src="https://github.com/user-attachments/assets/bca98fd7-5f28-4b1d-be51-bd38e13cac85" />
Aile Heavy Upright:
<img width="1526" height="540" alt="image" src="https://github.com/user-attachments/assets/dc2596e7-6216-43bc-be05-77e3cb30a901" />
Aile Thin Italic:
<img width="1526" height="555" alt="image" src="https://github.com/user-attachments/assets/cf47f489-6843-4da1-bbc7-915f260280a9" />
Aile Regular Italic:
<img width="1519" height="567" alt="image" src="https://github.com/user-attachments/assets/38a5d525-5843-4b35-b9f4-d340c5f41c13" />
Aile Heavy Italic:
<img width="1502" height="534" alt="image" src="https://github.com/user-attachments/assets/95ff496a-53cd-4e9d-907a-b85f204543a7" />
