### PR TITLE
Restore serif behavior to Latin Schwa (`Ə`, `ə`).

### DIFF
--- a/packages/font-glyphs/src/letter/cyrillic/iotified-a.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/iotified-a.ptl
@@ -162,15 +162,9 @@ glyph-block Letter-Cyrillic-Iotified-A : begin
 				include : Iotified.full df XH (shift + subDf.leftSB + [HSwToV : 0.5 * df.mvs]) (XH / 2)
 
 	do "iotified e"
-		glyph-block-import Letter-Latin-Lower-E : SmallEShape SmallERoundedShape
+		glyph-block-import Letter-Latin-Lower-E : SmallEConfig
 
-		define [EShape pShift df body] : begin
-
-		define Config : object
-			flatCrossbar { SmallEShape        }
-			rounded      { SmallERoundedShape }
-
-		foreach { suffix { body } } [Object.entries Config] : do
+		foreach { suffix { body revbody } } [Object.entries SmallEConfig] : do
 			create-glyph "latn/eIotified.\(suffix)" : glyph-proc
 				define df : include : DivFrame para.advanceScaleM 3
 				include : df.markSet.e

--- a/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
@@ -106,7 +106,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 			include : oeOPart 1 df CAP ArchDepth
 
 	do "e subglyphs"
-		glyph-block-import Letter-Latin-Lower-E : SmallEShape SmallERoundedShape RevSmallEShape RevSmallERoundedShape
+		glyph-block-import Letter-Latin-Lower-E : SmallEConfig
 
 		define [EShape pShift df body] : begin
 			local { subDf shift } : SubDfAndShift pShift df OX
@@ -127,11 +127,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 					adb    -- subDf.smallArchDepthB
 					turned -- true
 
-		define Config : object
-			flatCrossbar { SmallEShape        RevSmallEShape        }
-			rounded      { SmallERoundedShape RevSmallERoundedShape }
-
-		foreach { suffix { body revbody } } [Object.entries Config] : do
+		foreach { suffix { body revbody } } [Object.entries SmallEConfig] : do
 			create-glyph "ae/e.\(suffix)" : glyph-proc
 				local df : DivFrame para.advanceScaleMM 3
 				set-width 0
@@ -213,11 +209,10 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 				set-base-anchor 'cvDecompose' 0 0
 				include : EsTeLeftShape subDfLeft styBot
 
-	do "P/R subglyphs"
+	do "Ya subglyphs"
 		glyph-block-import Letter-Latin-Upper-P : PShape PBarPosY
 		glyph-block-import Letter-Latin-Upper-R : RevRShape RConfig RBarPos
 
-		# ya
 		foreach { suffix { legShape fOpen fTailed {slabs revSlabs doLegSlab} } } [Object.entries RConfig] : begin
 			local fSlabBot : slabs && slabs !== PShape.SlabMotion
 
@@ -243,8 +238,9 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 					eject-contour 'serifRT'
 					include : VBar.r subDf.rightSB [PBarPosY XH df.mvs bp] XH df.mvs
 
-		# p
+	do "Er subglyphs"
 		glyph-block-import Letter-Latin-Lower-P : PConfig
+
 		foreach { suffix { Body {Serifs doTS doBS} }} [Object.entries PConfig] : do
 			create-glyph "cyrl/rha/left.\(suffix)" : glyph-proc
 				local df : include : DivFrame para.advanceScaleM 3
@@ -259,7 +255,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 				include : Serifs subDf XH df.mvs
 				include : LeaningAnchor.Below.VBar.l SB
 
-	do "X subglyphs"
+	do "Kha subglyphs"
 		glyph-block-import Letter-Shared-Shapes : SerifFrame WithSerifOverflowMask
 		glyph-block-import Letter-Latin-X : XConfig XLetterForm XSerifs
 

--- a/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
@@ -134,7 +134,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 				set-mark-anchor 'cvDecompose' 0 0
 				include : EShape 1 df body
 
-			create-glyph "aeInvE/right.\(suffix)" : glyph-proc
+			create-glyph "ae/eInv.\(suffix)" : glyph-proc
 				local df : DivFrame para.advanceScaleMM 3
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
@@ -189,7 +189,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 			include : lf.full
 
 		foreach { suffix { sty styBot } } [Object.entries CConfig] : do
-			create-glyph "oeOpenO/left.\(suffix)" : glyph-proc
+			create-glyph "oe/oOpen.\(suffix)" : glyph-proc
 				local df : include : DivFrame para.advanceScaleMM 3
 				include : df.markSet.e
 				set-base-anchor 'cvDecompose' 0 0
@@ -217,7 +217,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 			local fSlabBot : slabs && slabs !== PShape.SlabMotion
 
 			if [not fTailed] : begin
-				create-glyph "cyrl/yae/left.\(suffix)" : glyph-proc
+				create-glyph "cyrl/yaie/ya.\(suffix)" : glyph-proc
 					local df : include : DivFrame para.advanceScaleMM 3
 					include : df.markSet.e
 					set-base-anchor 'cvDecompose' 0 0
@@ -404,14 +404,16 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 	select-variant "aa" 0xA733 (follow -- 'a/doubleStorey')
 
 	select-variant "ae/a"
-	select-variant "ae/e" (follow -- 'e')
-	select-variant "aeInvE/right" (follow -- 'e')
-	select-variant "ue/u"
+	select-variant "ae/e"     (follow -- 'e')
+	select-variant "ae/eInv"  (follow -- 'e')
 	select-variant "au/u"
-	select-variant "oeOpenO/left" (follow -- 'oOpen')
-	select-variant "cyrl/ae/a" (shapeFrom -- 'ae/a')
-	select-variant "cyrl/yae/left"
-	select-variant "cyrl/rha/left" (follow -- 'cyrl/er')
+	select-variant "oe/oOpen" (follow -- 'oOpen')
+	select-variant "ue/u"
+
+	select-variant "cyrl/aie/a" (shapeFrom -- 'ae/a')
+	select-variant "cyrl/yaie/ya"
+
+	select-variant "cyrl/rha/left"  (follow -- 'cyrl/er')
 	select-variant "cyrl/rha/right"
 	select-variant "cyrl/Lha/right" (follow -- 'cyrl/Rha/right')
 	select-variant "cyrl/lha/right" (follow -- 'cyrl/rha/right')
@@ -423,21 +425,24 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 	derive-composites 'au' 0xA737 'ae/a' 'au/u'
 	derive-composites 'oo' 0xA74F 'oe/o' 'ao/o'
 	derive-composites 'uo' 0xAB63 'ue/u' 'ao/o'
-	derive-composites 'oeOpenO' 0xAB62 'oeOpenO/left' 'ae/e'
-	derive-composites 'aeInvE'  0xAB31 'ae/a' 'aeInvE/right'
-	derive-composites 'oeInv'   0xAB40 'oe/o' 'aeInvE/right'
-	derive-composites 'cyrl/ae'  0x4D5 'cyrl/ae/a'     'ae/e'
-	derive-composites 'cyrl/lha' 0x515 'cyrl/lha/left' 'cyrl/lha/right'
+
+	derive-composites 'aeInv'  0xAB31 'ae/a' 'ae/eInv'
+	derive-composites 'oeInv'  0xAB40 'oe/o' 'ae/eInv'
+	derive-composites 'oOpene' 0xAB62 'oe/oOpen' 'ae/e'
+
+	derive-composites 'cyrl/aie'  0x4D5 'cyrl/aie/a'   'ae/e'
+	derive-composites 'cyrl/yaie' 0x519 'cyrl/yaie/ya' 'ae/e'
+
 	derive-composites 'cyrl/Lha' 0x514 'cyrl/Lha/left' 'cyrl/Lha/right'
-	derive-composites 'cyrl/yae' 0x519 'cyrl/yae/left' 'ae/e'
+	derive-composites 'cyrl/lha' 0x515 'cyrl/lha/left' 'cyrl/lha/right'
 
 	alias 'cyrl/oo' 0xA699 'oo'
 
 	CreateTurnedLetter 'turnae' 0x1D02 'ae' HalfAdvance (XH / 2) [DivFrame para.advanceScaleMM 3]
 	CreateTurnedLetter 'turnoe' 0x1D14 'oe' HalfAdvance (XH / 2) [DivFrame para.advanceScaleMM 3]
 
-	derive-composites 'turnoeSlashO' 0xAB41 'turnoe' 'rightHalfSlashOverlay'
-	derive-composites 'turnoeBarO' 0xAB42 'turnoe' 'rightHalfBarOverlay'
+	derive-composites 'turnoSlashe' 0xAB41 'turnoe' 'rightHalfSlashOverlay'
+	derive-composites 'turnoBare'   0xAB42 'turnoe' 'rightHalfBarOverlay'
 
 	derive-composites 'OO' 0xA74E 'OO/left' 'OO/right'
 	alias 'cyrl/OO' 0xA698 'OO'
@@ -448,11 +453,11 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 	derive-composites 'cyrl/OOBinocular' 0xA66C 'cyrl/OO' 'OODots'
 	derive-composites 'cyrl/ooBinocular' 0xA66D 'cyrl/oo' 'ooDots'
 
-	select-variant 'cyrl/este.upright/left' (follow -- 'cBottomSerifOnly')
+	select-variant 'cyrl/este.upright/left'  (follow -- 'cBottomSerifOnly')
 	select-variant 'cyrl/este.upright/right' (follow -- 'T')
 	derive-composites 'cyrl/este.upright' null 'cyrl/este.upright/left' 'cyrl/este.upright/right'
 
-	select-variant 'cyrl/este.italic/left' (follow -- 'cBottomSerifOnly')
+	select-variant 'cyrl/este.italic/left'  (follow -- 'cBottomSerifOnly')
 	select-variant 'cyrl/este.italic/right' (follow -- 'cyrl/este.italic/right')
 	derive-composites 'cyrl/este.italic' null 'cyrl/este.italic/left' 'cyrl/este.italic/right'
 

--- a/packages/font-glyphs/src/letter/latin-ext/upper-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/upper-ae-oe.ptl
@@ -140,7 +140,7 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 			local fSlabBot : slabs && slabs !== PShape.SlabMotion
 
 			if [not fTailed] : begin
-				create-glyph "cyrl/Yae/left.\(suffix)" : glyph-proc
+				create-glyph "cyrl/YaIe/YaHalf.\(suffix)" : glyph-proc
 					local df : include : DivFrame para.advanceScaleMM 3
 					include : df.markSet.capital
 					local sw : AESW df CAP
@@ -202,14 +202,16 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 
 	select-variant 'AE/AHalf' (follow -- 'A')
 	select-variant 'AE/EHalf' (follow -- 'AE/EHalf')
+	derive-composites "AE" 0xC6 'AE/AHalf' 'AE/EHalf'
+
 	select-variant 'smcpAE/AHalf' (follow -- 'A')
 	select-variant 'smcpAE/EHalf' (follow -- 'AE/EHalf')
-	select-variant 'cyrl/Yae/left'
-
-	derive-composites "AE" 0xC6 'AE/AHalf' 'AE/EHalf'
 	derive-composites "smcpAE" 0x1D01 'smcpAE/AHalf' 'smcpAE/EHalf'
-	derive-composites "cyrl/Yae" 0x518 'cyrl/Yae/left' 'AE/EHalf'
-	alias 'cyrl/AE' 0x4D4 'AE'
+
+	alias 'cyrl/AIe' 0x4D4 'AE'
+
+	select-variant 'cyrl/YaIe/YaHalf' (follow -- 'cyrl/YaIe/YaHalf')
+	derive-composites "cyrl/YaIe" 0x518 'cyrl/YaIe/YaHalf' 'AE/EHalf'
 
 	define [OEShape top df slabKind] : glyph-proc
 		define eBarPos DesignParameters.upperEBarPos
@@ -258,5 +260,5 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 			include : df.markSet.e
 			include : OEShape XH df slabKind
 
-	select-variant 'OE' 0x152 (follow -- 'AE/EHalf')
+	select-variant 'OE'     0x152 (follow -- 'AE/EHalf')
 	select-variant 'smcpOE' 0x276 (follow -- 'AE/EHalf')

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -46,7 +46,6 @@ glyph-block Letter-Latin-Lower-E : begin
 		[Just SLAB-INWARD]    : ArcEndSerif.InwardL df.leftSB 0 stroke hook
 		__ : no-shape
 
-	glyph-block-export SmallEShape
 	define flex-params [SmallEShape] : glyph-proc
 		local-parameter : df
 		local-parameter : top
@@ -75,7 +74,6 @@ glyph-block Letter-Latin-Lower-E : begin
 
 		return path.rhsKnots.[path.rhsKnots.length - 1]
 
-	glyph-block-export RevSmallEShape
 	define flex-params [RevSmallEShape] : glyph-proc
 		local-parameter : df
 		local-parameter : top
@@ -101,7 +99,6 @@ glyph-block Letter-Latin-Lower-E : begin
 
 		if turned : include : FlipAround df.middle (top / 2)
 
-	glyph-block-export SmallERoundedShape
 	define flex-params [SmallERoundedShape] : glyph-proc
 		local-parameter : df
 		local-parameter : top
@@ -133,7 +130,6 @@ glyph-block Letter-Latin-Lower-E : begin
 
 		return path.rhsKnots.[path.rhsKnots.length - 1]
 
-	glyph-block-export RevSmallERoundedShape
 	define flex-params [RevSmallERoundedShape] : glyph-proc
 		local-parameter : df
 		local-parameter : top
@@ -202,6 +198,7 @@ glyph-block Letter-Latin-Lower-E : begin
 			flat [Math.min (df.leftSB + hd.x - [HSwToV : 0.5 * stroke]) (subDf.leftSB + shift)] barBottom
 			curl (subDf.middle + shift) barBottom
 
+	glyph-block-export SmallEConfig
 	define SmallEConfig : object
 		flatCrossbar { SmallEShape        RevSmallEShape        }
 		rounded      { SmallERoundedShape RevSmallERoundedShape }

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -23,24 +23,41 @@ glyph-block Letter-Latin-Lower-E : begin
 	define SLAB-INWARD     2
 
 	define [SmallESerifedTerminalShape df top stroke hook tailSlab turned] : match tailSlab
-		[Just SLAB-CLASSICAL] : begin
-			SerifedArcEnd.LtrLhs df.rightSB 0 stroke hook
-		[Just SLAB-INWARD] : begin
-			InwardSlabArcEnd.LtrLhs df.rightSB 0 stroke hook
+		[Just SLAB-CLASSICAL] : SerifedArcEnd.LtrLhs df.rightSB 0 stroke hook
+		[Just SLAB-INWARD] : InwardSlabArcEnd.LtrLhs df.rightSB 0 stroke hook
 		__ : list
 			hookend 0 (sw -- stroke) (suppressSwash -- turned)
 			g4 (df.rightSB - [if (!turned && para.isItalic && (para.slopeAngle > 0)) 0 0.5] * OX) [SmallEHook top stroke hook (!turned && para.isItalic && (para.slopeAngle > 0))]
+
+	define [RevSmallESerifedTerminalShape df top stroke hook tailSlab turned] : match tailSlab
+		[Just SLAB-CLASSICAL] : SerifedArcEnd.RtlRhs df.leftSB 0 stroke hook
+		[Just SLAB-INWARD] : InwardSlabArcEnd.RtlRhs df.leftSB 0 stroke hook
+		__ : list
+			hookend 0 (sw -- stroke) (suppressSwash -- turned)
+			g4 (df.leftSB + [if (!turned && para.isItalic && (para.slopeAngle < 0)) 0 0.5] * OX) [SmallEHook top stroke hook (!turned && para.isItalic && (para.slopeAngle < 0))]
 
 	define [SmallETerminalSerif df top stroke hook tailSlab turned] : match tailSlab
 		[Just SLAB-CLASSICAL] : ArcEndSerif.R       df.rightSB 0 stroke hook
 		[Just SLAB-INWARD]    : ArcEndSerif.InwardR df.rightSB 0 stroke hook
 		__ : no-shape
 
+	define [RevSmallETerminalSerif df top stroke hook tailSlab turned] : match tailSlab
+		[Just SLAB-CLASSICAL] : ArcEndSerif.L       df.leftSB 0 stroke hook
+		[Just SLAB-INWARD]    : ArcEndSerif.InwardL df.leftSB 0 stroke hook
+		__ : no-shape
+
 	glyph-block-export SmallEShape
-	define [SmallEShape] : with-params [
-		df top [stroke [AdviceStroke2 2 3 top]] [hook AHook] [bbd 0]
-		[ada SmallArchDepthA] [adb SmallArchDepthB] [tailSlab nothing] [turned false]
-		] : glyph-proc
+	define flex-params [SmallEShape] : glyph-proc
+		local-parameter : df
+		local-parameter : top
+		local-parameter : stroke   -- [AdviceStroke2 2 3 top]
+		local-parameter : hook     -- AHook
+		local-parameter : bbd      -- 0
+		local-parameter : ada      -- SmallArchDepthA
+		local-parameter : adb      -- SmallArchDepthB
+		local-parameter : tailSlab -- nothing
+		local-parameter : turned   -- false
+
 		local barBottom : top * DesignParameters.eBarPos - (stroke / 2)
 
 		include : HBar.b ((df.leftSB + OX) + (stroke / 2) + bbd) ((df.rightSB - OX) - (stroke / 2)) barBottom stroke
@@ -59,10 +76,16 @@ glyph-block Letter-Latin-Lower-E : begin
 		return path.rhsKnots.[path.rhsKnots.length - 1]
 
 	glyph-block-export RevSmallEShape
-	define [RevSmallEShape] : with-params [
-		df top [stroke [AdviceStroke2 2 3 top]] [hook AHook]
-		[ada SmallArchDepthA] [adb SmallArchDepthB] [turned false]
-		] : glyph-proc
+	define flex-params [RevSmallEShape] : glyph-proc
+		local-parameter : df
+		local-parameter : top
+		local-parameter : stroke   -- [AdviceStroke2 2 3 top]
+		local-parameter : hook     -- AHook
+		local-parameter : ada      -- SmallArchDepthA
+		local-parameter : adb      -- SmallArchDepthB
+		local-parameter : tailSlab -- nothing
+		local-parameter : turned   -- false
+
 		local barBottom : top * DesignParameters.eBarPos - (stroke / 2)
 
 		include : HBar.b ((df.leftSB + OX) + (stroke / 2)) ((df.rightSB - OX) - (stroke / 2)) barBottom stroke
@@ -72,16 +95,23 @@ glyph-block Letter-Latin-Lower-E : begin
 			curl (df.leftSB + OX) (top - ada)
 			arch.rhs top (sw -- stroke)
 			flatside.rd df.rightSB 0 top ada adb
-			hookend 0 (sw -- stroke) (suppressSwash -- turned)
-			g4 (df.leftSB + [if (!turned && para.isItalic && (para.slopeAngle < 0)) 0 0.5] * OX) [SmallEHook top stroke hook (!turned && para.isItalic && (para.slopeAngle < 0))]
+			RevSmallESerifedTerminalShape df top stroke hook tailSlab turned
+
+		include : RevSmallETerminalSerif df top stroke hook tailSlab turned
 
 		if turned : include : FlipAround df.middle (top / 2)
 
 	glyph-block-export SmallERoundedShape
-	define [SmallERoundedShape] : with-params [
-		df top [stroke [AdviceStroke2 2 3 top]] [hook AHook]
-		[ada SmallArchDepthA] [adb SmallArchDepthB] [tailSlab nothing] [turned false]
-		] : glyph-proc
+	define flex-params [SmallERoundedShape] : glyph-proc
+		local-parameter : df
+		local-parameter : top
+		local-parameter : stroke   -- [AdviceStroke2 2 3 top]
+		local-parameter : hook     -- AHook
+		local-parameter : ada      -- SmallArchDepthA
+		local-parameter : adb      -- SmallArchDepthB
+		local-parameter : tailSlab -- nothing
+		local-parameter : turned   -- false
+
 		local barBottom : top * (DesignParameters.eBarPos * [if para.isItalic 1 0.95]) - (stroke / 2)
 		local xStart : df.leftSB + [HSwToV : 0.125 * stroke]
 		local extraCurliness : if para.isItalic (0.1 * (top - barBottom)) 0
@@ -104,10 +134,16 @@ glyph-block Letter-Latin-Lower-E : begin
 		return path.rhsKnots.[path.rhsKnots.length - 1]
 
 	glyph-block-export RevSmallERoundedShape
-	define [RevSmallERoundedShape] : with-params [
-		df top [stroke [AdviceStroke2 2 3 top]] [hook AHook]
-		[ada SmallArchDepthA] [adb SmallArchDepthB] [turned false]
-		] : glyph-proc
+	define flex-params [RevSmallERoundedShape] : glyph-proc
+		local-parameter : df
+		local-parameter : top
+		local-parameter : stroke   -- [AdviceStroke2 2 3 top]
+		local-parameter : hook     -- AHook
+		local-parameter : ada      -- SmallArchDepthA
+		local-parameter : adb      -- SmallArchDepthB
+		local-parameter : tailSlab -- nothing
+		local-parameter : turned   -- false
+
 		local barBottom : top * (DesignParameters.eBarPos * [if para.isItalic 1 0.95]) - (stroke / 2)
 		local xStart : df.rightSB - [HSwToV : 0.125 * stroke]
 		local extraCurliness : if para.isItalic (0.1 * (top - barBottom)) 0
@@ -121,23 +157,31 @@ glyph-block Letter-Latin-Lower-E : begin
 			g4 (df.leftSB + OX) [YSmoothMidL top barBottom ada2 adb2]
 			arch.rhs top (sw -- stroke)
 			flatside.rd df.rightSB 0 top ada adb
-			hookend 0 (sw -- stroke) (suppressSwash -- turned)
-			g4 (df.leftSB + [if (!turned && para.isItalic && (para.slopeAngle < 0)) 0 0.5] * OX) [SmallEHook top stroke hook (!turned && para.isItalic && (para.slopeAngle < 0))]
+			RevSmallESerifedTerminalShape df top stroke hook tailSlab turned
+
+		include : RevSmallETerminalSerif df top stroke hook tailSlab turned
 
 		if turned : include : FlipAround df.middle (top / 2)
 
-	define [AbkCheShape] : with-params [
-		fDesc Body df top [stroke [Math.min df.mvs : AdviceStroke2 2 3 top]] [hook AHook]
-		[ada SmallArchDepthA] [adb SmallArchDepthB] [tailSlab nothing]
-		] : glyph-proc
+	define flex-params [AbkCheShape] : glyph-proc
+		local-parameter : fDesc
+		local-parameter : Body
+		local-parameter : df
+		local-parameter : top
+		local-parameter : stroke   -- [Math.min df.mvs : AdviceStroke2 2 3 top]
+		local-parameter : hook     -- AHook
+		local-parameter : ada      -- SmallArchDepthA
+		local-parameter : adb      -- SmallArchDepthB
+		local-parameter : tailSlab -- nothing
+
 		local gap : 0.375 * (df.width - 2 * df.leftSB - 2.5 * stroke) - [HSwToV : 0.25 * stroke]
 		define divSub : (df.width - gap - stroke) / Width
 		define subDf : DivFrame divSub 2
 		include : Body subDf top
-			stroke -- stroke
-			hook -- hook
-			ada -- (ada * 0.7 * df.adws)
-			adb -- (adb * 0.7 * df.adws)
+			stroke   -- stroke
+			hook     -- hook
+			ada      -- (ada * 0.7 * df.adws)
+			adb      -- (adb * 0.7 * df.adws)
 			tailSlab -- tailSlab
 		define shift : Width * (df.adws - divSub)
 		if fDesc : begin
@@ -167,15 +211,15 @@ glyph-block Letter-Latin-Lower-E : begin
 			include : MarkSet.e
 			include : Body [DivFrame 1] XH
 				hook -- AHook
-				ada -- SmallArchDepthA
-				adb -- SmallArchDepthB
+				ada  -- SmallArchDepthA
+				adb  -- SmallArchDepthB
 
 		create-glyph "eOgonek.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			local lastKnot : include : Body [DivFrame 1] XH
 				hook -- AHook
-				ada -- SmallArchDepthA
-				adb -- SmallArchDepthB
+				ada  -- SmallArchDepthA
+				adb  -- SmallArchDepthB
 			include : refer-glyph 'ogonekTR/spacer'
 
 			# Connected Ogonek shape
@@ -211,8 +255,8 @@ glyph-block Letter-Latin-Lower-E : begin
 			include : MarkSet.e
 			local lastKnot : include : Body [DivFrame 1] XH
 				hook -- AHook
-				ada -- SmallArchDepthA
-				adb -- SmallArchDepthB
+				ada  -- SmallArchDepthA
+				adb  -- SmallArchDepthB
 			local sw : AdviceStroke 4
 			local ry : Math.min (lastKnot.y - sw) (XH * 0.08)
 			local rx : Math.min ry
@@ -227,75 +271,33 @@ glyph-block Letter-Latin-Lower-E : begin
 			include : MarkSet.e
 			include : Body [DivFrame 1] XH
 				hook -- AHook
-				ada -- SmallArchDepthA
-				adb -- SmallArchDepthB
+				ada  -- SmallArchDepthA
+				adb  -- SmallArchDepthB
 				tailSlab -- SLAB-CLASSICAL
 			include : RetroflexHook.r
 				x -- RightSB
 				y -- 0
 				yAttach -- DToothlessRise
 
-		create-glyph "Schwa.\(suffix)" : glyph-proc
-			include : MarkSet.capital
-			include : Body [DivFrame 1] CAP
-				hook -- Hook
-				ada -- ArchDepthA
-				adb -- ArchDepthB
-				turned -- true
-
-		create-glyph "schwa.\(suffix)" : glyph-proc
-			include : MarkSet.e
-			include : Body [DivFrame 1] XH
-				hook -- AHook
-				ada -- SmallArchDepthA
-				adb -- SmallArchDepthB
-				turned -- true
-
-		create-glyph "schwaRhoticHook.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.advanceScaleM 1
-			include : df.markSet.e
-			local dfSub : DivFrame [Math.min 1 : 0.85 * para.advanceScaleM] 2
-			local stroke : dfSub.adviceStroke2 2 3 XH
-			include : Body dfSub XH
-				stroke -- stroke
-				hook -- AHook
-				ada -- [dfSub.archDepthAOf SmallArchDepth stroke]
-				adb -- [dfSub.archDepthBOf SmallArchDepth stroke]
-				turned -- true
-			include : RhoticHookShape (dfSub.rightSB - [HSwToV : 1.25 * markFine]) df.width (XH * DesignParameters.eBarPos) (0.4 * (XH * DesignParameters.eBarPos))
-
-		create-glyph "schwaRetroflexHook.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.advanceScaleM 1
-			include : df.markSet.e
-			local dfSub : DivFrame [Math.min 1 : 0.85 * para.advanceScaleM] 2
-			local stroke : dfSub.adviceStroke2 2 3 XH
-			include : Body dfSub XH
-				stroke -- stroke
-				hook -- AHook
-				ada -- [dfSub.archDepthAOf SmallArchDepth stroke]
-				adb -- [dfSub.archDepthBOf SmallArchDepth stroke]
-				turned -- true
-			include : RetroflexHook.r
-				x -- [mix RightSB df.width 0.5]
-				y -- 0
-				yAttach -- (XH * DesignParameters.eBarPos - HalfStroke)
-				xLink -- (dfSub.rightSB - [HSwToV : 0.5 * stroke])
-				refSw -- [AdviceStroke 4]
-
 		create-glyph "eRev.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : RevBody [DivFrame 1] XH
 				hook -- AHook
-				ada -- SmallArchDepthA
-				adb -- SmallArchDepthB
+				ada  -- SmallArchDepthA
+				adb  -- SmallArchDepthB
 
 		create-glyph "eBar.\(suffix)" : glyph-proc
 			include [refer-glyph "e.\(suffix)"] AS_BASE ALSO_METRICS
 			local yBar : mix Stroke (XH * DesignParameters.eBarPos - HalfStroke) 0.5
 			include : HBar.m [mix SB 0 0.7] [mix RightSB Width 0.7] yBar [Math.min (yBar - Stroke) : AdviceStroke 5]
 
-		DefineSelectorGlyph "cyrl/Schwa" suffix [DivFrame 1] 'capital'
-		DefineSelectorGlyph "cyrl/schwa" suffix [DivFrame 1] 'e'
+		DefineSelectorGlyph "Schwa" suffix [DivFrame 1] 'capital'
+		DefineSelectorGlyph "schwa" suffix [DivFrame 1] 'e'
+
+		define rhoticDf : DivFrame para.advanceScaleM 1
+
+		DefineSelectorGlyph "schwaRhoticHook"    suffix rhoticDf 'e'
+		DefineSelectorGlyph "schwaRetroflexHook" suffix rhoticDf 'e'
 
 		define abkCheDf : DivFrame para.advanceScaleM 3
 
@@ -305,60 +307,95 @@ glyph-block Letter-Latin-Lower-E : begin
 		DefineSelectorGlyph "cyrl/abk/cheDescender" suffix abkCheDf 'p'
 
 		foreach { suffixSerif { styTop styBot } } [Object.entries CConfig] : do
-			create-glyph "cyrl/Schwa.\(suffix).\(suffixSerif)" : glyph-proc
+			create-glyph "Schwa.\(suffix).\(suffixSerif)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
 				include : Body [DivFrame 1] CAP
-					hook -- Hook
-					ada -- ArchDepthA
-					adb -- ArchDepthB
-					tailSlab -- styTop
+					hook   -- Hook
+					ada    -- ArchDepthA
+					adb    -- ArchDepthB
 					turned -- true
-			create-glyph "cyrl/schwa.\(suffix).\(suffixSerif)" : glyph-proc
+					tailSlab -- styTop
+			create-glyph "schwa.\(suffix).\(suffixSerif)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
 				include : Body [DivFrame 1] XH
-					hook -- AHook
-					ada -- SmallArchDepthA
-					adb -- SmallArchDepthB
-					tailSlab -- styTop
+					hook   -- AHook
+					ada    -- SmallArchDepthA
+					adb    -- SmallArchDepthB
 					turned -- true
+					tailSlab -- styTop
+
+			create-glyph "schwaRhoticHook.\(suffix).\(suffixSerif)" : glyph-proc
+				set-width 0
+				set-mark-anchor 'cvDecompose' 0 0
+				local dfSub : DivFrame [Math.min 1 : 0.85 * rhoticDf.adws] 2
+				local stroke : dfSub.adviceStroke2 2 3 XH
+				include : Body dfSub XH
+					stroke -- stroke
+					hook   -- AHook
+					ada    -- [dfSub.archDepthAOf SmallArchDepth stroke]
+					adb    -- [dfSub.archDepthBOf SmallArchDepth stroke]
+					turned -- true
+					tailSlab -- styTop
+				include : RhoticHookShape (dfSub.rightSB - [HSwToV : 1.25 * markFine]) rhoticDf.width (XH * DesignParameters.eBarPos) (0.4 * (XH * DesignParameters.eBarPos))
+
+			create-glyph "schwaRetroflexHook.\(suffix).\(suffixSerif)" : glyph-proc
+				set-width 0
+				set-mark-anchor 'cvDecompose' 0 0
+				local dfSub : DivFrame [Math.min 1 : 0.85 * rhoticDf.adws] 2
+				local stroke : dfSub.adviceStroke2 2 3 XH
+				include : Body dfSub XH
+					stroke -- stroke
+					hook   -- AHook
+					ada    -- [dfSub.archDepthAOf SmallArchDepth stroke]
+					adb    -- [dfSub.archDepthBOf SmallArchDepth stroke]
+					turned -- true
+					tailSlab -- styTop
+				include : RetroflexHook.r
+					x -- [mix RightSB rhoticDf.width 0.5]
+					y -- 0
+					yAttach -- (XH * DesignParameters.eBarPos - HalfStroke)
+					xLink -- (dfSub.rightSB - [HSwToV : 0.5 * stroke])
+					refSw -- [AdviceStroke 4]
 
 			create-glyph "cyrl/abk/Che.\(suffix).\(suffixSerif)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
 				include : AbkCheShape false Body abkCheDf CAP
 					hook -- Hook
-					ada -- ArchDepthA
-					adb -- ArchDepthB
+					ada  -- ArchDepthA
+					adb  -- ArchDepthB
 					tailSlab -- styBot
 			create-glyph "cyrl/abk/che.\(suffix).\(suffixSerif)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
 				include : AbkCheShape false Body abkCheDf XH
 					hook -- AHook
-					ada -- SmallArchDepthA
-					adb -- SmallArchDepthB
+					ada  -- SmallArchDepthA
+					adb  -- SmallArchDepthB
 					tailSlab -- styBot
 			create-glyph "cyrl/abk/CheDescender.\(suffix).\(suffixSerif)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
 				include : AbkCheShape true Body abkCheDf CAP
 					hook -- Hook
-					ada -- ArchDepthA
-					adb -- ArchDepthB
+					ada  -- ArchDepthA
+					adb  -- ArchDepthB
 					tailSlab -- styBot
 			create-glyph "cyrl/abk/cheDescender.\(suffix).\(suffixSerif)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
 				include : AbkCheShape true Body abkCheDf XH
 					hook -- AHook
-					ada -- SmallArchDepthA
-					adb -- SmallArchDepthB
+					ada  -- SmallArchDepthA
+					adb  -- SmallArchDepthB
 					tailSlab -- styBot
 
-		select-variant "cyrl/Schwa.\(suffix)" (follow -- 'cyrl/ETopSerifOnly')
-		select-variant "cyrl/schwa.\(suffix)" (follow -- 'cyrl/eTopSerifOnly')
+		select-variant "Schwa.\(suffix)" (follow -- 'cyrl/ETopSerifOnly')
+		select-variant "schwa.\(suffix)" (follow -- 'cyrl/eTopSerifOnly')
+		select-variant "schwaRhoticHook.\(suffix)" (follow -- 'cyrl/ETopSerifOnly')
+		select-variant "schwaRetroflexHook.\(suffix)" (follow -- 'cyrl/eTopSerifOnly')
 		select-variant "cyrl/abk/Che.\(suffix)" (follow -- 'CBottomSerifOnly')
 		select-variant "cyrl/abk/che.\(suffix)" (follow -- 'cBottomSerifOnly')
 		select-variant "cyrl/abk/CheDescender.\(suffix)" (follow -- 'CBottomSerifOnly')
@@ -372,20 +409,17 @@ glyph-block Letter-Latin-Lower-E : begin
 	select-variant 'eRetroflexHook' 0x1D92 (follow -- 'e')
 	select-variant 'eWithNotch' 0x2C78 (follow -- 'e')
 
-	select-variant 'Schwa' 0x18F
-	select-variant 'schwa' 0x259
-	select-variant 'schwaRhoticHook' 0x25A (follow -- 'schwa')
-	select-variant 'schwaRetroflexHook' 0x1D95 (follow -- 'schwa')
+	CreateSelectorVariants 'Schwa' 0x18F [Object.keys SmallEConfig]
+	CreateSelectorVariants 'schwa' 0x259 [Object.keys SmallEConfig]
+	CreateSelectorVariants 'schwaRhoticHook'    0x25A  [Object.keys SmallEConfig] (follow -- 'schwa')
+	CreateSelectorVariants 'schwaRetroflexHook' 0x1D95 [Object.keys SmallEConfig] (follow -- 'schwa')
 
 	select-variant 'eRev' 0x258 (follow -- 'e')
 
 	select-variant 'eBar' 0xAB33 (follow -- 'e')
 
-	CreateSelectorVariants 'cyrl/Schwa' 0x4D8 [Object.keys SmallEConfig] (follow -- 'Schwa')
-	alias 'Schwa.TRK' null 'cyrl/Schwa'
-
-	CreateSelectorVariants 'cyrl/schwa' 0x4D9 [Object.keys SmallEConfig] (follow -- 'schwa')
-	alias 'schwa.TRK' null 'cyrl/schwa'
+	alias 'cyrl/Schwa' 0x4D8 'Schwa'
+	alias 'cyrl/schwa' 0x4D9 'schwa'
 
 	CreateSelectorVariants 'cyrl/abk/Che' 0x4BC [Object.keys SmallEConfig]
 	CreateSelectorVariants 'cyrl/abk/che' 0x4BD [Object.keys SmallEConfig]
@@ -397,10 +431,10 @@ glyph-block Letter-Latin-Lower-E : begin
 		include : MarkSet.e
 		include : SmallEShape [DivFrame 1] XH
 			stroke -- BBS
-			hook -- AHook
-			bbd -- BBD
-			ada -- SmallArchDepthA
-			adb -- SmallArchDepthB
+			hook   -- AHook
+			bbd    -- BBD
+			ada    -- SmallArchDepthA
+			adb    -- SmallArchDepthB
 		include : intersection
 			OShapeOutline.NoOvershoot XH 0 SB RightSB BBS
 			union

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -22,26 +22,26 @@ glyph-block Letter-Latin-Lower-E : begin
 	define SLAB-CLASSICAL  1
 	define SLAB-INWARD     2
 
-	define [SmallESerifedTerminalShape df top stroke hook tailSlab turned] : match tailSlab
+	define [SmallESerifedTerminalShape df top stroke hook tailSlab isStart] : match tailSlab
 		[Just SLAB-CLASSICAL] : SerifedArcEnd.LtrLhs df.rightSB 0 stroke hook
 		[Just SLAB-INWARD] : InwardSlabArcEnd.LtrLhs df.rightSB 0 stroke hook
 		__ : list
-			hookend 0 (sw -- stroke) (suppressSwash -- turned)
-			g4 (df.rightSB - [if (!turned && para.isItalic && (para.slopeAngle > 0)) 0 0.5] * OX) [SmallEHook top stroke hook (!turned && para.isItalic && (para.slopeAngle > 0))]
+			hookend 0 (sw -- stroke) (suppressSwash -- isStart)
+			g4 (df.rightSB - [if (!isStart && para.isItalic && (para.slopeAngle > 0)) 0 0.5] * OX) [SmallEHook top stroke hook (!isStart && para.isItalic && (para.slopeAngle > 0))]
 
-	define [RevSmallESerifedTerminalShape df top stroke hook tailSlab turned] : match tailSlab
+	define [RevSmallESerifedTerminalShape df top stroke hook tailSlab isStart] : match tailSlab
 		[Just SLAB-CLASSICAL] : SerifedArcEnd.RtlRhs df.leftSB 0 stroke hook
 		[Just SLAB-INWARD] : InwardSlabArcEnd.RtlRhs df.leftSB 0 stroke hook
 		__ : list
-			hookend 0 (sw -- stroke) (suppressSwash -- turned)
-			g4 (df.leftSB + [if (!turned && para.isItalic && (para.slopeAngle < 0)) 0 0.5] * OX) [SmallEHook top stroke hook (!turned && para.isItalic && (para.slopeAngle < 0))]
+			hookend 0 (sw -- stroke) (suppressSwash -- isStart)
+			g4 (df.leftSB + [if (!isStart && para.isItalic && (para.slopeAngle < 0)) 0 0.5] * OX) [SmallEHook top stroke hook (!isStart && para.isItalic && (para.slopeAngle < 0))]
 
-	define [SmallETerminalSerif df top stroke hook tailSlab turned] : match tailSlab
+	define [SmallETerminalSerif df top stroke hook tailSlab isStart] : match tailSlab
 		[Just SLAB-CLASSICAL] : ArcEndSerif.R       df.rightSB 0 stroke hook
 		[Just SLAB-INWARD]    : ArcEndSerif.InwardR df.rightSB 0 stroke hook
 		__ : no-shape
 
-	define [RevSmallETerminalSerif df top stroke hook tailSlab turned] : match tailSlab
+	define [RevSmallETerminalSerif df top stroke hook tailSlab isStart] : match tailSlab
 		[Just SLAB-CLASSICAL] : ArcEndSerif.L       df.leftSB 0 stroke hook
 		[Just SLAB-INWARD]    : ArcEndSerif.InwardL df.leftSB 0 stroke hook
 		__ : no-shape
@@ -66,9 +66,9 @@ glyph-block Letter-Latin-Lower-E : begin
 			curl (df.rightSB - OX) (top - adb)
 			arch.lhs top (sw -- stroke)
 			flatside.ld df.leftSB 0 top ada adb
-			SmallESerifedTerminalShape df top stroke hook tailSlab turned
+			SmallESerifedTerminalShape df top stroke hook tailSlab (turned && (tailSlab != nothing))
 
-		include : SmallETerminalSerif df top stroke hook tailSlab turned
+		include : SmallETerminalSerif df top stroke hook tailSlab (turned && (tailSlab != nothing))
 
 		if turned : include : FlipAround df.middle (top / 2)
 
@@ -93,9 +93,9 @@ glyph-block Letter-Latin-Lower-E : begin
 			curl (df.leftSB + OX) (top - ada)
 			arch.rhs top (sw -- stroke)
 			flatside.rd df.rightSB 0 top ada adb
-			RevSmallESerifedTerminalShape df top stroke hook tailSlab turned
+			RevSmallESerifedTerminalShape df top stroke hook tailSlab (turned && (tailSlab != nothing))
 
-		include : RevSmallETerminalSerif df top stroke hook tailSlab turned
+		include : RevSmallETerminalSerif df top stroke hook tailSlab (turned && (tailSlab != nothing))
 
 		if turned : include : FlipAround df.middle (top / 2)
 
@@ -122,9 +122,9 @@ glyph-block Letter-Latin-Lower-E : begin
 			g4 (df.rightSB - OX) [YSmoothMidR top barBottom ada2 adb2]
 			arch.lhs top (sw -- stroke)
 			flatside.ld df.leftSB 0 top ada adb
-			SmallESerifedTerminalShape df top stroke hook tailSlab turned
+			SmallESerifedTerminalShape df top stroke hook tailSlab (turned && (tailSlab != nothing))
 
-		include : SmallETerminalSerif df top stroke hook tailSlab turned
+		include : SmallETerminalSerif df top stroke hook tailSlab (turned && (tailSlab != nothing))
 
 		if turned : include : FlipAround df.middle (top / 2)
 
@@ -153,9 +153,9 @@ glyph-block Letter-Latin-Lower-E : begin
 			g4 (df.leftSB + OX) [YSmoothMidL top barBottom ada2 adb2]
 			arch.rhs top (sw -- stroke)
 			flatside.rd df.rightSB 0 top ada adb
-			RevSmallESerifedTerminalShape df top stroke hook tailSlab turned
+			RevSmallESerifedTerminalShape df top stroke hook tailSlab (turned && (tailSlab != nothing))
 
-		include : RevSmallETerminalSerif df top stroke hook tailSlab turned
+		include : RevSmallETerminalSerif df top stroke hook tailSlab (turned && (tailSlab != nothing))
 
 		if turned : include : FlipAround df.middle (top / 2)
 
@@ -391,37 +391,42 @@ glyph-block Letter-Latin-Lower-E : begin
 
 		select-variant "Schwa.\(suffix)" (follow -- 'cyrl/ETopSerifOnly')
 		select-variant "schwa.\(suffix)" (follow -- 'cyrl/eTopSerifOnly')
-		select-variant "schwaRhoticHook.\(suffix)" (follow -- 'cyrl/ETopSerifOnly')
+
+		select-variant "schwaRhoticHook.\(suffix)"    (follow -- 'cyrl/eTopSerifOnly')
 		select-variant "schwaRetroflexHook.\(suffix)" (follow -- 'cyrl/eTopSerifOnly')
+
 		select-variant "cyrl/abk/Che.\(suffix)" (follow -- 'CBottomSerifOnly')
 		select-variant "cyrl/abk/che.\(suffix)" (follow -- 'cBottomSerifOnly')
+
 		select-variant "cyrl/abk/CheDescender.\(suffix)" (follow -- 'CBottomSerifOnly')
 		select-variant "cyrl/abk/cheDescender.\(suffix)" (follow -- 'cBottomSerifOnly')
 
 	select-variant 'e' 'e'
 	alias 'cyrl/ie' 0x435 'e'
+
 	CreateTurnedLetter 'turne' 0x1DD 'e' HalfAdvance (XH / 2)
 
-	select-variant 'eOgonek' 0x119 (follow -- 'e')
+	select-variant 'eOgonek'        0x119  (follow -- 'e')
 	select-variant 'eRetroflexHook' 0x1D92 (follow -- 'e')
-	select-variant 'eWithNotch' 0x2C78 (follow -- 'e')
+	select-variant 'eWithNotch'     0x2C78 (follow -- 'e')
 
-	CreateSelectorVariants 'Schwa' 0x18F [Object.keys SmallEConfig]
-	CreateSelectorVariants 'schwa' 0x259 [Object.keys SmallEConfig]
-	CreateSelectorVariants 'schwaRhoticHook'    0x25A  [Object.keys SmallEConfig] (follow -- 'schwa')
-	CreateSelectorVariants 'schwaRetroflexHook' 0x1D95 [Object.keys SmallEConfig] (follow -- 'schwa')
+	CreateSelectorVariants 'Schwa' 0x18F [Object.keys SmallEConfig] (follow -- 'eCap')
+	CreateSelectorVariants 'schwa' 0x259 [Object.keys SmallEConfig] (follow -- 'e')
 
-	select-variant 'eRev' 0x258 (follow -- 'e')
+	CreateSelectorVariants 'schwaRhoticHook'    0x25A  [Object.keys SmallEConfig] (follow -- 'e')
+	CreateSelectorVariants 'schwaRetroflexHook' 0x1D95 [Object.keys SmallEConfig] (follow -- 'e')
 
+	select-variant 'eRev' 0x258  (follow -- 'e')
 	select-variant 'eBar' 0xAB33 (follow -- 'e')
 
 	alias 'cyrl/Schwa' 0x4D8 'Schwa'
 	alias 'cyrl/schwa' 0x4D9 'schwa'
 
-	CreateSelectorVariants 'cyrl/abk/Che' 0x4BC [Object.keys SmallEConfig]
-	CreateSelectorVariants 'cyrl/abk/che' 0x4BD [Object.keys SmallEConfig]
-	CreateSelectorVariants 'cyrl/abk/CheDescender' 0x4BE [Object.keys SmallEConfig] (follow -- 'cyrl/abk/Che')
-	CreateSelectorVariants 'cyrl/abk/cheDescender' 0x4BF [Object.keys SmallEConfig] (follow -- 'cyrl/abk/che')
+	CreateSelectorVariants 'cyrl/abk/Che' 0x4BC [Object.keys SmallEConfig] (follow -- 'eCap')
+	CreateSelectorVariants 'cyrl/abk/che' 0x4BD [Object.keys SmallEConfig] (follow -- 'e')
+
+	CreateSelectorVariants 'cyrl/abk/CheDescender' 0x4BE [Object.keys SmallEConfig] (follow -- 'eCap')
+	CreateSelectorVariants 'cyrl/abk/cheDescender' 0x4BF [Object.keys SmallEConfig] (follow -- 'e')
 
 	glyph-block-import Letter-Blackboard : BBS BBD
 	create-glyph 'mathbb/e' 0x1D556 : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/orthography.ptl
+++ b/packages/font-glyphs/src/letter/latin/orthography.ptl
@@ -23,6 +23,4 @@ glyph-block Letter-Latin-Orthography : begin
 	link-gr LocalizedForm.PLK 'ZDot'   'ZDot.PLK'
 	link-gr LocalizedForm.PLK 'zDot'   'zDot.PLK'
 
-	link-gr LocalizedForm.TRK 'Schwa' 'Schwa.TRK'
-	link-gr LocalizedForm.TRK 'schwa' 'schwa.TRK'
 	link-gr LocalizedForm.TRK 'i'     'i.TRK'

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -7934,6 +7934,7 @@ description = "Serifless Cyrillic Capital E (`Э`)"
 selector."cyrl/E" = "serifless"
 selector."cyrl/ETopSerifOnly" = "serifless"
 selector."cyrl/Ye" = "serifless"
+selector."cyrl/YeTopSerifOnly" = "serifless"
 selector."currency/euroSign" = "serifless"
 
 [prime.cyrl-capital-e.variants.unilateral-serifed]
@@ -7942,6 +7943,7 @@ description = "Cyrillic Capital E (`Э`) with serif at top"
 selector."cyrl/E" = "unilateralSerifed"
 selector."cyrl/ETopSerifOnly" = "unilateralSerifed"
 selector."cyrl/Ye" = "unilateralSerifed"
+selector."cyrl/YeTopSerifOnly" = "unilateralSerifed"
 selector."currency/euroSign" = "unilateralSerifed"
 
 [prime.cyrl-capital-e.variants.unilateral-bottom-serifed]
@@ -7950,6 +7952,7 @@ description = "Cyrillic Capital E (`Э`) with serif at bottom"
 selector."cyrl/E" = "bottomSerifed"
 selector."cyrl/ETopSerifOnly" = "serifless"
 selector."cyrl/Ye" = "unilateralSerifed"
+selector."cyrl/YeTopSerifOnly" = "unilateralSerifed"
 selector."currency/euroSign" = "unilateralSerifed"
 
 [prime.cyrl-capital-e.variants.bilateral-serifed]
@@ -7958,6 +7961,7 @@ description = "Cyrillic Capital E (`Э`) with serifs at both top and bottom"
 selector."cyrl/E" = "bilateralSerifed"
 selector."cyrl/ETopSerifOnly" = "unilateralSerifed"
 selector."cyrl/Ye" = "bilateralSerifed"
+selector."cyrl/YeTopSerifOnly" = "unilateralSerifed"
 selector."currency/euroSign" = "bilateralSerifed"
 
 [prime.cyrl-capital-e.variants.unilateral-inward-serifed]
@@ -7966,6 +7970,7 @@ description = "Cyrillic Capital E (`Э`) with inward serif at top"
 selector."cyrl/E" = "unilateralInwardSerifed"
 selector."cyrl/ETopSerifOnly" = "unilateralInwardSerifed"
 selector."cyrl/Ye" = "unilateralInwardSerifed"
+selector."cyrl/YeTopSerifOnly" = "unilateralInwardSerifed"
 selector."currency/euroSign" = "unilateralInwardSerifed"
 
 [prime.cyrl-capital-e.variants.unilateral-bottom-inward-serifed]
@@ -7974,6 +7979,7 @@ description = "Cyrillic Capital E (`Э`) with inward serif at bottom"
 selector."cyrl/E" = "bottomInwardSerifed"
 selector."cyrl/ETopSerifOnly" = "serifless"
 selector."cyrl/Ye" = "unilateralInwardSerifed"
+selector."cyrl/YeTopSerifOnly" = "unilateralInwardSerifed"
 selector."currency/euroSign" = "unilateralInwardSerifed"
 
 [prime.cyrl-capital-e.variants.bilateral-inward-serifed]
@@ -7982,6 +7988,7 @@ description = "Cyrillic Capital E (`Э`) with inward serif at both top and botto
 selector."cyrl/E" = "bilateralInwardSerifed"
 selector."cyrl/ETopSerifOnly" = "unilateralInwardSerifed"
 selector."cyrl/Ye" = "bilateralInwardSerifed"
+selector."cyrl/YeTopSerifOnly" = "unilateralInwardSerifed"
 selector."currency/euroSign" = "bilateralInwardSerifed"
 
 [prime.cyrl-capital-e.variants.unilateral-mid-serifed]
@@ -7990,6 +7997,7 @@ description = "Cyrillic Capital E (`Э`) with serif at top and center"
 selector."cyrl/E" = "unilateralMidSerifed"
 selector."cyrl/ETopSerifOnly" = "unilateralSerifed"
 selector."cyrl/Ye" = "unilateralMidSerifed"
+selector."cyrl/YeTopSerifOnly" = "unilateralSerifed"
 selector."currency/euroSign" = "unilateralSerifed"
 
 [prime.cyrl-capital-e.variants.unilateral-bottom-mid-serifed]
@@ -7998,6 +8006,7 @@ description = "Cyrillic Capital E (`Э`) with serif at bottom and center"
 selector."cyrl/E" = "bottomMidSerifed"
 selector."cyrl/ETopSerifOnly" = "serifless"
 selector."cyrl/Ye" = "unilateralMidSerifed"
+selector."cyrl/YeTopSerifOnly" = "unilateralSerifed"
 selector."currency/euroSign" = "unilateralSerifed"
 
 [prime.cyrl-capital-e.variants.bilateral-mid-serifed]
@@ -8006,6 +8015,7 @@ description = "Cyrillic Capital E (`Э`) with serifs at both top, bottom and cen
 selector."cyrl/E" = "bilateralMidSerifed"
 selector."cyrl/ETopSerifOnly" = "unilateralSerifed"
 selector."cyrl/Ye" = "bilateralMidSerifed"
+selector."cyrl/YeTopSerifOnly" = "unilateralSerifed"
 selector."currency/euroSign" = "bilateralSerifed"
 
 [prime.cyrl-capital-e.variants.unilateral-inward-mid-serifed]
@@ -8014,6 +8024,7 @@ description = "Cyrillic Capital E (`Э`) with inward serif at top and center"
 selector."cyrl/E" = "unilateralInwardMidSerifed"
 selector."cyrl/ETopSerifOnly" = "unilateralInwardSerifed"
 selector."cyrl/Ye" = "unilateralInwardMidSerifed"
+selector."cyrl/YeTopSerifOnly" = "unilateralInwardSerifed"
 selector."currency/euroSign" = "unilateralInwardSerifed"
 
 [prime.cyrl-capital-e.variants.unilateral-bottom-inward-mid-serifed]
@@ -8022,6 +8033,7 @@ description = "Cyrillic Capital E (`Э`) with inward serif at bottom and center"
 selector."cyrl/E" = "bottomInwardMidSerifed"
 selector."cyrl/ETopSerifOnly" = "serifless"
 selector."cyrl/Ye" = "unilateralInwardMidSerifed"
+selector."cyrl/YeTopSerifOnly" = "unilateralInwardSerifed"
 selector."currency/euroSign" = "unilateralInwardSerifed"
 
 [prime.cyrl-capital-e.variants.bilateral-inward-mid-serifed]
@@ -8030,6 +8042,7 @@ description = "Cyrillic Capital E (`Э`) with inward serif at both top, bottom a
 selector."cyrl/E" = "bilateralInwardMidSerifed"
 selector."cyrl/ETopSerifOnly" = "unilateralInwardSerifed"
 selector."cyrl/Ye" = "bilateralInwardMidSerifed"
+selector."cyrl/YeTopSerifOnly" = "unilateralInwardSerifed"
 selector."currency/euroSign" = "bilateralInwardSerifed"
 
 
@@ -8045,6 +8058,7 @@ description = "Serifless Cyrillic Lower E (`э`)"
 selector."cyrl/e" = "serifless"
 selector."cyrl/eTopSerifOnly" = "serifless"
 selector."cyrl/ye" = "serifless"
+selector."cyrl/yeTopSerifOnly" = "serifless"
 
 [prime.cyrl-e.variants.unilateral-serifed]
 rank = 2
@@ -8052,6 +8066,7 @@ description = "Cyrillic Lower E (`э`) with serif at top"
 selector."cyrl/e" = "unilateralSerifed"
 selector."cyrl/eTopSerifOnly" = "unilateralSerifed"
 selector."cyrl/ye" = "unilateralSerifed"
+selector."cyrl/yeTopSerifOnly" = "unilateralSerifed"
 
 [prime.cyrl-e.variants.unilateral-bottom-serifed]
 rank = 3
@@ -8059,6 +8074,7 @@ description = "Cyrillic Lower E (`э`) with serif at bottom"
 selector."cyrl/e" = "bottomSerifed"
 selector."cyrl/eTopSerifOnly" = "serifless"
 selector."cyrl/ye" = "unilateralSerifed"
+selector."cyrl/yeTopSerifOnly" = "unilateralSerifed"
 
 [prime.cyrl-e.variants.bilateral-serifed]
 rank = 4
@@ -8066,6 +8082,7 @@ description = "Cyrillic Lower E (`э`) with serifs at both top and bottom"
 selector."cyrl/e" = "bilateralSerifed"
 selector."cyrl/eTopSerifOnly" = "unilateralSerifed"
 selector."cyrl/ye" = "bilateralSerifed"
+selector."cyrl/yeTopSerifOnly" = "unilateralSerifed"
 
 [prime.cyrl-e.variants.unilateral-inward-serifed]
 rank = 5
@@ -8073,6 +8090,7 @@ description = "Cyrillic Lower E (`э`) with inward serif at top"
 selector."cyrl/e" = "unilateralInwardSerifed"
 selector."cyrl/eTopSerifOnly" = "unilateralInwardSerifed"
 selector."cyrl/ye" = "unilateralInwardSerifed"
+selector."cyrl/yeTopSerifOnly" = "unilateralInwardSerifed"
 
 [prime.cyrl-e.variants.unilateral-bottom-inward-serifed]
 rank = 6
@@ -8080,6 +8098,7 @@ description = "Cyrillic Lower E (`э`) with inward serif at bottom"
 selector."cyrl/e" = "bottomInwardSerifed"
 selector."cyrl/eTopSerifOnly" = "serifless"
 selector."cyrl/ye" = "unilateralInwardSerifed"
+selector."cyrl/yeTopSerifOnly" = "unilateralInwardSerifed"
 
 [prime.cyrl-e.variants.bilateral-inward-serifed]
 rank = 7
@@ -8087,6 +8106,7 @@ description = "Cyrillic Lower E (`э`) with inward serif at both top and bottom"
 selector."cyrl/e" = "bilateralInwardSerifed"
 selector."cyrl/eTopSerifOnly" = "unilateralInwardSerifed"
 selector."cyrl/ye" = "bilateralInwardSerifed"
+selector."cyrl/yeTopSerifOnly" = "unilateralInwardSerifed"
 
 [prime.cyrl-e.variants.unilateral-mid-serifed]
 rank = 8
@@ -8094,6 +8114,7 @@ description = "Cyrillic Lower E (`э`) with serif at top and center"
 selector."cyrl/e" = "unilateralMidSerifed"
 selector."cyrl/eTopSerifOnly" = "unilateralSerifed"
 selector."cyrl/ye" = "unilateralMidSerifed"
+selector."cyrl/yeTopSerifOnly" = "unilateralSerifed"
 
 [prime.cyrl-e.variants.unilateral-bottom-mid-serifed]
 rank = 9
@@ -8101,6 +8122,7 @@ description = "Cyrillic Lower E (`э`) with serif at bottom and center"
 selector."cyrl/e" = "bottomMidSerifed"
 selector."cyrl/eTopSerifOnly" = "serifless"
 selector."cyrl/ye" = "unilateralMidSerifed"
+selector."cyrl/yeTopSerifOnly" = "unilateralSerifed"
 
 [prime.cyrl-e.variants.bilateral-mid-serifed]
 rank = 10
@@ -8108,6 +8130,7 @@ description = "Cyrillic Lower E (`э`) with serifs at both top, bottom and cente
 selector."cyrl/e" = "bilateralMidSerifed"
 selector."cyrl/eTopSerifOnly" = "unilateralSerifed"
 selector."cyrl/ye" = "bilateralMidSerifed"
+selector."cyrl/yeTopSerifOnly" = "unilateralSerifed"
 
 [prime.cyrl-e.variants.unilateral-inward-mid-serifed]
 rank = 11
@@ -8115,6 +8138,7 @@ description = "Cyrillic Lower E (`э`) with inward serif at top and center"
 selector."cyrl/e" = "unilateralInwardMidSerifed"
 selector."cyrl/eTopSerifOnly" = "unilateralInwardSerifed"
 selector."cyrl/ye" = "unilateralInwardMidSerifed"
+selector."cyrl/yeTopSerifOnly" = "unilateralInwardSerifed"
 
 [prime.cyrl-e.variants.unilateral-bottom-inward-mid-serifed]
 rank = 12
@@ -8122,6 +8146,7 @@ description = "Cyrillic Lower E (`э`) with inward serif at bottom and center"
 selector."cyrl/e" = "bottomInwardMidSerifed"
 selector."cyrl/eTopSerifOnly" = "serifless"
 selector."cyrl/ye" = "unilateralInwardMidSerifed"
+selector."cyrl/yeTopSerifOnly" = "unilateralInwardSerifed"
 
 [prime.cyrl-e.variants.bilateral-inward-mid-serifed]
 rank = 13
@@ -8129,6 +8154,7 @@ description = "Cyrillic Lower E (`э`) with inward serif at both top, bottom and
 selector."cyrl/e" = "bilateralInwardMidSerifed"
 selector."cyrl/eTopSerifOnly" = "unilateralInwardSerifed"
 selector."cyrl/ye" = "bilateralInwardMidSerifed"
+selector."cyrl/yeTopSerifOnly" = "unilateralInwardSerifed"
 
 
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2729,19 +2729,13 @@ tagKind = "letter"
 rank = 1
 description = "`e` with flat crossbar"
 selector.e = "flatCrossbar"
-selector.Schwa = "flatCrossbar"
-selector.schwa = "flatCrossbar"
-selector."cyrl/abk/Che" = "flatCrossbar"
-selector."cyrl/abk/che" = "flatCrossbar"
+selector.eCap = "flatCrossbar"
 
 [prime.e.variants.rounded]
 rank = 2
 description = "`e` with more rounded shape"
 selector.e = "rounded"
-selector.Schwa = "flatCrossbar"
-selector.schwa = "rounded"
-selector."cyrl/abk/Che" = "flatCrossbar"
-selector."cyrl/abk/che" = "rounded"
+selector.eCap = "flatCrossbar"
 
 
 
@@ -6652,14 +6646,14 @@ rank = 1
 next = "double-storey-hook"
 descriptionAffix = "double-storey body"
 selectorAffix."cyrl/a" = "doubleStorey"
-selectorAffix."cyrl/ae/a" = "doubleStorey"
+selectorAffix."cyrl/aie/a" = "doubleStorey"
 
 [prime.cyrl-a.variants-buildup.stages.storey.single-storey]
 rank = 2
 next = "ear"
 descriptionAffix = "single-storey body"
 selectorAffix."cyrl/a" = "singleStorey"
-selectorAffix."cyrl/ae/a" = "doubleStorey"
+selectorAffix."cyrl/aie/a" = "doubleStorey"
 
 [prime.cyrl-a.variants-buildup.stages.double-storey-hook."*"]
 next = "bar"
@@ -6669,14 +6663,14 @@ rank = 1
 keyAffix = ""
 descriptionAffix = "serifless hook"
 selectorAffix."cyrl/a" = ""
-selectorAffix."cyrl/ae/a" = ""
+selectorAffix."cyrl/aie/a" = ""
 
 [prime.cyrl-a.variants-buildup.stages.double-storey-hook.hook-serifed]
 rank = 2
 keyAffix = "hook-inward-serifed"
 descriptionAffix = "serifed hook"
 selectorAffix."cyrl/a" = "hookInwardSerifed"
-selectorAffix."cyrl/ae/a" = "hookInwardSerifed"
+selectorAffix."cyrl/aie/a" = "hookInwardSerifed"
 
 [prime.cyrl-a.variants-buildup.stages.ear."*"]
 next = "bar"
@@ -6685,72 +6679,72 @@ next = "bar"
 rank = 1
 keyAffix = ""
 selectorAffix."cyrl/a" = ""
-selectorAffix."cyrl/ae/a" = ""
+selectorAffix."cyrl/aie/a" = ""
 
 [prime.cyrl-a.variants-buildup.stages.ear.top-cut]
 rank = 2
 descriptionAffix = "a diagonal cut at top"
 selectorAffix."cyrl/a" = "topCut"
-selectorAffix."cyrl/ae/a" = ""
+selectorAffix."cyrl/aie/a" = ""
 
 [prime.cyrl-a.variants-buildup.stages.ear.earless-corner]
 rank = 3
 descriptionAffix = "earless (cornered top-right)"
 selectorAffix."cyrl/a" = "earlessCorner"
-selectorAffix."cyrl/ae/a" = ""
+selectorAffix."cyrl/aie/a" = ""
 
 [prime.cyrl-a.variants-buildup.stages.ear.earless-rounded]
 rank = 4
 descriptionAffix = "earless (rounded top-right)"
 selectorAffix."cyrl/a" = "earlessRounded"
-selectorAffix."cyrl/ae/a" = ""
+selectorAffix."cyrl/aie/a" = ""
 
 [prime.cyrl-a.variants-buildup.stages.bar.serifless]
 rank = 1
 descriptionAffix = "serif at terminal"
 descriptionJoiner = "without"
 selectorAffix."cyrl/a" = "serifless"
-selectorAffix."cyrl/ae/a" = "serifless"
+selectorAffix."cyrl/aie/a" = "serifless"
 
 [prime.cyrl-a.variants-buildup.stages.bar.serifed]
 rank = 2
 descriptionAffix = "serif at terminal"
 selectorAffix."cyrl/a" = "serifed"
-selectorAffix."cyrl/ae/a" = "serifless"
+selectorAffix."cyrl/aie/a" = "serifless"
 
 [prime.cyrl-a.variants-buildup.stages.bar.double-serifed]
 rank = 3
 disableIf = [{ storey = "double-storey" }, { ear = "NOT eared" }]
 descriptionAffix = "serifs at top and bottom"
 selectorAffix."cyrl/a" = "doubleSerifed"
-selectorAffix."cyrl/ae/a" = "serifless"
+selectorAffix."cyrl/aie/a" = "serifless"
 
 [prime.cyrl-a.variants-buildup.stages.bar.tailed]
 rank = 4
 descriptionAffix = "curly tail"
 selectorAffix."cyrl/a" = "tailed"
-selectorAffix."cyrl/ae/a" = "serifless"
+selectorAffix."cyrl/aie/a" = "serifless"
 
 [prime.cyrl-a.variants-buildup.stages.bar.tailed-serifed]
 rank = 5
 disableIf = [{ storey = "double-storey" }, { ear = "NOT eared" }]
 descriptionAffix = "curly tail; with serifs at top and bottom"
 selectorAffix."cyrl/a" = "tailedSerifed"
-selectorAffix."cyrl/ae/a" = "serifless"
+selectorAffix."cyrl/aie/a" = "serifless"
 
 [prime.cyrl-a.variants-buildup.stages.bar.toothless-corner]
 rank = 6
 disableIf = [{ storey = "single-storey" }]
 descriptionAffix = "toothless (cornered bottom-right)"
 selectorAffix."cyrl/a" = "toothlessCorner"
-selectorAffix."cyrl/ae/a" = "serifless"
+selectorAffix."cyrl/aie/a" = "serifless"
 
 [prime.cyrl-a.variants-buildup.stages.bar.toothless-rounded]
 rank = 7
 disableIf = [{ storey = "single-storey" }]
 descriptionAffix = "toothless (rounded bottom-right)"
 selectorAffix."cyrl/a" = "toothlessRounded"
-selectorAffix."cyrl/ae/a" = "serifless"
+selectorAffix."cyrl/aie/a" = "serifless"
 
 
 
@@ -8154,19 +8148,19 @@ next = "openness"
 rank = 1
 descriptionAffix = "straight leg"
 selectorAffix."cyrl/Ya" = "straight"
-selectorAffix."cyrl/Yae/left" = "straight"
+selectorAffix."cyrl/YaIe/YaHalf" = "straight"
 
 [prime.cyrl-capital-ya.variants-buildup.stages.leg.curly]
 rank = 2
 descriptionAffix = "curly leg"
 selectorAffix."cyrl/Ya" = "curly"
-selectorAffix."cyrl/Yae/left" = "curly"
+selectorAffix."cyrl/YaIe/YaHalf" = "curly"
 
 [prime.cyrl-capital-ya.variants-buildup.stages.leg.standing]
 rank = 3
 descriptionAffix = "standing leg (like Helvetica)"
 selectorAffix."cyrl/Ya" = "standing"
-selectorAffix."cyrl/Yae/left" = "standing"
+selectorAffix."cyrl/YaIe/YaHalf" = "standing"
 
 [prime.cyrl-capital-ya.variants-buildup.stages.openness."*"]
 next = "serifs"
@@ -8175,32 +8169,32 @@ next = "serifs"
 rank = 1
 keyAffix = ""
 selectorAffix."cyrl/Ya" = ""
-selectorAffix."cyrl/Yae/left" = ""
+selectorAffix."cyrl/YaIe/YaHalf" = ""
 
 [prime.cyrl-capital-ya.variants-buildup.stages.openness.open]
 rank = 2
 descriptionAffix = "open contour"
 selectorAffix."cyrl/Ya" = "open"
-selectorAffix."cyrl/Yae/left" = "open"
+selectorAffix."cyrl/YaIe/YaHalf" = "open"
 
 [prime.cyrl-capital-ya.variants-buildup.stages.serifs.serifless]
 rank = 1
 descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix."cyrl/Ya" = "serifless"
-selectorAffix."cyrl/Yae/left" = "serifless"
+selectorAffix."cyrl/YaIe/YaHalf" = "serifless"
 
 [prime.cyrl-capital-ya.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
 descriptionAffix = "motion serifs at bottom-left"
 selectorAffix."cyrl/Ya" = "bottomRightSerifed"
-selectorAffix."cyrl/Yae/left" = "bottomRightSerifed"
+selectorAffix."cyrl/YaIe/YaHalf" = "bottomRightSerifed"
 
 [prime.cyrl-capital-ya.variants-buildup.stages.serifs.serifed]
 rank = 3
 descriptionAffix = "serifs"
 selectorAffix."cyrl/Ya" = "serifed"
-selectorAffix."cyrl/Yae/left" = "bottomRightSerifed"
+selectorAffix."cyrl/YaIe/YaHalf" = "bottomRightSerifed"
 
 
 
@@ -8221,21 +8215,21 @@ rank = 1
 groupRank = 1
 descriptionAffix = "straight leg"
 selectorAffix."cyrl/ya" = "straight"
-selectorAffix."cyrl/yae/left" = "straight"
+selectorAffix."cyrl/yaie/ya" = "straight"
 
 [prime.cyrl-ya.variants-buildup.stages.leg.curly]
 rank = 2
 groupRank = 2
 descriptionAffix = "curly leg"
 selectorAffix."cyrl/ya" = "curly"
-selectorAffix."cyrl/yae/left" = "curly"
+selectorAffix."cyrl/yaie/ya" = "curly"
 
 [prime.cyrl-ya.variants-buildup.stages.leg.standing]
 rank = 3
 groupRank = 3
 descriptionAffix = "standing leg (like Helvetica)"
 selectorAffix."cyrl/ya" = "standing"
-selectorAffix."cyrl/yae/left" = "standing"
+selectorAffix."cyrl/yaie/ya" = "standing"
 
 [prime.cyrl-ya.variants-buildup.stages.openness."*"]
 next = "tails"
@@ -8245,14 +8239,14 @@ rank = 1
 groupRrank = 10
 keyAffix = ""
 selectorAffix."cyrl/ya" = ""
-selectorAffix."cyrl/yae/left" = ""
+selectorAffix."cyrl/yaie/ya" = ""
 
 [prime.cyrl-ya.variants-buildup.stages.openness.open]
 rank = 2
 groupRrank = 20
 descriptionAffix = "open contour"
 selectorAffix."cyrl/ya" = "open"
-selectorAffix."cyrl/yae/left" = "open"
+selectorAffix."cyrl/yaie/ya" = "open"
 
 [prime.cyrl-ya.variants-buildup.stages.tails."*"]
 next = "serifs"
@@ -8261,32 +8255,32 @@ next = "serifs"
 rank = 1
 keyAffix = ""
 selectorAffix."cyrl/ya" = ""
-selectorAffix."cyrl/yae/left" = ""
+selectorAffix."cyrl/yaie/ya" = ""
 
 [prime.cyrl-ya.variants-buildup.stages.tails.tailed]
 rank = 2
 descriptionAffix = "tail"
 selectorAffix."cyrl/ya" = "tailed"
-selectorAffix."cyrl/yae/left" = ""
+selectorAffix."cyrl/yaie/ya" = ""
 
 [prime.cyrl-ya.variants-buildup.stages.serifs.serifless]
 rank = 1
 descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix."cyrl/ya" = "serifless"
-selectorAffix."cyrl/yae/left" = "serifless"
+selectorAffix."cyrl/yaie/ya" = "serifless"
 
 [prime.cyrl-ya.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
 descriptionAffix = "motion serifs at bottom-left"
 selectorAffix."cyrl/ya" = "bottomRightSerifed"
-selectorAffix."cyrl/yae/left" = "bottomRightSerifed"
+selectorAffix."cyrl/yaie/ya" = "bottomRightSerifed"
 
 [prime.cyrl-ya.variants-buildup.stages.serifs.serifed]
 rank = 3
 descriptionAffix = "serifs"
 selectorAffix."cyrl/ya" = "smallCyrl"
-selectorAffix."cyrl/yae/left" = "bottomRightSerifed"
+selectorAffix."cyrl/yaie/ya" = "bottomRightSerifed"
 
 
 


### PR DESCRIPTION
My [original](https://github.com/be5invis/Iosevka/pull/2499) argument for removing the serifs was to better match Open O (`Ɔ`, `ɔ`), but since my recent PR at #2852 , the earlier half-measure is no longer necessary.

For each screenshot below, left is before, right is after.

```
ƏəӘәЭэ
EeƎɘƎǝ
CcↃↄƆɔ
oɔɵɘ𝼛ᶗ
```
Sans Thin Upright:
<img width="1424" height="1069" alt="image" src="https://github.com/user-attachments/assets/a55fb23a-81ed-4b97-bfc5-7dec0979574d" />
Sans Regular Upright:
<img width="1425" height="1078" alt="image" src="https://github.com/user-attachments/assets/9b865f60-31f6-49bd-9e23-98c4f4b9716d" />
Sans Heavy Upright:
<img width="1425" height="1069" alt="image" src="https://github.com/user-attachments/assets/e77b6a38-5154-414d-ac80-5ce46cbff01c" />
Sans Thin Italic:
<img width="1419" height="1077" alt="image" src="https://github.com/user-attachments/assets/521d8c0e-81c1-465d-9bc7-32625196cad0" />
Sans Regular Italic:
<img width="1419" height="1069" alt="image" src="https://github.com/user-attachments/assets/b03cc339-9291-4ef1-b082-ef530ccbd72f" />
Sans Heavy Italic:
<img width="1431" height="1061" alt="image" src="https://github.com/user-attachments/assets/237cdd18-8be4-4e43-a657-d72e8c2abfc0" />
Slab Thin Upright:
<img width="1427" height="1083" alt="image" src="https://github.com/user-attachments/assets/d3b6b872-7f48-4403-b126-5c6910111c8c" />
Slab Regular Upright:
<img width="1422" height="1075" alt="image" src="https://github.com/user-attachments/assets/c0bbcb41-35f8-4b7b-a1d9-b8a5da2715b1" />
Slab Heavy Upright:
<img width="1425" height="1066" alt="image" src="https://github.com/user-attachments/assets/06b2f725-387b-4ab2-b9f4-ba2d9608f8d0" />
Slab Thin Italic:
<img width="1426" height="1077" alt="image" src="https://github.com/user-attachments/assets/eea330eb-76f9-4886-9b41-af6a1465d382" />
Slab Regular Italic:
<img width="1428" height="1068" alt="image" src="https://github.com/user-attachments/assets/61d969ac-1d28-46f9-be0a-06a5d6f3aa7a" />
Slab Heavy Italic:
<img width="1431" height="1072" alt="image" src="https://github.com/user-attachments/assets/f800e799-f312-464e-aa91-ef76489528cf" />
