### PR TITLE
Add new argument `swRef` to `[SerifFrame.fromDf]`.

### DIFF
--- a/packages/font-glyphs/src/letter/cyrillic/ze.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/ze.ptl
@@ -422,11 +422,11 @@ glyph-block Letter-Cyrillic-Ze : begin
 				adb       -- adb
 			define [object stroke] : eps.Dim
 			include : eps.Shape
-			include : bar df (top - stroke / 2) stroke
+			include : bar df (top - HalfStroke) stroke
 			include : spiro-outline
 				corner  df.rightSB                     top
-				corner  df.rightSB                    (top - stroke / 2)
-				corner (df.rightSB - [HSwToV stroke]) (top - stroke / 2)
+				corner  df.rightSB                    (top - HalfStroke)
+				corner (df.rightSB - [HSwToV stroke]) (top - HalfStroke)
 
 		define [EarlessCornerBody df top bar hook ada adb] : glyph-proc
 			local eps : SmallEpsilon SLAB-INWARD CLOSED-STEM top 0
@@ -495,7 +495,7 @@ glyph-block Letter-Cyrillic-Ze : begin
 			define [object stroke] : eps.Dim
 			include : eps.Shape
 			include : VBar.r df.rightSB 0 top stroke
-			include : slab df top
+			include : slab df top stroke
 
 		define [UTailed df top slab hook ada adb] : glyph-proc
 			set-base-anchor 'trailing' (df.rightSB + SideJut) 0
@@ -508,7 +508,7 @@ glyph-block Letter-Cyrillic-Ze : begin
 			define [object stroke] : eps.Dim
 			include : eps.Shape
 			include : RightwardTailedBar df.rightSB 0 top stroke
-			include : slab df top
+			include : slab df top stroke
 
 		define [UToothlessRounded df top slab hook ada adb] : glyph-proc
 			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-ROUND top 0
@@ -520,7 +520,7 @@ glyph-block Letter-Cyrillic-Ze : begin
 			define [object stroke] : eps.Dim
 			include : eps.Shape
 			include : VBar.r df.rightSB ada top stroke
-			include : slab df top
+			include : slab df top stroke
 
 		define [UToothlessCorner df top slab hook ada adb] : glyph-proc
 			local eps : SmallEpsilon OPEN-VERTICAL SLAB-INWARD top 0

--- a/packages/font-glyphs/src/letter/latin/lower-a.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-a.ptl
@@ -60,7 +60,7 @@ glyph-block Letter-Latin-Lower-A : begin
 				[if isMask corner flat] (df.rightSB + O) barTop [heading Leftward]
 				curl [mix df.rightSB df.middle 0.9] barTop
 				archv
-				g4 (df.leftSB + OX) (bowlArcY1 - [HSwToV : SmoothAdjust * leftSlopeS]) [heading {.x HVContrast .y leftSlope}]
+				g4 (df.leftSB + OX) (bowlArcY1 - SmoothAdjust * [HSwToV leftSlopeS]) [heading {.x HVContrast .y leftSlope}]
 				match kind
 					0 : list
 						arch.lhs 0 (sw -- stroke) (swAfter -- df.shoulderFine)
@@ -72,7 +72,7 @@ glyph-block Letter-Latin-Lower-A : begin
 					2 : list
 						arch.lhs 0 (sw -- stroke)
 						flat df.rightSB [Math.min bowlArcY2 rise]
-						curl df.rightSB (rise + [HSwToV : stroke * TanSlope] + TINY) [heading Upward]
+						curl df.rightSB (rise + [HSwToV : Math.abs : stroke * TanSlope] + TINY) [heading Upward]
 
 		export : define [Arc df kind rise _sw _exd] : ADoubleStoreyArcT df dispiro kind rise
 			fallback _sw : ADoubleStoreyStroke df
@@ -88,7 +88,7 @@ glyph-block Letter-Latin-Lower-A : begin
 
 		export : define [Serifed df hookStyle sw] : union
 			Serifless  df hookStyle sw
-			begin [SerifFrame.fromDf df XH 0].rb.outer
+			begin [SerifFrame.fromDf df XH 0 (swRef -- [fallback sw : ADoubleStoreyStroke df]) (swSerif -- df.mvs)].rb.outer
 
 		export : define [Tailed df hookStyle sw] : union
 			HookAndBar df hookStyle (XH - [ADoubleStoreySmoothB df] + O) sw
@@ -199,11 +199,11 @@ glyph-block Letter-Latin-Lower-A : begin
 				fine  -- (ShoulderFine * (sw / Stroke))
 				ada   -- ada
 				adb   -- adb
-			include : bar df (top - sw / 2) sw
+			include : bar df (top - HalfStroke) sw
 			include : spiro-outline
 				corner  df.rightSB                 top
-				corner  df.rightSB                (top - sw / 2)
-				corner (df.rightSB - [HSwToV sw]) (top - sw / 2)
+				corner  df.rightSB                (top - HalfStroke)
+				corner (df.rightSB - [HSwToV sw]) (top - HalfStroke)
 		export : define [EarlessCornerBody df top bar _sw] : glyph-proc
 			local sw : fallback _sw df.mvs
 			local ada : df.archDepthAOf SmallArchDepth sw
@@ -239,22 +239,22 @@ glyph-block Letter-Latin-Lower-A : begin
 			include : VBar.r df.rightSB 0 top sw
 		export : define [TopSerifedBar df top sw] : glyph-proc
 			include : SeriflessBar df top sw
-			local sf : SerifFrame.fromDf df top 0 (swSerif -- sw)
+			local sf : SerifFrame.fromDf df top 0 (swRef -- sw)
 			include sf.rt.outer
 		export : define [BottomSerifedBar df top sw] : glyph-proc
 			include : SeriflessBar df top sw
-			local sf : SerifFrame.fromDf df top 0 (swSerif -- sw)
+			local sf : SerifFrame.fromDf df top 0 (swRef -- sw)
 			include sf.rb.outer
 		export : define [DoubleSerifedBar df top sw] : glyph-proc
 			include : SeriflessBar df top sw
-			local sf : SerifFrame.fromDf df top 0 (swSerif -- sw)
+			local sf : SerifFrame.fromDf df top 0 (swRef -- sw)
 			include : composite-proc sf.rt.outer sf.rb.outer
 		export : define [TailedBar df top sw] : glyph-proc
 			set-base-anchor 'trailing' (df.rightSB + SideJut) 0
 			include : RightwardTailedBar df.rightSB 0 top sw
 		export : define [TailedSerifedBar df top sw] : glyph-proc
 			include : TailedBar df top sw
-			local sf : SerifFrame.fromDf df top 0 (swSerif -- sw)
+			local sf : SerifFrame.fromDf df top 0 (swRef -- sw)
 			include sf.rt.outer
 
 	glyph-block-export SingleStoreyConfig

--- a/packages/font-glyphs/src/letter/latin/lower-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-m.ptl
@@ -122,7 +122,7 @@ glyph-block Letter-Latin-Lower-M : begin
 		include : SmallMBottomMotionRightSerif df top rbot fFull
 
 	define [SmallMShortLegHeight top df] : (top - df.mvs) * 0.45
-	define [SmallMSmoothHeight top df] : top - [SmallMSmoothB df] - [HSwToV : TanSlope * df.mvs] - TINY
+	define [SmallMSmoothHeight top df] : top - [SmallMSmoothB df] - [HSwToV : Math.abs : TanSlope * df.mvs] - TINY
 
 	glyph-block-export SmallMArches
 	define [SmallMArches df top lbot mbot rbot _mid] : glyph-proc
@@ -402,10 +402,10 @@ glyph-block Letter-Latin-Lower-M : begin
 			local realHeight : XH * para.advanceScaleMM
 			local realTop : XH / 2 + realHeight / 2
 			local realBot : XH / 2 - realHeight / 2
-			local df : DivFrame (realHeight / Width) 3 (XH * 0.1 / SB)
+			local df : DivFrame (realHeight / Width) 3 ((XH * 0.1) / SB)
 			include : df.markSet.e
 			include : PointingTo Width realTop Width realBot : function [] : glyph-proc
-				include : turnMShapeBody df (Width - SB)
+				include : turnMShapeBody df RightSB
 				include : Translate 0 (SB / 2)
 
 		if (Body === SmallMArches && !tailed) : begin

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -78,15 +78,15 @@ glyph-block Letter-Latin-U : begin
 	define ULower : UShapeGroup SmallArchDepthA SmallArchDepthB
 
 	define [UTopLeftSerif df yTop _sw] : begin
-		local sf : SerifFrame.fromDf df yTop 0 (swSerif -- _sw)
+		local sf : SerifFrame.fromDf df yTop 0 (swRef -- _sw)
 		return sf.lt.outer
 
 	define [UTopRightSerif df yTop _sw] : begin
-		local sf : SerifFrame.fromDf df yTop 0 (swSerif -- _sw)
+		local sf : SerifFrame.fromDf df yTop 0 (swRef -- _sw)
 		return sf.rt.inner
 
 	define [UBottomRightSerif df yTop _sw] : glyph-proc
-		local sf : SerifFrame.fromDf df yTop 0 (swSerif -- _sw)
+		local sf : SerifFrame.fromDf df yTop 0 (swRef -- _sw)
 		include sf.rb.outer
 		define trAnchor currentGlyph.baseAnchors.trailing
 		if trAnchor : begin
@@ -99,7 +99,7 @@ glyph-block Letter-Latin-U : begin
 			include : UTopRightSerif df top _sw
 			include : UBottomRightSerif df top _sw
 
-		export : define [RTBase df top _sw] : glyph-proc
+		export : define [DescBase df top _sw] : glyph-proc
 			include : UTopLeftSerif df top _sw
 			include : UTopRightSerif df top _sw
 
@@ -108,7 +108,7 @@ glyph-block Letter-Latin-U : begin
 			include : UTopRightSerif df top _sw
 
 		export : define [BilateralMotion df top _sw] : begin
-			local sf : SerifFrame.fromDf df top 0 (swSerif -- _sw)
+			local sf : SerifFrame.fromDf df top 0 (swRef -- _sw)
 			return : composite-proc sf.lt.outer sf.rt.outer
 
 		export : define [SmallToothless df top _sw] : glyph-proc
@@ -126,7 +126,7 @@ glyph-block Letter-Latin-U : begin
 			include : UTopLeftSerif df top _sw
 
 		export : define [Toothless df top _sw] : begin
-			local sf : SerifFrame.fromDf df top 0 (swSerif -- _sw)
+			local sf : SerifFrame.fromDf df top 0 (swRef -- _sw)
 			return : composite-proc sf.lt.full sf.rt.full
 
 	glyph-block-export CapitalUConfigT
@@ -150,20 +150,20 @@ glyph-block Letter-Latin-U : begin
 
 	foreach { suffix { Base {Slabs fLTSlab} } } [Object.entries : CapitalUConfigT UUpper] : do
 		create-glyph "U.\(suffix)" : glyph-proc
-			local df : DivFrame 1
+			local df : include : DivFrame 1
 			include : MarkSet.capital
-			include : Base df CAP Stroke
-			include : Slabs df CAP
+			include : Base  df CAP Stroke
+			include : Slabs df CAP Stroke
 
 		create-glyph "U/withTonos.\(suffix)" : glyph-proc
 			include [refer-glyph "U.\(suffix)"] AS_BASE ALSO_METRICS
 			include : SetGrekUpperTonos [if fLTSlab (-SideJut) 0]
 
 		create-glyph "smcpU.\(suffix)" : glyph-proc
-			local df : DivFrame 1
+			local df : include : DivFrame 1
 			include : MarkSet.e
-			include : Base df XH Stroke
-			include : Slabs df XH
+			include : Base  df XH Stroke
+			include : Slabs df XH Stroke
 
 	glyph-block-export SmallUConfigT
 	define [SmallUConfigT shapeGroup] : SuffixCfg.weave
@@ -182,26 +182,26 @@ glyph-block Letter-Latin-U : begin
 			serifed : match body
 				[Just 'toothed']   USerifs.Toothed
 				[Just 'tailed']    USerifs.Tailed
-				[Just 'descBase']  USerifs.RTBase
+				[Just 'descBase']  USerifs.DescBase
 				__                 USerifs.SmallToothless
 
 	foreach { suffix { Base Slabs } } [Object.entries : SmallUConfigT ULower] : do
 		create-glyph "u.\(suffix)" : glyph-proc
-			local df : DivFrame 1
+			local df : include : DivFrame 1
 			include : df.markSet.e
-			include : Base df XH Stroke
-			include : Slabs df XH
+			include : Base  df XH Stroke
+			include : Slabs df XH Stroke
 
 		create-glyph "grek/mu.\(suffix)" : glyph-proc
-			local df : DivFrame 1
+			local df : include : DivFrame 1
 			include : df.markSet.p
-			include : Base df XH Stroke
+			include : Base  df XH Stroke
+			include : Slabs df XH Stroke
 			include : dispiro
 				widths.rhs
-				flat df.leftSB Descender [heading Upward]
-				curl df.leftSB (Descender / 2) [heading Upward]
-				straight.up.end df.leftSB SmallArchDepthB [widths.heading 0 [AdviceStroke 4] Upward]
-			include : Slabs df XH
+				flat df.leftSB      Descender        [heading Upward]
+				curl df.leftSB [mix Descender 0 0.5] [heading Upward]
+				straight.up.end df.leftSB SmallArchDepthB [widths.rhs.heading [AdviceStroke 4] Upward]
 			include : LeaningAnchor.Below.VBar.l df.leftSB
 
 		create-glyph "cyrl/tse.italic.\(suffix)" : glyph-proc
@@ -219,10 +219,10 @@ glyph-block Letter-Latin-U : begin
 			include [refer-glyph 'descenderBarBelow']
 
 		create-glyph "turnh.\(suffix)" : glyph-proc
-			local df : DivFrame 1
+			local df : include : DivFrame 1
 			include : df.markSet.p
-			include : Base df XH Stroke
-			include : Slabs df XH
+			include : Base  df XH Stroke
+			include : Slabs df XH Stroke
 			eject-contour 'serifRB'
 			include : VBar.r df.rightSB Descender XH Stroke
 			if (Slabs !== no-shape) : begin
@@ -231,24 +231,24 @@ glyph-block Letter-Latin-U : begin
 			include : LeaningAnchor.Below.VBar.r df.rightSB
 
 		create-glyph "uShortLeg.\(suffix)" : glyph-proc
-			local df : DivFrame 1
+			local df : include : DivFrame 1
 			include : df.markSet.e
-			include : Base df XH Stroke false true
-			include : Slabs df XH
+			include : Base  df XH Stroke false true
+			include : Slabs df XH Stroke
 			eject-contour 'serifRT'
 
 		create-glyph "uHookLeft.\(suffix)" : glyph-proc
-			local df : DivFrame 1
+			local df : include : DivFrame 1
 			include : df.markSet.e
-			include : Base df XH Stroke true
-			include : Slabs df XH
+			include : Base  df XH Stroke true
+			include : Slabs df XH Stroke
 			eject-contour 'serifLT'
 
 		create-glyph "turnhHookLeft.\(suffix)" : glyph-proc
-			local df : DivFrame 1
+			local df : include : DivFrame 1
 			include : df.markSet.p
-			include : Base df XH Stroke true
-			include : Slabs df XH
+			include : Base  df XH Stroke true
+			include : Slabs df XH Stroke
 			eject-contour 'serifLT'
 			eject-contour 'serifRB'
 			include : VBar.r df.rightSB Descender XH Stroke
@@ -258,10 +258,10 @@ glyph-block Letter-Latin-U : begin
 			include : LeaningAnchor.Below.VBar.r df.rightSB
 
 		create-glyph "turnhHookLeftRTail.\(suffix)" : glyph-proc
-			local df : DivFrame 1
+			local df : include : DivFrame 1
 			include : df.markSet.p
-			include : Base df XH Stroke true
-			include : Slabs df XH
+			include : Base  df XH Stroke true
+			include : Slabs df XH Stroke
 			eject-contour 'serifLT'
 			eject-contour 'serifRB'
 			include : VBar.r df.rightSB 0 XH Stroke
@@ -273,18 +273,18 @@ glyph-block Letter-Latin-U : begin
 			include : df.markSet.e
 			include : PointingTo Width XH Width 0 : function [] : glyph-proc
 				include : Base  df RightSB Stroke
-				include : Slabs df RightSB
+				include : Slabs df RightSB Stroke
 				include : Translate 0 (SB / 2)
 
 		create-glyph "uDieresisSideways/base.\(suffix)" : glyph-proc
 			local df : DivFrame (XH / Width) 2 ((XH * 0.1) / SB)
 			include : df.markSet.e
-			local ww : Width * para.advanceScaleT
+			local ww : Width * para.advanceScaleM
 			set-width ww
 			set-base-anchor 'cvDecompose' 0 0
 			include : PointingTo ww XH ww 0 : function [] : glyph-proc
-				include : Base  df ((ww - SB) - AccentHeight * 0.75 * para.advanceScaleT) Stroke
-				include : Slabs df ((ww - SB) - AccentHeight * 0.75 * para.advanceScaleT)
+				include : Base  df [Math.min RightSB : (ww - SB) - AccentHeight * 0.75 * para.advanceScaleM] Stroke
+				include : Slabs df [Math.min RightSB : (ww - SB) - AccentHeight * 0.75 * para.advanceScaleM] Stroke
 				include : Translate 0 (SB / 2)
 
 	select-variant 'U' 'U'
@@ -362,12 +362,12 @@ glyph-block Letter-Latin-U : begin
 
 	# Sideways dieresis for U+1D1E
 	derive-glyphs "uDieresisSideways/mark" null "dieresisAbove/alwaysUpright" : function [gns] : glyph-proc
-		local ww : Width * para.advanceScaleT
+		local ww : Width * para.advanceScaleM
 		set-width 0
 		set-mark-anchor 'cvDecompose' 0 0
 		include : PointingTo ww XH ww 0 : function [] : glyph-proc
 			include : refer-glyph gns
-			include : Translate ((XH / 2) - markMiddle) ((ww - SB) - XH - AccentHeight)
+			include : Translate ((XH / 2) - markMiddle) ([Math.min RightSB : (ww - SB) - AccentHeight] - XH)
 			include : Translate 0 (SB / 2)
 
 	CreateAccentedComposition 'uDieresisSideways' 0x1D1E 'uDieresisSideways/base' 'uDieresisSideways/mark'

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -816,9 +816,9 @@ glyph-block Letter-Shared-Shapes : begin
 		local-parameter : fForceSymmetric -- false
 		return : new CSerifFrame top bot left right swRef swSerif adws hSplit fForceSymmetric
 
-	define SerifFrame.fromDf : function [] : with-params [df top bot [swSerif df.mvs] [fForceSymmetric false]] : begin
+	define SerifFrame.fromDf : function [] : with-params [df top bot [swRef df.mvs] [swSerif swRef] [fForceSymmetric false]] : begin
 		return : SerifFrame top bot df.leftSB df.rightSB
-			swRef   -- df.mvs
+			swRef   -- swRef
 			adws    -- df.adws
 			hSplit  -- [Math.max 2 df.hPack]
 			swSerif -- swSerif


### PR DESCRIPTION
Basically allowing for the serifs from `[SerifFrame.fromDf]` to fit the character better (example: properly centered on e.g. its leg) when its body's stroke width does not exactly conform to its prescribed `[DivFrame].mvs` value.