### PR TITLE
Fix horizontal bar of Digit Four (`4`) clashing with serif under heavy.

### DIFF
--- a/packages/font-glyphs/src/number/4.ptl
+++ b/packages/font-glyphs/src/number/4.ptl
@@ -10,9 +10,9 @@ glyph-block Digits-Four : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Digits-Shared : OnumMarks ShiftDown CodeLnum CodeOnum
 
-	define [FourStdShape] : with-params [top open crossing [fine : AdviceStroke 3] [sw Stroke] [bbd 0] [slab SLAB]] : glyph-proc
-		define yBar : top * 0.25 + 0.625 * sw
-		define swVBar : sw * [AdviceStroke 2.5] / [AdviceStroke 2]
+	define [FourStdShape] : with-params [top open crossing [fine [AdviceStroke 3]] [sw Stroke] [bbd 0] [slab SLAB]] : glyph-proc
+		define yBar : Math.max (top * 0.25 + 0.625 * sw) (top * 0.05 + sw + [if (!bbd && slab) Stroke 0])
+		define swVBar : [AdviceStroke 2.5] * (sw / Stroke)
 
 		define xVertBar : [mix SB RightSB : if crossing 0.78 0.9125] - (bbd * 0.75) + [if crossing [HSwToV : 0.375 * sw] 0]
 		define yVertBarTop : [mix (yBar - sw) top : if open 0.5 1] - [if open (0.3 * sw) 0]
@@ -42,7 +42,7 @@ glyph-block Digits-Four : begin
 		if bbd : begin
 			include : VBar.r (xVertBar + bbd) 0 yVertBarTop sw
 			include : HBar.t xVertBar (xVertBar + bbd) CAP sw
-			include : HBar.b xVertBar (xVertBar + bbd) 0 sw
+			include : HBar.b xVertBar (xVertBar + bbd) 0   sw
 		if (!bbd && slab) : begin
 			include : HSerif.rb (xVertBar - [HSwToV HalfStroke]) 0 Jut
 			include : HSerif.lb (xVertBar - [HSwToV HalfStroke]) 0 MidJutSide
@@ -54,10 +54,10 @@ glyph-block Digits-Four : begin
 		return : FourStdShape top true crossing (fine -- [AdviceStroke 2.75]) (slab -- slab)
 
 	define [FourOpenShape top crossing slab] : glyph-proc
-		local yBar (top * 0.4)
+		local yBar : top * 0.4
 		local fine : AdviceStroke 3
 
-		define xVertBar : mix SB RightSB [if crossing 0.825 0.9125]
+		define xVertBar : mix SB RightSB : if crossing 0.825 0.9125
 		define xHBarTerminal : if crossing RightSB xVertBar
 
 		include : HBar.t SB xHBarTerminal yBar


### PR DESCRIPTION
Fixing a defect from 22f70de .

The value I chose for the minimum gap between the bottom of the bar and top of the serif is `CAP * 0.05`. I'm not sure whether this is too stingy or too generous, but it works.

The screenshots below contain rows of weights 100/400/700/900 and columns of widths normal/extended.

I do not have screenshots from before this fix, but it tended to overlap with the serif under _Slab Extended Heavy_ in particular.

Sans:
<img width="315" height="1159" alt="image" src="https://github.com/user-attachments/assets/06400db7-80a8-45cf-ad0b-0de97cbf6081" />
Slab
<img width="289" height="1133" alt="image" src="https://github.com/user-attachments/assets/6c1c445d-8ef1-4716-a3ec-b90a6967cb5c" />
