### PR TITLE
Cleanup of `marks/above.ptl`, also re-unify width of Combining Square (`◌᫤`, `◌̻`) with that of Combining Bridge (`◌͆`, `◌̪`, `◌᫣`, `◌̺`).

### DIFF
--- a/changes/33.3.2.md
+++ b/changes/33.3.2.md
@@ -1,2 +1,5 @@
- - Changed the default style of Cyrillic lowercase Ef (ф) in Aile and Etoile (upright) to use non-split rings, for better style consistency (#2879).
- - Fix style assignment of `l` in Libration Mono style (SS06) (#2882).
+* Refine shape of the following characters:
+  - COMBINING SQUARE BELOW (`U+0349`).
+  - COMBINING SQUARE ABOVE (`U+1AE4`).
+* Changed the default style of Cyrillic lowercase Ef (ф) in Aile and Etoile (upright) to use non-split rings, for better style consistency (#2879).
+* Fix style assignment of `l` in Libration Mono style (SS06) (#2882).

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -98,20 +98,20 @@ glyph-block Mark-Above : begin
 			set-width 0
 			include : StdAnchors.wide
 			local fine : Math.min (markDotsRadius * kdr) (markExtend * 0.375)
-			local coFine : markExtend * 1.5 - fine
-			include : DrawAt (markMiddle - coFine) aboveMarkMid fine
-			include : DrawAt  markMiddle           aboveMarkMid fine
-			include : DrawAt (markMiddle + coFine) aboveMarkMid fine
+			local ext : markExtend * 1.5 - fine
+			include : DrawAt (markMiddle - ext) aboveMarkMid fine
+			include : DrawAt  markMiddle        aboveMarkMid fine
+			include : DrawAt (markMiddle + ext) aboveMarkMid fine
 
 		create-glyph "fourDotsAbove.\(suffix)" : glyph-proc
 			set-width 0
 			include : StdAnchors.extraWide
 			local fine : Math.min (markDotsRadius * kdr) (markExtend * 0.3125)
-			local coFine : markExtend * 2 - fine
-			include : DrawAt (markMiddle - coFine)     aboveMarkMid fine
-			include : DrawAt (markMiddle - coFine / 3) aboveMarkMid fine
-			include : DrawAt (markMiddle + coFine / 3) aboveMarkMid fine
-			include : DrawAt (markMiddle + coFine)     aboveMarkMid fine
+			local ext : markExtend * 2.0 - fine
+			include : DrawAt (markMiddle - ext)     aboveMarkMid fine
+			include : DrawAt (markMiddle - ext / 3) aboveMarkMid fine
+			include : DrawAt (markMiddle + ext / 3) aboveMarkMid fine
+			include : DrawAt (markMiddle + ext)     aboveMarkMid fine
 
 	select-variant 'dotAbove'             0x307  (follow -- 'diacriticDot')
 	select-variant 'dieresisAbove'        0x308  (follow -- 'diacriticDot')
@@ -145,7 +145,7 @@ glyph-block Mark-Above : begin
 	create-glyph 'dblRingAbove' 0x1AB2 : glyph-proc
 		set-width 0
 		local [object radiusIn radiusOut] : RingDims
-		local k : 2 * (radiusOut - (radiusOut - radiusIn) * 0.25)
+		local k : 2 * [mix radiusOut radiusIn 0.25]
 		include : with-transform [Translate (k * (+0.5)) 0] : refer-glyph 'ringAbove'
 		include : with-transform [Translate (k * (-0.5)) 0] : refer-glyph 'ringAbove'
 		include : StdAnchors.wide
@@ -171,27 +171,27 @@ glyph-block Mark-Above : begin
 		set-width 0
 		include : StdAnchors.medium
 		include : dispiro
-			flat (markMiddle + markStress) aboveMarkBot [widths.center : 2 * markFine]
+			flat (markMiddle + 1.000 * markStress) aboveMarkBot [widths.center : 2 * markFine]
 			curl (markMiddle - 0.875 * markExtend) aboveMarkTop [widths.center : 2 * markStress]
 
 	create-glyph 'asciiGrave/body/straight' : glyph-proc
 		local df : include : DivFrame para.advanceScaleF
 		include : dispiro
 			flat (df.middle + HalfStroke * 1.1 * asciiMarkZoomX * [Math.sqrt df.adws]) [mix aboveMarkMid aboveMarkBot asciiMarkZoomY] [widths.center : Stroke * 0.9]
-			curl (df.middle - markExtend * asciiMarkZoomX * [Math.sqrt df.adws]) [mix aboveMarkMid aboveMarkTop asciiMarkZoomY] [widths.center : Stroke * 1.1]
+			curl (df.middle - markExtend * 1.0 * asciiMarkZoomX * [Math.sqrt df.adws]) [mix aboveMarkMid aboveMarkTop asciiMarkZoomY] [widths.center : Stroke * 1.1]
 
 	create-glyph 'acuteAbove' 0x301 : glyph-proc
 		set-width 0
 		include : StdAnchors.medium
 		include : dispiro
-			flat (markMiddle - markStress) aboveMarkBot [widths.center : 2 * markFine]
+			flat (markMiddle - 1.000 * markStress) aboveMarkBot [widths.center : 2 * markFine]
 			curl (markMiddle + 0.875 * markExtend) aboveMarkTop [widths.center : 2 * markStress]
 
 	create-glyph 'latin1acute' 0xB4 : glyph-proc
 		local df : include : DivFrame para.advanceScaleF
 		include : dispiro
 			flat (df.middle - HalfStroke * 1.1 * asciiMarkZoomX * [Math.sqrt df.adws]) [mix aboveMarkMid aboveMarkBot asciiMarkZoomY] [widths.center : Stroke * 0.9]
-			curl (df.middle + markExtend * asciiMarkZoomX * [Math.sqrt df.adws]) [mix aboveMarkMid aboveMarkTop asciiMarkZoomY] [widths.center : Stroke * 1.1]
+			curl (df.middle + markExtend * 1.0 * asciiMarkZoomX * [Math.sqrt df.adws]) [mix aboveMarkMid aboveMarkTop asciiMarkZoomY] [widths.center : Stroke * 1.1]
 
 	glyph-block-export CaretCaronWidth CaretCaronMidSw CaretCaronTerminalSw
 	define CaretCaronWidth : 2 * markExtend + markStress
@@ -200,15 +200,15 @@ glyph-block Mark-Above : begin
 
 	glyph-block-export CaretShape
 	define [CaretLeftShape] : with-params [top bottom xMiddle width swEnd swMid] : dispiro
-		flat (xMiddle - 0.5 * width) bottom [widths.center swEnd]
-		curl xMiddle                 top    [widths.center.heading swMid Upward]
+		flat (xMiddle - (width / 2)) bottom [widths.center swEnd]
+		curl  xMiddle                top    [widths.center.heading swMid Upward]
 	define [CaretRightShape] : with-params [top bottom xMiddle width swEnd swMid] : dispiro
-		flat (xMiddle + 0.5 * width) bottom [widths.center swEnd]
-		curl xMiddle                 top    [widths.center.heading swMid Upward]
+		flat (xMiddle + (width / 2)) bottom [widths.center swEnd]
+		curl  xMiddle                top    [widths.center.heading swMid Upward]
 	define [CaretTopBarShape] : with-params [top xMiddle width pL pR swMid swBar] : dispiro
 		widths.rhs swBar
-		flat [Math.min (xMiddle + 0.5 * width * pL) (xMiddle - [HSwToV : 0.5 * swMid])] top
-		curl [Math.max (xMiddle + 0.5 * width * pR) (xMiddle + [HSwToV : 0.5 * swMid])] top
+		flat [Math.min (xMiddle + (width / 2) * pL) (xMiddle - [HSwToV : 0.5 * swMid])] top
+		curl [Math.max (xMiddle + (width / 2) * pR) (xMiddle + [HSwToV : 0.5 * swMid])] top
 	define [CaretShape] : with-params [top bottom xMiddle width swEnd swMid] : union
 		CaretLeftShape  top bottom xMiddle width swEnd swMid
 		CaretRightShape top bottom xMiddle width swEnd swMid
@@ -216,7 +216,7 @@ glyph-block Mark-Above : begin
 	create-glyph 'asciiCaret.high' : glyph-proc
 		include : CaretShape
 			xMiddle -- Middle
-			width   -- (3 * markExtend * asciiMarkZoomX - QuarterStroke)
+			width   -- (2 * (markExtend * 1.5) * asciiMarkZoomX - QuarterStroke)
 			top     -- ([mix aboveMarkMid aboveMarkTop asciiMarkZoomY] + HalfStroke)
 			bottom  -- [mix aboveMarkMid aboveMarkBot asciiMarkZoomY]
 			swEnd   -- (Stroke * 1.05)
@@ -272,15 +272,15 @@ glyph-block Mark-Above : begin
 			swBar   -- (2 * markFine)
 
 	define [CaronLeftShape] : with-params [top bottom xMiddle width swEnd swMid] : dispiro
-		flat (xMiddle - 0.5 * width) top    [widths.center swEnd]
-		curl xMiddle                 bottom [widths.center.heading swMid Downward]
+		flat (xMiddle - (width / 2)) top    [widths.center swEnd]
+		curl  xMiddle                bottom [widths.center.heading swMid Downward]
 	define [CaronRightShape] : with-params [top bottom xMiddle width swEnd swMid] : dispiro
-		flat (xMiddle + 0.5 * width) top    [widths.center swEnd]
-		curl xMiddle                 bottom [widths.center.heading swMid Downward]
+		flat (xMiddle + (width / 2)) top    [widths.center swEnd]
+		curl  xMiddle                bottom [widths.center.heading swMid Downward]
 	define [CaronBottomBarShape] : with-params [bottom xMiddle width pL pR swMid swBar] : dispiro
 		widths.lhs swBar
-		flat [Math.min (xMiddle + 0.5 * width * pL) (xMiddle - [HSwToV : 0.5 * swMid])] bottom
-		curl [Math.max (xMiddle + 0.5 * width * pR) (xMiddle + [HSwToV : 0.5 * swMid])] bottom
+		flat [Math.min (xMiddle + (width / 2) * pL) (xMiddle - [HSwToV : 0.5 * swMid])] bottom
+		curl [Math.max (xMiddle + (width / 2) * pR) (xMiddle + [HSwToV : 0.5 * swMid])] bottom
 	define [CaronShape] : with-params [top bottom xMiddle width swEnd swMid] : union
 		CaronLeftShape  top bottom xMiddle width swEnd swMid
 		CaronRightShape top bottom xMiddle width swEnd swMid
@@ -354,7 +354,7 @@ glyph-block Mark-Above : begin
 		local height : Math.abs (ttop - tbot)
 		local hsvh : (2 * hs) / height
 		local hvc : (rightEnd - leftEnd) / height
-		local defaultHvc : (3 * markExtend) / ((aboveMarkTop - aboveMarkBot) - markFine / 2)
+		local defaultHvc : 2 * (markExtend * 1.5) / ((aboveMarkTop - aboveMarkBot) - markFine / 2)
 
 		local hsvhThin 0.116
 		local hsvhHeav 0.732
@@ -362,7 +362,7 @@ glyph-block Mark-Above : begin
 		local tildeWaveX 0.51
 
 		define z1 : currentGlyph.gizmo.apply : object [x leftEnd] [y tbot]
-		define z2 : currentGlyph.gizmo.apply : object [x : mix leftEnd rightEnd tildeWaveX] [y : mix tbot ttop tildeWave]
+		define z2 : currentGlyph.gizmo.apply : object [x : mix leftEnd rightEnd (0 + tildeWaveX)] [y : mix tbot ttop (0 + tildeWave)]
 		define z3 : currentGlyph.gizmo.apply : object [x : mix leftEnd rightEnd (1 - tildeWaveX)] [y : mix tbot ttop (1 - tildeWave)]
 		define z4 : currentGlyph.gizmo.apply : object [x rightEnd] [y ttop]
 
@@ -501,21 +501,24 @@ glyph-block Mark-Above : begin
 		local rightEnd : markMiddle + markExtend * 1.5
 
 		include : dispiro
-			flat leftEnd  aboveMarkMid [widths.center : 2 * markHalfStroke]
+			widths.center markStroke
+			flat leftEnd  aboveMarkMid
 			curl rightEnd aboveMarkMid
 
 	create-glyph 'overlineAbove' 0x305 : glyph-proc
 		set-width 0
 		include : StdAnchors.impl 'above' 0 2
 		include : dispiro
-			flat (0 - Width) aboveMarkMid [widths.center : 2 * markHalfStroke]
+			widths.center markStroke
+			flat (0 - Width) aboveMarkMid
 			curl  0          aboveMarkMid
 
 	create-glyph 'sbRsbOverlineAbove' : glyph-proc
 		set-width 0
 		include : StdAnchors.impl 'above' 0 1.5
 		include : dispiro
-			flat (SB      - Width) aboveMarkMid [widths.center : 2 * markHalfStroke]
+			widths.center markStroke
+			flat (SB      - Width) aboveMarkMid
 			curl (RightSB - Width) aboveMarkMid
 
 	create-glyph 'cyrl/ghe.SRB/overlineAbove' : glyph-proc
@@ -526,11 +529,12 @@ glyph-block Mark-Above : begin
 		local leftEnd  : markMiddle - (df.rightSB - df.leftSB) / 2
 		local rightEnd : markMiddle + (df.rightSB - df.leftSB) / 2
 
-		set-base-anchor 'aboveBraceL' leftEnd aboveMarkMid
+		set-base-anchor 'aboveBraceL' leftEnd  aboveMarkMid
 		set-base-anchor 'aboveBraceR' rightEnd aboveMarkMid
 
 		include : dispiro
-			flat leftEnd  aboveMarkMid [widths.center : 2 * markHalfStroke]
+			widths.center markStroke
+			flat leftEnd  aboveMarkMid
 			curl rightEnd aboveMarkMid
 
 	create-glyph 'cyrl/pe.SRB/overlineAbove' : glyph-proc
@@ -541,11 +545,12 @@ glyph-block Mark-Above : begin
 		local leftEnd  : markMiddle - (df.rightSB - df.leftSB) / 2
 		local rightEnd : markMiddle + (df.rightSB - df.leftSB) / 2
 
-		set-base-anchor 'aboveBraceL' leftEnd aboveMarkMid
+		set-base-anchor 'aboveBraceL' leftEnd  aboveMarkMid
 		set-base-anchor 'aboveBraceR' rightEnd aboveMarkMid
 
 		include : dispiro
-			flat leftEnd  aboveMarkMid [widths.center : 2 * markHalfStroke]
+			widths.center markStroke
+			flat leftEnd  aboveMarkMid
 			curl rightEnd aboveMarkMid
 
 	create-glyph 'cyrl/te.SRB/overlineAbove' : glyph-proc
@@ -556,63 +561,67 @@ glyph-block Mark-Above : begin
 		local leftEnd  : markMiddle - (df.rightSB - df.leftSB) / 2
 		local rightEnd : markMiddle + (df.rightSB - df.leftSB) / 2
 
-		set-base-anchor 'aboveBraceL' leftEnd aboveMarkMid
+		set-base-anchor 'aboveBraceL' leftEnd  aboveMarkMid
 		set-base-anchor 'aboveBraceR' rightEnd aboveMarkMid
 
 		include : dispiro
-			flat leftEnd  aboveMarkMid [widths.center : 2 * markHalfStroke]
+			widths.center markStroke
+			flat leftEnd  aboveMarkMid
 			curl rightEnd aboveMarkMid
 
 	create-glyph 'latin1macron' 0xAF : glyph-proc
 		local df : include : DivFrame 1
 		include : dispiro
-			flat df.leftSB  aboveMarkMid [widths.center : 2 * markHalfStroke]
+			widths.center markStroke
+			flat df.leftSB  aboveMarkMid
 			curl df.rightSB aboveMarkMid
 
 	create-glyph 'dblOverlineAbove' 0x33F : glyph-proc
 		set-width 0
 		include : StdAnchors.impl 'above' 0 2
 
-		local boxsw : Math.min (markFine * 2) ((aboveMarkTop - aboveMarkBot) / 3)
+		local eqsw : Math.min (markFine * 2) ((aboveMarkTop - aboveMarkBot) / 3)
 
 		include : dispiro
-			widths.lhs boxsw
+			widths.lhs eqsw
 			flat (0 - Width) aboveMarkBot
 			curl  0          aboveMarkBot
 
 		include : dispiro
-			widths.rhs boxsw
+			widths.rhs eqsw
 			flat (0 - Width) aboveMarkTop
 			curl  0          aboveMarkTop
 
 	glyph-block-export BreveShape
 	define [BreveShape] : with-params [top bottom xMiddle width hs] : glyph-proc
-		local leftEnd  : xMiddle - width * 0.5
-		local rightEnd : xMiddle + width * 0.5
+		local leftEnd  : xMiddle - width / 2
+		local rightEnd : xMiddle + width / 2
 		include : dispiro
-			g4.down.start leftEnd top [widths.heading hs hs Downward]
+			widths.center (hs * 2)
+			g4.down.start leftEnd  top          [heading Downward]
 			arcvh
-			g4.right.mid xMiddle (bottom + hs) [heading Rightward]
+			g4.right.mid  xMiddle (bottom + hs) [heading Rightward]
 			archv
-			g4.up.end rightEnd top [heading Upward]
+			g4.up.end     rightEnd top          [heading Upward]
 
 	glyph-block-export InvBreveShape
 	define [InvBreveShape] : with-params [top bottom xMiddle width hs] : glyph-proc
-		local leftEnd  : xMiddle - width * 0.5
-		local rightEnd : xMiddle + width * 0.5
+		local leftEnd  : xMiddle - width / 2
+		local rightEnd : xMiddle + width / 2
 		include : dispiro
-			g4.up.start leftEnd bottom [widths.heading hs hs Upward]
+			widths.center (hs * 2)
+			g4.up.start  leftEnd  bottom    [heading Upward]
 			arcvh
 			g4.right.mid xMiddle (top - hs) [heading Rightward]
 			archv
-			g4.down.end rightEnd bottom [heading Downward]
+			g4.down.end  rightEnd bottom    [heading Downward]
 
 	create-glyph 'breveAbove' 0x306 : glyph-proc
 		set-width 0
 		include : StdAnchors.wide
 		include : BreveShape
 			xMiddle -- markMiddle
-			width   -- (2.4 * markExtend)
+			width   -- (2 * (markExtend * 1.2))
 			top     -- aboveMarkTop
 			bottom  -- aboveMarkBot
 			hs      -- markHalfStroke
@@ -622,10 +631,79 @@ glyph-block Mark-Above : begin
 		include : StdAnchors.wide
 		include : InvBreveShape
 			xMiddle -- markMiddle
-			width   -- (2.4 * markExtend)
+			width   -- (2 * (markExtend * 1.2))
 			top     -- aboveMarkTop
 			bottom  -- aboveMarkBot
 			hs      -- markHalfStroke
+
+	create-glyph 'dblBreveAbove' 0x1AC7 : glyph-proc
+		set-width 0
+		include : StdAnchors.wide
+
+		local hs : 0.5 * ([AdviceStroke 3.5] * (markStroke / Stroke))
+		local width : ((aboveMarkTop - aboveMarkBot) - markHalfStroke) * 2.5
+
+		local leftEnd  : markMiddle - width / 2
+		local rightEnd : markMiddle + width / 2
+
+		include : dispiro
+			widths.center (hs * 2)
+			g4.down.start     leftEnd                  aboveMarkTop       [heading Downward]
+			arcvh
+			g4.right.mid [mix leftEnd markMiddle 0.5] (aboveMarkBot + hs) [heading Rightward]
+			archv
+			g4.up.end                 markMiddle       aboveMarkTop       [heading Upward]
+		include : dispiro
+			widths.center (hs * 2)
+			g4.down.start     markMiddle                aboveMarkTop       [heading Downward]
+			arcvh
+			g4.right.mid [mix markMiddle rightEnd 0.5] (aboveMarkBot + hs) [heading Rightward]
+			archv
+			g4.up.end                    rightEnd       aboveMarkTop       [heading Upward]
+
+	create-glyph 'dblInvBreveAbove' 0x1AE5 : glyph-proc
+		set-width 0
+		include : refer-glyph "dblBreveAbove"
+		include : FlipAround markMiddle aboveMarkMid
+		include : StdAnchors.wide
+
+	create-glyph 'breveMacronAbove' 0x1DCB : glyph-proc
+		set-width 0
+		include : StdAnchors.wide
+
+		local hs : 0.5 * ([AdviceStroke 3.5] * (markStroke / Stroke))
+		local width : ((aboveMarkTop - aboveMarkBot) - markHalfStroke) * 2.5
+
+		local leftEnd  : markMiddle - width / 2
+		local rightEnd : markMiddle + width / 2
+
+		include : dispiro
+			widths.center (hs * 2)
+			g4.down.start     leftEnd                  aboveMarkTop       [heading Downward]
+			arcvh
+			g4.right.mid [mix leftEnd markMiddle 0.5] (aboveMarkBot + hs) [heading Rightward]
+			archv
+			g4.up.end                 markMiddle       aboveMarkTop       [heading Upward]
+		include : HBar.t markMiddle (rightEnd + 0.5 * markStress) aboveMarkTop (hs * 2)
+
+	create-glyph 'macronBreveAbove' 0x1DCC : glyph-proc
+		set-width 0
+		include : StdAnchors.wide
+
+		local hs : 0.5 * ([AdviceStroke 3.5] * (markStroke / Stroke))
+		local width : ((aboveMarkTop - aboveMarkBot) - markHalfStroke) * 2.5
+
+		local leftEnd  : markMiddle - width / 2
+		local rightEnd : markMiddle + width / 2
+
+		include : HBar.t (leftEnd - 0.5 * markStress) markMiddle aboveMarkTop (hs * 2)
+		include : dispiro
+			widths.center (hs * 2)
+			g4.down.start     markMiddle                aboveMarkTop       [heading Downward]
+			arcvh
+			g4.right.mid [mix markMiddle rightEnd 0.5] (aboveMarkBot + hs) [heading Rightward]
+			archv
+			g4.up.end                    rightEnd       aboveMarkTop       [heading Upward]
 
 	create-glyph 'hookAbove' 0x309 : glyph-proc
 		set-width 0
@@ -638,12 +716,12 @@ glyph-block Mark-Above : begin
 		include : dispiro
 			widths.lhs (fine * 2)
 			flat (markMiddle - [HSwToV fine]) hookBot [heading Rightward]
-			curl (markMiddle + fine * 0.4) hookBot [heading Rightward]
+			curl (markMiddle + fine * 0.4)    hookBot [heading Rightward]
 			archv
 			g4.up.mid (markMiddle + markExtend - O) [mix hookBot hookTop (ArchDepthB / (ArchDepthB + ArchDepthA))] [heading Upward]
 			arcvh
-			flat (markMiddle + fine * 0.4) hookTop [heading Leftward]
-			curl (markMiddle - markExtend + fine) hookTop [heading Leftward]
+			flat (markMiddle + fine * 0.4)          hookTop [heading Leftward]
+			curl (markMiddle - (markExtend - fine)) hookTop [heading Leftward]
 
 	create-glyph 'doubleGraveAbove' 0x30F : glyph-proc
 		set-width 0
@@ -769,7 +847,7 @@ glyph-block Mark-Above : begin
 	create-glyph 'barAbove' 0x30D : glyph-proc
 		set-width 0
 		include : StdAnchors.narrow
-		include : VBar.m markMiddle aboveMarkBot aboveMarkTop markStroke
+		include : VBar.m markMiddle aboveMarkBot aboveMarkTop (markFine * 2)
 
 	create-glyph 'ascenderBarAbove' : glyph-proc
 		set-width 0
@@ -779,35 +857,67 @@ glyph-block Mark-Above : begin
 	create-glyph 'dblBarAbove' 0x30E : glyph-proc
 		set-width 0
 		include : StdAnchors.mediumWide
+		include : VBar.m (markMiddle - markExtend * 0.75) aboveMarkBot aboveMarkTop (markFine * 2)
+		include : VBar.m (markMiddle + markExtend * 0.75) aboveMarkBot aboveMarkTop (markFine * 2)
 
-		include : VBar.m (markMiddle - markExtend * 0.75) aboveMarkBot aboveMarkTop markStroke
-		include : VBar.m (markMiddle + markExtend * 0.75) aboveMarkBot aboveMarkTop markStroke
+	define [BoxDims hPack vPack k _swRef] : begin
+		local swRef : fallback _swRef markStroke
+		local leftEnd  : markMiddle - (markExtend * k + [HSwToV : 0.5 * swRef])
+		local rightEnd : markMiddle + (markExtend * k + [HSwToV : 0.5 * swRef])
+		local boxhs : Math.min swRef : (aboveMarkTop - aboveMarkBot) / (2 * vPack - 1)
+		local boxvs : Math.min swRef : VSwToH : (rightEnd - leftEnd) / (2 * hPack - 1)
+		return [object boxvs boxhs leftEnd rightEnd]
 
 	create-glyph 'bridgeAbove' 0x346 : glyph-proc
 		set-width 0
 		include : StdAnchors.wide
 
-		include : VBar.m (markMiddle - markExtend) aboveMarkBot aboveMarkTop (markFine * 2)
-		include : VBar.m (markMiddle + markExtend) aboveMarkBot aboveMarkTop (markFine * 2)
-		include : HBar.t (markMiddle - markExtend) (markMiddle + markExtend) aboveMarkTop (markFine * 2)
+		local [object boxvs boxhs leftEnd rightEnd] : BoxDims 2 1 1 (markFine * 2)
+
+		include : VBar.l leftEnd  aboveMarkBot aboveMarkTop boxvs
+		include : VBar.r rightEnd aboveMarkBot aboveMarkTop boxvs
+		include : HBar.t leftEnd rightEnd aboveMarkTop boxhs
+
+	create-glyph 'invBridgeAbove' 0x1AE3 : glyph-proc
+		set-width 0
+		include : StdAnchors.wide
+
+		local [object boxvs boxhs leftEnd rightEnd] : BoxDims 2 1 1 (markFine * 2)
+
+		include : VBar.l leftEnd  aboveMarkBot aboveMarkTop boxvs
+		include : VBar.r rightEnd aboveMarkBot aboveMarkTop boxvs
+		include : HBar.b leftEnd rightEnd aboveMarkBot boxhs
+
+	create-glyph 'boxAbove' 0x1AE4 : glyph-proc
+		set-width 0
+		include : StdAnchors.wide
+
+		local [object boxvs boxhs leftEnd rightEnd] : BoxDims 2 2 1 (markFine * 2)
+
+		include : VBar.l leftEnd  aboveMarkBot aboveMarkTop boxvs
+		include : VBar.r rightEnd aboveMarkBot aboveMarkTop boxvs
+		include : HBar.b leftEnd rightEnd aboveMarkBot boxhs
+		include : HBar.t leftEnd rightEnd aboveMarkTop boxhs
 
 	create-glyph 'wideBridgeAbove' 0x20E9 : glyph-proc
 		set-width 0
 		include : StdAnchors.impl 'above' 0 1.5
 
-		include : VBar.m (SB      - Width) aboveMarkBot aboveMarkTop (markFine * 2)
-		include : VBar.m (RightSB - Width) aboveMarkBot aboveMarkTop (markFine * 2)
-		include : HBar.t (SB - Width) (RightSB - Width) aboveMarkTop (markFine * 2)
+		include : VBar.l (0 - Width) aboveMarkBot aboveMarkTop (markFine * 2)
+		include : VBar.r  0          aboveMarkBot aboveMarkTop (markFine * 2)
+		include : HBar.t (0 - Width) 0 aboveMarkTop (markFine * 2)
 
 	create-glyph 'crossAbove' 0x33D : glyph-proc
 		set-width 0
 		include : StdAnchors.mediumWide
 
 		include : dispiro
-			flat (markMiddle - markExtend) aboveMarkTop [widths.center : 2 * markFine]
+			widths.center (markFine * 2)
+			flat (markMiddle - markExtend) aboveMarkTop
 			curl (markMiddle + markExtend) aboveMarkBot
 		include : dispiro
-			flat (markMiddle - markExtend) aboveMarkBot [widths.center : 2 * markFine]
+			widths.center (markFine * 2)
+			flat (markMiddle - markExtend) aboveMarkBot
 			curl (markMiddle + markExtend) aboveMarkTop
 
 	create-glyph 'yerikAbove' 0x33E : glyph-proc
@@ -861,7 +971,8 @@ glyph-block Mark-Above : begin
 			local bottom : yDot - radius
 			local top : bottom + AccentHeight
 			include : dispiro
-				g4.down.start (markMiddle - radius) (top - arcHs) [widths.heading arcHs arcHs Downward]
+				widths.center (arcHs * 2)
+				g4.down.start (markMiddle - radius) (top - arcHs) [heading Downward]
 				arcvh
 				g4.right.mid markMiddle bottom
 				archv
@@ -883,8 +994,8 @@ glyph-block Mark-Above : begin
 		include : StdAnchors.narrow
 		local shift : 0.05 * markExtend + [HSwToV : markStress - markFine]
 		include : dispiro
-			flat (markMiddle + shift) (aboveMarkTop + 0.4 * markStress) [widths.center.heading (markStress * 2) Downward]
-			curl (markMiddle - 0.5 * shift) aboveMarkBot [widths.center.heading (markFine * 2) Downward]
+			flat (markMiddle - shift * 0.5) (aboveMarkBot - markFine   * 0)   [widths.center.heading (2 * markFine)   Upward]
+			curl (markMiddle + shift * 1.0) (aboveMarkTop + markStress * 0.4) [widths.center.heading (2 * markStress) Upward]
 
 	create-glyph 'tonosGrekUpperTonos' : glyph-proc
 		set-width 0
@@ -896,7 +1007,7 @@ glyph-block Mark-Above : begin
 		include : StdAnchors.medium
 
 		include : dispiro
-			flat (markMiddle + markStress) (aboveMarkBot - markFine * 0.5) [widths.center : 2 * markFine]
+			flat (markMiddle + markStress * 1.0) (aboveMarkBot - markFine   * 0.5)  [widths.center : 2 * markFine]
 			curl (markMiddle - markExtend * 0.5) (aboveMarkTop + markStress * 0.25) [widths.center : 2 * markStress]
 
 	create-glyph 'variaGrekUpperTonos' : glyph-proc
@@ -909,7 +1020,7 @@ glyph-block Mark-Above : begin
 		include : StdAnchors.medium
 
 		include : dispiro
-			flat (markMiddle - markStress) (aboveMarkBot - markFine * 0.5) [widths.center : 2 * markFine]
+			flat (markMiddle - markStress * 1.0) (aboveMarkBot - markFine   * 0.5)  [widths.center : 2 * markFine]
 			curl (markMiddle + markExtend * 0.5) (aboveMarkTop + markStress * 0.25) [widths.center : 2 * markStress]
 
 	create-glyph 'oxiaGrekUpperTonos' : glyph-proc
@@ -927,21 +1038,21 @@ glyph-block Mark-Above : begin
 	foreach { suffix { DrawAt kdr } } [Object.entries DotVariants] : do
 		create-glyph "dialytikaTonosAbove.\(suffix)" : glyph-proc
 			set-width 0
-			include : with-transform [ApparentTranslate 0 (AccentHeight * (-0.125))] : refer-glyph "dialytikaAbove.\(suffix)"
+			include : with-transform [ApparentTranslate 0 ((-0.125) * (aboveMarkTop - aboveMarkBot))] : refer-glyph "dialytikaAbove.\(suffix)"
 			include : with-transform [ApparentTranslate 0 0] : refer-glyph 'tonosAbove'
 			include : StdAnchors.wide
 
 		create-glyph "dialytikaVariaAbove.\(suffix)" : glyph-proc
 			set-width 0
 			local shift : 0.125 * (markExtend * 0.875 - markStress)
-			include : with-transform [ApparentTranslate 0 (AccentHeight * (-0.125))] : refer-glyph "dialytikaAbove.\(suffix)"
-			include : with-transform [ApparentTranslate shift 0] : refer-glyph 'variaAbove'
+			include : with-transform [ApparentTranslate 0 ((-0.125) * (aboveMarkTop - aboveMarkBot))] : refer-glyph "dialytikaAbove.\(suffix)"
+			include : with-transform [ApparentTranslate (+shift) 0] : refer-glyph 'variaAbove'
 			include : StdAnchors.wide
 
 		create-glyph "dialytikaOxiaAbove.\(suffix)" : glyph-proc
 			set-width 0
 			local shift : 0.125 * (markExtend * 0.875 - markStress)
-			include : with-transform [ApparentTranslate 0 (AccentHeight * (-0.125))] : refer-glyph "dialytikaAbove.\(suffix)"
+			include : with-transform [ApparentTranslate 0 ((-0.125) * (aboveMarkTop - aboveMarkBot))] : refer-glyph "dialytikaAbove.\(suffix)"
 			include : with-transform [ApparentTranslate (-shift) 0] : refer-glyph 'oxiaAbove'
 			include : StdAnchors.wide
 
@@ -973,7 +1084,8 @@ glyph-block Mark-Above : begin
 		include : StdAnchors.narrow
 		local [object radiusIn radiusOut] : RingDims
 		include : dispiro
-			g4.left.start markMiddle aboveMarkTop [widths.center.heading (radiusOut - radiusIn) Leftward]
+			widths.center (radiusOut - radiusIn)
+			g4.left.start markMiddle aboveMarkTop [heading Leftward]
 			archv
 			g4.down.mid  (markMiddle - (aboveMarkTop - aboveMarkBot) / 2) [mix aboveMarkTop aboveMarkBot 0.5] [heading Downward]
 			arcvh
@@ -985,7 +1097,8 @@ glyph-block Mark-Above : begin
 		include : StdAnchors.narrow
 		local [object radiusIn radiusOut] : RingDims
 		include : dispiro
-			g4.right.start markMiddle aboveMarkTop [widths.center.heading (radiusOut - radiusIn) Rightward]
+			widths.center (radiusOut - radiusIn)
+			g4.right.start markMiddle aboveMarkTop [heading Rightward]
 			archv
 			g4.down.mid   (markMiddle + (aboveMarkTop - aboveMarkBot) / 2) [mix aboveMarkTop aboveMarkBot 0.5] [heading Downward]
 			arcvh
@@ -1011,7 +1124,7 @@ glyph-block Mark-Above : begin
 
 		local top aboveMarkTop
 		local bot aboveMarkBot
-		local exp : Math.hypot 1 : 3 * markExtend / (top - bot)
+		local exp : Math.hypot 1 : 2 * (markExtend * 1.5) / (top - bot)
 		include : dispiro
 			widths.center (markFine * 2)
 			flat (markMiddle - markExtend) bot
@@ -1115,11 +1228,12 @@ glyph-block Mark-Above : begin
 		local rightEnd : markMiddle + markExtend * 1.2
 
 		include : dispiro
-			g4.up.start rightEnd aboveMarkBot [widths.heading markHalfStroke markHalfStroke Upward]
+			widths.center markStroke
+			g4.up.start rightEnd aboveMarkBot [heading Upward]
 			arcvh
 			g2.left.mid markMiddle (aboveMarkTop - markHalfStroke) [heading Leftward]
 			alsoThru.g2 0.5 0.5
-			g2.left.end leftEnd ([mix aboveMarkBot aboveMarkTop 0.5] - markHalfStroke) [heading Leftward]
+			g2.left.end leftEnd    (aboveMarkMid - markHalfStroke) [heading Leftward]
 
 	create-glyph 'cyrlPokrytieAbove' 0x487 : glyph-proc
 		set-width 0
@@ -1129,11 +1243,12 @@ glyph-block Mark-Above : begin
 		local rightEnd : markMiddle + markExtend * 2.0
 
 		include : dispiro
-			g4.up.start leftEnd aboveMarkBot [widths.heading markHalfStroke markHalfStroke Upward]
+			widths.center markStroke
+			g4.up.start leftEnd aboveMarkBot [heading Upward]
 			arcvh
 			g2.right.mid markMiddle (aboveMarkTop - markHalfStroke) [heading Rightward]
 			alsoThru.g2 0.5 0.5
-			g2.right.end rightEnd ([mix aboveMarkBot aboveMarkTop 0.5] - markHalfStroke) [heading Rightward]
+			g2.right.end rightEnd   (aboveMarkMid - markHalfStroke) [heading Rightward]
 
 	create-glyph 'cyrlTitloAbove' 0x483 : glyph-proc
 		set-width 0
@@ -1156,7 +1271,7 @@ glyph-block Mark-Above : begin
 		include : StdAnchors.extraWide
 		include : BreveShape
 			xMiddle -- markMiddle
-			width   -- (3 * markExtend)
+			width   -- (2 * (markExtend * 1.5))
 			top     -- aboveMarkTop
 			bottom  -- aboveMarkBot
 			hs      -- markHalfStroke
@@ -1166,7 +1281,7 @@ glyph-block Mark-Above : begin
 		include : StdAnchors.extraWide
 		include : InvBreveShape
 			xMiddle -- markMiddle
-			width   -- (3 * markExtend)
+			width   -- (2 * (markExtend * 1.5))
 			top     -- aboveMarkTop
 			bottom  -- aboveMarkBot
 			hs      -- markHalfStroke
@@ -1209,56 +1324,6 @@ glyph-block Mark-Above : begin
 				g4 (markMiddle + [mix (+extR) (-extL) 0.625]) (XH + depth - O) [heading Leftward]
 				g4 (markMiddle - extL) (XH + depth - 0.5 * O) [heading Leftward]
 
-	create-glyph 'dblBreveAbove' 0x1AC7 : glyph-proc
-		set-width 0
-		include : StdAnchors.wide
-
-		local sw : [AdviceStroke 3.5] * (markStroke / Stroke)
-		local extend : ((aboveMarkTop - aboveMarkBot) - markHalfStroke) * 1.25
-
-		include : dispiro
-			g4.down.start (markMiddle - extend) aboveMarkTop [widths.center.heading sw Downward]
-			arcvh
-			g4.right.mid  [mix markMiddle (markMiddle - extend) 0.5] (aboveMarkBot + 0.5 * sw) [heading Rightward]
-			archv
-			g4.up.end     markMiddle aboveMarkTop [heading Upward]
-		include : dispiro
-			g4.down.start markMiddle aboveMarkTop [widths.center.heading sw Downward]
-			arcvh
-			g4.right.mid  [mix markMiddle (markMiddle + extend) 0.5] (aboveMarkBot + 0.5 * sw) [heading Rightward]
-			archv
-			g4.up.end     (markMiddle + extend) aboveMarkTop [heading Upward]
-
-	create-glyph 'breveMacronAbove' 0x1DCB : glyph-proc
-		set-width 0
-		include : StdAnchors.wide
-
-		local sw : [AdviceStroke 3.5] * (markStroke / Stroke)
-		local extend : ((aboveMarkTop - aboveMarkBot) - markHalfStroke) * 1.25
-
-		include : dispiro
-			g4.down.start (markMiddle - extend) aboveMarkTop [widths.center.heading sw Downward]
-			arcvh
-			g4.right.mid  [mix markMiddle (markMiddle - extend) 0.5] (aboveMarkBot + 0.5 * sw) [heading Rightward]
-			archv
-			g4.up.end     markMiddle aboveMarkTop [heading Upward]
-		include : HBar.t markMiddle (markMiddle + extend + 0.5 * markStress) aboveMarkTop sw
-
-	create-glyph 'macronBreveAbove' 0x1DCC : glyph-proc
-		set-width 0
-		include : StdAnchors.wide
-
-		local sw : [AdviceStroke 3.5] * (markStroke / Stroke)
-		local extend : ((aboveMarkTop - aboveMarkBot) - markHalfStroke) * 1.25
-
-		include : HBar.t (markMiddle - extend - 0.5 * markStress) markMiddle aboveMarkTop sw
-		include : dispiro
-			g4.down.start markMiddle aboveMarkTop [widths.center.heading sw Downward]
-			arcvh
-			g4.right.mid  [mix markMiddle (markMiddle + extend) 0.5] (aboveMarkBot + 0.5 * sw) [heading Rightward]
-			archv
-			g4.up.end     (markMiddle + extend) aboveMarkTop [heading Upward]
-
 	create-glyph 'plusAbove' 0x1AC8 : glyph-proc
 		set-width 0
 		include : StdAnchors.mediumWide
@@ -1274,14 +1339,14 @@ glyph-block Mark-Above : begin
 
 	create-glyph 'upTackAbove' 0x1DF5 : glyph-proc
 		set-width 0
-		include : StdAnchors.medium
+		include : StdAnchors.mediumWide
 
 		include : VBar.m markMiddle aboveMarkBot aboveMarkTop (markFine * 2)
 		include : HBar.b (markMiddle - markExtend) (markMiddle + markExtend) aboveMarkBot (markFine * 2)
 
 	create-glyph 'downTackAbove' 0x1ADB : glyph-proc
 		set-width 0
-		include : StdAnchors.medium
+		include : StdAnchors.mediumWide
 
 		include : VBar.m markMiddle aboveMarkBot aboveMarkTop (markFine * 2)
 		include : HBar.t (markMiddle - markExtend) (markMiddle + markExtend) aboveMarkTop (markFine * 2)
@@ -1305,32 +1370,6 @@ glyph-block Mark-Above : begin
 		include : StdAnchors.mediumWide
 
 		include : HBar.m (markMiddle - markExtend) (markMiddle + markExtend) aboveMarkMid (markFine * 2)
-
-	create-glyph 'invBridgeAbove' 0x1AE3 : glyph-proc
-		set-width 0
-		include : StdAnchors.wide
-
-		include : VBar.m (markMiddle - markExtend) aboveMarkBot aboveMarkTop (markFine * 2)
-		include : VBar.m (markMiddle + markExtend) aboveMarkBot aboveMarkTop (markFine * 2)
-		include : HBar.b (markMiddle - markExtend) (markMiddle + markExtend) aboveMarkBot (markFine * 2)
-
-	create-glyph 'boxAbove' 0x1AE4 : glyph-proc
-		set-width 0
-		include : StdAnchors.mediumWide
-
-		local boxhs : Math.min (markFine * 2) ((aboveMarkTop - aboveMarkBot) / 3)
-		local boxvs : Math.min (markFine * 2) [VSwToH : markExtend * (2/3)]
-
-		include : VBar.l (markMiddle - markExtend) aboveMarkBot aboveMarkTop boxvs
-		include : VBar.r (markMiddle + markExtend) aboveMarkBot aboveMarkTop boxvs
-		include : HBar.b (markMiddle - markExtend) (markMiddle + markExtend) aboveMarkBot boxhs
-		include : HBar.t (markMiddle - markExtend) (markMiddle + markExtend) aboveMarkTop boxhs
-
-	create-glyph 'dblInvBreveAbove' 0x1AE5 : glyph-proc
-		set-width 0
-		include : refer-glyph "dblBreveAbove"
-		include : FlipAround markMiddle aboveMarkMid
-		include : StdAnchors.wide
 
 	create-glyph 'equalAbove' 0x1AE8 : glyph-proc
 		set-width 0
@@ -1356,11 +1395,12 @@ glyph-block Mark-Above : begin
 		local rightEnd : markMiddle + markExtend * 2.0
 
 		include : dispiro
-			g4.down.start leftEnd aboveMarkTop [widths.heading markHalfStroke markHalfStroke Downward]
+			widths.center markStroke
+			g4.down.start leftEnd aboveMarkTop [heading Downward]
 			arcvh
 			g2.right.mid markMiddle (aboveMarkBot + markHalfStroke) [heading Rightward]
 			alsoThru.g2 0.5 0.5
-			g2.right.end rightEnd (aboveMarkTop - markHalfStroke) [heading Rightward]
+			g2.right.end rightEnd   (aboveMarkTop - markHalfStroke) [heading Rightward]
 
 	create-glyph 'deletionMarkAbove' 0x1DFB : glyph-proc
 		set-width 0

--- a/packages/font-glyphs/src/marks/below.ptl
+++ b/packages/font-glyphs/src/marks/below.ptl
@@ -98,7 +98,7 @@ glyph-block Mark-Below : begin
 		set-width 0
 		include : StdAnchors.impl 0 1.5
 
-		include : VBar.m (SB - Width) belowMarkBot belowMarkTop (markFine * 2)
+		include : VBar.m (SB      - Width) belowMarkBot belowMarkTop (markFine * 2)
 		include : VBar.m (RightSB - Width) belowMarkBot belowMarkTop (markFine * 2)
 		include : HBar.b (SB - Width) (RightSB - Width) belowMarkBot (markFine * 2)
 
@@ -170,15 +170,15 @@ glyph-block Mark-Below : begin
 	TurnAboveMarkToBelow 'dblPlusBelow'            0x1ACA 'dblPlusAbove'
 	TurnAboveMarkToBelow 'dotRingBelow'            0x1ADD 'ringDotAbove'
 	TurnAboveMarkToBelow 'zigzagBelow'             0x1DCF 'zigzagAbove'
-	TurnAboveMarkToBelow 'wideInvertedBridgeBelow' 0x1DF9 'wideBridgeAbove'
+	TurnAboveMarkToBelow 'wideInvBridgeBelow'      0x1DF9 'wideBridgeAbove'
 	TurnAboveMarkToBelow 'dblTildeBelow'           0x1DFD 'dblTildeAbove'
 	TurnAboveMarkToBelow 'elipsisBelow'            0x20E8 'elipsisAbove'
 	TurnAboveMarkToBelow 'leftArrowBelow'          0x20EE 'rightArrowAbove'
 	TurnAboveMarkToBelow 'rightArrowBelow'         0x20EF 'leftArrowAbove'
-	TurnAboveMarkToBelow 'invCommaBelow'           null   'revCommaAbove'
 	TurnAboveMarkToBelow 'upArrowHeadBelow'        null   'downArrowHeadAbove'
 	TurnAboveMarkToBelow 'downArrowHeadBelow'      null   'upArrowHeadAbove'
 	TurnAboveMarkToBelow 'descenderBarBelow'       null   'ascenderBarAbove'
+	TurnAboveMarkToBelow 'invCommaBelow'           null   'revCommaAbove'
 	TurnAboveMarkToBelow 'sbRsbUnderlineBelow'     null   'sbRsbOverlineAbove'
 	TurnAboveMarkToBelow 'largeCandrabinduBelow'   null   'largeFermataAbove'
 

--- a/packages/font-glyphs/src/marks/horn-and-angle.ptl
+++ b/packages/font-glyphs/src/marks/horn-and-angle.ptl
@@ -163,7 +163,7 @@ glyph-block Mark-Horn-And-Angle : begin
 		set-width 0
 		include : BreveShape
 			xMiddle -- 0
-			width   -- 2 * (markExtend * 1.5 - [HSwToV markHalfStroke])
+			width   -- (2 * (markExtend * 1.5 - [HSwToV markHalfStroke]))
 			top     -- aboveMarkTop
 			bottom  -- aboveMarkBot
 			hs      -- markHalfStroke
@@ -175,7 +175,7 @@ glyph-block Mark-Horn-And-Angle : begin
 		set-width 0
 		include : BreveShape
 			xMiddle -- 0
-			width   -- 2 * (markExtend * 1.5 - [HSwToV markHalfStroke])
+			width   -- (2 * (markExtend * 1.5 - [HSwToV markHalfStroke]))
 			top     -- aboveMarkTop
 			bottom  -- aboveMarkBot
 			hs      -- markHalfStroke

--- a/packages/font-glyphs/src/symbol/letter.ptl
+++ b/packages/font-glyphs/src/symbol/letter.ptl
@@ -409,14 +409,14 @@ glyph-block Symbol-Letter-Phonetic : begin
 
 		include : BreveShape
 			xMiddle -- df.middle
-			width   -- (3 * markExtend)
+			width   -- (2 * (markExtend * 1.5))
 			top     -- XH
 			bottom  -- (XH - AccentHeight)
 			hs      -- markHalfStroke
 
 		include : InvBreveShape
 			xMiddle -- df.middle
-			width   -- (3 * markExtend)
+			width   -- (2 * (markExtend * 1.5))
 			top     -- AccentHeight
 			bottom  -- 0
 			hs      -- markHalfStroke


### PR DESCRIPTION
Using a new function `[BoxDims]` to control the vertical/horizontal stroke width and make sure the stroke is drawn on the inside, without actually changing the width of the bridges.

This basically re-unifies this specific subset of (modern) IPA overscript/underscript _place-of-articulation_ diacritics.

For each screenshot below, top row is before, bottom row is after.

`a᫣a̺a͆a̪a᫨a͇a᫤a̻a᫥a̼`

Thin:
<img width="767" height="376" alt="image" src="https://github.com/user-attachments/assets/68f98564-b95a-46cb-92b7-11c2370ae23b" />
Regular:
<img width="746" height="379" alt="image" src="https://github.com/user-attachments/assets/3ce7d9a1-32e3-4a1b-a4a3-adcb95c9d36e" />
Heavy:
<img width="748" height="357" alt="image" src="https://github.com/user-attachments/assets/f406e095-ebcc-4e9d-b743-580b472b21bc" />
