### PR TITLE
Add ligation set for markdown checkboxes under `dlig` feature

### DIFF
--- a/changes/33.3.2.md
+++ b/changes/33.3.2.md
@@ -2,3 +2,4 @@
   - COMBINING SQUARE BELOW (`U+0349`).
   - COMBINING SQUARE ABOVE (`U+1AE4`).
 * Changed the default style of Cyrillic lowercase Ef (ф) in Aile and Etoile (upright) to use non-split rings, for better style consistency (#2879).
+* Add ligation set for markdown checkboxes under `dlig` feature. This ligation will render sequcences like `- [ ]` and `- [x]` as checkbox shape.

--- a/packages/font-glyphs/src/common/shapes.ptl
+++ b/packages/font-glyphs/src/common/shapes.ptl
@@ -45,6 +45,9 @@ glyph-block CommonShapes : begin
 				local {.x mx1 .y my1} : giz.apply {.x mx .y my}
 				include : Translate (mx1 - mx) (my1 - my)
 
+	set Rect.fromBox : function [box transformShiftOnly]
+		Rect box.top box.bottom box.left box.right transformShiftOnly
+
 	glyph-block-export SquareAt
 	define [SquareAt x y r] : Rect (y + r) (y - r) (x - r) (x + r)
 

--- a/packages/font-glyphs/src/symbol/ligation.ptl
+++ b/packages/font-glyphs/src/symbol/ligation.ptl
@@ -2,6 +2,7 @@
 $$include '../meta/macros.ptl'
 
 import [mix clamp fallback] from "@iosevka/util"
+import [Box] from "@iosevka/geometry/box"
 import [Joining NeqLigationSlashDotted] from "@iosevka/glyph/relation"
 import [DesignParameters] from "../meta/aesthetics.mjs"
 
@@ -13,6 +14,7 @@ glyph-block Symbol-Ligation : begin
 	glyph-block-import Symbol-Math-Relation-Common : LessSlope EqualHalfSpace EqualHoleWidth
 	glyph-block-import Symbol-Math-Relation-Equal : EqualShape EqualHole IdentShape IdentHole
 	glyph-block-import Symbol-Math-Arith : PlusShape JunctDiamond
+	glyph-block-import Symbol-Geometric-Shared : GeometricDim GeometricSizes ConvexPolygonOutline
 
 	local arrowheadsKern : (2 / 3) * [clamp 0 (Width * 0.4) (Width - OperatorStroke * 3)]
 
@@ -467,3 +469,24 @@ glyph-block Symbol-Ligation : begin
 		create-glyph 'greaterArrow' : composite-proc
 			refer-glyph 'hyphen.lig.jp'
 			refer-glyph 'greater'
+
+	do 'Markdown checkboxes'
+		define borderSw : AdviceStroke 3.5
+		define box : new Box BgTkTop BgTkBot [mix SB RightSB 0.375] [mix SB RightSB 0.625]
+
+		create-glyph 'markdownCheckBox/leftHalfBorder' : glyph-proc
+			include : VBar.l box.left box.bot box.top borderSw
+			include : HBar.t box.left (1.51 * Width) box.top borderSw
+			include : HBar.b box.left (1.51 * Width) box.bot borderSw
+
+		create-glyph 'markdownCheckBox/rightHalfBorder' : glyph-proc
+			include : VBar.r box.right box.bot box.top borderSw
+			include : HBar.t (-0.51 * Width) box.right box.top borderSw
+			include : HBar.b (-0.51 * Width) box.right box.bot borderSw
+
+		create-glyph 'markdownCheckBox/cross' : glyph-proc
+			local gap : Math.max (Width / 12) [AdviceStroke 6]
+			local innerBox : [box.pad : borderSw + gap].withWidth (RightSB - SB)
+			include : intersection [Rect.fromBox innerBox] : union
+				ExtLineCenter 4 Stroke (box.xMid - box.height) (box.yMid - box.height) (box.xMid + box.height) (box.yMid + box.height)
+				ExtLineCenter 4 Stroke (box.xMid - box.height) (box.yMid + box.height) (box.xMid + box.height) (box.yMid - box.height)

--- a/packages/font-otl/src/gsub-ligation.ptl
+++ b/packages/font-otl/src/gsub-ligation.ptl
@@ -1124,3 +1124,20 @@ define [buildLigationsImpl gsub para $LigGroup$] : begin
 			chain-rule
 				dRight ~> dRightHalf
 				dLeft  ~> dLeftHalf
+
+	LigGroup "Markdown Checkboxes" : if [hasLG 'markdown-checkboxes'] : begin
+		# Transform [ ], [x] and [X] after `* `, `- ` or `+ ` into checkboxes
+		CreateLigationLookup : list
+			chain-rule
+				{'asterisk' 'asterisk/sMid' 'hyphen' 'plus'} ~> look-around
+				{'space'} ~> look-around
+				{'bracketLeft'} ~> {'markdownCheckBox/leftHalfBorder'}
+				{'space' 'x' 'X'} ~> {'space' 'markdownCheckBox/cross' 'markdownCheckBox/cross'}
+				{'bracketRight'} ~> {'markdownCheckBox/rightHalfBorder'}
+
+		# Transform asterisk before madkwownCheckBox/leftHalfBorder into asterisk/sMid
+		CreateLigationLookup : list
+			chain-rule
+				{'asterisk'} ~> {'asterisk/sMid'}
+				{'space'} ~> look-around
+				{'markdownCheckBox/leftHalfBorder'} ~> look-around

--- a/packages/geometry/src/box.mjs
+++ b/packages/geometry/src/box.mjs
@@ -2,12 +2,16 @@ import { mix } from "@iosevka/util";
 
 export class Box {
 	constructor(t, b, l, r) {
-		this.top = t;
-		this.bot = this.bottom = b;
-		this.left = l;
-		this.right = r;
+		this.t = this.top = t;
+		this.b = this.bot = this.bottom = b;
+		this.l = this.left = l;
+		this.r = this.right = r;
+
 		this.xMid = this.xMiddle = mix(l, r, 0.5);
 		this.yMid = this.yMiddle = mix(b, t, 0.5);
+
+		this.height = t - b;
+		this.width = r - l;
 	}
 	withTop(t) {
 		return new Box(t, this.bottom, this.left, this.right);
@@ -28,6 +32,9 @@ export class Box {
 		return new Box(this.top - d, this.bottom + d, this.left, this.right);
 	}
 
+	pad(d) {
+		return new Box(this.top - d, this.bottom + d, this.left - d, this.right + d);
+	}
 	padLeft(d) {
 		return new Box(this.top, this.bottom, this.left + d, this.right);
 	}
@@ -39,6 +46,15 @@ export class Box {
 	}
 	padBottom(d) {
 		return new Box(this.top, this.bottom + d, this.left, this.right);
+	}
+
+	withWidth(w) {
+		const cx = this.xMid;
+		return new Box(this.top, this.bottom, cx - w / 2, cx + w / 2);
+	}
+	withHeight(h) {
+		const cy = this.yMid;
+		return new Box(cy + h / 2, cy - h / 2, this.left, this.right);
 	}
 
 	withXMix(pL, pR) {

--- a/params/ligation-set.toml
+++ b/params/ligation-set.toml
@@ -312,6 +312,10 @@ desc = 'Enable ligation for `{|` and `|}`'
 samples = ["[|", "|]"]
 desc = 'Enable ligation for `[|` and `|]`'
 
+[simple.markdown-checkboxes]
+sample = ["- [ ]", "- [x]", "- [X]"]
+desc = 'Enable ligation for Markdown checkboxes like `- [ ]` and `- [x]`'
+
 ###################################################################################################
 # The following section defines composites of ligation sets.
 # The buildup property defines its formation, and we allow composites to be recursive.
@@ -467,6 +471,7 @@ buildup = [
 	'brst',
 	'brace-bar',
 	'brack-bar',
+	'markdown-checkboxes'
 ]
 
 [composite.clike]


### PR DESCRIPTION
Render sequcences like `- [ ]` and `- [x]` as checkbox shape.

<img width="1296" height="918" alt="image" src="https://github.com/user-attachments/assets/352c552b-893e-4ba1-ae74-bf98e6fafe8a" />
