### PR TITLE
Disunify Combining Inverted Double Arch (`◌᫇`, `◌̫`) with Combining Seagull (`◌᫥`, `◌̼`), unify with Combining Double Arch (`◌᫧`, `◌᫦`) instead.

### DIFF
--- a/changes/33.3.2.md
+++ b/changes/33.3.2.md
@@ -1,5 +1,7 @@
 * Refine shape of the following characters:
+  - COMBINING INVERTED DOUBLE ARCH BELOW (`U+032B`).
   - COMBINING SQUARE BELOW (`U+0349`).
+  - COMBINING INVERTED DOUBLE ARCH ABOVE (`U+1AC7`).
   - COMBINING SQUARE ABOVE (`U+1AE4`).
 * Changed the default style of Cyrillic lowercase Ef (ф) in Aile and Etoile (upright) to use non-split rings, for better style consistency (#2879).
 * Add ligation set for markdown checkboxes under `dlig` feature. This ligation will render sequcences like `- [ ]` and `- [x]` as checkbox shape.

--- a/packages/font-glyphs/src/auto-build/transformed-jobs-data.ptl
+++ b/packages/font-glyphs/src/auto-build/transformed-jobs-data.ptl
@@ -356,6 +356,7 @@ export : define MedievalComb_e : list
 	list 0x36C 'r'
 	list 0x36E 'v'
 	list 0x36F 'x'
+	list 0x1AC7 'grek/omega'
 	list 0x1ACE 'tInsular'
 	list 0x1AE7 'turnomega'
 	list 0x1DD3 'flattenedOpena'
@@ -454,6 +455,7 @@ export : define MedievalComb_bp : list
 	list 0xA69E 'cyrl/ef'
 
 export : define MedievalBelowComb_e : list
+	list 0x032B 'grek/omega'
 	list 0x0359 'asterisk/sMid'
 	list 0x1ABF 'w'
 	list 0x1AC0 'turnw'

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -145,9 +145,9 @@ glyph-block Mark-Above : begin
 	create-glyph 'dblRingAbove' 0x1AB2 : glyph-proc
 		set-width 0
 		local [object radiusIn radiusOut] : RingDims
-		local k : 2 * [mix radiusOut radiusIn 0.25]
-		include : with-transform [Translate (k * (+0.5)) 0] : refer-glyph 'ringAbove'
-		include : with-transform [Translate (k * (-0.5)) 0] : refer-glyph 'ringAbove'
+		local shift : mix radiusOut radiusIn 0.25
+		include : with-transform [Translate (+shift) 0] : refer-glyph 'ringAbove'
+		include : with-transform [Translate (-shift) 0] : refer-glyph 'ringAbove'
 		include : StdAnchors.wide
 
 	foreach { suffix { DrawAt kdr } } [Object.entries DotVariants] : do
@@ -465,7 +465,7 @@ glyph-block Mark-Above : begin
 
 		foreach { suffix { DrawAt kdr } } [Object.entries DotVariants] : do
 			create-forked-glyph "tildedotdotAbove.\(suffix)" : glyph-proc
-				include : StdAnchors.impl 'above' (1 / 4) 1
+				include : StdAnchors.impl 'above' 0.25 1
 				local r : 0.75 * DotRadius * fine / HalfStroke
 				include : DrawAt markMiddle [mix tbot ttop 1.5] (r * kdr)
 				include : DrawAt markMiddle [mix ttop tbot 1.5] (r * kdr)
@@ -636,46 +636,14 @@ glyph-block Mark-Above : begin
 			bottom  -- aboveMarkBot
 			hs      -- markHalfStroke
 
-	create-glyph 'dblBreveAbove' 0x1AC7 : glyph-proc
-		set-width 0
-		include : StdAnchors.wide
-
-		local hs : 0.5 * ([AdviceStroke 3.5] * (markStroke / Stroke))
-		local width : ((aboveMarkTop - aboveMarkBot) - markHalfStroke) * 2.5
-
-		local leftEnd  : markMiddle - width / 2
-		local rightEnd : markMiddle + width / 2
-
-		include : dispiro
-			widths.center (hs * 2)
-			g4.down.start     leftEnd                  aboveMarkTop       [heading Downward]
-			arcvh
-			g4.right.mid [mix leftEnd markMiddle 0.5] (aboveMarkBot + hs) [heading Rightward]
-			archv
-			g4.up.end                 markMiddle       aboveMarkTop       [heading Upward]
-		include : dispiro
-			widths.center (hs * 2)
-			g4.down.start     markMiddle                aboveMarkTop       [heading Downward]
-			arcvh
-			g4.right.mid [mix markMiddle rightEnd 0.5] (aboveMarkBot + hs) [heading Rightward]
-			archv
-			g4.up.end                    rightEnd       aboveMarkTop       [heading Upward]
-
-	create-glyph 'dblInvBreveAbove' 0x1AE5 : glyph-proc
-		set-width 0
-		include : refer-glyph "dblBreveAbove"
-		include : FlipAround markMiddle aboveMarkMid
-		include : StdAnchors.wide
-
 	create-glyph 'breveMacronAbove' 0x1DCB : glyph-proc
 		set-width 0
 		include : StdAnchors.wide
 
 		local hs : 0.5 * ([AdviceStroke 3.5] * (markStroke / Stroke))
-		local width : ((aboveMarkTop - aboveMarkBot) - markHalfStroke) * 2.5
 
-		local leftEnd  : markMiddle - width / 2
-		local rightEnd : markMiddle + width / 2
+		local leftEnd  : markMiddle - ((aboveMarkTop - aboveMarkBot) - hs) * 1.25
+		local rightEnd : markMiddle + ((aboveMarkTop - aboveMarkBot) - hs) * 1.25
 
 		include : dispiro
 			widths.center (hs * 2)
@@ -691,10 +659,9 @@ glyph-block Mark-Above : begin
 		include : StdAnchors.wide
 
 		local hs : 0.5 * ([AdviceStroke 3.5] * (markStroke / Stroke))
-		local width : ((aboveMarkTop - aboveMarkBot) - markHalfStroke) * 2.5
 
-		local leftEnd  : markMiddle - width / 2
-		local rightEnd : markMiddle + width / 2
+		local leftEnd  : markMiddle - ((aboveMarkTop - aboveMarkBot) - hs) * 1.25
+		local rightEnd : markMiddle + ((aboveMarkTop - aboveMarkBot) - hs) * 1.25
 
 		include : HBar.t (leftEnd - 0.5 * markStress) markMiddle aboveMarkTop (hs * 2)
 		include : dispiro
@@ -860,6 +827,18 @@ glyph-block Mark-Above : begin
 		include : VBar.m (markMiddle - markExtend * 0.75) aboveMarkBot aboveMarkTop (markFine * 2)
 		include : VBar.m (markMiddle + markExtend * 0.75) aboveMarkBot aboveMarkTop (markFine * 2)
 
+	create-glyph 'leftAngleAbove' 0x1AE9 : glyph-proc
+		set-width 0
+		include : StdAnchors.mediumWide
+		include : VBar.r (markMiddle + markExtend) aboveMarkBot aboveMarkTop (markFine * 2)
+		include : HBar.t (markMiddle - markExtend) (markMiddle + markExtend) aboveMarkTop (markFine * 2)
+
+	create-glyph 'turnLeftAngleAbove' : glyph-proc
+		set-width 0
+		include : refer-glyph "leftAngleAbove"
+		include : FlipAround markMiddle aboveMarkMid
+		include : StdAnchors.mediumWide
+
 	define [BoxDims hPack vPack k _swRef] : begin
 		local swRef : fallback _swRef markStroke
 		local leftEnd  : markMiddle - (markExtend * k + [HSwToV : 0.5 * swRef])
@@ -906,6 +885,36 @@ glyph-block Mark-Above : begin
 		include : VBar.l (0 - Width) aboveMarkBot aboveMarkTop (markFine * 2)
 		include : VBar.r  0          aboveMarkBot aboveMarkTop (markFine * 2)
 		include : HBar.t (0 - Width) 0 aboveMarkTop (markFine * 2)
+
+	create-glyph 'seagullAbove' 0x1AE5 : glyph-proc
+		set-width 0
+		include : StdAnchors.wide
+
+		local fine : Math.min markFine : 0.5 * ([AdviceStroke 3.5] * (markStroke / Stroke))
+		local coFine : fine * 2 * (CThin - 0.5)
+
+		local leftEnd  : markMiddle - ((aboveMarkTop - aboveMarkBot) - fine) * 1.25
+		local rightEnd : markMiddle + ((aboveMarkTop - aboveMarkBot) - fine) * 1.25
+
+		include : union
+			dispiro
+				g4.up.start       leftEnd                  aboveMarkBot         [widths.heading fine fine Upward]
+				arcvh
+				g4.right.mid [mix leftEnd markMiddle 0.5] (aboveMarkTop - fine) [heading Rightward]
+				archv
+				g4.down.end               markMiddle       aboveMarkBot         [widths.heading coFine fine Downward]
+			dispiro
+				g4.up.start       markMiddle                aboveMarkBot         [widths.heading coFine fine Upward]
+				arcvh
+				g4.right.mid [mix markMiddle rightEnd 0.5] (aboveMarkTop - fine) [widths.heading fine fine Rightward]
+				archv
+				g4.down.end                  rightEnd       aboveMarkBot         [heading Downward]
+
+	create-glyph 'turnSeagullAbove' : glyph-proc
+		set-width 0
+		include : refer-glyph "seagullAbove"
+		include : FlipAround markMiddle aboveMarkMid
+		include : StdAnchors.wide
 
 	create-glyph 'crossAbove' 0x33D : glyph-proc
 		set-width 0
@@ -1044,16 +1053,16 @@ glyph-block Mark-Above : begin
 
 		create-glyph "dialytikaVariaAbove.\(suffix)" : glyph-proc
 			set-width 0
-			local shift : 0.125 * (markExtend * 0.875 - markStress)
+			local shift : (+0.125) * (markExtend * 0.875 - markStress)
 			include : with-transform [ApparentTranslate 0 ((-0.125) * (aboveMarkTop - aboveMarkBot))] : refer-glyph "dialytikaAbove.\(suffix)"
-			include : with-transform [ApparentTranslate (+shift) 0] : refer-glyph 'variaAbove'
+			include : with-transform [ApparentTranslate shift 0] : refer-glyph 'variaAbove'
 			include : StdAnchors.wide
 
 		create-glyph "dialytikaOxiaAbove.\(suffix)" : glyph-proc
 			set-width 0
-			local shift : 0.125 * (markExtend * 0.875 - markStress)
+			local shift : (-0.125) * (markExtend * 0.875 - markStress)
 			include : with-transform [ApparentTranslate 0 ((-0.125) * (aboveMarkTop - aboveMarkBot))] : refer-glyph "dialytikaAbove.\(suffix)"
-			include : with-transform [ApparentTranslate (-shift) 0] : refer-glyph 'oxiaAbove'
+			include : with-transform [ApparentTranslate shift 0] : refer-glyph 'oxiaAbove'
 			include : StdAnchors.wide
 
 	select-variant 'dialytikaTonosAbove' 0x344 (follow -- 'diacriticDot')
@@ -1379,13 +1388,6 @@ glyph-block Mark-Above : begin
 
 		include : HBar.b (markMiddle - markExtend) (markMiddle + markExtend) aboveMarkBot eqsw
 		include : HBar.t (markMiddle - markExtend) (markMiddle + markExtend) aboveMarkTop eqsw
-
-	create-glyph 'leftAngleAbove' 0x1AE9 : glyph-proc
-		set-width 0
-		include : StdAnchors.mediumWide
-
-		include : VBar.r (markMiddle + markExtend) aboveMarkBot aboveMarkTop (markFine * 2)
-		include : HBar.t (markMiddle - markExtend) (markMiddle + markExtend) aboveMarkTop (markFine * 2)
 
 	create-glyph 'suspensionMarkAbove' 0x1DC3 : glyph-proc
 		set-width 0

--- a/packages/font-glyphs/src/marks/below.ptl
+++ b/packages/font-glyphs/src/marks/below.ptl
@@ -87,13 +87,6 @@ glyph-block Mark-Below : begin
 		set-mark-anchor 'lf' markMiddle 0 markMiddle belowMarkStack
 		include : VBar.m markMiddle belowMarkBot belowMarkTop markStroke
 
-	create-glyph 'leftAngleBelow' 0x349 : glyph-proc
-		set-width 0
-		include : StdAnchors.mediumWide
-
-		include : VBar.r (markMiddle + markExtend) belowMarkBot belowMarkTop (markFine * 2)
-		include : HBar.t (markMiddle - markExtend) (markMiddle + markExtend) belowMarkTop (markFine * 2)
-
 	create-glyph 'shelfBelow' : glyph-proc
 		set-width 0
 		include : StdAnchors.impl 0 1.5
@@ -146,7 +139,6 @@ glyph-block Mark-Below : begin
 	TurnAboveMarkToBelow 'ogonekBelow'             0x328  'ogonekAbove'
 	TurnAboveMarkToBelow 'barBelow'                0x329  'barAbove'
 	TurnAboveMarkToBelow 'bridgeBelow'             0x32A  'invBridgeAbove'
-	TurnAboveMarkToBelow 'dblBreveBelow'           0x32B  'dblInvBreveAbove'
 	TurnAboveMarkToBelow 'caronBelow'              0x32C  'circumflexAbove'
 	TurnAboveMarkToBelow 'circumflexBelow'         0x32D  'caronAbove'
 	TurnAboveMarkToBelow 'breveBelow'              0x32E  'invBreveAbove'
@@ -158,9 +150,10 @@ glyph-block Mark-Below : begin
 	TurnAboveMarkToBelow 'rightHalfCircleBelow'    0x339  'leftHalfCircleAbove'
 	TurnAboveMarkToBelow 'invBridgeBelow'          0x33A  'bridgeAbove'
 	TurnAboveMarkToBelow 'boxBelow'                0x33B  'boxAbove'
-	TurnAboveMarkToBelow 'dblInvBreveBelow'        0x33C  'dblBreveAbove'
+	TurnAboveMarkToBelow 'seagullBelow'            0x33C  'turnSeagullAbove'
 	TurnAboveMarkToBelow 'equalBelow'              0x347  'equalAbove'
 	TurnAboveMarkToBelow 'dblBarBelow'             0x348  'dblBarAbove'
+	TurnAboveMarkToBelow 'leftAngleBelow'          0x349  'turnLeftAngleAbove'
 	TurnAboveMarkToBelow 'lrArrowBelow'            0x34D  'lrArrowAbove'
 	TurnAboveMarkToBelow 'upArrowBelow'            0x34E  'downArrowAbove'
 	TurnAboveMarkToBelow 'crossBelow'              0x353  'crossAbove'


### PR DESCRIPTION
Basically disunifying inverted double arch (i.e. an overscript/underscript lowercase omega or script w) with a diacritic which this font previously presumed to be somewhat of a turned version — which it may or may not be tangentially related to — and instead unifying it with the real turned version that came out in Unicode 17.0.0, based on SIL's fonts, which are (allegedly) what the new characters in the Unicode 17.0.0 charts are shown under.

For each screenshot below: Top row is before, bottom row is after.
From left to right: Articulation strength, place of articulation, secondary articulation.

`a̍a̩a̎a͈a᫩a͉ a᫥a̼a͆a̪a᫤a̻a᫣a̺a᫨a͇ a᫇a̫a᫧a᫦`

Thin:
<img width="1600" height="357" alt="image" src="https://github.com/user-attachments/assets/76a70c22-b857-45c5-a757-23d54407fa76" />
Regular:
<img width="1603" height="365" alt="image" src="https://github.com/user-attachments/assets/fe929615-09a7-4c73-8c8f-3714621dc164" />
Heavy:
<img width="1603" height="365" alt="image" src="https://github.com/user-attachments/assets/6a5183f0-aab8-4431-8332-e37b9b971b00" />
Compared to Gentium (future version, via Wikimedia):
<img width="2048" height="2048" alt="◌᫇" src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Unicode_0x1AC7.svg/2048px-Unicode_0x1AC7.svg.png" />
<img width="2048" height="2048" alt="◌̫" src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/f5/IPA_Unicode_0x032B.svg/2048px-IPA_Unicode_0x032B.svg.png" />