### PR TITLE
Allow {`V`|`v`}`Script` (`Ʋ`, `ʋ`) to respond to fully-`serifed` variants of `V`/`v` (`cv31`, `cv56`).

### DIFF
--- a/packages/font-glyphs/src/letter/latin/v.ptl
+++ b/packages/font-glyphs/src/letter/latin/v.ptl
@@ -203,6 +203,13 @@ glyph-block Letter-Latin-V : begin
 			include : VShape [DivFrame 1] fStraightBar XH Stroke
 			include : Serifs [DivFrame 1] fStraightBar XH
 
+		create-glyph "vPalatalHook.\(suffix)" : glyph-proc
+			include [refer-glyph "v.\(suffix)"] AS_BASE ALSO_METRICS
+			include : PalatalHook.r
+				xLink -- Middle
+				x -- (Middle + [HSwToV HalfStroke] + [PalatalHook.adviceGap Stroke])
+				y -- 0
+
 		create-glyph "VHookRight.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : VHookRightShape [DivFrame 1] fStraightBar CAP
@@ -242,13 +249,6 @@ glyph-block Letter-Latin-V : begin
 				eject-contour 'serifRT'
 			include : OShape (Ascender - vPartHeight + Stroke + O) 0 SB RightSB
 
-		create-glyph "vPalatalHook.\(suffix)" : glyph-proc
-			include [refer-glyph "v.\(suffix)"] AS_BASE ALSO_METRICS
-			include : PalatalHook.r
-				xLink -- Middle
-				x -- (Middle + [HSwToV HalfStroke] + [PalatalHook.adviceGap Stroke])
-				y -- 0
-
 	define VCursiveConfig : object
 		cursiveSerifless     { (1/24) false }
 		cursiveSerifed       { (1/16) true  }
@@ -259,7 +259,7 @@ glyph-block Letter-Latin-V : begin
 			include : VCursiveShape pxBar XH Stroke
 			if fDoSerif : begin
 				local xBar : VCursiveShapeBarPos pxBar
-				include : tagged 'serifLT' : HSerif.lt xBar XH (SideJut + xBar - SB)
+				include : tagged 'serifLT' : HSerif.lt xBar XH (SideJut + (xBar - SB))
 
 		create-glyph "vPalatalHook.\(suffix)" : glyph-proc
 			include [refer-glyph "v.\(suffix)"] AS_BASE ALSO_METRICS
@@ -308,9 +308,12 @@ glyph-block Letter-Latin-V : begin
 		include : MarkSet.capital
 		include : VScriptShape [DivFrame 1] CAP ArchDepthA ArchDepthB
 
-	create-glyph 'VScript.motionSerifed' : glyph-proc
-		include [refer-glyph "VScript.serifless"] AS_BASE ALSO_METRICS
-		include : tagged 'serifLT' : HSerif.lt SB CAP SideJut
+		create-forked-glyph 'VScript.motionSerifed' : glyph-proc
+			local sf : SerifFrame.fromDf [DivFrame 1] CAP 0
+			include sf.lt.outer
+		create-forked-glyph 'VScript.serifed' : glyph-proc
+			local sf : SerifFrame.fromDf [DivFrame 1] CAP 0
+			include sf.lt.full
 
 	select-variant 'VScript' 0x1B2
 
@@ -318,9 +321,12 @@ glyph-block Letter-Latin-V : begin
 		include : MarkSet.e
 		include : VScriptShape [DivFrame 1] XH SmallArchDepthA SmallArchDepthB
 
-	create-glyph 'vScript.motionSerifed' : glyph-proc
-		include [refer-glyph "vScript.serifless"] AS_BASE ALSO_METRICS
-		include : tagged 'serifLT' : HSerif.lt SB XH SideJut
+		create-forked-glyph 'vScript.motionSerifed' : glyph-proc
+			local sf : SerifFrame.fromDf [DivFrame 1] XH 0
+			include sf.lt.outer
+		create-forked-glyph 'vScript.serifed' : glyph-proc
+			local sf : SerifFrame.fromDf [DivFrame 1] XH 0
+			include sf.lt.full
 
 	select-variant 'vScript' 0x28B
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1815,7 +1815,7 @@ rank = 3
 descriptionAffix = "serifs"
 selectorAffix.V = "serifed"
 selectorAffix."V/sansSerif" = "serifless"
-selectorAffix.VScript = "motionSerifed"
+selectorAffix.VScript = "serifed"
 selectorAffix."cyrl/Izhitsa" = "serifed"
 
 
@@ -4832,7 +4832,7 @@ rank = 3
 descriptionAffix = "serifs"
 selectorAffix.v = "serifed"
 selectorAffix."v/sansSerif" = "serifless"
-selectorAffix.vScript = "motionSerifed"
+selectorAffix.vScript = {if = [{body = "cursive"}], then = "motionSerifed", else = "serifed"}
 selectorAffix.vHookRight = {if = [{body = "cursive"}], then = "motionSerifed", else = "serifed"}
 selectorAffix.vLoop = {if = [{body = "cursive"}], then = "serifless", else = "serifed"}
 selectorAffix."cyrl/izhitsa" = {if = [{body = "cursive"}], then = "motionSerifed", else = "serifed"}


### PR DESCRIPTION
This makes `Ʋ`/`ʋ` respond to _all_ serifed variants of `V`/`v`, not just `motion-serifed`.

Since the hook is limited to half the characters' widths minus `[HSwToV HalfStroke]`, it wouldn't ever collide with the serif unless the serifs were _over_ half the characters' widths (which that wouldn't ever happen under the current configuration without also allowing the serifs of e.g. `u`/`n` to collide with _each other_).

For each screenshot below: Top row is `straight-serifless`, middle row is `straight-motion-serifed`, bottom row is `straight-serifed`.

`Vv Ʋʋ`

Thin Upright:
<img width="435" height="577" alt="image" src="https://github.com/user-attachments/assets/befefd49-5ce6-41d7-8f76-24612be6c48a" />
Regular Upright:
<img width="432" height="565" alt="image" src="https://github.com/user-attachments/assets/31becb4a-b599-4fc8-ba2c-012ffc13ae47" />
Heavy Upright:
<img width="441" height="566" alt="image" src="https://github.com/user-attachments/assets/5ad6e468-68ff-4d00-99d3-ac1b46aa6fea" />
Thin Italic:
<img width="444" height="582" alt="image" src="https://github.com/user-attachments/assets/d2d79988-1058-4f78-9a43-c8ed0cf93dc1" />
Regular Italic:
<img width="451" height="577" alt="image" src="https://github.com/user-attachments/assets/8c099e0f-2c06-4e55-8c38-ac1daac48a1f" />
Heavy Italic:
<img width="451" height="572" alt="image" src="https://github.com/user-attachments/assets/6878fd21-9173-47ac-bcec-657e281acf7f" />
