### PR TITLE
Unify characters derived from, or related to, Cyrillic Uk (`Ѹ`, `ѹ`, `Ꙋ`, `ᲈ`).

### DIFF
--- a/changes/33.3.2.md
+++ b/changes/33.3.2.md
@@ -10,8 +10,12 @@
 * Refine shape of the following characters:
   - COMBINING INVERTED DOUBLE ARCH BELOW (`U+032B`).
   - COMBINING SQUARE BELOW (`U+0349`).
+  - CYRILLIC CAPITAL LETTER UK (`U+0478`).
+  - CYRILLIC SMALL LETTER UK (`U+0479`).
   - COMBINING INVERTED DOUBLE ARCH ABOVE (`U+1AC7`).
   - COMBINING SQUARE ABOVE (`U+1AE4`).
+  - CYRILLIC SMALL LETTER UNBLENDED UK (`U+1C88`).
+  - CYRILLIC CAPITAL LETTER MONOGRAPH UK (`U+A64A`).
 * Changed the default style of Cyrillic lowercase Ef (ф) in Aile and Etoile (upright) to use non-split rings, for better style consistency (#2879).
 * Add ligation set for markdown checkboxes under `dlig` feature. This ligation will render sequcences like `- [ ]` and `- [x]` as checkbox shape.
 * Fix mapping of `U+2B38` with `U+2911`, and `U+2B37` with `U+2910`.

--- a/packages/font-glyphs/src/auto-build/composite.ptl
+++ b/packages/font-glyphs/src/auto-build/composite.ptl
@@ -1463,8 +1463,8 @@ glyph-block Autobuild-Ligatures : begin
 		list 0x1F1 { 'D' 'Z' }
 		list 0x1F2 { 'D' 'z' }
 		list 0x1F3 { 'd' 'z' }
-		list 0x478 { 'cyrl/O' 'cyrl/u' }
-		list 0x479 { 'cyrl/uk/o' 'cyrl/u' }
+		list 0x478 { 'cyrl/O' 'cyrl/uk/u' }
+		list 0x479 { 'cyrl/uk/o' 'cyrl/uk/u' }
 		list 0x20A7 { 'P' 't' }
 		list 0x20A8 { 'R' 's' }
 		list 0x20AF { 'D' 'grek/rho' }

--- a/packages/font-glyphs/src/letter/cyrillic/ze.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/ze.ptl
@@ -348,12 +348,12 @@ glyph-block Letter-Cyrillic-Ze : begin
 			local sf2 : [SerifFrame.fromDf df (XH / 2 + HalfStroke) 0].slice 1 2
 			if SLAB : include sf2.rt.full
 
-		create-glyph "cyrl/KsiBase.\(suffix)" : glyph-proc
+		create-glyph "cyrl/Ksi/base.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
 			include : let [ze : CyrZe slabTop SLAB-NONE CAP 0 (hook -- Hook)]
 				union [ze.KsiBaseShape] [ze.AutoStartSerifL]
 
-		create-glyph "cyrl/ksiBase.\(suffix)" : glyph-proc
+		create-glyph "cyrl/ksi/base.\(suffix)" : glyph-proc
 			include : MarkSet.p
 			include : let [ze : CyrZe slabTop SLAB-NONE XH 0 (hook -- SHook)]
 				union [ze.KsiBaseShape] [ze.AutoStartSerifL]
@@ -584,8 +584,8 @@ glyph-block Letter-Cyrillic-Ze : begin
 	alias 'latn/epsilonRev' 0x25C  'cyrl/ze'
 	select-variant 'latn/epsilonRevRhoticHook' 0x25D (shapeFrom -- 'cyrl/zeRhoticHook') (follow -- 'cyrl/ze')
 
-	select-variant 'cyrl/KsiBase' (follow -- 'cyrl/ZeTopSerifOnly')
-	select-variant 'cyrl/ksiBase' (follow -- 'cyrl/zeTopSerifOnly')
+	select-variant 'cyrl/Ksi/base' (follow -- 'cyrl/ZeTopSerifOnly')
+	select-variant 'cyrl/ksi/base' (follow -- 'cyrl/zeTopSerifOnly')
 
 	select-variant 'cyrl/ZjeKomi'  0x504 (follow -- 'cyrl/ZeTopSerifOnly')
 	select-variant 'cyrl/zjeKomi'  0x505 (follow -- 'cyrl/zeTopSerifOnly')

--- a/packages/font-glyphs/src/letter/latin/lower-y.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-y.ptl
@@ -422,9 +422,21 @@ glyph-block Letter-Latin-Lower-Y : begin
 			include : Cursive.Serifs CAP slabKind
 
 	select-variant 'y' 'y'
-	select-variant 'y/nonCursive' (shapeFrom -- 'y')
 	link-reduced-variant 'y/sansSerif' 'y' MathSansSerif
+	select-variant 'y/nonCursive' (shapeFrom -- 'y')
+
+	select-variant 'yHookTop' 0x1B4
+
+	select-variant 'cyrl/U' 0x423 (shapeFrom -- 'yCap')
 	select-variant 'cyrl/u' 0x443 (shapeFrom -- 'y')
+	select-variant 'cyrl/uk/u' (shapeFrom -- 'yHookTop') (follow -- 'cyrl/u/nonCursive')
+
+	select-variant 'YLoop' 0x1EFE (shapeFrom -- 'yCap')
+	select-variant 'yLoop' 0x1EFF (shapeFrom -- 'y')
+
+	select-variant 'grek/lambda' 0x3BB
+	select-variant 'latn/lambda' 0xA7DB (shapeFrom -- 'grek/lambda')
+	select-variant 'latn/lambdaStroke' 0x19B (follow -- 'latn/lambda')
 
 	CreateTurnedLetter 'turny' 0x28E 'y/nonCursive' HalfAdvance (XH / 2)
 	derive-glyphs 'turnyBelt' 0x1DF06 'y/nonCursive' : function [src sel] : glyph-proc
@@ -439,16 +451,6 @@ glyph-block Letter-Latin-Lower-Y : begin
 			include : DrawAt 0 (-AccentStackOffset) (DotRadius * kdr)
 	select-variant 'yDotBelowDot1' (follow -- 'diacriticDot')
 	CreateAccentedComposition 'yDotBelow' 0x1EF5 'y' 'yDotBelowDot1'
-
-	select-variant 'yHookTop' 0x1B4
-	select-variant 'cyrl/U' 0x423 (shapeFrom -- 'yCap')
-
-	select-variant 'YLoop' 0x1EFE (shapeFrom -- 'yCap')
-	select-variant 'yLoop' 0x1EFF (shapeFrom -- 'y')
-
-	select-variant 'grek/lambda' 0x3BB
-	select-variant 'latn/lambda' 0xA7DB (shapeFrom -- 'grek/lambda')
-	select-variant 'latn/lambdaStroke' 0x19B (follow -- 'latn/lambda')
 
 	# Blackboard
 	glyph-block-import Letter-Blackboard : BBS BBD

--- a/packages/font-glyphs/src/letter/latin/o.ptl
+++ b/packages/font-glyphs/src/letter/latin/o.ptl
@@ -158,7 +158,7 @@ glyph-block Letter-Latin-O : begin
 			OShapeOutline.NoOvershoot CAP 0 SB RightSB stroke ArchDepthA ArchDepthB
 			union
 				HBar.m (SB + OX) (RightSB - OX) (CAP * 0.5) stroke
-				VBar.m Middle O (CAP - O) [Math.min stroke : VSwToH : (RightSB - SB) / 2 - [HSwToV stroke]]
+				VBar.m Middle O (CAP - O) [Math.min stroke : VSwToH : 0.5 * ((RightSB - SB) - [HSwToV : 2 * stroke])]
 
 	create-glyph 'cyrl/oCross' 0xA69B : glyph-proc
 		include : MarkSet.e
@@ -168,7 +168,7 @@ glyph-block Letter-Latin-O : begin
 			OShapeOutline.NoOvershoot XH 0 SB RightSB stroke nothing nothing
 			union
 				HBar.m (SB + OX) (RightSB - OX) (XH * 0.5) stroke
-				VBar.m Middle O (XH - O) [Math.min stroke : VSwToH : (RightSB - SB) / 2 - [HSwToV stroke]]
+				VBar.m Middle O (XH - O) [Math.min stroke : VSwToH : 0.5 * ((RightSB - SB) - [HSwToV : 2 * stroke])]
 
 	create-glyph 'romanThousandCD' 0x2180 : glyph-proc
 		local df : include : DivFrame para.advanceScaleMM 3

--- a/packages/font-glyphs/src/letter/latin/upper-q.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-q.ptl
@@ -179,7 +179,7 @@ glyph-block Letter-Latin-Upper-Q : begin
 	glyph-block-export QInnerDiagSw
 	define QInnerDiagSw : AdviceStroke 4
 
-	define QInnerVertSw : Math.min VJutStroke : VSwToH : (RightSB - SB) / 2 - [HSwToV Stroke]
+	define QInnerVertSw : Math.min VJutStroke : VSwToH : 0.5 * ((RightSB - SB) - [HSwToV : 2 * Stroke])
 
 	define QConfig : object
 		straight            { QStdBody                Stroke             QStraightTail      'capDesc' 'p' }
@@ -209,10 +209,10 @@ glyph-block Letter-Latin-Upper-Q : begin
 			include : tailShape df XH swTailInner
 
 		create-glyph "QSideways.\(suffix)" : glyph-proc
-			local df : DivFrame (XH / Width) 2 (XH * 0.1 / SB)
+			local df : DivFrame (XH / Width) 2 ((XH * 0.1) / SB)
 			include : PointingTo Width XH Width 0 : function [] : glyph-proc
-				include : body df (Width - SB) Stroke
-				include : tailShape df (Width - SB) swTailInner
+				include : body df RightSB Stroke
+				include : tailShape df RightSB swTailInner
 
 	select-variant 'Q' 'Q'
 	alias 'cyrl/Qa' 0x51A 'Q'
@@ -229,7 +229,7 @@ glyph-block Letter-Latin-Upper-Q : begin
 		include : intersection
 			QInner
 			union
-				VBar.l (SB + BBD)      0 CAP BBS
+				VBar.l (SB      + BBD) 0 CAP BBS
 				VBar.r (RightSB - BBD) 0 CAP BBS
 
 		define terminalX : Middle + HookX
@@ -237,8 +237,8 @@ glyph-block Letter-Latin-Upper-Q : begin
 		define qTerminalY : BBS - Hook - BBD / 4
 		define [QTail x] : dispiro
 			widths.center BBS
-			flat (x) (CAP / 2)
-			curl (x) 0
+			flat x (CAP / 2)
+			curl x 0
 			arcvh
 			flat [Math.min (terminalX - 1) (x - qTerminalY)] qTerminalY
 			curl terminalX qTerminalY

--- a/packages/font-glyphs/src/letter/latin/v.ptl
+++ b/packages/font-glyphs/src/letter/latin/v.ptl
@@ -207,47 +207,54 @@ glyph-block Letter-Latin-V : begin
 			include [refer-glyph "v.\(suffix)"] AS_BASE ALSO_METRICS
 			include : PalatalHook.r
 				xLink -- Middle
-				x -- (Middle + [HSwToV HalfStroke] + [PalatalHook.adviceGap Stroke])
-				y -- 0
+				x     -- (Middle + [HSwToV HalfStroke] + [PalatalHook.adviceGap Stroke])
+				y     -- 0
 
 		create-glyph "VHookRight.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : VHookRightShape [DivFrame 1] fStraightBar CAP
-			include : Serifs [DivFrame 1] fStraightBar CAP
+			include : Serifs          [DivFrame 1] fStraightBar CAP
 			eject-contour 'serifRT'
 
 		create-glyph "vHookRight.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : VHookRightShape [DivFrame 1] fStraightBar XH
-			include : Serifs [DivFrame 1] fStraightBar XH
+			include : Serifs          [DivFrame 1] fStraightBar XH
 			eject-contour 'serifRT'
 
 		create-glyph "vLoop.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : VLoopShape [DivFrame 1] fStraightBar XH
-			include : Serifs [DivFrame 1] fStraightBar XH
+			include : Serifs     [DivFrame 1] fStraightBar XH
 			eject-contour 'serifLT'
 
 		create-glyph "cyrl/Uk.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			local vPartHeight : CAP * 0.45 + HalfStroke
-			include : with-transform [ApparentTranslate 0 (CAP - vPartHeight)] : glyph-proc
-				include : VHookRightShape [DivFrame 1] fStraightBar vPartHeight
-				include : Serifs [DivFrame 1] fStraightBar vPartHeight
-				eject-contour 'serifRT'
+			local yBarPos : CAP * 0.55
 
-			local oHeight : CAP - vPartHeight + Stroke + O
-			include : OShape oHeight 0 SB RightSB [AdviceStroke 2.75]
-			include : VBar.m Middle (0.5 * oHeight) oHeight [AdviceStroke 4]
+			local sw : AdviceStroke 2.75
+			include : OShape ((yBarPos + 0.5 * sw) + O) 0 SB RightSB sw ArchDepthA ArchDepthB
+
+			local fine : Math.min VJutStroke : VSwToH : 0.5 * ((RightSB - SB) - [HSwToV : 2 * sw])
+			include : VBar.m Middle [mix O (yBarPos + 0.5 * sw) 0.5] yBarPos fine
+
+			include : with-transform [ApparentTranslate 0 (yBarPos - 0.5 * sw)] : glyph-proc
+				include : VHookRightShape [DivFrame 1] fStraightBar (CAP - (yBarPos - 0.5 * sw))
+				include : Serifs          [DivFrame 1] fStraightBar (CAP - (yBarPos - 0.5 * sw))
+				eject-contour 'serifRT'
 
 		create-glyph "cyrl/ukUnblended.\(suffix)" : glyph-proc
 			include : MarkSet.b
-			local vPartHeight : Ascender * 0.45 + HalfStroke
-			include : with-transform [ApparentTranslate 0 (Ascender - vPartHeight)] : glyph-proc
-				include : VHookRightShape [DivFrame 1] fStraightBar vPartHeight
-				include : Serifs [DivFrame 1] fStraightBar vPartHeight
+			local yBarPos : Ascender * 0.55
+
+			local subDf : DivFrame (5 / 6) 2
+			include : with-transform [ApparentTranslate (0.5 * (Width - subDf.width)) 0]
+				OShape ((yBarPos + 0.5 * subDf.mvs) + O) 0 subDf.leftSB subDf.rightSB subDf.mvs subDf.smallArchDepthA subDf.smallArchDepthB
+
+			include : with-transform [ApparentTranslate 0 (yBarPos - 0.5 * subDf.mvs)] : glyph-proc
+				include : VHookRightShape [DivFrame 1] fStraightBar (Ascender - (yBarPos - 0.5 * subDf.mvs))
+				include : Serifs          [DivFrame 1] fStraightBar (Ascender - (yBarPos - 0.5 * subDf.mvs))
 				eject-contour 'serifRT'
-			include : OShape (Ascender - vPartHeight + Stroke + O) 0 SB RightSB
 
 	define VCursiveConfig : object
 		cursiveSerifless     { (1/24) false }
@@ -265,8 +272,8 @@ glyph-block Letter-Latin-V : begin
 			include [refer-glyph "v.\(suffix)"] AS_BASE ALSO_METRICS
 			local attach : currentGlyph.gizmo.unapply currentGlyph.baseAnchors.palatalHookAttach
 			include : PalatalHook.r
-				x -- attach.x
-				y -- 0
+				x       -- attach.x
+				y       -- 0
 				yAttach -- attach.y
 
 	select-variant 'V' 'V'
@@ -293,14 +300,14 @@ glyph-block Letter-Latin-V : begin
 	define [VScriptShape df top ada adb] : glyph-proc
 		include : dispiro
 			widths.lhs
-			flat df.leftSB top [heading Downward]
-			curl df.leftSB [Math.min (0 + adb) (top - TINY)]
+			flat df.leftSB  top [heading Downward]
+			curl df.leftSB  [Math.min (0 + adb) (top - TINY)]
 			arch.lhs 0
 			flat df.rightSB [Math.min (0 + ada) (top - Hook - HalfStroke - TINY)]
 			curl df.rightSB (top - Hook - HalfStroke) [heading Upward]
 		include : VerticalHook.r
-			x -- df.rightSB
-			y -- (top - Hook - HalfStroke)
+			x      -- df.rightSB
+			y      -- (top - Hook - HalfStroke)
 			xDepth -- ((df.middle + [HSwToV HalfStroke]) - df.rightSB)
 			yDepth -- (-Hook)
 

--- a/packages/font-glyphs/src/meta/unicode-knowledge.ptl
+++ b/packages/font-glyphs/src/meta/unicode-knowledge.ptl
@@ -142,8 +142,8 @@ export : define decompOverrides : object
 	0x3CD { 'grek/upsilon' 'tonosAbove' }
 	0x3CE { 'grek/omega'   'tonosAbove' }
 
-	0x46E  { 'cyrl/KsiBase' 'caronAbove' }
-	0x46F  { 'cyrl/ksiBase' 'caronAbove' }
+	0x46E  { 'cyrl/Ksi/base' 'caronAbove' }
+	0x46F  { 'cyrl/ksi/base' 'caronAbove' }
 	0x47C  { 'cyrl/BroadOmega' 'cyrlPsiliAbove' 'cyrlPokrytieAbove' }
 	0x47D  { 'cyrl/broadOmega' 'cyrlPsiliAbove' 'cyrlPokrytieAbove' }
 	0x47E  { 'cyrl/Omega' 'cyrl/teAbove' }

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1783,7 +1783,6 @@ descriptionAffix = "straight shape"
 selectorAffix.V = "straight"
 selectorAffix."V/sansSerif" = "straight"
 selectorAffix.VScript = ""
-selectorAffix."cyrl/Izhitsa" = "straight"
 
 [prime.capital-v.variants-buildup.stages.body.curly]
 rank = 2
@@ -1791,7 +1790,6 @@ descriptionAffix = "curly shape"
 selectorAffix.V = "curly"
 selectorAffix."V/sansSerif" = "curly"
 selectorAffix.VScript = ""
-selectorAffix."cyrl/Izhitsa" = "curly"
 
 [prime.capital-v.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -1800,7 +1798,6 @@ descriptionJoiner = "without"
 selectorAffix.V = "serifless"
 selectorAffix."V/sansSerif" = "serifless"
 selectorAffix.VScript = "serifless"
-selectorAffix."cyrl/Izhitsa" = "serifless"
 
 [prime.capital-v.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
@@ -1808,7 +1805,6 @@ descriptionAffix = "motion serifs"
 selectorAffix.V = "motionSerifed"
 selectorAffix."V/sansSerif" = "serifless"
 selectorAffix.VScript = "motionSerifed"
-selectorAffix."cyrl/Izhitsa" = "motionSerifed"
 
 [prime.capital-v.variants-buildup.stages.serifs.serifed]
 rank = 3
@@ -1816,7 +1812,6 @@ descriptionAffix = "serifs"
 selectorAffix.V = "serifed"
 selectorAffix."V/sansSerif" = "serifless"
 selectorAffix.VScript = "serifed"
-selectorAffix."cyrl/Izhitsa" = "serifed"
 
 
 
@@ -4783,7 +4778,6 @@ selectorAffix."v/sansSerif" = "straight"
 selectorAffix.vScript = ""
 selectorAffix.vHookRight = "straight"
 selectorAffix.vLoop = "straight"
-selectorAffix."cyrl/izhitsa" = "straight"
 
 [prime.v.variants-buildup.stages.body.curly]
 rank = 2
@@ -4793,7 +4787,6 @@ selectorAffix."v/sansSerif" = "curly"
 selectorAffix.vScript = ""
 selectorAffix.vHookRight = "curly"
 selectorAffix.vLoop = "curly"
-selectorAffix."cyrl/izhitsa" = "curly"
 
 [prime.v.variants-buildup.stages.body.cursive]
 rank = 3
@@ -4803,7 +4796,6 @@ selectorAffix."v/sansSerif" = "cursive"
 selectorAffix.vScript = ""
 selectorAffix.vHookRight = "straight"
 selectorAffix.vLoop = "straight"
-selectorAffix."cyrl/izhitsa" = "straight"
 
 [prime.v.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -4814,7 +4806,6 @@ selectorAffix."v/sansSerif" = "serifless"
 selectorAffix.vScript = "serifless"
 selectorAffix.vHookRight = "serifless"
 selectorAffix.vLoop = "serifless"
-selectorAffix."cyrl/izhitsa" = "serifless"
 
 [prime.v.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
@@ -4825,7 +4816,6 @@ selectorAffix."v/sansSerif" = "serifless"
 selectorAffix.vScript = "motionSerifed"
 selectorAffix.vHookRight = "motionSerifed"
 selectorAffix.vLoop = "serifless"
-selectorAffix."cyrl/izhitsa" = "motionSerifed"
 
 [prime.v.variants-buildup.stages.serifs.serifed]
 rank = 3
@@ -4835,7 +4825,6 @@ selectorAffix."v/sansSerif" = "serifless"
 selectorAffix.vScript = {if = [{body = "cursive"}], then = "motionSerifed", else = "serifed"}
 selectorAffix.vHookRight = {if = [{body = "cursive"}], then = "motionSerifed", else = "serifed"}
 selectorAffix.vLoop = {if = [{body = "cursive"}], then = "serifless", else = "serifed"}
-selectorAffix."cyrl/izhitsa" = {if = [{body = "cursive"}], then = "motionSerifed", else = "serifed"}
 
 
 
@@ -7574,18 +7563,21 @@ next = "hook"
 rank = 1
 descriptionAffix = "straight shape"
 selectorAffix."cyrl/U" = "straight"
+selectorAffix."cyrl/Izhitsa" = "straight"
 selectorAffix."cyrl/Ue" = "straight"
 
 [prime.cyrl-capital-u.variants-buildup.stages.body.curly]
 rank = 2
 descriptionAffix = "curly shape"
 selectorAffix."cyrl/U" = "curly"
+selectorAffix."cyrl/Izhitsa" = "curly"
 selectorAffix."cyrl/Ue" = "curly"
 
 [prime.cyrl-capital-u.variants-buildup.stages.body.cursive]
 rank = 3
 descriptionAffix = "cursive shape"
 selectorAffix."cyrl/U" = "cursive"
+selectorAffix."cyrl/Izhitsa" = "straight"
 selectorAffix."cyrl/Ue" = "straight"
 
 [prime.cyrl-capital-u.variants-buildup.stages.hook."*"]
@@ -7595,6 +7587,7 @@ next = "serifs"
 rank = 1
 keyAffix = ""
 selectorAffix."cyrl/U" = ""
+selectorAffix."cyrl/Izhitsa" = ""
 selectorAffix."cyrl/Ue" = ""
 
 [prime.cyrl-capital-u.variants-buildup.stages.hook.turn]
@@ -7602,6 +7595,7 @@ rank = 2
 disableIf = [{ body = "cursive" }]
 descriptionAffix = "a tail turns leftward"
 selectorAffix."cyrl/U" = "turn"
+selectorAffix."cyrl/Izhitsa" = ""
 selectorAffix."cyrl/Ue" = ""
 
 [prime.cyrl-capital-u.variants-buildup.stages.hook.flat-hook]
@@ -7609,6 +7603,7 @@ rank = 3
 disableIf = [{ body = "NOT cursive" }]
 descriptionAffix = "a flat terminal hook"
 selectorAffix."cyrl/U" = "flatHook"
+selectorAffix."cyrl/Izhitsa" = ""
 selectorAffix."cyrl/Ue" = ""
 
 [prime.cyrl-capital-u.variants-buildup.stages.serifs.serifless]
@@ -7616,18 +7611,21 @@ rank = 1
 descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix."cyrl/U" = "serifless"
+selectorAffix."cyrl/Izhitsa" = "serifless"
 selectorAffix."cyrl/Ue" = "serifless"
 
 [prime.cyrl-capital-u.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
 descriptionAffix = "motion serifs"
 selectorAffix."cyrl/U" = "motionSerifed"
+selectorAffix."cyrl/Izhitsa" = "motionSerifed"
 selectorAffix."cyrl/Ue" = "motionSerifed"
 
 [prime.cyrl-capital-u.variants-buildup.stages.serifs.serifed]
 rank = 3
 descriptionAffix = "serifs"
 selectorAffix."cyrl/U" = "serifed"
+selectorAffix."cyrl/Izhitsa" = "serifed"
 selectorAffix."cyrl/Ue" = "serifed"
 
 
@@ -7648,18 +7646,24 @@ next = "hook"
 rank = 1
 descriptionAffix = "straight shape"
 selectorAffix."cyrl/u" = "straight"
+selectorAffix."cyrl/u/nonCursive" = "straight"
+selectorAffix."cyrl/izhitsa" = "straight"
 selectorAffix."cyrl/ue" = "straight"
 
 [prime.cyrl-u.variants-buildup.stages.body.curly]
 rank = 2
 descriptionAffix = "curly shape"
 selectorAffix."cyrl/u" = "curly"
+selectorAffix."cyrl/u/nonCursive" = "curly"
+selectorAffix."cyrl/izhitsa" = "curly"
 selectorAffix."cyrl/ue" = "curly"
 
 [prime.cyrl-u.variants-buildup.stages.body.cursive]
 rank = 3
 descriptionAffix = "cursive shape"
 selectorAffix."cyrl/u" = "cursive"
+selectorAffix."cyrl/u/nonCursive" = "straight"
+selectorAffix."cyrl/izhitsa" = "straight"
 selectorAffix."cyrl/ue" = "straight"
 
 [prime.cyrl-u.variants-buildup.stages.hook."*"]
@@ -7669,6 +7673,8 @@ next = "serifs"
 rank = 1
 keyAffix = ""
 selectorAffix."cyrl/u" = ""
+selectorAffix."cyrl/u/nonCursive" = ""
+selectorAffix."cyrl/izhitsa" = ""
 selectorAffix."cyrl/ue" = ""
 
 [prime.cyrl-u.variants-buildup.stages.hook.turn]
@@ -7676,6 +7682,8 @@ rank = 2
 disableIf = [{ body = "cursive" }]
 descriptionAffix = "a tail turns leftward"
 selectorAffix."cyrl/u" = "turn"
+selectorAffix."cyrl/u/nonCursive" = "turn"
+selectorAffix."cyrl/izhitsa" = ""
 selectorAffix."cyrl/ue" = ""
 
 [prime.cyrl-u.variants-buildup.stages.hook.flat-hook]
@@ -7683,6 +7691,8 @@ rank = 3
 disableIf = [{ body = "NOT cursive" }]
 descriptionAffix = "a flat terminal hook"
 selectorAffix."cyrl/u" = "flatHook"
+selectorAffix."cyrl/u/nonCursive" = ""
+selectorAffix."cyrl/izhitsa" = ""
 selectorAffix."cyrl/ue" = ""
 
 [prime.cyrl-u.variants-buildup.stages.serifs.serifless]
@@ -7690,18 +7700,24 @@ rank = 1
 descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix."cyrl/u" = "serifless"
+selectorAffix."cyrl/u/nonCursive" = "serifless"
+selectorAffix."cyrl/izhitsa" = "serifless"
 selectorAffix."cyrl/ue" = "serifless"
 
 [prime.cyrl-u.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
 descriptionAffix = "motion serifs"
 selectorAffix."cyrl/u" = "motionSerifed"
+selectorAffix."cyrl/u/nonCursive" = "motionSerifed"
+selectorAffix."cyrl/izhitsa" = "motionSerifed"
 selectorAffix."cyrl/ue" = "motionSerifed"
 
 [prime.cyrl-u.variants-buildup.stages.serifs.serifed]
 rank = 3
 descriptionAffix = "serifs"
 selectorAffix."cyrl/u" = "serifed"
+selectorAffix."cyrl/u/nonCursive" = "serifed"
+selectorAffix."cyrl/izhitsa" = "serifed"
 selectorAffix."cyrl/ue" = "serifed"
 
 


### PR DESCRIPTION
According to [this Wikipedia article](https://en.wikipedia.org/wiki/Uk_(Cyrillic)#Representation_on_computers), with evidence from [this Unicode document](https://www.unicode.org/notes/tn41/tn41-1.pdf#page=17), the `у` part of Cyrillic Digraph Uk (`Ѹ`, `ѹ`) may be based on a "tailed" version of Cyrillic Izhitsa (`Ѵ`, `ѵ`).

Furthermore, also according to the aforementioned Unicode document, the `о` part of Cyrillic Unblended Monograph Uk (`ᲈ`) is actually specifically based on a narrow o (`ᲂ`) much like the o part in the digraph form.

Effectively, the digraph form writes the two characters side-by-side, while the (unblended) monograph form writes them vertically stacked.

This PR makes Cyrillic Izhitsa (`Ѵ`, `ѵ`) follow Cyrillic U (`VAAB`, `VAAC`) and adds a custom glyph for the `у` part of Cyrillic Digraph Uk (`Ѹ`, `ѹ`)

-----

For each screenshot below:
first row is under `'VAAB'01,'VAAC'01;`,
second row is under `'VAAB'02,'VAAC'02;`,
third row is under `'VAAB'06,'VAAC'06;`.

`Оᲂ Уу Ѵѵ Оуᲂу Оѵᲂѵ Ѹѹ Ꙋᲈ`

Monospace Thin Upright:
<img width="1947" height="599" alt="image" src="https://github.com/user-attachments/assets/465e08d9-cb32-49bf-ba4c-74c87d9fb06f" />
Monospace Regular Upright:
<img width="1958" height="615" alt="image" src="https://github.com/user-attachments/assets/5b4158c8-d921-4c9d-b774-caf0c4e26b42" />
Monospace Heavy Upright:
<img width="1950" height="620" alt="image" src="https://github.com/user-attachments/assets/97ba16eb-a26e-4298-918a-340ab78230fa" />

-----

For each screenshot below:
first row is under  `'VAAB'01,'VAAC'13;`,
second row is under `'VAAB'02,'VAAC'14;`,
third row is under `''VAAB'06,'VAAC'15;`.

`Оᲂ Уу Ѵѵ Оуᲂу Оѵᲂѵ Ѹѹ Ꙋᲈ`

Monospace Thin Italic:
<img width="1946" height="606" alt="image" src="https://github.com/user-attachments/assets/433c2037-dccb-4269-a2dc-da2928ddce02" />
Monospace Regular Italic:
<img width="1950" height="618" alt="image" src="https://github.com/user-attachments/assets/c2c3c677-54cc-4208-84d8-fb60f0219b23" />
Monospace Heavy Italic:
<img width="1945" height="605" alt="image" src="https://github.com/user-attachments/assets/77b71650-6c1d-4a40-8818-17dd59f2aa77" />

-----

For each screenshot below:
first row is under `'VAAB'01,'VAAC'01;`,
second row is under `'VAAB'02,'VAAC'02;`,
third row is under `'VAAB'06,'VAAC'06;`.

`Оᲂ Уу Ѵѵ Оуᲂу Оѵᲂѵ Ѹѹ Ꙋᲈ`

Quasi-Proportional Thin Upright:
<img width="2224" height="625" alt="image" src="https://github.com/user-attachments/assets/14e6078e-aabb-4edd-a9a2-762d829954d2" />
Quasi-Proportional Regular Upright:
<img width="2224" height="610" alt="image" src="https://github.com/user-attachments/assets/72b5675a-9600-4aa8-840d-3c2247f41eca" />
Quasi-Proportional Heavy Upright:
<img width="2209" height="607" alt="image" src="https://github.com/user-attachments/assets/b3bc9fc7-ba7f-4a9f-960d-87f21913dbd1" />

-----

For each screenshot below:
first row is under  `'VAAB'01,'VAAC'13;`,
second row is under `'VAAB'02,'VAAC'14;`,
third row is under `''VAAB'06,'VAAC'15;`.

`Оᲂ Уу Ѵѵ Оуᲂу Оѵᲂѵ Ѹѹ Ꙋᲈ`

Quasi-Proportional Thin Italic:
<img width="2228" height="612" alt="image" src="https://github.com/user-attachments/assets/4bc3b89e-b858-43f3-bffc-0a7b881bc309" />
Quasi-Proportional Regular Italic:
<img width="2233" height="592" alt="image" src="https://github.com/user-attachments/assets/97e701fb-c076-4659-b777-0ded25d4a180" />
Quasi-Proportional Heavy Italic:
<img width="2219" height="610" alt="image" src="https://github.com/user-attachments/assets/ada92830-d5dd-4f01-aadf-4f7cca4c0cb5" />

