### PR TITLE
Add italic form for Cyrillic Lower Tswe (`ꚏ`).

### DIFF
--- a/changes/33.3.3.md
+++ b/changes/33.3.3.md
@@ -1,0 +1,1 @@
+* Add italic form for Cyrillic Lower Tswe (`U+A68F`).

--- a/packages/font-glyphs/src/letter/cyrillic/orthography.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/orthography.ptl
@@ -39,6 +39,7 @@ glyph-block Letter-Cyrillic-Orthography : begin
 	orthographic-italic 'cyrl/tseRev'         0xA661
 	orthographic-italic 'cyrl/dzze'           0xA689
 	orthographic-italic 'cyrl/teMidHook'      0xA68B
+	orthographic-italic 'cyrl/tswe'           0xA68F
 	orthographic-italic 'cyrl/shwe'           0xA697
 	orthographic-italic 'latn/yatSakha'       0xAB60
 

--- a/packages/font-glyphs/src/letter/cyrillic/tse.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/tse.ptl
@@ -99,6 +99,6 @@ glyph-block Letter-Cyrillic-Tse : begin
 	create-glyph 'cyrl/Tswe' 0xA68E : glyph-proc
 		include : MarkSet.capDesc
 		include : CyrTsweShape CAP
-	create-glyph 'cyrl/tswe' 0xA68F : glyph-proc
+	create-glyph 'cyrl/tswe.upright' : glyph-proc
 		include : MarkSet.p
 		include : CyrTsweShape XH

--- a/packages/font-glyphs/src/letter/latin/lower-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-m.ptl
@@ -381,7 +381,7 @@ glyph-block Letter-Latin-Lower-M : begin
 			include : df.markSet.e
 			include : turnMShapeBody df XH
 
-		create-glyph "capitalTurnm.\(suffix)" : glyph-proc
+		create-glyph "turnmCap.\(suffix)" : glyph-proc
 			local df : include : dfM
 			include : df.markSet.capital
 			include : turnMShapeBody df CAP
@@ -417,7 +417,7 @@ glyph-block Letter-Latin-Lower-M : begin
 				include : CyrDescender.rSideJut df.rightSB 0 (refSw -- df.mvs)
 			create-glyph "cyrl/shwe.italic.\(suffix)" : glyph-proc
 				local df : include : dfM
-				include : df.markSet.e
+				include : df.markSet.p
 				include : turnMShapeBody df XH
 				eject-contour 'serifLT'
 				include : CyrCurlDescender.rSideJut df.rightSB 0 (refSw -- df.mvs)
@@ -425,7 +425,7 @@ glyph-block Letter-Latin-Lower-M : begin
 	select-variant 'turnm' 0x26F (follow -- [conditional-follow [MEnoughSpaceForFullSerifs] 'turnm/full' 'turnm/reduced'])
 	select-variant 'turnm/reduced' (shapeFrom -- 'turnm')
 
-	select-variant 'capitalTurnm' 0x19C (follow -- [conditional-follow [MEnoughSpaceForFullSerifs] 'turnm/full' 'turnm/reduced'])
+	select-variant 'turnmCap' 0x19C (follow -- [conditional-follow [MEnoughSpaceForFullSerifs] 'turnm/full' 'turnm/reduced'])
 
 	select-variant 'turnmLeg' 0x270 (follow -- [conditional-follow [MEnoughSpaceForFullSerifs] 'turnmLeg/full' 'turnmLeg/reduced'])
 	select-variant 'turnmLeg/reduced' (shapeFrom -- 'turnmLeg')
@@ -433,18 +433,20 @@ glyph-block Letter-Latin-Lower-M : begin
 	select-variant 'turnmSideways' 0x1D1F (follow -- [conditional-follow [MEnoughSpaceForFullSerifs] 'turnm/full' 'turnm/reduced'])
 
 	select-variant 'cyrl/sha.italic' (shapeFrom -- 'turnm') (follow -- [conditional-follow [MEnoughSpaceForFullSerifs] 'cyrl/sha.italic/full' 'cyrl/sha.italic/reduced'])
-	alias 'cyrl/sha.BGR' null 'cyrl/sha.italic'
 	select-variant 'cyrl/sha/reduced.italic' (shapeFrom -- 'turnm') (follow -- 'cyrl/sha.italic/reduced')
-	alias 'cyrl/sha/reduced.BGR' null 'cyrl/sha/reduced.italic'
 
 	select-variant 'cyrl/shcha.italic' (follow -- [conditional-follow [MEnoughSpaceForFullSerifs] 'cyrl/shcha.italic/full' 'cyrl/shcha.italic/reduced'])
-	alias 'cyrl/shcha.BGR' null 'cyrl/shcha.italic'
 	select-variant 'cyrl/shcha/reduced.italic' (shapeFrom -- 'cyrl/shcha.italic') (follow -- 'cyrl/shcha.italic/reduced')
-	alias 'cyrl/shcha/reduced.BGR' null 'cyrl/shcha/reduced.italic'
 
 	select-variant 'cyrl/shwe.italic' (follow -- [conditional-follow [MEnoughSpaceForFullSerifs] 'cyrl/shcha.italic/full' 'cyrl/shcha.italic/reduced'])
 
-	derive-composites 'cyrl/te.SRB' null 'cyrl/sha.italic' 'cyrl/te.SRB/overlineAbove'
+	alias 'cyrl/sha.BGR'         null 'cyrl/sha.italic'
+	alias 'cyrl/sha/reduced.BGR' null 'cyrl/sha/reduced.italic'
+
+	alias 'cyrl/shcha.BGR'         null 'cyrl/shcha.italic'
+	alias 'cyrl/shcha/reduced.BGR' null 'cyrl/shcha/reduced.italic'
+
+	derive-composites 'cyrl/te.SRB'         null 'cyrl/sha.italic'         'cyrl/te.SRB/overlineAbove'
 	derive-composites 'cyrl/te/reduced.SRB' null 'cyrl/sha/reduced.italic' 'cyrl/te.SRB/overlineAbove'
 
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarLeft

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -12,7 +12,8 @@ glyph-block Letter-Latin-U : begin
 	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared : CreateAccentedComposition SetGrekUpperTonos
 	glyph-block-import Letter-Shared-Shapes : uBowl RightwardTailedBar SerifFrame
-	glyph-block-import Letter-Shared-Shapes : CyrDescender CyrTailDescender RetroflexHook TopHook
+	glyph-block-import Letter-Shared-Shapes : CyrDescender CyrTailDescender CyrCurlDescender
+	glyph-block-import Letter-Shared-Shapes : RetroflexHook TopHook
 
 	glyph-block-export UShapeGroup
 	define [UShapeGroup ada adb] : namespace
@@ -50,6 +51,18 @@ glyph-block Letter-Latin-U : begin
 			if fHookLeft : include : TopHook.toLeft.lBarInner df.leftSB [Math.min (adb + TINY) (yTL - 0)] top (sw -- sw)
 			include : tagged 'strokeR' : RightwardTailedBar df.rightSB 0 yTR (sw -- sw)
 
+		export : define [ToothlessCorner df top sw fHookLeft fShortLeg] : glyph-proc
+			local yTL : top - [if fHookLeft (TailY + HalfStroke) 0]
+			local yTR : if fShortLeg [mix [Math.min ada : YSmoothMidR top 0 ada adb] top 0.5] top
+			include : dispiro
+				widths.lhs sw
+				flat df.leftSB yTL [heading Downward]
+				curl df.leftSB [Math.min (0 + adb) (yTL - TINY)]
+				arch.lhs 0 (sw -- sw) (blendPost -- {})
+				g4 df.rightSB DToothlessRise
+			if fHookLeft : include : TopHook.toLeft.lBarInner df.leftSB [Math.min (adb + TINY) (yTL - 0)] top (sw -- sw)
+			include : tagged 'strokeR' : VBar.r df.rightSB DToothlessRise yTR sw
+
 		export : define [ToothlessRounded df top sw fHookLeft fShortLeg] : glyph-proc
 			local yTL : top - [if fHookLeft (TailY + HalfStroke) 0]
 			local yTR : if fShortLeg [mix [Math.min ada : YSmoothMidR top 0 ada adb] top 0.5] top
@@ -61,18 +74,6 @@ glyph-block Letter-Latin-U : begin
 				flat df.rightSB [Math.min (0 + ada) (yTR - TINY)]
 				curl df.rightSB yTR [heading Upward]
 			if fHookLeft : include : TopHook.toLeft.lBarInner df.leftSB [Math.min (adb + TINY) (yTL - 0)] top (sw -- sw)
-
-		export : define [ToothlessCorner df top sw fHookLeft fShortLeg] : glyph-proc
-			local yTL : top - [if fHookLeft (TailY + HalfStroke) 0]
-			local yTR : if fShortLeg [mix [Math.min ada : YSmoothMidR top 0 ada adb] top 0.5] top
-			include : dispiro
-				widths.lhs sw
-				flat df.leftSB yTL [heading Downward]
-				curl df.leftSB [Math.min (0 + adb) (yTL - TINY)]
-				arch.lhs 0 (sw -- sw) (blendPost -- {})
-				g4 df.rightSB DToothlessRise
-			if fHookLeft : include : TopHook.toLeft.lBarInner df.leftSB [Math.min (adb + TINY) (yTL - 0)] top (sw -- sw)
-			include : VBar.r df.rightSB DToothlessRise yTR sw
 
 	define UUpper : UShapeGroup ArchDepthA ArchDepthB
 	define ULower : UShapeGroup SmallArchDepthA SmallArchDepthB
@@ -209,6 +210,12 @@ glyph-block Letter-Latin-U : begin
 			eject-contour 'serifRB'
 			include : CyrDescender.rSideJut RightSB 0
 
+		create-glyph "cyrl/tswe.italic.\(suffix)" : glyph-proc
+			include [refer-glyph "u.\(suffix)"] AS_BASE
+			include : MarkSet.p
+			eject-contour 'serifRB'
+			include : CyrCurlDescender.rSideJut RightSB 0
+
 		create-glyph "cyrl/tseRev.italic.\(suffix)" : glyph-proc
 			include [refer-glyph "u.\(suffix)"] AS_BASE
 			include : VBar.l SB 0 SmallArchDepthB [AdviceStroke 4]
@@ -224,6 +231,7 @@ glyph-block Letter-Latin-U : begin
 			include : Base  df XH Stroke
 			include : Slabs df XH Stroke
 			eject-contour 'serifRB'
+			eject-contour 'strokeR'
 			include : VBar.r df.rightSB Descender XH Stroke
 			if (Slabs !== no-shape) : begin
 				local sf : SerifFrame.fromDf df XH Descender
@@ -251,6 +259,7 @@ glyph-block Letter-Latin-U : begin
 			include : Slabs df XH Stroke
 			eject-contour 'serifLT'
 			eject-contour 'serifRB'
+			eject-contour 'strokeR'
 			include : VBar.r df.rightSB Descender XH Stroke
 			if (Slabs !== no-shape) : begin
 				local sf : SerifFrame.fromDf df XH Descender
@@ -264,6 +273,7 @@ glyph-block Letter-Latin-U : begin
 			include : Slabs df XH Stroke
 			eject-contour 'serifLT'
 			eject-contour 'serifRB'
+			eject-contour 'strokeR'
 			include : VBar.r df.rightSB 0 XH Stroke
 			include : RetroflexHook.rExt df.rightSB (Descender + TailY + HalfStroke) (yAttach -- 0)
 			include : LeaningAnchor.Below.VBar.r df.rightSB
@@ -288,35 +298,40 @@ glyph-block Letter-Latin-U : begin
 				include : Translate 0 (SB / 2)
 
 	select-variant 'U' 'U'
-	select-variant 'U/withTonos' (follow -- 'U')
 	link-reduced-variant 'U/sansSerif' 'U' MathSansSerif
+	select-variant 'U/withTonos' (follow -- 'U')
 	select-variant 'smcpU' 0x1D1C (follow -- 'U')
 
 	select-variant 'u' 'u'
 	link-reduced-variant 'u/sansSerif' 'u' MathSansSerif
 	select-variant 'u/descBase' (shapeFrom -- 'u')
+
+	select-variant 'turnh' 0x265
+
 	select-variant 'uShortLeg' 0xAB4E
 	select-variant 'uHookLeft' 0xAB52
 
-	select-variant 'grek/mu' 0x3BC
-	link-reduced-variant 'grek/mu/sansSerif' 'grek/mu' MathSansSerif
-	select-variant 'micro'   0xB5  (shapeFrom -- 'grek/mu')
-
-	select-variant 'cyrl/i.italic' (shapeFrom -- 'u')
-	select-variant 'cyrl/i.italic/descBase' (shapeFrom -- 'u')
-	alias 'cyrl/i.BGR' null 'cyrl/i.italic'
-
-	select-variant 'cyrl/tse.italic'
-	alias 'cyrl/tse.BGR' null 'cyrl/tse.italic'
-	select-variant 'cyrl/tseRev.italic'
-	select-variant 'cyrl/dzhe.italic'
-
-	select-variant 'turnh' 0x265
-	select-variant 'turnhHookLeft' 0x2AE
+	select-variant 'turnhHookLeft'      0x2AE
 	select-variant 'turnhHookLeftRTail' 0x2AF
 
 	select-variant 'uSideways' 0x1D1D (follow -- 'u')
 	select-variant 'uDieresisSideways/base' null (follow -- 'u')
+
+	select-variant 'grek/mu' 0x3BC
+	link-reduced-variant 'grek/mu/sansSerif' 'grek/mu' MathSansSerif
+	select-variant 'micro' 0xB5 (shapeFrom -- 'grek/mu')
+
+	select-variant 'cyrl/i.italic' (shapeFrom -- 'u')
+	select-variant 'cyrl/i.italic/descBase' (shapeFrom -- 'u')
+
+	select-variant 'cyrl/tse.italic'
+	select-variant 'cyrl/tseRev.italic'
+	select-variant 'cyrl/tswe.italic' (follow -- 'cyrl/tse.italic')
+
+	select-variant 'cyrl/dzhe.italic'
+
+	alias 'cyrl/i.BGR'   null 'cyrl/i.italic'
+	alias 'cyrl/tse.BGR' null 'cyrl/tse.italic'
 
 	derive-glyphs 'cyrl/ibreve.BGR' null 'cyrl/i.BGR' : lambda [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS


### PR DESCRIPTION
This form was oddly missing from #2909 despite it existing in the historical text that used it, and by extension the Unicode proposal documents way back when it was being added to Unicode.

Also fix `[DivFrame].markSet.p` application to `cyrl/shwe.italic`.

`ꚎꚏꚖꚗ`

Sans Monospace Thin:
<img width="665" height="739" alt="image" src="https://github.com/user-attachments/assets/af4badae-c887-4bc6-8b21-0891d2efa616" />
Sans Monospace Regular:
<img width="656" height="744" alt="image" src="https://github.com/user-attachments/assets/b20691b2-0218-43da-9d3e-aa9954613ef8" />
Sans Monospace Heavy:
<img width="668" height="759" alt="image" src="https://github.com/user-attachments/assets/8355a462-bc03-4f3b-b067-7679747e0fb7" />
Slab Monospace Thin:
<img width="669" height="753" alt="image" src="https://github.com/user-attachments/assets/f5d7f016-b3cc-4ac3-81e4-973e49a0f2f8" />
Slab Monospace Regular:
<img width="682" height="753" alt="image" src="https://github.com/user-attachments/assets/a65968fd-0276-461e-ba31-faf88f861a81" />
Slab Monospace Heavy:
<img width="671" height="744" alt="image" src="https://github.com/user-attachments/assets/356d61ea-2c08-447e-a21a-95a8175d1127" />
Aile Thin:
<img width="975" height="754" alt="image" src="https://github.com/user-attachments/assets/a46d5895-8a7c-4101-a745-051c38bd01ad" />
Aile Regular:
<img width="949" height="747" alt="image" src="https://github.com/user-attachments/assets/8405fdf6-09d6-4597-82be-b268c108a565" />
Aile Heavy:
<img width="975" height="753" alt="image" src="https://github.com/user-attachments/assets/ea28eaa1-a71a-432a-b5c0-8cb07af3711e" />
Etoile Thin:
<img width="975" height="769" alt="image" src="https://github.com/user-attachments/assets/07d5ca49-749e-4807-aee7-af961afcf3d4" />
Etoile Regular:
<img width="957" height="741" alt="image" src="https://github.com/user-attachments/assets/bdca01ec-0ac3-4b67-9d79-4e2b304f6e2f" />
Etoile Heavy:
<img width="987" height="763" alt="image" src="https://github.com/user-attachments/assets/e461aa55-0197-4534-b3f3-c6ccffdccd5d" />
