### PR TITLE
Make serifs of Cyrillic Lower Dwe (`ꚁ`) respond to italics.

### DIFF
--- a/changes/33.3.4.md
+++ b/changes/33.3.4.md
@@ -1,0 +1,1 @@
+* Refine serifs of Cyrillic Lower Dwe (`U+A681`) under italics.

--- a/packages/font-glyphs/src/letter/cyrillic/de.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/de.ptl
@@ -12,11 +12,10 @@ glyph-block Letter-Cyrillic-De : begin
 
 	glyph-block-export BottomExtension
 	local BottomExtension : (-LongVJut) + QuarterStroke
-	local TopExtension        LongVJut
 
 	glyph-block-export CyrDeBottom
 	define [CyrDeBottom left right _sw _desc] : glyph-proc
-		local descenderOverflow : if SLAB SideJut ((right - left) * 0.075)
+		local descenderOverflow : if SLAB SideJut : (right - left) * 0.075
 		local xTopLeft  : mix left right : StrokeWidthBlend 0.15 0.1
 		local xTopRight : mix left right : StrokeWidthBlend 0.95 0.96
 		local swOuter : fallback _sw Stroke
@@ -32,11 +31,11 @@ glyph-block Letter-Cyrillic-De : begin
 
 	glyph-block-export CyrDeShape
 	define [CyrDeShape top left right _sw _desc fLower] : glyph-proc
-		local descenderOverflow : if SLAB SideJut ((right - left) * 0.075)
+		local descenderOverflow : if SLAB SideJut : (right - left) * 0.075
 		local xTopLeft  : mix left right : StrokeWidthBlend 0.15 0.1
 		local xTopRight : mix left right : StrokeWidthBlend 0.95 0.96
 		local swOuter : fallback _sw Stroke
-		local swInner : swOuter * [AdviceStroke 2.75] / Stroke
+		local swInner : [AdviceStroke 2.75] * (swOuter / Stroke)
 		local desc : fallback _desc BottomExtension
 
 		include : CyrDeBottom left right _sw _desc
@@ -60,7 +59,7 @@ glyph-block Letter-Cyrillic-De : begin
 		return : object desc xTopLeft xTopRight swInner
 
 	define [CyrSoftDeShape df top _sw _desc fLower vSlab] : glyph-proc
-		local descenderOverflow : if SLAB SideJut ((df.rightSB - df.leftSB) * 0.075)
+		local descenderOverflow : if SLAB SideJut : (df.rightSB - df.leftSB) * 0.075
 		local sw : fallback _sw Stroke
 		local xm : if SLAB
 			[mix df.leftSB df.rightSB 0.625] + [HSwToV : 0.25 * sw]
@@ -74,17 +73,17 @@ glyph-block Letter-Cyrillic-De : begin
 			then : HBar.t (xTopRight + descenderOverflow) xTopBarRightEnd top sw
 			else : HBar.t xTopRight xTopBarRightEnd top sw
 
-		if vSlab : include : VSerif.dr xTopBarRightEnd top VJut (VJutStroke * sw / Stroke)
+		if vSlab : include : VSerif.dr xTopBarRightEnd top VJut (VJutStroke * (sw / Stroke))
 
 	create-glyph 'cyrl/De' 0x414 : glyph-proc
 		include : MarkSet.capital
 		include : ExtendBelowBaseAnchors BottomExtension
-		include : CyrDeShape CAP SB RightSB
+		include : CyrDeShape CAP SB RightSB nothing nothing false
 
 	create-glyph 'cyrl/de.upright' : glyph-proc
 		include : MarkSet.e
 		include : ExtendBelowBaseAnchors BottomExtension
-		include : CyrDeShape XH SB RightSB
+		include : CyrDeShape XH SB RightSB nothing nothing true
 
 	create-glyph 'cyrl/deLongLeg' 0x1C81 : glyph-proc
 		include : MarkSet.p
@@ -122,7 +121,7 @@ glyph-block Letter-Cyrillic-De : begin
 		define [DzzeDescendershape de] : begin
 			local sr : [mix RightSB Width 0.5] - O * 2
 			local sl : mix sr de.xTopRight 2
-			local sw : AdviceStroke 2.5 ((sr - sl + 2 * SB) / Width)
+			local sw : AdviceStroke 2.5 : ((sr - sl) + 2 * SB) / Width
 			local shapeBot : de.desc - 0.5 * sw
 			local hook : Hook * (0 - shapeBot) / CAP
 			local ze : CyrZe 3 sb sw shapeBot
@@ -137,30 +136,32 @@ glyph-block Letter-Cyrillic-De : begin
 		create-glyph "cyrl/Dzze.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			include : ExtendBelowBaseAnchors BottomExtension
-			local de : include : CyrDeShape CAP SB RightSB
+			local de : include : CyrDeShape CAP SB RightSB nothing nothing false
 			eject-contour 'footR'
 			include : DzzeDescendershape de
 
 		create-glyph "cyrl/dzze.upright.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : ExtendBelowBaseAnchors BottomExtension
-			local de : include : CyrDeShape XH SB RightSB
+			local de : include : CyrDeShape XH SB RightSB nothing nothing true
 			eject-contour 'footR'
 			include : DzzeDescendershape de
 
 	create-glyph "cyrl/Dwe" 0xA680 : glyph-proc
 		include : MarkSet.capital
-		include : ExtendAboveBaseAnchors TopExtension
+		local asc : CAP + LongVJut - QuarterStroke
+		include : ExtendAboveBaseAnchors asc
 		include : ExtendBelowBaseAnchors BottomExtension
-		local m : include : CyrDeShape CAP SB RightSB
-		include : VBar.l m.xTopLeft CAP (CAP + TopExtension) (m.swInner)
+		local de : include : CyrDeShape CAP SB RightSB nothing nothing false
+		include : VBar.l de.xTopLeft CAP asc de.swInner
 
 	create-glyph "cyrl/dwe" 0xA681 : glyph-proc
 		include : MarkSet.e
-		include : ExtendAboveBaseAnchors TopExtension
+		local asc : XH + LongVJut - QuarterStroke
+		include : ExtendAboveBaseAnchors asc
 		include : ExtendBelowBaseAnchors BottomExtension
-		local m : include : CyrDeShape XH SB RightSB
-		include : VBar.l m.xTopLeft XH (XH + TopExtension) (m.swInner)
+		local de : include : CyrDeShape XH SB RightSB nothing nothing true
+		include : VBar.l de.xTopLeft XH asc de.swInner
 
 	## Italic
 	glyph-block-export CyrDeItalicShapeT
@@ -168,8 +169,8 @@ glyph-block Letter-Cyrillic-De : begin
 		local sw : fallback _sw df.mvs
 
 		local yRingTop : Math.min (XH + O) (XH - QuarterStroke)
-		local ada : df.archDepthAOf : SmallArchDepth * yRingTop / XH
-		local adb : df.archDepthBOf : SmallArchDepth * yRingTop / XH
+		local ada : df.archDepthAOf : SmallArchDepth * (yRingTop / XH)
+		local adb : df.archDepthBOf : SmallArchDepth * (yRingTop / XH)
 
 		return : sink
 			widths.lhs ShoulderFine
@@ -194,8 +195,8 @@ glyph-block Letter-Cyrillic-De : begin
 			local dfLeft : df.slice 3 2 OX
 			include : CyrDeItalicShapeT dispiro dfLeft
 
-			local xZeLeft  : dfLeft.leftSB  + df.width - dfLeft.width + OX
-			local xZeRight : dfLeft.rightSB + df.width - dfLeft.width - OX
+			local xZeLeft  : df.width - dfLeft.width + dfLeft.leftSB  + OX
+			local xZeRight : df.width - dfLeft.width + dfLeft.rightSB - OX
 			local ze : CyrZe 1 sb XH Descender
 				left      -- xZeLeft
 				right     -- xZeRight

--- a/packages/font-glyphs/src/letter/cyrillic/dzzhe-zhwe.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/dzzhe-zhwe.ptl
@@ -19,30 +19,30 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 
 	do "de subglyph"
 		glyph-block-import Mark-Adjustment : ExtendBelowBaseAnchors
-		glyph-block-import Letter-Cyrillic-De : CyrDeShape CyrDeItalicShapeT
+		glyph-block-import Letter-Cyrillic-De : CyrDeShape CyrDeItalicShapeT BottomExtension
 
-		define [CyrDzzheDeShape df top] : glyph-proc
+		define [CyrDzzheDeShape df top _sw _desc fLower] : glyph-proc
 			local [object subDf sw] : SubDfDimBy4 0 2 df OX
 			local left : if SLAB (subDf.leftSB + 0.5 * SideJut) subDf.leftSB
-			include : CyrDeShape top left subDf.rightSB sw
+			include : CyrDeShape top left subDf.rightSB [fallback _sw sw] [fallback _desc BottomExtension] fLower
 
-		define [CyrDzzheDeItalicShape df] : glyph-proc
+		define [CyrDzzheDeItalicShape df _sw] : glyph-proc
 			local [object subDf sw] : SubDfDimBy4 0 2 df OX
-			include : CyrDeItalicShapeT dispiro subDf sw
+			include : CyrDeItalicShapeT dispiro subDf [fallback _sw sw]
 
 		create-glyph "cyrl/Dzzhe/left" : glyph-proc
 			define df : include : DivFrame [mix 1 para.advanceScaleMM 2] 3.5
 			include : df.markSet.capital
-			include : ExtendBelowBaseAnchors ((-LongVJut) + QuarterStroke)
+			include : ExtendBelowBaseAnchors BottomExtension
 			set-base-anchor 'cvDecompose' 0 0
-			include : CyrDzzheDeShape df CAP
+			include : CyrDzzheDeShape df CAP nothing nothing false
 
 		create-glyph "cyrl/dzzhe.upright/left" : glyph-proc
 			define df : include : DivFrame [mix 1 para.advanceScaleM 2] 3.5
 			include : df.markSet.e
-			include : ExtendBelowBaseAnchors ((-LongVJut) + QuarterStroke)
+			include : ExtendBelowBaseAnchors BottomExtension
 			set-base-anchor 'cvDecompose' 0 0
-			include : CyrDzzheDeShape df XH
+			include : CyrDzzheDeShape df XH nothing nothing true
 
 		create-glyph "cyrl/dzzhe.italic/left" : glyph-proc
 			define df : include : DivFrame [mix 1 para.advanceScaleM 2] 3.5
@@ -51,13 +51,13 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 			include : CyrDzzheDeItalicShape df
 
 	do "ze subglyph"
-		define [CyrZhweZeShape slabTop slabBot df top hook] : glyph-proc
+		define [CyrZhweZeShape slabTop slabBot df top hook _sw] : glyph-proc
 			local [object subDf sw] : SubDfDimBy4 0 2 df OX
 			local ze : CyrZe slabTop slabBot top 0
 				left   -- subDf.leftSB
 				right  -- subDf.rightSB
 				hook   -- hook
-				stroke -- sw
+				stroke -- [fallback _sw sw]
 				xo     -- (0.33 * OX)
 			include : ze.Shape
 			include : ze.AutoStartSerifL
@@ -78,33 +78,33 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 
 	do "zhe subglyphs"
 		glyph-block-import Letter-Cyrillic-Zhe : Zhe
-		define [CyrRightZheShape legShape fSlab fMidSlab df top barLeft] : glyph-proc
+		define [CyrRightZheShape legShape fSlab fMidSlab df top barLeft _sw] : glyph-proc
 			local [object subDf shift sw] : SubDfDimBy4 1 3 df OX
 			include : with-transform [ApparentTranslate shift 0] : Zhe.HalfShape legShape fSlab fMidSlab subDf 0 top top
-			include : HBar.m barLeft (shift + subDf.middle) (0.5 * top) sw
+			include : HBar.m barLeft (shift + subDf.middle) (0.5 * top) [fallback _sw sw]
 
-		define [DzzheLeft df] : begin
+		define [DzzheLeft df _sw] : begin
 			local [object subDf sw] : SubDfDimBy4 0 2 df OX
-			local swInner : sw * [AdviceStroke 2.75] / Stroke
+			local swInner : [AdviceStroke 2.75] * ([fallback _sw sw] / Stroke)
 			return : [mix subDf.leftSB subDf.rightSB : StrokeWidthBlend 0.95 0.96] - [HSwToV : 0.5 * swInner]
 
-		define [ZhweZheShape legShape fSlab fMidSlab df top hook] : glyph-proc
+		define [ZhweZheShape legShape fSlab fMidSlab df top hook _sw] : glyph-proc
 			local [object subDf sw] : SubDfDimBy4 0 2 df OX
 			local zeNoO : CyrZe 0 0 top 0
 				left   -- subDf.leftSB
 				right  -- subDf.rightSB
 				hook   -- hook
-				stroke -- (0.5 * sw)
+				stroke -- (0.5 * [fallback _sw sw])
 				xo     -- 0
 				yo     -- 0
 			include : difference [CyrRightZheShape legShape fSlab fMidSlab df top subDf.middle] [zeNoO.ShapeMask]
 
 		glyph-block-import Letter-Cyrillic-De : CyrDeItalicShapeT
-		define [DzzheZheItalicShape legShape fSlab fMidSlab df top] : glyph-proc
+		define [DzzheZheItalicShape legShape fSlab fMidSlab df top _sw] : glyph-proc
 			local [object subDf sw] : SubDfDimBy4 0 2 df OX
 			include : difference
 				CyrRightZheShape legShape fSlab fMidSlab df top subDf.middle
-				CyrDeItalicShapeT spiro-outline subDf sw
+				CyrDeItalicShapeT spiro-outline subDf [fallback _sw sw]
 
 		define ZheConfig : object
 			straight            { Zhe.StraightLegs   SLAB  SLAB }
@@ -117,12 +117,12 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 			create-glyph "cyrl/Dzzhe/right.\(suffix)" : glyph-proc
 				define df : include : DivFrame [mix 1 para.advanceScaleMM 2] 3.5
 				include : df.markSet.capital
-				include : CyrRightZheShape legShape fSlab fMidSlab df CAP : DzzheLeft df
+				include : CyrRightZheShape legShape fSlab fMidSlab df CAP [DzzheLeft df]
 
 			create-glyph "cyrl/dzzhe.upright/right.\(suffix)" : glyph-proc
 				define df : include : DivFrame [mix 1 para.advanceScaleM 2] 3.5
 				include : df.markSet.e
-				include : CyrRightZheShape legShape fSlab fMidSlab df XH : DzzheLeft df
+				include : CyrRightZheShape legShape fSlab fMidSlab df XH [DzzheLeft df]
 
 			create-glyph "cyrl/dzzhe.italic/right.\(suffix)" : glyph-proc
 				define df : include : DivFrame [mix 1 para.advanceScaleM 2] 3.5
@@ -143,14 +143,14 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 
 	select-variant "cyrl/Dzzhe/right" (follow -- "cyrl/Zhe")
 	select-variant "cyrl/dzzhe.upright/right" (follow -- "cyrl/zhe")
-	select-variant "cyrl/dzzhe.italic/right" (follow -- "cyrl/zhe")
+	select-variant "cyrl/dzzhe.italic/right"  (follow -- "cyrl/zhe")
 	select-variant "cyrl/Zhwe/right" (follow -- "cyrl/Zhe")
 	select-variant "cyrl/zhwe/right" (follow -- "cyrl/zhe")
-	select-variant "cyrl/Zhwe/left" (follow -- "cyrl/Ze")
-	select-variant "cyrl/zhwe/left" (follow -- "cyrl/ze")
+	select-variant "cyrl/Zhwe/left"  (follow -- "cyrl/Ze")
+	select-variant "cyrl/zhwe/left"  (follow -- "cyrl/ze")
 
-	derive-composites 'cyrl/Dzzhe' 0x52A  'cyrl/Dzzhe/left' 'cyrl/Dzzhe/right'
+	derive-composites 'cyrl/Dzzhe' 0x52A 'cyrl/Dzzhe/left' 'cyrl/Dzzhe/right'
 	derive-composites 'cyrl/dzzhe.upright' null 'cyrl/dzzhe.upright/left' 'cyrl/dzzhe.upright/right'
-	derive-composites 'cyrl/dzzhe.italic' null 'cyrl/dzzhe.italic/left' 'cyrl/dzzhe.italic/right'
-	derive-composites 'cyrl/Zhwe'  0xA684 'cyrl/Zhwe/left' 'cyrl/Zhwe/right'
-	derive-composites 'cyrl/zhwe'  0xA685 'cyrl/zhwe/left' 'cyrl/zhwe/right'
+	derive-composites 'cyrl/dzzhe.italic'  null 'cyrl/dzzhe.italic/left'  'cyrl/dzzhe.italic/right'
+	derive-composites 'cyrl/Zhwe' 0xA684 'cyrl/Zhwe/left' 'cyrl/Zhwe/right'
+	derive-composites 'cyrl/zhwe' 0xA685 'cyrl/zhwe/left' 'cyrl/zhwe/right'


### PR DESCRIPTION
This is in lieu of a proper italic form — which technically existed — until it gets added to the font. If that ever happens, this PR at least serves as minor cleanup.

This also enforces the serif behavior on _all_ (upright) Cyrillic Lower De derived characters, even though it's only ever visible for `ᲁ` (long-legged de) and `ꚁ` (this character) since the rest of them have proper italic forms (or, in the case of Lower Soft De `ꙣ`, covers up the only serif that actually changes with its augmentation).

`Ддᲁ Ꚁꚁ Лл`

Thin:
<img width="768" height="426" alt="image" src="https://github.com/user-attachments/assets/5609f06d-694c-4454-acbd-dbc45e24e19c" />
Regular:
<img width="757" height="419" alt="image" src="https://github.com/user-attachments/assets/38bb2e51-233c-48e4-9231-e358c2fa71b2" />
Heavy:
<img width="755" height="397" alt="image" src="https://github.com/user-attachments/assets/95c310f2-2543-4704-aba3-49626615518c" />
