### PR TITLE
Refine shape/metrics of Modifier Letter Unaspirated (`˭`).

### DIFF
--- a/changes/33.3.4.md
+++ b/changes/33.3.4.md
@@ -1,4 +1,5 @@
 * Add Characters:
   - COMBINING OPEN MARK BELOW (`U+1AB7`).
   - COMBINING DOUBLE OPEN MARK BELOW (`U+1AB8`).
+* Refine shape of Modifier Letter Unaspirated (`U+02ED`).
 * Refine serifs of Cyrillic Lower Dwe (`U+A681`) under italics.

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -592,6 +592,13 @@ glyph-block Mark-Above : begin
 			flat leftEnd  aboveMarkMid
 			curl rightEnd aboveMarkMid
 
+	create-glyph 'latin1macron' 0xAF : glyph-proc
+		local df : include : DivFrame 1
+		include : dispiro
+			widths.center markStroke
+			flat df.leftSB  aboveMarkMid
+			curl df.rightSB aboveMarkMid
+
 	create-glyph 'overlineAbove' 0x305 : glyph-proc
 		set-width 0
 		include : StdAnchors.impl 'above' 0 2
@@ -600,6 +607,22 @@ glyph-block Mark-Above : begin
 			flat (0 - Width) aboveMarkMid
 			curl  0          aboveMarkMid
 
+	create-glyph 'dblOverlineAbove' 0x33F : glyph-proc
+		set-width 0
+		include : StdAnchors.impl 'above' 0 2
+
+		local eqsw : Math.min (markFine * 2) ((aboveMarkTop - aboveMarkBot) / 3)
+
+		include : dispiro
+			widths.lhs eqsw
+			flat (0 - Width) aboveMarkBot
+			curl  0          aboveMarkBot
+
+		include : dispiro
+			widths.rhs eqsw
+			flat (0 - Width) aboveMarkTop
+			curl  0          aboveMarkTop
+
 	create-glyph 'sbRsbOverlineAbove' : glyph-proc
 		set-width 0
 		include : StdAnchors.impl 'above' 0 1.5
@@ -607,6 +630,22 @@ glyph-block Mark-Above : begin
 			widths.center markStroke
 			flat (SB      - Width) aboveMarkMid
 			curl (RightSB - Width) aboveMarkMid
+
+	create-glyph 'dblSbRsbOverlineAbove' : glyph-proc
+		set-width 0
+		include : StdAnchors.impl 'above' 0 1.5
+
+		local eqsw : Math.min (markFine * 2) ((aboveMarkTop - aboveMarkBot) / 3)
+
+		include : dispiro
+			widths.lhs eqsw
+			flat (SB      - Width) aboveMarkBot
+			curl (RightSB - Width) aboveMarkBot
+
+		include : dispiro
+			widths.rhs eqsw
+			flat (SB      - Width) aboveMarkTop
+			curl (RightSB - Width) aboveMarkTop
 
 	create-glyph 'cyrl/ghe.SRB/overlineAbove' : glyph-proc
 		local df : DivFrame para.advanceScaleI
@@ -655,29 +694,6 @@ glyph-block Mark-Above : begin
 			widths.center markStroke
 			flat leftEnd  aboveMarkMid [heading Rightward]
 			curl rightEnd aboveMarkMid [heading Rightward]
-
-	create-glyph 'latin1macron' 0xAF : glyph-proc
-		local df : include : DivFrame 1
-		include : dispiro
-			widths.center markStroke
-			flat df.leftSB  aboveMarkMid
-			curl df.rightSB aboveMarkMid
-
-	create-glyph 'dblOverlineAbove' 0x33F : glyph-proc
-		set-width 0
-		include : StdAnchors.impl 'above' 0 2
-
-		local eqsw : Math.min (markFine * 2) ((aboveMarkTop - aboveMarkBot) / 3)
-
-		include : dispiro
-			widths.lhs eqsw
-			flat (0 - Width) aboveMarkBot
-			curl  0          aboveMarkBot
-
-		include : dispiro
-			widths.rhs eqsw
-			flat (0 - Width) aboveMarkTop
-			curl  0          aboveMarkTop
 
 	#### Breve Marks
 	glyph-block-export BreveShape

--- a/packages/font-glyphs/src/marks/below.ptl
+++ b/packages/font-glyphs/src/marks/below.ptl
@@ -96,15 +96,15 @@ glyph-block Mark-Below : begin
 		set-width 0
 		include : StdAnchors.impl 0 1.5
 
-		include : VBar.m (SB      - Width) belowMarkBot belowMarkTop (markFine * 2)
-		include : VBar.m (RightSB - Width) belowMarkBot belowMarkTop (markFine * 2)
+		include : VBar.l (SB      - Width) belowMarkBot belowMarkTop (markFine * 2)
+		include : VBar.r (RightSB - Width) belowMarkBot belowMarkTop (markFine * 2)
 		include : HBar.b (SB - Width) (RightSB - Width) belowMarkBot (markFine * 2)
 
 	create-glyph 'openShelfBelow' : glyph-proc
 		set-width 0
 		include : StdAnchors.impl 0 1.5
 
-		include : VBar.m (SB - Width) belowMarkBot belowMarkTop (markFine * 2)
+		include : VBar.l (SB - Width) belowMarkBot belowMarkTop (markFine * 2)
 		include : HBar.b (SB - Width) (RightSB - Width) belowMarkBot (markFine * 2)
 
 	define [mirrorAnchor gs gt srcCls dstCls] : begin

--- a/packages/font-glyphs/src/space/index.ptl
+++ b/packages/font-glyphs/src/space/index.ptl
@@ -18,13 +18,17 @@ glyph-block Spaces : begin
 
 	alias 'nbsp' 0xA0 'space'
 
-	create-glyph 'markDemoBaseSpace' 0xEF0E : glyph-proc
-		local df : include : DivFrame 1
-		include : df.markSet.plus
-
 	create-glyph 'markBaseSpace' 0xEF0D : glyph-proc
 		local df : include : DivFrame para.advanceScaleSp
 		include : df.markSet.e
+
+	create-glyph 'markBaseSpaceDiv1' : glyph-proc
+		local df : include : DivFrame 1
+		include : df.markSet.e
+
+	create-glyph 'markDemoBaseSpace' 0xEF0E : glyph-proc
+		local df : include : DivFrame 1
+		include : df.markSet.plus
 
 	create-glyph 'sp1' : glyph-proc
 		local df : include : DivFrame 1

--- a/packages/font-glyphs/src/symbol/punctuation/ascii-marks.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/ascii-marks.ptl
@@ -45,7 +45,7 @@ glyph-block Symbol-Punctuation-Ascii-Marks : begin
 
 	WithDotVariants 'dotTilde' 0x2E1E : function [DrawAt kr ov] : composite-proc
 		refer-glyph 'asciiTilde/sMid'
-		DrawAt Middle PlusTop (DotRadius * kr * OperatorStroke / Stroke - ov)
+		DrawAt Middle (PlusTop + AccentClearance) (DotRadius * kr * OperatorStroke / Stroke - ov)
 
 	turned 'tildeDot' 0x2E1F 'dotTilde' Middle SymbolMid
 
@@ -65,8 +65,10 @@ glyph-block Symbol-Punctuation-Ascii-Marks : begin
 		derive-composites 'mdfMidDoubleGrave' 0x2F5 'markBaseSpace' 'doubleGraveAbove' shift
 		derive-composites 'mdfMidDoubleAcute' 0x2F6 'markBaseSpace' 'doubleAcuteAbove' shift
 
-		derive-composites 'mdfShelf'     0x2FD 'markBaseSpace' 'shelfBelow'
-		derive-composites 'mdfOpenShelf' 0x2FE 'markBaseSpace' 'openShelfBelow'
+		derive-composites 'mdfUnaspirated' 0x2ED 'markBaseSpaceDiv1' 'dblSbRsbOverlineAbove'
 
-		derive-composites 'fermata'    0x1D110 'markDemoBaseSpace' 'largeFermataAbove'
-		derive-composites 'lowFermata' 0x1D111 'markDemoBaseSpace' 'largeCandrabinduBelow'
+		derive-composites 'mdfShelf'     0x2FD 'markBaseSpaceDiv1' 'shelfBelow'
+		derive-composites 'mdfOpenShelf' 0x2FE 'markBaseSpaceDiv1' 'openShelfBelow'
+
+		derive-composites 'fermata'    0x1D110 'markBaseSpaceDiv1' 'largeFermataAbove'
+		derive-composites 'lowFermata' 0x1D111 'markBaseSpaceDiv1' 'largeCandrabinduBelow'

--- a/packages/font-glyphs/src/symbol/punctuation/dashes.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/dashes.ptl
@@ -66,9 +66,6 @@ glyph-block Symbol-Punctuation-Dashes : begin
 
 	create-glyph 'figureDash' 0x2012 : HBar.m SB RightSB SymbolMid
 	create-glyph 'overline' 0x203E : HBar.t SB RightSB CAP
-	create-glyph 'mdfUnaspirated' 0x2ED : composite-proc
-		HBar.t SB RightSB  CAP
-		HBar.t SB RightSB (CAP - openBoxGap)
 
 	create-glyph 'enDash' 0x2013 : glyph-proc
 		set-width Width
@@ -84,14 +81,15 @@ glyph-block Symbol-Punctuation-Dashes : begin
 
 		create-glyph [MangleName 'spear'] [MangleUnicode 0x2E43] : glyph-proc
 			set-width emDashWidth
-			local yExt : (RightSB - SB) * 0.55 + HalfStroke
+			local bot : SymbolMid - HalfStroke
+			local top : SymbolMid + (RightSB - SB) * 0.55
 			include : dispiro
 				widths.lhs
-				flat (SB + OX) (SymbolMid - HalfStroke + yExt) [heading Downward]
-				curl (SB + OX) (SymbolMid - HalfStroke + [Math.min SmallArchDepthB : yExt - TINY])
+				flat (SB + OX) top [heading Downward]
+				curl (SB + OX) [Math.min (bot + SmallArchDepthB) (top - TINY)]
 				arcvh
-				flat Middle (SymbolMid - HalfStroke)
-				curl (emDashWidth - SB) (SymbolMid - HalfStroke) [heading Rightward]
+				flat Middle bot
+				curl (emDashWidth - SB) bot [heading Rightward]
 
 	derive-multi-part-glyphs 'hyphenDieresis' 0x2E1A { 'figureDash' 'dieresisAbove'}
 		function [src sel] : composite-proc

--- a/tools/generate-samples/src/templates/char-grid.mjs
+++ b/tools/generate-samples/src/templates/char-grid.mjs
@@ -81,7 +81,7 @@ function CharGrid(args) {
 			contents: [
 				...fontSettings,
 				{ color: char.inFont ? theme.body : theme.dimmed },
-				char.inFont ? (isMark ? "\uE00E" : "") + String.fromCodePoint(char.lch) : "\uF00F",
+				char.inFont ? (isMark ? "\uEF0E" : "") + String.fromCodePoint(char.lch) : "\uF00F",
 			],
 		});
 	}


### PR DESCRIPTION
Make the stroke width match other modifier letters, and also restore its anchor points for diacritics and diacritic stacking.

Also make modifier shelves' advance widths account for their SB-to-RightSB mark widths under Quasi-Proportional.

` [s͇᫫t̪˭᪻ɔ˞] ⟨store⟩, [t͇ʰɔ˞] ⟨tore⟩`

(Ignore the rhotic hook overlapping with open o under heavy, that defect wasn't a result of this PR).

Thin:
<img width="2190" height="465" alt="image" src="https://github.com/user-attachments/assets/13bfdbd6-c097-46a8-957b-15b1d522c19a" />
Regular:
<img width="2177" height="476" alt="image" src="https://github.com/user-attachments/assets/c4e5b9a1-16b9-44ed-a8be-d0366e8a9346" />
Heavy:
<img width="2184" height="488" alt="image" src="https://github.com/user-attachments/assets/c3149692-50e7-413b-938a-c5ae1b7e1b50" />
