### PR TITLE
Cleanup of #2917 and #2919 .

### DIFF
--- a/packages/font-glyphs/src/auto-build/composite.ptl
+++ b/packages/font-glyphs/src/auto-build/composite.ptl
@@ -1332,7 +1332,7 @@ glyph-block AutoBuild-Accented-Equal : begin
 	createAccentedOp 'equal' 8 0.3 0 aboveMarkBot : list
 		list 0x225d {"d" "e" "f"}
 	createAccentedOp 'markDemoBaseSpace' 6 0.40 0 (aboveMarkBot - (CAP * 0.40 - XH * 0.40)) : list
-		list 0xAE    {"R" "combRingCapDiv1"}
+		list 0xAE    {"R" "combRingCap/adwsN"}
 	createAccentedOp 'markDemoBaseSpace' 6 0.45 0 (aboveMarkBot - (CAP * 0.45 - XH * 0.45)) : list
 		list 0x2122  {"T" "M"}
 		list 0x2120  {"S" "M"}
@@ -1464,7 +1464,7 @@ glyph-block Autobuild-Ligatures : begin
 		list 0x1F2 { 'D' 'z' }
 		list 0x1F3 { 'd' 'z' }
 		list 0x478 { 'cyrl/O' 'cyrl/uk/u' }
-		list 0x479 { 'cyrl/uk/o' 'cyrl/uk/u' }
+		list 0x479 { 'cyrl/oNarrow' 'cyrl/uk/u' }
 		list 0x20A7 { 'P' 't' }
 		list 0x20A8 { 'R' 's' }
 		list 0x20AF { 'D' 'grek/rho' }

--- a/packages/font-glyphs/src/letter/latin/lower-a.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-a.ptl
@@ -40,7 +40,7 @@ glyph-block Letter-Latin-Lower-A : begin
 			if ((hookStyle != 1) && (hookStyle != 2)) : throw : new Error "Invalid hookStyle"
 			local sw : fallback _stroke : ADoubleStoreyStroke df
 			include : ADoubleStoreyHookAndBarT dispiro df hookStyle y0 sw
-			if (hookStyle == 2) : include : ArcStartSerif.L df.leftSB (XH - DToothlessRise) sw AHook
+			if (hookStyle == 2) : include : ArcStartSerif.InwardL df.leftSB XH sw AHook
 
 		export : define [HookAndBarMask df hookStyle y0 _stroke] : begin
 			local sw : fallback _stroke : ADoubleStoreyStroke df

--- a/packages/font-glyphs/src/letter/latin/o.ptl
+++ b/packages/font-glyphs/src/letter/latin/o.ptl
@@ -36,11 +36,6 @@ glyph-block Letter-Latin-O : begin
 	alias 'cyrl/O' 0x41E 'O'
 	alias 'cyrl/o' 0x43E 'o'
 
-	create-glyph 'cyrl/uk/o' : glyph-proc
-		local df : include : DivFrame para.advanceScaleF 2
-		include : df.markSet.e
-		include : OShape XH 0 df.leftSB df.rightSB df.mvs df.smallArchDepthA df.smallArchDepthB
-
 	create-glyph 'cyrl/oNarrow' 0x1C82 : glyph-proc
 		local df : include : DivFrame para.advanceScaleF 2
 		include : df.markSet.e

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -592,13 +592,6 @@ glyph-block Mark-Above : begin
 			flat leftEnd  aboveMarkMid
 			curl rightEnd aboveMarkMid
 
-	create-glyph 'latin1macron' 0xAF : glyph-proc
-		local df : include : DivFrame 1
-		include : dispiro
-			widths.center markStroke
-			flat df.leftSB  aboveMarkMid
-			curl df.rightSB aboveMarkMid
-
 	create-glyph 'overlineAbove' 0x305 : glyph-proc
 		set-width 0
 		include : StdAnchors.impl 'above' 0 2

--- a/packages/font-glyphs/src/marks/overlay.ptl
+++ b/packages/font-glyphs/src/marks/overlay.ptl
@@ -171,7 +171,7 @@ glyph-block Mark-Overlay : begin
 				rightEnd  --  (markMiddle + Width / 2 - SB)
 				hs        --  (OverlayStroke / 2)
 
-		create-glyph 'tildeStrikeDivMM' : glyph-proc
+		create-glyph 'tildeStrike/adwsMM' : glyph-proc
 			set-width 0
 			set-mark-anchor 'strike' markMiddle (XH / 2) markMiddle (XH / 2)
 			include : TildeShape

--- a/packages/font-glyphs/src/meta/unicode-knowledge.ptl
+++ b/packages/font-glyphs/src/meta/unicode-knowledge.ptl
@@ -152,7 +152,7 @@ export : define decompOverrides : object
 	0x1D6C { 'b' 'tildeOverOnExension' }
 	0x1D6D { 'd' 'tildeOverOnExension' }
 	0x1D6E { 'f' 'tildeOver' }
-	0x1D6F { 'm' 'tildeStrikeDivMM' }
+	0x1D6F { 'm' 'tildeStrike/adwsMM' }
 	0x1D70 { 'n' 'tildeStrike' }
 	0x1D71 { 'p' 'tildeOverOnExension' }
 	0x1D72 { 'r' 'tildeOver' }

--- a/packages/font-glyphs/src/space/index.ptl
+++ b/packages/font-glyphs/src/space/index.ptl
@@ -22,7 +22,7 @@ glyph-block Spaces : begin
 		local df : include : DivFrame para.advanceScaleSp
 		include : df.markSet.e
 
-	create-glyph 'markBaseSpaceDiv1' : glyph-proc
+	create-glyph 'markBaseSpace/adwsN' : glyph-proc
 		local df : include : DivFrame 1
 		include : df.markSet.e
 

--- a/packages/font-glyphs/src/symbol/enclosure.ptl
+++ b/packages/font-glyphs/src/symbol/enclosure.ptl
@@ -8,9 +8,10 @@ glyph-module
 glyph-block Symbol-Combining-Enclosure : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
+	glyph-block-import Mark-Shared-Metrics : markMiddle 
 
-	create-glyph 'combRingCapDiv1' : glyph-proc
+	create-glyph 'combRingCap/adwsN' : glyph-proc
 		set-width 0
-		define innerRad : CAP / 2 + CAP / 8
-		include : RingStrokeAt (-Width / 2) (CAP / 2) (innerRad + Stroke) Stroke
+		define innerRad : CAP * (5 / 8)
+		include : RingStrokeAt markMiddle (CAP / 2) (innerRad + Stroke) Stroke
 

--- a/packages/font-glyphs/src/symbol/mosaic/notdef.ptl
+++ b/packages/font-glyphs/src/symbol/mosaic/notdef.ptl
@@ -18,3 +18,6 @@ glyph-block Symbol-Mosaic-NotDef : begin
 				Rect CAP 0 SB RightSB
 				Rect (CAP - sw) (0 + sw) (SB + sw) (RightSB - sw)
 		set currentGlyph.glyphRank   (9999)
+
+	create-glyph '.notdefCloneE000' 0xF00F : glyph-proc
+		include [refer-glyph '.notdef'] AS_BASE ALSO_METRICS

--- a/packages/font-glyphs/src/symbol/punctuation/ascii-marks.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/ascii-marks.ptl
@@ -45,7 +45,7 @@ glyph-block Symbol-Punctuation-Ascii-Marks : begin
 
 	WithDotVariants 'dotTilde' 0x2E1E : function [DrawAt kr ov] : composite-proc
 		refer-glyph 'asciiTilde/sMid'
-		DrawAt Middle (PlusTop + AccentClearance) (DotRadius * kr * OperatorStroke / Stroke - ov)
+		DrawAt Middle (PlusTop + AccentClearance) (DotRadius * kr * (OperatorStroke / Stroke) - ov)
 
 	turned 'tildeDot' 0x2E1F 'dotTilde' Middle SymbolMid
 
@@ -65,10 +65,11 @@ glyph-block Symbol-Punctuation-Ascii-Marks : begin
 		derive-composites 'mdfMidDoubleGrave' 0x2F5 'markBaseSpace' 'doubleGraveAbove' shift
 		derive-composites 'mdfMidDoubleAcute' 0x2F6 'markBaseSpace' 'doubleAcuteAbove' shift
 
-		derive-composites 'mdfUnaspirated' 0x2ED 'markBaseSpaceDiv1' 'dblSbRsbOverlineAbove'
+		derive-composites 'latin1macron'   0xAF  'markBaseSpace/adwsN' 'sbRsbOverlineAbove'
+		derive-composites 'mdfUnaspirated' 0x2ED 'markBaseSpace/adwsN' 'dblSbRsbOverlineAbove'
 
-		derive-composites 'mdfShelf'     0x2FD 'markBaseSpaceDiv1' 'shelfBelow'
-		derive-composites 'mdfOpenShelf' 0x2FE 'markBaseSpaceDiv1' 'openShelfBelow'
+		derive-composites 'mdfShelf'     0x2FD 'markBaseSpace/adwsN' 'shelfBelow'
+		derive-composites 'mdfOpenShelf' 0x2FE 'markBaseSpace/adwsN' 'openShelfBelow'
 
-		derive-composites 'fermata'    0x1D110 'markBaseSpaceDiv1' 'largeFermataAbove'
-		derive-composites 'lowFermata' 0x1D111 'markBaseSpaceDiv1' 'largeCandrabinduBelow'
+		derive-composites 'fermata'    0x1D110 'markBaseSpace/adwsN' 'largeFermataAbove'
+		derive-composites 'lowFermata' 0x1D111 'markBaseSpace/adwsN' 'largeCandrabinduBelow'

--- a/tools/generate-samples/src/templates/char-grid.mjs
+++ b/tools/generate-samples/src/templates/char-grid.mjs
@@ -55,7 +55,7 @@ function CharGrid(args) {
 			});
 		}
 
-		const isMark = char.inFont && gcMap.get(char.lch) === "Nonspacing_Mark";
+		const isMark = char.inFont && (gcMap.get(char.lch) === "Nonspacing_Mark" || gcMap.get(char.lch) === "Enclosing_Mark");
 		const dimensions = {
 			"horizontal-align": "center",
 			"vertical-align": "center",


### PR DESCRIPTION
Some renames/rerouts of some marks/sub-glyphs that I previously neglected to update to more recent conventions during the PR's mentioned in the header.

Also fix hook-serif of `a` clashing with bowl under heavy.

Also use `cyrl/oNarrow` for Cyrillic Lower Digraph Uk (`ѹ`) which I was too cowardice to do during #2902 but after further testing appears to both look and work fine and not break anything (completely unchanged under Quasi-Proportional).