### PR TITLE
Fix character mapping for: `U+2916`, `U+2B3B`, `U+2905` and `U+2B36`.

### DIFF
--- a/changes/33.3.4.md
+++ b/changes/33.3.4.md
@@ -6,3 +6,4 @@
   - MODIFIER LETTER LEFT TACK (`U+AB6A`).
   - MODIFIER LETTER RIGHT TACK (`U+AB6B`).
 * Refine serifs of Cyrillic Lower Dwe (`U+A681`) under italics.
+* Fix character mapping for: `U+2916`, `U+2B3B`, `U+2905` and `U+2B36`.

--- a/packages/font-glyphs/src/symbol/arrow/simple.ptl
+++ b/packages/font-glyphs/src/symbol/arrow/simple.ptl
@@ -175,8 +175,8 @@ glyph-block Symbol-Arrow-Simple : for-width-kinds WideWidth1
 	MkArrow.double BarToBarShape Arrow.lhsShape [MangleName 'barArrowUpHL']    [MangleUnicode 0x2960] arrowMidX arrowBot arrowMidX arrowTop
 	MkArrow.double BarToBarShape Arrow.rhsShape [MangleName 'barArrowDownHR']  [MangleUnicode 0x2961] arrowMidX arrowTop arrowMidX arrowBot
 
-	[MkArrow.doubleAnchorAt 0.2] BarToBarShape Arrow.dblShape [MangleName 'barDhArrowLeft']  [MangleUnicode 0x2905] arrowRSB SymbolMid arrowSB SymbolMid
-	[MkArrow.doubleAnchorAt 0.2] BarToBarShape Arrow.dblShape [MangleName 'barDhArrowRight'] [MangleUnicode 0x2B36] arrowSB SymbolMid arrowRSB SymbolMid
+	[MkArrow.doubleAnchorAt 0.2] BarToBarShape Arrow.dblShape [MangleName 'barDhArrowLeft']  [MangleUnicode 0x2B36] arrowRSB SymbolMid arrowSB SymbolMid
+	[MkArrow.doubleAnchorAt 0.2] BarToBarShape Arrow.dblShape [MangleName 'barDhArrowRight'] [MangleUnicode 0x2905] arrowSB SymbolMid arrowRSB SymbolMid
 
 	MkArrow.double DoubleBarToBarShape DoubleBarArrowShape [MangleName 'barDblArrowLeft']  [MangleUnicode 0x2906] arrowRSB SymbolMid arrowSB SymbolMid
 	MkArrow.double DoubleBarToBarShape DoubleBarArrowShape [MangleName 'barDblArrowRight'] [MangleUnicode 0x2907] arrowSB SymbolMid arrowRSB SymbolMid
@@ -184,8 +184,8 @@ glyph-block Symbol-Arrow-Simple : for-width-kinds WideWidth1
 	[MkArrow.doubleAnchorAt htAnchorP 0.5] Arrow.tailShape Arrow.shape [MangleName 'htArrowLeft'] [MangleUnicode 0x21A2] arrowRSB SymbolMid arrowSB SymbolMid
 	[MkArrow.doubleAnchorAt htAnchorP 0.5] Arrow.tailShape Arrow.shape [MangleName 'htArrowRight'] [MangleUnicode 0x21A3] arrowSB SymbolMid arrowRSB SymbolMid
 
-	[MkArrow.doubleAnchorAt dhtAnchorP 0.4] Arrow.tailShape Arrow.dblShape [MangleName 'dhtArrowLeft']  [MangleUnicode 0x2916] arrowRSB SymbolMid arrowSB SymbolMid
-	[MkArrow.doubleAnchorAt dhtAnchorP 0.4] Arrow.tailShape Arrow.dblShape [MangleName 'dhtArrowRight'] [MangleUnicode 0x2B3B] arrowSB SymbolMid arrowRSB SymbolMid
+	[MkArrow.doubleAnchorAt dhtAnchorP 0.4] Arrow.tailShape Arrow.dblShape [MangleName 'dhtArrowLeft']  [MangleUnicode 0x2B3B] arrowRSB SymbolMid arrowSB SymbolMid
+	[MkArrow.doubleAnchorAt dhtAnchorP 0.4] Arrow.tailShape Arrow.dblShape [MangleName 'dhtArrowRight'] [MangleUnicode 0x2916] arrowSB SymbolMid arrowRSB SymbolMid
 
 	# Arrow to Bar/Diamond
 	define ArrowToBarShape : Arrow.toBarShapeT Arrow.shape


### PR DESCRIPTION
#2932
