### PR TITLE
Move `[AdviceGlottalStopArchDepth]` from `meta/aesthetics.ptl` to `letter/latin-ext/glottal-stop.ptl`.

### DIFF
--- a/packages/font-glyphs/src/letter/latin-ext/glottal-stop.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/glottal-stop.ptl
@@ -11,13 +11,18 @@ glyph-block Letter-Latin-Glottal-Stop : begin
 	glyph-block-import Letter-Shared : CreateTurnedLetter
 	glyph-block-import Letter-Shared-Shapes : LetterBarOverlay CurlyTail
 
+	glyph-block-export AdviceGlottalStopArchDepth
+	define [AdviceGlottalStopArchDepth top sign] : begin
+		return : top * 0.24 + Stroke * 0.385 + sign * TanSlope * SmoothAdjust
+
 	create-glyph 'glottalStop' 0x294 : glyph-proc
 		include : MarkSet.b
+		local adb : AdviceGlottalStopArchDepth Ascender (+1)
 		include : dispiro
 			widths.rhs
-			g4 SB (Ascender - Hook)
+			g4 SB      (Ascender - Hook)
 			hookstart Ascender
-			g4 RightSB (Ascender - [AdviceGlottalStopArchDepth Ascender (+1)])
+			g4 RightSB (Ascender - adb)
 			alsoThru.g2 0.5 0.5 important
 			flat (Middle + [HSwToV HalfStroke]) (XH * 0.3)
 			curl (Middle + [HSwToV HalfStroke]) 0 [heading Downward]
@@ -26,11 +31,12 @@ glyph-block Letter-Latin-Glottal-Stop : begin
 
 	create-glyph 'revGlottalStop' 0x295 : glyph-proc
 		include : MarkSet.b
+		local ada : AdviceGlottalStopArchDepth Ascender (-1)
 		include : dispiro
 			widths.lhs
 			g4 RightSB (Ascender - Hook)
 			hookstart Ascender
-			g4 SB (Ascender - [AdviceGlottalStopArchDepth Ascender (-1)])
+			g4 SB      (Ascender - ada)
 			alsoThru.g2 0.5 0.5 important
 			flat (Middle - [HSwToV HalfStroke]) (XH * 0.3)
 			curl (Middle - [HSwToV HalfStroke]) 0 [heading Downward]
@@ -39,11 +45,12 @@ glyph-block Letter-Latin-Glottal-Stop : begin
 
 	create-glyph 'capGlottalStop' 0x241 : glyph-proc
 		include : MarkSet.capital
+		local adb : AdviceGlottalStopArchDepth CAP (+1)
 		include : dispiro
 			widths.rhs
-			g4 SB (CAP - Hook)
+			g4 SB      (CAP - Hook)
 			hookstart CAP
-			g4 RightSB (CAP - [AdviceGlottalStopArchDepth CAP (+1)])
+			g4 RightSB (CAP - adb)
 			alsoThru.g2 0.5 0.5 important
 			flat (Middle + [HSwToV HalfStroke]) (XH * 0.3)
 			curl (Middle + [HSwToV HalfStroke]) 0 [heading Downward]
@@ -52,11 +59,12 @@ glyph-block Letter-Latin-Glottal-Stop : begin
 
 	create-glyph 'revCapGlottalStop' 0xA7CE : glyph-proc
 		include : MarkSet.capital
+		local ada : AdviceGlottalStopArchDepth CAP (-1)
 		include : dispiro
 			widths.lhs
 			g4 RightSB (CAP - Hook)
 			hookstart CAP
-			g4 SB (CAP - [AdviceGlottalStopArchDepth CAP (-1)])
+			g4 SB      (CAP - ada)
 			alsoThru.g2 0.5 0.5 important
 			flat (Middle - [HSwToV HalfStroke]) (XH * 0.3)
 			curl (Middle - [HSwToV HalfStroke]) 0 [heading Downward]
@@ -65,11 +73,12 @@ glyph-block Letter-Latin-Glottal-Stop : begin
 
 	create-glyph 'smallGlottalStop' 0x242 : glyph-proc
 		include : MarkSet.e
+		local adb : AdviceGlottalStopArchDepth XH (+1)
 		include : dispiro
 			widths.rhs
-			g4 SB (XH - Hook)
+			g4 SB      (XH - Hook)
 			hookstart XH
-			g4 RightSB (XH - [AdviceGlottalStopArchDepth XH (+1)])
+			g4 RightSB (XH - adb)
 			alsoThru.g2 0.5 0.5 important
 			flat (Middle + [HSwToV HalfStroke]) (XH * 0.15)
 			curl (Middle + [HSwToV HalfStroke]) 0 [heading Downward]
@@ -78,11 +87,12 @@ glyph-block Letter-Latin-Glottal-Stop : begin
 
 	create-glyph 'revSmallGlottalStop' 0xA7CF : glyph-proc
 		include : MarkSet.e
+		local ada : AdviceGlottalStopArchDepth XH (-1)
 		include : dispiro
 			widths.lhs
 			g4 RightSB (XH - Hook)
 			hookstart XH
-			g4 SB (XH - [AdviceGlottalStopArchDepth XH (-1)])
+			g4 SB      (XH - ada)
 			alsoThru.g2 0.5 0.5 important
 			flat (Middle - [HSwToV HalfStroke]) (XH * 0.15)
 			curl (Middle - [HSwToV HalfStroke]) 0 [heading Downward]
@@ -93,21 +103,16 @@ glyph-block Letter-Latin-Glottal-Stop : begin
 
 	create-glyph 'invGlottalStopCurlyTail' 0x1DF0E : glyph-proc
 		include : MarkSet.b
-
-		local yMid : AdviceGlottalStopArchDepth Ascender (+1)
-		local fine : AdviceStroke 3.5
-
+		local ada : AdviceGlottalStopArchDepth Ascender (-1)
 		include : dispiro
 			widths.rhs
 			flat (Middle + [HSwToV HalfStroke]) Ascender [heading Downward]
 			curl (Middle + [HSwToV HalfStroke]) (Ascender - XH * 0.3)
 			alsoThru.g2 0.5 0.5 important
-			g4 RightSB yMid
-			CurlyTail.n fine 0 SB RightSB 0 yMid
-
+			g4 RightSB (0 + ada)
+			CurlyTail.n [AdviceStroke 3.5] 0 SB RightSB 0 (0 + ada)
 		if SLAB : begin
 			include : HSerif.mt Middle Ascender MidJutCenter
-
 
 	create-glyph 'glottalStopBar' 0x2A1 : glyph-proc
 		include [refer-glyph 'glottalStop'] AS_BASE

--- a/packages/font-glyphs/src/meta/aesthetics.ptl
+++ b/packages/font-glyphs/src/meta/aesthetics.ptl
@@ -202,9 +202,6 @@ export : define [calculateMetrics para] : begin
 		local kAdj : [fallback _swRef Stroke] / [AdviceStroke 6]
 		return : kMul * kAdj * [AdviceStroke kw]
 
-	define [AdviceGlottalStopArchDepth y sign] : begin
-		return : y * 0.24 + Stroke * 0.385 + sign * TanSlope * SmoothAdjust
-
 	define VERY-FAR : UPM * 16
 	define TINY     :  1 / 128
 
@@ -220,10 +217,10 @@ export : define [calculateMetrics para] : begin
 		WideWidth2 WideWidth3 WideWidth4 EssUpper EssLower EssQuestion RightSB Middle DotRadius
 		PeriodRadius ArchDepthA ArchDepthB SmallArchDepthA SmallArchDepthB CorrectionOMidX
 		CorrectionOMidS compositeBaseAnchors AdviceStroke AdviceStroke2 AdviceStrokeInSpace
-		OverlayStroke OperatorStroke GeometryStroke UnicodeWeightGrade AdviceGlottalStopArchDepth
-		StrokeWidthBlend ArchDepthAOf ArchDepthBOf SmoothAdjust SideJut MidJutSide MidJutCenter
-		YSmoothMidR YSmoothMidL DToothlessRise DMBlend ShoulderFine DefaultTightBendInnerRadius
-		HSwToV VSwToH NarrowUnicodeT WideUnicodeT VERY-FAR TINY]
+		OverlayStroke OperatorStroke GeometryStroke UnicodeWeightGrade StrokeWidthBlend ArchDepthAOf
+		ArchDepthBOf SmoothAdjust SideJut MidJutSide MidJutCenter YSmoothMidR YSmoothMidL
+		DToothlessRise DMBlend ShoulderFine DefaultTightBendInnerRadius HSwToV VSwToH NarrowUnicodeT
+		WideUnicodeT VERY-FAR TINY]
 
 export : define [setFontMetrics para metrics fm] : begin
 	define [object CAP Descender XH Width SymbolMid] metrics

--- a/packages/font-glyphs/src/meta/macros.ptl
+++ b/packages/font-glyphs/src/meta/macros.ptl
@@ -387,10 +387,10 @@ define-macro glyph-block : syntax-rules
 			WideWidth3 WideWidth4 EssUpper EssLower EssQuestion RightSB Middle DotRadius
 			PeriodRadius ArchDepthA ArchDepthB SmallArchDepthA SmallArchDepthB CorrectionOMidX
 			CorrectionOMidS compositeBaseAnchors AdviceStroke AdviceStroke2 AdviceStrokeInSpace
-			OverlayStroke OperatorStroke GeometryStroke UnicodeWeightGrade AdviceGlottalStopArchDepth
-			StrokeWidthBlend ArchDepthAOf ArchDepthBOf SmoothAdjust SideJut MidJutSide MidJutCenter
-			YSmoothMidR YSmoothMidL DToothlessRise DMBlend ShoulderFine DefaultTightBendInnerRadius
-			HSwToV VSwToH NarrowUnicodeT WideUnicodeT VERY-FAR TINY]
+			OverlayStroke OperatorStroke GeometryStroke UnicodeWeightGrade StrokeWidthBlend
+			ArchDepthAOf ArchDepthBOf SmoothAdjust SideJut MidJutSide MidJutCenter YSmoothMidR
+			YSmoothMidL DToothlessRise DMBlend ShoulderFine DefaultTightBendInnerRadius HSwToV
+			VSwToH NarrowUnicodeT WideUnicodeT VERY-FAR TINY]
 
 		define spiroFnImports `[g4 g2 corner flat curl virt close end straight g2c cg2 flatc ccurl
 			widths disable-contrast heading unimportant important alsoThru alsoThruThem bezControls

--- a/packages/font-glyphs/src/number/2.ptl
+++ b/packages/font-glyphs/src/number/2.ptl
@@ -9,9 +9,10 @@ glyph-block Digits-Two : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Digits-Shared : OnumHeight OnumMarks CodeLnum CodeOnum
+	glyph-block-import Letter-Latin-Glottal-Stop : AdviceGlottalStopArchDepth
 
 	define [TwoStraightNeckArcT sink offset sw top] : begin
-		define archDepth : [AdviceGlottalStopArchDepth top 1] * 0.95
+		define archDepth : [AdviceGlottalStopArchDepth top (+1)] * 0.95
 		define xLB : SB + offset
 		define xR : RightSB - OX / 2
 		define yPhRight : top - archDepth * 1.5 - sw / 2 * (top / CAP - TanSlope)
@@ -25,7 +26,7 @@ glyph-block Digits-Two : begin
 			curl xLB sw [widths.lhs sw]
 
 	define [TwoArcShapeT sink offsetU offsetD sw top] : begin
-		define archDepth : [AdviceGlottalStopArchDepth top 1] * 0.95
+		define archDepth : [AdviceGlottalStopArchDepth top (+1)] * 0.95
 		return : sink
 			widths.rhs sw
 			g4 (SB - offsetU) (top - Hook)


### PR DESCRIPTION
This function is only ever used by Glottal Stop itself and Digit 2 (`2`).

Since Digit 3 (`3`) derives one of its shape variants based on Latin Ezh (`Ʒ`, `ʒ`), a letter that's also defined in `letter/latin-ext/`, I think it's fine if Digit 2 imports its arch depth function directly from `letter/latin-ext/glottal-stop.ptl`.

This is also consistent with certain mathematical characters importing arch depth values for Latin S (`S`, `s`) directly from `letter/latin/s.ptl`.

Also fix `sign` argument for arch depth of Glottal Stop with Curl (`𝼎`), which was backwards before. This defect is made more clear in the code when going through and labeling each instantiation of the function as either `local ada` or `local adb` for each character individually.