### PR TITLE
Add all modified chars to APL variant

### DIFF
--- a/params/variants.toml
+++ b/params/variants.toml
@@ -9266,7 +9266,7 @@ snapshotFeatureApplication = { 'onum' = 1 }
 # This is a special variant selector that controls APL form
 [prime.apl-form]
 isSpecial = true
-hotChars = "∆∇∊○←→↑↓"
+hotChars = "∆∇∊○←→↑↓↕↖↙⥊⇐↩⎉⌜⎊◶⚇◇□△▽◿◹↘⤚⤙↥↧⌵↻⇡◌⬚☇↬↫⋯⌕◫↯⇌⌝⎋◠◡◰◳◴⚂"
 description = "APL form"
 
 [prime.apl-form.variants.none]


### PR DESCRIPTION
At this point, there are quite a few APL (and related languages) chars that have been adjusted, but `variant.toml` (and thus also the generated before/after pictures) only contains the initial set. 

(I think I did that right? If I read the makefile correctly, this should cause the SVGs that are generate with every release to be updated with these symbols)