### PR TITLE
Add {`straight`|`rounded`}`-vertical-sides-almost-flat-top` variants for `W`/`w` (`cv23`, `cv32`) for more consistent slab variants.

### DIFF
--- a/changes/33.4.0.md
+++ b/changes/33.4.0.md
@@ -1,0 +1,1 @@
+* Add `straight-vertical-sides-almost-flat-top` and `rounded-vertical-sides-almost-flat-top` variants for `W` and `w`.

--- a/packages/font-glyphs/src/letter/latin/w.ptl
+++ b/packages/font-glyphs/src/letter/latin/w.ptl
@@ -387,8 +387,10 @@ glyph-block Letter-Latin-W : begin
 			straightAlmostFlatTop              { WShapeImpl   WHookRightShape   FORM-STRAIGHT   MIDH-ALMOST-TOP para.advanceScaleMM para.advanceScaleM  }
 			straightFlatTop                    { WShapeImpl   WHookRightShape   FORM-STRAIGHT   MIDH-TOP        para.advanceScaleMM para.advanceScaleM  }
 			straightVerticalSides              { WVertSides   WVSHookRightShape FORM-VERTICAL   MIDH-OTHER      para.advanceScaleM  para.advanceScaleT  }
+			straightVerticalSidesAlmostFlatTop { WVertSides   WVSHookRightShape FORM-VERTICAL   MIDH-ALMOST-TOP para.advanceScaleM  para.advanceScaleT  }
 			straightVerticalSidesFlatTop       { WVertSides   WVSHookRightShape FORM-VERTICAL   MIDH-TOP        para.advanceScaleM  para.advanceScaleT  }
 			roundedVerticalSides               { WRounded     WHookRightRounded FORM-CURLY      MIDH-OTHER      para.advanceScaleMM para.advanceScaleMM }
+			roundedVerticalSidesAlmostFlatTop  { WRounded     WHookRightRounded FORM-CURLY      MIDH-ALMOST-TOP para.advanceScaleMM para.advanceScaleMM }
 			roundedVerticalSidesFlatTop        { WRounded     WHookRightRounded FORM-CURLY      MIDH-TOP        para.advanceScaleMM para.advanceScaleMM }
 			curly                              { WShapeImpl   WHookRightShape   FORM-CURLY      MIDH-OTHER      para.advanceScaleM  para.advanceScaleM  }
 			curlyAlmostFlatTop                 { WShapeImpl   WHookRightShape   FORM-CURLY      MIDH-ALMOST-TOP para.advanceScaleMM para.advanceScaleM  }

--- a/packages/font-glyphs/src/meta/aesthetics.ptl
+++ b/packages/font-glyphs/src/meta/aesthetics.ptl
@@ -221,7 +221,7 @@ export : define [calculateMetrics para] : begin
 		CorrectionOMidS compositeBaseAnchors AdviceStroke AdviceStroke2 AdviceStrokeInSpace
 		OverlayStroke OperatorStroke GeometryStroke UnicodeWeightGrade StrokeWidthBlend ArchDepthAOf
 		ArchDepthBOf ArchDepthAClamped ArchDepthBClamped SmoothAdjust SideJut MidJutSide MidJutCenter
-		YSmoothMidR YSmoothMidL	DToothlessRise DMBlend ShoulderFine DefaultTightBendInnerRadius
+		YSmoothMidR YSmoothMidL DToothlessRise DMBlend ShoulderFine DefaultTightBendInnerRadius
 		HSwToV VSwToH NarrowUnicodeT WideUnicodeT VERY-FAR TINY]
 
 export : define [setFontMetrics para metrics fm] : begin

--- a/packages/font-glyphs/src/meta/macros.ptl
+++ b/packages/font-glyphs/src/meta/macros.ptl
@@ -389,7 +389,7 @@ define-macro glyph-block : syntax-rules
 			CorrectionOMidS compositeBaseAnchors AdviceStroke AdviceStroke2 AdviceStrokeInSpace
 			OverlayStroke OperatorStroke GeometryStroke UnicodeWeightGrade StrokeWidthBlend
 			ArchDepthAOf ArchDepthBOf ArchDepthAClamped ArchDepthBClamped SmoothAdjust SideJut
-			MidJutSide MidJutCenter YSmoothMidR	YSmoothMidL DToothlessRise DMBlend ShoulderFine
+			MidJutSide MidJutCenter YSmoothMidR YSmoothMidL DToothlessRise DMBlend ShoulderFine
 			DefaultTightBendInnerRadius HSwToV VSwToH NarrowUnicodeT WideUnicodeT VERY-FAR TINY]
 
 		define spiroFnImports `[g4 g2 corner flat curl virt close end straight g2c cg2 flatc ccurl

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1874,8 +1874,17 @@ selectorAffix.W = "straightVerticalSides"
 selectorAffix."W/sansSerif" = "straightVerticalSides"
 selectorAffix.WHookRight = "straightVerticalSides"
 
-[prime.capital-w.variants-buildup.stages.body.straight-vertical-sides-flat-top]
+[prime.capital-w.variants-buildup.stages.body.straight-vertical-sides-almost-flat-top]
 rank = 7
+groupRank = 3
+nonBreakingVariantAdditionPriority = 200
+descriptionAffix = "straight body shape with vertical sides, and a middle stem aligned to the top"
+selectorAffix.W = "straightVerticalSidesAlmostFlatTop"
+selectorAffix."W/sansSerif" = "straightVerticalSidesFlatTop"
+selectorAffix.WHookRight = "straightVerticalSidesAlmostFlatTop"
+
+[prime.capital-w.variants-buildup.stages.body.straight-vertical-sides-flat-top]
+rank = 8
 groupRank = 3
 nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "straight body shape with vertical sides, and a middle stem aligned to the top"
@@ -1884,15 +1893,24 @@ selectorAffix."W/sansSerif" = "straightVerticalSidesFlatTop"
 selectorAffix.WHookRight = "straightVerticalSidesFlatTop"
 
 [prime.capital-w.variants-buildup.stages.body.rounded-vertical-sides]
-rank = 8
+rank = 9
 groupRank = 3
 descriptionAffix = "rounded body shape with vertical sides"
 selectorAffix.W = "roundedVerticalSides"
 selectorAffix."W/sansSerif" = "roundedVerticalSides"
 selectorAffix.WHookRight = "roundedVerticalSides"
 
+[prime.capital-w.variants-buildup.stages.body.rounded-vertical-sides-almost-flat-top]
+rank = 10
+groupRank = 3
+nonBreakingVariantAdditionPriority = 200
+descriptionAffix = "rounded body shape with vertical sides, and a middle stem almost aligned to the top"
+selectorAffix.W = "roundedVerticalSidesAlmostFlatTop"
+selectorAffix."W/sansSerif" = "roundedVerticalSidesFlatTop"
+selectorAffix.WHookRight = "roundedVerticalSidesAlmostFlatTop"
+
 [prime.capital-w.variants-buildup.stages.body.rounded-vertical-sides-flat-top]
-rank = 9
+rank = 11
 groupRank = 3
 nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "rounded body shape with vertical sides, and a middle stem aligned to the top"
@@ -1901,7 +1919,7 @@ selectorAffix."W/sansSerif" = "roundedVerticalSidesFlatTop"
 selectorAffix.WHookRight = "roundedVerticalSidesFlatTop"
 
 [prime.capital-w.variants-buildup.stages.body.curly]
-rank = 10
+rank = 12
 groupRank = 3
 descriptionAffix = "curly body"
 selectorAffix.W = "curly"
@@ -1909,7 +1927,7 @@ selectorAffix."W/sansSerif" = "curly"
 selectorAffix.WHookRight = "curly"
 
 [prime.capital-w.variants-buildup.stages.body.curly-almost-flat-top]
-rank = 11
+rank = 13
 groupRank = 3
 nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "curly body with a middle stem almost aligned to the top"
@@ -1918,7 +1936,7 @@ selectorAffix."W/sansSerif" = "curlyFlatTop"
 selectorAffix.WHookRight = "curlyAlmostFlatTop"
 
 [prime.capital-w.variants-buildup.stages.body.curly-flat-top]
-rank = 12
+rank = 14
 groupRank = 3
 nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "curly body with a middle stem aligned to the top"
@@ -4887,8 +4905,17 @@ selectorAffix.w = "straightVerticalSides"
 selectorAffix."w/sansSerif" = "straightVerticalSides"
 selectorAffix.wHookRight = "straightVerticalSides"
 
-[prime.w.variants-buildup.stages.body.straight-vertical-sides-flat-top]
+[prime.w.variants-buildup.stages.body.straight-vertical-sides-almost-flat-top]
 rank = 7
+groupRank = 3
+nonBreakingVariantAdditionPriority = 200
+descriptionAffix = "straight body shape with vertical sides, and a middle stem almost aligned to the top"
+selectorAffix.w = "straightVerticalSidesAlmostFlatTop"
+selectorAffix."w/sansSerif" = "straightVerticalSidesFlatTop"
+selectorAffix.wHookRight = "straightVerticalSidesAlmostFlatTop"
+
+[prime.w.variants-buildup.stages.body.straight-vertical-sides-flat-top]
+rank = 8
 groupRank = 3
 nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "straight body shape with vertical sides, and a middle stem aligned to the top"
@@ -4897,15 +4924,24 @@ selectorAffix."w/sansSerif" = "straightVerticalSidesFlatTop"
 selectorAffix.wHookRight = "straightVerticalSidesFlatTop"
 
 [prime.w.variants-buildup.stages.body.rounded-vertical-sides]
-rank = 8
+rank = 9
 groupRank = 3
 descriptionAffix = "rounded body shape with vertical sides"
 selectorAffix.w = "roundedVerticalSides"
 selectorAffix."w/sansSerif" = "roundedVerticalSides"
 selectorAffix.wHookRight = "roundedVerticalSides"
 
+[prime.w.variants-buildup.stages.body.rounded-vertical-sides-almost-flat-top]
+rank = 10
+groupRank = 3
+nonBreakingVariantAdditionPriority = 200
+descriptionAffix = "rounded body shape with vertical sides, and a middle stem almost aligned to the top"
+selectorAffix.w = "roundedVerticalSidesAlmostFlatTop"
+selectorAffix."w/sansSerif" = "roundedVerticalSidesFlatTop"
+selectorAffix.wHookRight = "roundedVerticalSidesAlmostFlatTop"
+
 [prime.w.variants-buildup.stages.body.rounded-vertical-sides-flat-top]
-rank = 9
+rank = 11
 groupRank = 3
 nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "rounded body shape with vertical sides, and a middle stem aligned to the top"
@@ -4914,7 +4950,7 @@ selectorAffix."w/sansSerif" = "roundedVerticalSidesFlatTop"
 selectorAffix.wHookRight = "roundedVerticalSidesFlatTop"
 
 [prime.w.variants-buildup.stages.body.curly]
-rank = 10
+rank = 12
 groupRank = 3
 descriptionAffix = "curly body"
 selectorAffix.w = "curly"
@@ -4922,7 +4958,7 @@ selectorAffix."w/sansSerif" = "curly"
 selectorAffix.wHookRight = "curly"
 
 [prime.w.variants-buildup.stages.body.curly-almost-flat-top]
-rank = 11
+rank = 13
 groupRank = 3
 nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "curly body with a middle stem almost aligned to the top"
@@ -4931,7 +4967,7 @@ selectorAffix."w/sansSerif" = "curlyFlatTop"
 selectorAffix.wHookRight = "curlyAlmostFlatTop"
 
 [prime.w.variants-buildup.stages.body.curly-flat-top]
-rank = 12
+rank = 14
 groupRank = 3
 nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "curly body with a middle stem aligned to the top"
@@ -4940,7 +4976,7 @@ selectorAffix."w/sansSerif" = "curlyFlatTop"
 selectorAffix.wHookRight = "curlyFlatTop"
 
 [prime.w.variants-buildup.stages.body.cursive]
-rank = 13
+rank = 15
 groupRank = 4
 descriptionAffix = "cursive shape"
 selectorAffix.w = "cursive"


### PR DESCRIPTION
This completes the applicable `almost-flat-top` variants, permitting full-length serifs for `straight-vertical-sides` and `rounded-vertical-sides` variants under slab.

I have no further plans to add any more variants for `W`/`w`.

Shown below is a series of stylistic variations of `ss10`, under both monospace and quasi-proportional, for demonstration.

```
ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ
abc.def.ghi.jkl.mno.pqrs.tuv.wxyz
THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG.
The quick brown fox jumps over the lazy dog.
```

-----

Sans for comparison (using existing variants):

Sans Monospace Thin under `'ss10','cv23'4,'cv32'25,'cv57'30;`:
<img width="2066" height="505" alt="image" src="https://github.com/user-attachments/assets/60f7d8a2-6623-42d3-9273-a375f993914a" />
Sans Monospace Regular under `'ss10','cv23'4,'cv32'25,'cv57'30;`:
<img width="2069" height="464" alt="image" src="https://github.com/user-attachments/assets/97594530-bba6-418e-b6f6-1ab2ba7a5ad7" />
Sans Monospace Heavy under `'ss10','cv23'4,'cv32'25,'cv57'30;`:
<img width="2068" height="471" alt="image" src="https://github.com/user-attachments/assets/a199db9e-06f1-4ace-935b-28bcdc29d866" />
Aile thin under `'ss10','cv23'4,'cv32'25,'cv57'30;`:
<img width="2307" height="495" alt="image" src="https://github.com/user-attachments/assets/4a8c91e8-43ec-42b0-8cf2-7fab1f17b020" />
Aile Regular under `'ss10','cv23'4,'cv32'25,'cv57'30;`:
<img width="2308" height="465" alt="image" src="https://github.com/user-attachments/assets/823701c8-4e51-43d2-a45b-438362f4ecc5" />
Aile Heavy under `'ss10','cv23'4,'cv32'25,'cv57'30;`:
<img width="2312" height="467" alt="image" src="https://github.com/user-attachments/assets/830eea8e-8eed-4756-a89e-423ea61f21cf" />

-----

Compared to Slab (using new variants):

Slab Monospace Thin under `'ss10','cv23'6,'cv32'39,'cv57'44`:
<img width="2063" height="471" alt="image" src="https://github.com/user-attachments/assets/9377131b-783a-4b84-a516-1800c7c40e48" />
Slab Monospace Regular under `'ss10','cv23'6,'cv32'39,'cv57'44`:
<img width="2064" height="474" alt="image" src="https://github.com/user-attachments/assets/909e38a1-2e9a-4c74-be32-024708edae2d" />
Slab Monospace Heavy under `'ss10','cv23'6,'cv32'39,'cv57'44`:
<img width="2075" height="476" alt="image" src="https://github.com/user-attachments/assets/4ebcd249-9323-4153-ad03-0ced91678059" />
Etoile Thin under `'ss10','cv23'6,'cv32'39,'cv57'44`:
<img width="2317" height="472" alt="image" src="https://github.com/user-attachments/assets/ad40577b-1073-43d4-ae5c-121ed551d052" />
Etoile Regular under `'ss10','cv23'6,'cv32'39,'cv57'44`:
<img width="2332" height="484" alt="image" src="https://github.com/user-attachments/assets/6beb4a5f-e9f3-4a60-be78-72feae30fddc" />
Etoile Heavy under `'ss10','cv23'6,'cv32'39,'cv57'44`:
<img width="2319" height="480" alt="image" src="https://github.com/user-attachments/assets/dfb5f7bb-1022-4a96-ace6-49d061586900" />
