### PR TITLE
Refine stroke width and arch depth of Cyrillic Yu (`Ю`, `ю`).

### DIFF
--- a/changes/33.4.0.md
+++ b/changes/33.4.0.md
@@ -1,1 +1,10 @@
 * Add `straight-vertical-sides-almost-flat-top` and `rounded-vertical-sides-almost-flat-top` variants for `W` and `w`.
+* Refine shape of the following characters:
+  - LATIN CAPITAL LETTER GHA (`U+01A2`).
+  - LATIN SMALL LETTER GHA (`U+01A3`).
+  - CYRILLIC CAPITAL LETTER YU (`U+042E`).
+  - CYRILLIC SMALL LETTER YU (`U+044E`).
+  - COMBINING CYRILLIC CYRILLIC LETTER YU (`U+2DFB`).
+  - CYRILLIC CAPITAL LETTER REVERSED YU (`U+A654`).
+  - CYRILLIC SMALL LETTER REVERSED YU (`U+A655`).
+  - MODIFIER LETTER CYRILLIC SMALL YU (`U+1E049`).

--- a/packages/font-glyphs/src/letter/cyrillic/iotified-a.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/iotified-a.ptl
@@ -10,51 +10,46 @@ glyph-block Letter-Cyrillic-Iotified-A : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Shapes : SerifFrame RightwardTailedBar
 
-	define SLAB-NONE		0
-	define SLAB-FULL		1
-	define SLAB-OUTWARD		2
+	define SLAB-NONE     0
+	define SLAB-FULL     1
+	define SLAB-OUTWARD  2
 
 	glyph-block-export Iotified
 	define Iotified : namespace
 		export : define [Shape] : with-params [df top hBarRight [hBarY (top / 2)] [slabTop false] [slabBottom false] [swRef df.mvs] [swSerif swRef]] : glyph-proc
 			include : VBar.l df.leftSB 0 top swRef
-			if (hBarRight > df.leftSB)
-				include : HBar.m df.leftSB hBarRight hBarY swRef
-
-			local sf : SerifFrame.fromDf df top 0 (swRef -- swRef) (swSerif -- swSerif)
+			if (hBarRight > df.leftSB) : include : HBar.m df.leftSB hBarRight hBarY swRef
 			if SLAB : begin
+				local sf : SerifFrame.fromDf df top 0 (swRef -- swRef) (swSerif -- swSerif)
 				include : tagged "serifLT" : match slabTop
-					[Just SLAB-FULL] : begin sf.lt.full
+					[Just SLAB-FULL]    : begin sf.lt.full
 					[Just SLAB-OUTWARD] : begin sf.lt.outer
-					__ : glyph-proc
+					__                  : glyph-proc
 				include : tagged "serifLB" : match slabBottom
-					[Just SLAB-FULL] : begin sf.lb.full
+					[Just SLAB-FULL]    : begin sf.lb.full
 					[Just SLAB-OUTWARD] : begin sf.lb.outer
-					__ : glyph-proc
+					__                  : glyph-proc
 
-		export : define [RevShape] : with-params [df top hBarLeft [hBarY (top / 2)] [slabTop false] [slabBottom false] [swRef df.mvs] [swSerif swRef] [fTail false]] : glyph-proc
-			include : if fTail
+		export : define [RevShape] : with-params [df top hBarLeft [hBarY (top / 2)] [slabTop false] [slabBottom false] [swRef df.mvs] [swSerif swRef] [fTailed false]] : glyph-proc
+			include : if fTailed
 				RightwardTailedBar df.rightSB 0 top swRef
-				VBar.r df.rightSB 0 top swRef
-
-			if (hBarLeft < df.rightSB)
-				include : HBar.m hBarLeft df.rightSB hBarY swRef
-
-			local sf : SerifFrame.fromDf df top 0 (swRef -- swRef) (swSerif -- swSerif)
+				VBar.r             df.rightSB 0 top swRef
+			if (hBarLeft < df.rightSB) : include : HBar.m hBarLeft df.rightSB hBarY swRef
 			if SLAB : begin
+				local sf : SerifFrame.fromDf df top 0 (swRef -- swRef) (swSerif -- swSerif)
 				include : tagged "serifRT" : match slabTop
-					[Just SLAB-FULL] : begin sf.rt.full
+					[Just SLAB-FULL]    : begin sf.rt.full
 					[Just SLAB-OUTWARD] : begin sf.rt.outer
-					__ : glyph-proc
-				if (!fTail) : include : tagged "serifRB" : match slabBottom
-					[Just SLAB-FULL] : begin sf.rb.full
+					__                  : glyph-proc
+				if [not fTailed] : include : tagged "serifRB" : match slabBottom
+					[Just SLAB-FULL]    : begin sf.rb.full
 					[Just SLAB-OUTWARD] : begin sf.rb.outer
-					__ : glyph-proc
+					__                  : glyph-proc
 
 		# "Default" version
 		export : define [full] : with-params [df top hBarRight hBarY [fCapital false] [swRef df.mvs] [swSerif swRef]] : begin
 			local useItalicShape : [not fCapital] && para.isItalic
-			return : Shape
+			return : new-glyph : Shape
 				df         -- df
 				top        -- top
 				hBarRight  -- hBarRight
@@ -67,7 +62,7 @@ glyph-block Letter-Cyrillic-Iotified-A : begin
 		# Outwards only
 		export : define [outer] : with-params [df top hBarRight hBarY [fCapital false] [swRef df.mvs] [swSerif swRef]] : begin
 			local useItalicShape : [not fCapital] && para.isItalic
-			return : Shape
+			return : new-glyph : Shape
 				df         -- df
 				top        -- top
 				hBarRight  -- hBarRight
@@ -80,7 +75,7 @@ glyph-block Letter-Cyrillic-Iotified-A : begin
 		# Iotified A-shaped glyphs
 		export : define [A] : with-params [df top hBarRight hBarY [fCapital false] [swRef df.mvs] [swSerif swRef]] : begin
 			local useItalicShape : [not fCapital] && para.isItalic
-			return : Shape
+			return : new-glyph : Shape
 				df         -- df
 				top        -- top
 				hBarRight  -- hBarRight
@@ -93,7 +88,7 @@ glyph-block Letter-Cyrillic-Iotified-A : begin
 		# Used for Bulgarian Lower Yu
 		export : define [ascender] : with-params [df top hBarRight hBarY [fCapital false] [swRef df.mvs] [swSerif swRef]] : begin
 			local useItalicShape : [not fCapital] && para.isItalic
-			return : Shape
+			return : new-glyph : Shape
 				df         -- df
 				top        -- top
 				hBarRight  -- hBarRight
@@ -121,11 +116,12 @@ glyph-block Letter-Cyrillic-Iotified-A : begin
 				include : difference
 					with-transform [ApparentTranslate shift 0]
 						AShape.Letter subDf bodyShape slabKind CAP df.mvs
-					intersection [MaskBelow df.mvs]
-						MaskLeft : mix xIotifiedBarRight [Math.min (subDf.leftSB + shift) (xIotifiedBarRight + botGap)] 0.5
+					intersection
+						MaskBelow df.mvs
+						MaskLeft [mix xIotifiedBarRight [Math.min (subDf.leftSB + shift) (xIotifiedBarRight + botGap)] 0.5]
 
 				include : difference
-					Iotified.A df CAP [mix df.leftSB df.rightSB (3 / 4)] (CAP / 2) (fCapital -- true)
+					Iotified.A df CAP [mix df.leftSB df.rightSB 0.75] (CAP / 2) (fCapital -- true)
 					with-transform [ApparentTranslate shift 0]
 						AShape.Mask subDf bodyShape CAP df.mvs
 
@@ -147,7 +143,7 @@ glyph-block Letter-Cyrillic-Iotified-A : begin
 					body subDf hookStyle sw
 
 				include : difference
-					Iotified.full df XH [mix df.leftSB df.rightSB (3 / 4)] (XH / 2) (swRef -- sw) (swSerif -- subDf.mvs)
+					Iotified.full df XH [mix df.leftSB df.rightSB 0.75] (XH / 2) (swRef -- sw) (swSerif -- subDf.mvs)
 					with-transform [ApparentTranslate shift 0]
 						DoubleStorey.GetMask body df sw
 

--- a/packages/font-glyphs/src/letter/cyrillic/yu.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/yu.ptl
@@ -13,41 +13,21 @@ glyph-block Letter-Cyrillic-Yu : begin
 	define SLAB-LOWER      2
 	define SLAB-BULGARIAN  3
 
-	define SLAB-NONE		0
-	define SLAB-FULL		1
-	define SLAB-OUTWARD		2
-
-	define [CyrYuShape df slabType top xtop ada adb] : glyph-proc
-		local gap : 0.375 * (df.width - 2 * df.leftSB - 2.5 * df.mvs) - [HSwToV : 0.25 * df.mvs]
-		local divSub : (df.width - gap - df.mvs) / Width
+	define [CyrYuShape df slabType top oTop ada adb] : glyph-proc
+		local sw : Math.min df.mvs : AdviceStroke 2 (0.75 * df.adws)
+		local gap : 0.375 * (df.width - 2 * df.leftSB - 2.5 * sw) - [HSwToV : 0.25 * sw]
+		local divSub : (df.width - gap - sw) / Width
 		local subDf : DivFrame divSub 2
 
 		local shift : Width * (df.adws - divSub)
 		include : with-transform [ApparentTranslate shift 0]
-			OShape top 0 subDf.leftSB subDf.rightSB df.mvs (ada * 0.7 * df.adws) (adb * 0.7 * df.adws)
+			OShape oTop 0 subDf.leftSB subDf.rightSB sw (ada * 0.75 * df.adws) (adb * 0.75 * df.adws)
 
-		include : if (slabType === SLAB-BULGARIAN)
-			Iotified.ascender df xtop (shift + subDf.leftSB + [HSwToV : 0.5 * df.mvs]) (top / 2)
-			Iotified.full     df xtop (shift + subDf.leftSB + [HSwToV : 0.5 * df.mvs]) (top / 2)
-				fCapital -- (slabType === SLAB-ALL)
-
-	define [CyrRevYuShape df slabType top xtop ada adb fTail] : glyph-proc
-		local gap : 0.375 * (df.width - 2 * df.leftSB - 2.5 * df.mvs) - [HSwToV : 0.25 * df.mvs]
-		local divSub : (df.width - gap - df.mvs) / Width
-		local subDf : DivFrame divSub 2
-
-		include : OShape top 0 subDf.leftSB subDf.rightSB df.mvs (ada * 0.7 * df.adws) (adb * 0.7 * df.adws)
-
-		local useItalicShape : slabType !== SLAB-ALL && para.isItalic
-		local slabTop : if useItalicShape SLAB-NONE SLAB-FULL
-		local slabBottom : if useItalicShape SLAB-OUTWARD SLAB-FULL
-
-		include : Iotified.RevShape df xtop
-			hBarLeft   -- (subDf.rightSB - [HSwToV : 0.5 * df.mvs])
-			hBarY      -- (top / 2)
-			slabTop    -- slabTop
-			slabBottom -- slabBottom
-			fTail      -- fTail
+		include : Iotified.[if (slabType === SLAB-BULGARIAN) 'ascender' 'full'] df top
+			hBarRight -- ((subDf.leftSB + [HSwToV : 0.5 * sw]) + shift)
+			hBarY     -- (oTop / 2)
+			fCapital  -- (slabType === SLAB-ALL)
+			swRef     -- sw
 
 	create-glyph 'cyrl/Yu' 0x42E : glyph-proc
 		local df : include : DivFrame para.advanceScaleM 3
@@ -62,21 +42,42 @@ glyph-block Letter-Cyrillic-Yu : begin
 	create-glyph 'cyrl/yu.BGR' : glyph-proc
 		local df : include : DivFrame para.advanceScaleM 3
 		include : df.markSet.b
-		include : CyrYuShape df SLAB-BULGARIAN XH Ascender SmallArchDepthA SmallArchDepthB
+		include : CyrYuShape df SLAB-BULGARIAN Ascender XH SmallArchDepthA SmallArchDepthB
+
+	define SLAB-NONE       0
+	define SLAB-FULL       1
+	define SLAB-OUTWARD    2
+
+	define [CyrRevYuShape df slabType top oTop ada adb fTailed] : glyph-proc
+		local sw : Math.min df.mvs : AdviceStroke 2 (0.75 * df.adws)
+		local gap : 0.375 * (df.width - 2 * df.leftSB - 2.5 * sw) - [HSwToV : 0.25 * sw]
+		local divSub : (df.width - gap - sw) / Width
+		local subDf : DivFrame divSub 2
+
+		include : OShape oTop 0 subDf.leftSB subDf.rightSB sw (ada * 0.75 * df.adws) (adb * 0.75 * df.adws)
+
+		local useItalicShape : para.isItalic && slabType !== SLAB-ALL
+		include : Iotified.RevShape df top
+			hBarLeft   -- (subDf.rightSB - [HSwToV : 0.5 * sw])
+			hBarY      -- (oTop / 2)
+			slabTop    -- [if useItalicShape SLAB-NONE SLAB-FULL]
+			slabBottom -- [if useItalicShape SLAB-OUTWARD SLAB-FULL]
+			swRef      -- sw
+			fTailed    -- fTailed
 
 	define YuRevConfig : object
 		straight  false
 		tailed    true
 
-	foreach { suffix fTail } [Object.entries YuRevConfig] : do
-		if [not fTail] : create-glyph "cyrl/YuRev.\(suffix)" : glyph-proc
+	foreach { suffix fTailed } [Object.entries YuRevConfig] : do
+		if [not fTailed] : create-glyph "cyrl/YuRev.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleM 3
 			include : df.markSet.capital
-			include : CyrRevYuShape df SLAB-ALL CAP CAP ArchDepthA ArchDepthB fTail
+			include : CyrRevYuShape df SLAB-ALL CAP CAP ArchDepthA ArchDepthB fTailed
 		create-glyph "cyrl/yuRev.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleM 3
 			include : df.markSet.e
-			include : CyrRevYuShape df SLAB-LOWER XH XH SmallArchDepthA SmallArchDepthB fTail
+			include : CyrRevYuShape df SLAB-LOWER XH XH SmallArchDepthA SmallArchDepthB fTailed
 
 	select-variant 'cyrl/YuRev' 0xA654
 	select-variant 'cyrl/yuRev' 0xA655

--- a/packages/font-glyphs/src/letter/latin-ext/gha.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/gha.ptl
@@ -16,28 +16,31 @@ glyph-block Letter-Latin-Gha : begin
 	define TERMINAL-TAILED  1
 	define TERMINAL-DIAG    2
 
-	define [GhaShape df terminal top bot _ada _adb slab] : glyph-proc
-		local gap : 0.375 * (df.width - 2 * df.leftSB - 2.5 * df.mvs) - [HSwToV : 0.25 * df.mvs]
-		local divSub : (df.width - gap - df.mvs) / Width
+	define [GhaShape df terminal top bot _ada _adb fSlab] : glyph-proc
+		local sw : Math.min df.mvs : AdviceStroke 2 : 0.75 * df.adws
+		local gap : 0.375 * (df.width - 2 * df.leftSB - 2.5 * sw) - [HSwToV : 0.25 * sw]
+		local divSub : (df.width - gap - sw) / Width
 		local subDf : DivFrame divSub 2
 
-		local ada : _ada * 0.7 * df.adws
-		local adb : _adb * 0.7 * df.adws
-		include : OShape top 0 subDf.leftSB subDf.rightSB df.mvs ada adb
+		local ada : _ada * 0.75 * df.adws
+		local adb : _adb * 0.75 * df.adws
+		include : OShape top 0 subDf.leftSB subDf.rightSB sw ada adb
 		include : match terminal
-			[Just TERMINAL-NORMAL] : VBar.r             (df.rightSB - O) bot top df.mvs
-			[Just TERMINAL-TAILED] : RightwardTailedBar (df.rightSB - O) bot top df.mvs
-			[Just TERMINAL-DIAG]   : RDiagTailedBar     (df.rightSB - O) bot top df.mvs
+			[Just TERMINAL-NORMAL] : VBar.r             (df.rightSB - OX) bot top sw
+			[Just TERMINAL-TAILED] : RightwardTailedBar (df.rightSB - OX) bot top sw
+			[Just TERMINAL-DIAG]   : RDiagTailedBar     (df.rightSB - OX) bot top sw
 		include : dispiro
-			widths.lhs df.mvs
-			flat (subDf.rightSB - [HSwToV : 0.5 * df.mvs])        (top - adb) [heading Rightward]
-			curl (subDf.rightSB - [HSwToV : 0.5 * df.mvs] + TINY) (top - adb) [heading Rightward]
+			widths.lhs sw
+			flat (subDf.rightSB - [HSwToV : 0.5 * sw])        (top - adb) [heading Rightward]
+			curl (subDf.rightSB - [HSwToV : 0.5 * sw] + TINY) (top - adb) [heading Rightward]
 			alsoThru 0.5 0.15
-			g4   (df.rightSB - O - [HSwToV df.mvs]) top [widths 0 df.mvs]
+			g4   ((df.rightSB - OX) - [HSwToV sw]) top [widths.rhs sw]
 
-		if slab : begin
-			include : HSerif.rb (df.rightSB - O - [HSwToV : 0.5 * df.mvs]) bot Jut
-			include : HSerif.lb (df.rightSB - O - [HSwToV : 0.5 * df.mvs]) bot MidJutSide
+		if fSlab : include : tagged 'serifRB' : union
+			HSerif.rb ((df.rightSB - OX) - [HSwToV : 0.5 * sw]) bot (Jut        - [HSwToV : 0.5 * (Stroke - sw)]) sw
+			HSerif.lb ((df.rightSB - OX) - [HSwToV : 0.5 * sw]) bot (MidJutSide - [HSwToV : 0.5 * (Stroke - sw)]) sw
+
+		include : LeaningAnchor.Below.VBar.r (df.rightSB - OX) sw
 
 	define GhaConfig : object
 		straightSerifless       { TERMINAL-NORMAL false }
@@ -45,18 +48,16 @@ glyph-block Letter-Latin-Gha : begin
 		tailedSerifless         { TERMINAL-TAILED false }
 		diagonalTailedSerifless { TERMINAL-DIAG   false }
 
-	foreach { suffix { terminal doSerif } } [Object.entries GhaConfig] : do
+	foreach { suffix { terminal doSB } } [Object.entries GhaConfig] : do
 		create-glyph "Gha.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleM 3
 			include : df.markSet.capDesc
-			include : GhaShape df terminal CAP Descender ArchDepthA ArchDepthB doSerif
-			include : LeaningAnchor.Below.VBar.r (df.rightSB - O)
+			include : GhaShape df terminal CAP Descender ArchDepthA ArchDepthB doSB
 
 		create-glyph "gha.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleM 3
 			include : df.markSet.p
-			include : GhaShape df terminal XH Descender SmallArchDepthA SmallArchDepthB doSerif
-			include : LeaningAnchor.Below.VBar.r (df.rightSB - O)
+			include : GhaShape df terminal XH Descender SmallArchDepthA SmallArchDepthB doSB
 
 	select-variant 'Gha' 0x1A2 (follow -- 'gha')
 	select-variant 'gha' 0x1A3


### PR DESCRIPTION
Basically I forgot to update these characters with #2972 for consistency.

The arch depth is set to {`Small`}`ArchDepth`{`A`|`B`}` * 0.75 * para.advanceScaleM`
(evaluating to just {`Small`}`ArchDepth`{`A`|`B`}` * 1` under Quasi-proportional)
and the stroke width is set to `[Math.min [DivFrame].mvs [AdviceStroke 2 (0.75 * para.advanceScaleM)]]`
(evaluating to just `[Math.min [DivFrame].mvs [AdviceStroke 2 1]]` under Quasi-Proportional).

Also improve stroke width of serifs for Latin Gha (`Ƣ`, `ƣ`).

`ЮююꙔꙕƢƣ`

Sans Monospace:
<img width="905" height="1158" alt="image" src="https://github.com/user-attachments/assets/85181e00-be27-4817-8cc8-49fb990be635" />
Slab Monospace:
<img width="893" height="1140" alt="image" src="https://github.com/user-attachments/assets/1a93d3fc-67af-4d19-b75b-9bec414480ce" />
Aile:
<img width="1338" height="1149" alt="image" src="https://github.com/user-attachments/assets/5959bef1-2887-444a-b4f5-166140390092" />
Etoile:
<img width="1343" height="1148" alt="image" src="https://github.com/user-attachments/assets/5ca390bd-2a58-402d-9f3f-b631ee7211cf" />
