### PR TITLE
Refine the flat-hook `t`.

### DIFF
--- a/packages/font-glyphs/src/letter/latin/lower-t.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-t.ptl
@@ -108,11 +108,7 @@ glyph-block Letter-Latin-Lower-T : begin
 	define Flat : namespace
 		export : define [xCrossBarPos df sym] : match sym
 			([Just SYM-LEFT] || [Just SYM-PR-LEFT]) {([BarLeftPos df sym] + TanSlope * Stroke) [mix df.width df.rightSB : mix 1 df.adws 2]}
-			__ {[mix 0 df.leftSB : mix 1 df.adws 2] [mix df.width df.rightSB : mix 1 df.adws 2]}
-
-
-		define [CrossLeft df]  : mix 0        df.leftSB  : mix 1 df.adws 2
-		define [CrossRight df] : mix df.width df.rightSB : mix 1 df.adws 2
+			__ {[mix 0 (df.leftSB * 0.6) : mix 1 df.adws 2] [mix df.width df.rightSB : mix 1 df.adws 2]}
 
 		define NORMAL    0
 		define RETROFLEX 1
@@ -120,7 +116,7 @@ glyph-block Letter-Latin-Lower-T : begin
 
 		export : define [BarLeftPos df sym] : match sym
 			[Just SYM-LEFT]      : mix df.leftSB [xSmallTBarLeftT df] 0.5
-			[Just SYM-BALANCED]  : [mix [CrossLeft df] [CrossRight df] 0.42] - [HSwToV : 0.375 * Stroke]
+			[Just SYM-BALANCED]  : xSmallTBarLeftT df
 			([Just SYM-PR-LEFT] || [Just SYM-PR-BALANCED]) : df.middle - [HSwToV HalfStroke]
 
 		export : define [Body        df sym top bot] : Impl NORMAL    df sym top bot 0


### PR DESCRIPTION
Use the same `xSmallTBarLeftT` for the flat-hook `t` as in its BentHook variant. This moves the middle bar of flat-hook `t` slightly to the left. The left sidebearing is slightly reduced for visual balance.

Removes unused definitions `CrossLeft` and `CrossRight`.

<img width="1677" height="678" alt="image" src="https://github.com/user-attachments/assets/d834d9f1-5d27-4ab0-ac32-163dc9a3cdc8" />
<img width="677" height="300" alt="image" src="https://github.com/user-attachments/assets/3118fbac-48a8-44c7-9772-7a5a587b1fd5" />
<img width="486" height="1151" alt="image" src="https://github.com/user-attachments/assets/ba737912-ab5b-4896-b57e-d6819c2a8504" />
