### PR TITLE
Refine Komi Cyrillic letters, also make Hwair (`Ƕ`, `ƕ`) respond to serif variants of `V`/`v` (`cv31`, `cv76`).

### DIFF
--- a/packages/font-glyphs/src/letter/cyrillic/el.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/el.ptl
@@ -162,8 +162,8 @@ glyph-block Letter-Cyrillic-El : begin
 			right  -- df.rightSB
 			ybegin -- CAP
 			yend   -- (CAP / 2 + HalfStroke)
-			ada    -- (SmallArchDepthA * 0.6 * df.adws)
-			adb    -- (SmallArchDepthB * 0.6 * df.adws)
+			ada    -- (ArchDepthA * (2 / df.hPack) * df.adws)
+			adb    -- (ArchDepthB * (2 / df.hPack) * df.adws)
 			sw     -- df.mvs
 		local sf2 : [SerifFrame.fromDf df (CAP / 2 + HalfStroke) 0].slice 1 2
 		if SLAB : include sf2.rt.full
@@ -179,8 +179,8 @@ glyph-block Letter-Cyrillic-El : begin
 			right  -- df.rightSB
 			ybegin -- XH
 			yend   -- (XH / 2 + HalfStroke)
-			ada    -- (SmallArchDepthA * 0.6 * df.adws)
-			adb    -- (SmallArchDepthB * 0.6 * df.adws)
+			ada    -- (ArchDepthA * (2 / df.hPack) * df.adws)
+			adb    -- (ArchDepthB * (2 / df.hPack) * df.adws)
 			sw     -- df.mvs
 		local sf2 : [SerifFrame.fromDf df (XH / 2 + HalfStroke) 0].slice 1 2
 		if SLAB : include sf2.rt.full

--- a/packages/font-glyphs/src/letter/cyrillic/yeri.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/yeri.ptl
@@ -353,7 +353,7 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			include : CyrYerShape Lc Ascender
 				left  -- df.leftSB
 				right -- df.rightSB
-				pBar  -- (YeriBarPos * (XH / Ascender))
+				pBar  -- ([mix 0 XH YeriBarPos] / Ascender)
 		create-glyph "cyrl/YerNeutral.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleT 2
 			include : df.markSet.capital
@@ -455,8 +455,8 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			right  -- df.rightSB
 			ybegin -- CAP
 			yend   -- (CAP / 2 + HalfStroke)
-			ada    -- (ArchDepthA * 0.6 * df.adws)
-			adb    -- (ArchDepthB * 0.6 * df.adws)
+			ada    -- (ArchDepthA * (2 / df.hPack) * df.adws)
+			adb    -- (ArchDepthB * (2 / df.hPack) * df.adws)
 			sw     -- df.mvs
 		if SLAB : begin
 			local sf2 : [SerifFrame.fromDf df (CAP / 2 + HalfStroke) 0].slice 1 2

--- a/packages/font-glyphs/src/letter/cyrillic/ze.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/ze.ptl
@@ -267,7 +267,7 @@ glyph-block Letter-Cyrillic-Ze : begin
 				xo   -- 0
 				yo   -- 0
 			include : difference
-				VBar.m [arch.adjust-x.bot Middle] desc (Stroke + O) VJutStroke
+				VBar.m [arch.adjust-x.bot Middle] desc (O + Stroke) VJutStroke
 				zeNoO.ShapeMask
 
 		create-glyph "cyrl/dhe.\(suffix)" : glyph-proc
@@ -281,7 +281,7 @@ glyph-block Letter-Cyrillic-Ze : begin
 				xo   -- 0
 				yo   -- 0
 			include : difference
-				VBar.m [arch.adjust-x.bot Middle] desc (Stroke + O) VJutStroke
+				VBar.m [arch.adjust-x.bot Middle] desc (O + Stroke) VJutStroke
 				zeNoO.ShapeMask
 
 		create-glyph "latn/Epsilon.\(suffix)" : glyph-proc
@@ -352,8 +352,8 @@ glyph-block Letter-Cyrillic-Ze : begin
 				right  -- df.rightSB
 				ybegin -- [YSmoothMidR (midy + stroke / 2) 0 ArchDepthA ArchDepthB]
 				yend   -- (CAP / 2 + HalfStroke)
-				ada    -- (ArchDepthA * 0.6 * df.adws)
-				adb    -- (ArchDepthB * 0.6 * df.adws)
+				ada    -- (ArchDepthA * (2 / df.hPack) * df.adws)
+				adb    -- (ArchDepthB * (2 / df.hPack) * df.adws)
 				sw     -- stroke
 			if SLAB : begin
 				local sf2 : [SerifFrame.fromDf df (CAP / 2 + HalfStroke) 0].slice 1 2
@@ -378,8 +378,8 @@ glyph-block Letter-Cyrillic-Ze : begin
 				right  -- df.rightSB
 				ybegin -- [YSmoothMidR (midy + stroke / 2) 0 SmallArchDepthA SmallArchDepthB]
 				yend   -- (XH / 2 + HalfStroke)
-				ada    -- (ArchDepthA * 0.6 * df.adws)
-				adb    -- (ArchDepthB * 0.6 * df.adws)
+				ada    -- (ArchDepthA * (2 / df.hPack) * df.adws)
+				adb    -- (ArchDepthB * (2 / df.hPack) * df.adws)
 				sw     -- stroke
 			if SLAB : begin
 				local sf2 : [SerifFrame.fromDf df (XH / 2 + HalfStroke) 0].slice 1 2

--- a/packages/font-glyphs/src/letter/latin-ext/hwair.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/hwair.ptl
@@ -1,7 +1,7 @@
 $$include '../../meta/macros.ptl'
 
 import [mix linreg clamp fallback] from "@iosevka/util"
-
+import [DependentSelector] from "@iosevka/glyph/relation"
 
 glyph-module
 
@@ -9,44 +9,56 @@ glyph-block Letter-Latin-Hwair : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Adjustment : LeaningAnchor
+	glyph-block-import Letter-Shared : CreateSelectorVariants DefineSelectorGlyph
 	glyph-block-import Letter-Shared-Shapes : nShoulder uBowl SerifFrame
 
-	define Variants : object
-		straightSerifless      { false false }
-		straightTopLeftSerifed { true  false }
-		straightSerifed        { true  true  }
+	define HConfig : object
+		straightSerifless                { false false }
+		straightTopLeftSerifed           { true  false }
+		straightSerifedExceptBottomRight { true  true  }
 
-	foreach { suffix { serifLT serifLB } } [pairs-of Variants] : do
-		create-glyph "hwair.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.advanceScaleMM 3
-			include : df.markSet.b
-			include : LeaningAnchor.Above.VBar.l df.leftSB
-			local ada : SmallArchDepthA * 0.6 * df.adws
-			local adb : SmallArchDepthB * 0.6 * df.adws
-			include : VBar.l df.leftSB 0 Ascender df.mvs
-			include : nShoulder.shape
-				top     -- XH
-				bottom  -- (XH / 2 - TINY)
-				left    -- (df.leftSB + [HSwToV df.mvs])
-				right   -- (df.middle + [HSwToV : 0.5 * df.mvs])
-				stroke  -- df.mvs
-				fine    -- df.shoulderFine
-				ada     -- ada
-				adb     -- adb
-			include : uBowl.toothlessRounded
-				top     -- (XH / 2 + TINY)
-				bottom  -- 0
-				left    -- (df.middle - [HSwToV : 0.5 * df.mvs])
-				right   -- df.rightSB
-				stroke  -- df.mvs
-				ada     -- ada
-				adb     -- adb
-				rightY0 -- XH
-			local sf : SerifFrame.fromDf df Ascender 0
-			if serifLT : include : tagged 'serifLT' sf.lt.outer
-			if serifLB : include : tagged 'serifLB' sf.lb.full
-			if SLAB : begin
-				local sf2 : SerifFrame.fromDf df XH 0
-				include : tagged 'serifRT' sf2.rt.full
+	define VConfig : object
+		roundedSerifless false
+		roundedSerifed   true
 
-	select-variant 'hwair' 0x195 (follow -- 'heng')
+	foreach { suffix { serifLT serifLB } } [pairs-of HConfig] : do
+		local df : DivFrame para.advanceScaleMM 3
+		DefineSelectorGlyph "hwair" suffix df 'b'
+
+		foreach { suffixV serifRT } [Object.entries VConfig] : do
+			create-glyph "hwair.\(suffix).\(suffixV)" : glyph-proc
+				set-width 0
+				set-mark-anchor 'cvDecompose' 0 0
+				include : LeaningAnchor.Above.VBar.l df.leftSB df.mvs
+				local ada : SmallArchDepthA * (2 / df.hPack) * df.adws
+				local adb : SmallArchDepthB * (2 / df.hPack) * df.adws
+				include : VBar.l df.leftSB 0 Ascender df.mvs
+				include : let [yJoin : mix 0 XH 0.5] : union
+					nShoulder.shape
+						top     -- XH
+						bottom  -- (yJoin - TINY)
+						left    -- (df.leftSB + [HSwToV df.mvs])
+						right   -- (df.middle + [HSwToV : 0.5 * df.mvs])
+						stroke  -- df.mvs
+						fine    -- df.shoulderFine
+						ada     -- ada
+						adb     -- adb
+					uBowl.toothlessRounded
+						top     -- (yJoin + TINY)
+						bottom  -- 0
+						left    -- (df.middle - [HSwToV : 0.5 * df.mvs])
+						right   -- df.rightSB
+						stroke  -- df.mvs
+						ada     -- ada
+						adb     -- adb
+						rightY0 -- XH
+				local sf : SerifFrame.fromDf df Ascender 0
+				if serifLT : include : tagged 'serifLT' sf.lt.outer
+				if serifLB : include : tagged 'serifLB' sf.lb.full
+				if serifRT : begin
+					local sf2 : SerifFrame.fromDf df XH 0
+					include : tagged 'serifRT' sf2.rt.full
+
+		select-variant "hwair.\(suffix)" (follow -- 'hv/v')
+
+	CreateSelectorVariants 'hwair' 0x195 [Object.keys HConfig] (follow -- 'hv/h')

--- a/packages/font-glyphs/src/letter/latin/lower-d.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-d.ptl
@@ -64,11 +64,9 @@ glyph-block Letter-Latin-Lower-D : begin
 			ada   -- df.smallArchDepthA
 			adb   -- df.smallArchDepthB
 
-	define [TopSerif df yTop] : tagged 'serifRT'
-		HSerif.lt (df.rightSB - [HSwToV Stroke]) yTop SideJut
+	define [TopSerif df yTop] : tagged 'serifRT' : HSerif.lt (df.rightSB - [HSwToV df.mvs]) yTop SideJut
 
-	define [BaseSerif df yTop] : tagged 'serifRB'
-		HSerif.rb df.rightSB 0 SideJut
+	define [BaseSerif df yTop] : tagged 'serifRB' : HSerif.rb df.rightSB 0 SideJut
 
 	define DConfig : SuffixCfg.weave
 		object # body
@@ -88,15 +86,16 @@ glyph-block Letter-Latin-Lower-D : begin
 		local yOverlay : mix XH (Ascender - [if topSerif Stroke 0]) 0.5
 
 		do
-			create-glyph "d.\(suffix)" : make [DivFrame 1]
+			create-glyph "d.\(suffix)"           : make [DivFrame 1]
 			create-glyph "dCaron/base.\(suffix)" : make [DivFrame 0.95]
 		: where : [make df] : glyph-proc
+			include : DivFrame 1
 			include : df.markSet.b
 			include : Body df Ascender
-			if topSerif    : include : topSerif df Ascender
+			if topSerif    : include : topSerif    df Ascender
 			if bottomSerif : include : bottomSerif df Ascender
-			include : LeaningAnchor.Above.VBar.r df.rightSB
-			set-base-anchor 'overlayOnExtension' (df.rightSB - [HSwToV HalfStroke]) yOverlay
+			include : LeaningAnchor.Above.VBar.r df.rightSB df.mvs
+			set-base-anchor 'overlayOnExtension' (df.rightSB - [HSwToV : 0.5 * df.mvs]) yOverlay
 
 		create-glyph "dStroke.\(suffix)" : glyph-proc
 			local df : DivFrame 1
@@ -104,7 +103,7 @@ glyph-block Letter-Latin-Lower-D : begin
 			include : LetterBarOverlay.r.in df.rightSB XH (Ascender - [if topSerif Stroke 0])
 
 		create-glyph "latn/de.\(suffix)" : glyph-proc
-			local df : DivFrame 1
+			local df : include : DivFrame 1
 			include : df.markSet.b
 			include : Body df Ascender
 			local xLeft : mix df.rightSB df.leftSB 0.9
@@ -117,7 +116,7 @@ glyph-block Letter-Latin-Lower-D : begin
 			include : LeaningAnchor.Above.VBar.m [mix xLeft xRight 0.5]
 
 		if [not topSerif] : create-glyph "dHookTop.\(suffix)" : glyph-proc
-			local df : DivFrame 1
+			local df : include : DivFrame 1
 			include : df.markSet.b
 			include : Body df (Ascender - Hook - HalfStroke)
 			include : TopHook.toRight.rBarInner df.rightSB (XH / 2) Ascender
@@ -137,8 +136,8 @@ glyph-block Letter-Latin-Lower-D : begin
 				right  -- dfHalf.rightSB
 				ybegin -- Ascender
 				yend   -- (XH / 2 + HalfStroke)
-				ada    -- (SmallArchDepthA * 0.6 * df.adws)
-				adb    -- (SmallArchDepthB * 0.6 * df.adws)
+				ada    -- (ArchDepthA * (2 / df.hPack) * df.adws)
+				adb    -- (ArchDepthB * (2 / df.hPack) * df.adws)
 				sw     -- df.mvs
 
 			if topSerif : include : topSerif dfHalf Ascender

--- a/packages/font-glyphs/src/letter/latin/lower-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-m.ptl
@@ -23,10 +23,10 @@ glyph-block Letter-Latin-Lower-M : begin
 			arcvh 8
 			g2     [mix (right - [HSwToV stroke]) (left + [HSwToV fine]) 0.5] ((top - O) - stroke)
 			archv 8
-			flat   (left + [HSwToV fine]) [Math.max (top - ada - fix) ([if (leftY0 != nothing) leftY0 bottom] + TINY)]
-			corner (left + [HSwToV fine]) [if (leftY0 != nothing) leftY0 [Math.max ((top - ada - fix) - TINY) bottom]]
-			corner left                   [if (leftY0 != nothing) leftY0 [Math.max ((top - ada)       - TINY) bottom]]
-			curl   left                   [Math.max (top - ada)       ([if (leftY0 != nothing) leftY0 bottom] + TINY)]
+			flat   (left + [HSwToV fine]) [Math.max ([fallback leftY0            bottom] + TINY) (top - ada - fix)]
+			corner (left + [HSwToV fine])            [fallback leftY0 : Math.max bottom        : (top - ada - fix) - TINY]
+			corner  left                             [fallback leftY0 : Math.max bottom        : (top - ada)       - TINY]
+			curl    left                  [Math.max ([fallback leftY0            bottom] + TINY) (top - ada)]
 			arcvh 8
 			g2     [mix left right 0.5] (top - O)
 			archv 8
@@ -42,10 +42,10 @@ glyph-block Letter-Latin-Lower-M : begin
 			arcvh 8
 			g2     [mix (left + [HSwToV stroke]) (right - [HSwToV fine]) 0.5] ((top - O) - stroke)
 			archv 8
-			flat   (right - [HSwToV fine]) [Math.max (top - adb + fix) ([if (rightY0 != nothing) rightY0 bottom] + TINY)]
-			corner (right - [HSwToV fine]) [if (rightY0 != nothing) rightY0 [Math.max ((top - adb + fix) - TINY) bottom]]
-			corner right                   [if (rightY0 != nothing) rightY0 [Math.max ((top - adb)       - TINY) bottom]]
-			curl   right                   [Math.max (top - adb)       ([if (rightY0 != nothing) rightY0 bottom] + TINY)]
+			flat   (right - [HSwToV fine]) [Math.max ([fallback rightY0            bottom] + TINY) (top - adb + fix)]
+			corner (right - [HSwToV fine])            [fallback rightY0 : Math.max bottom        : (top - adb + fix) - TINY]
+			corner  right                             [fallback rightY0 : Math.max bottom        : (top - adb)       - TINY]
+			curl    right                  [Math.max ([fallback rightY0            bottom] + TINY) (top - adb)]
 			arcvh 8
 			g2     [mix right left 0.5] (top - O)
 			archv 8
@@ -121,20 +121,20 @@ glyph-block Letter-Latin-Lower-M : begin
 		local fFull : MEnoughSpaceForFullSerifs df : fallback _mid df.middle
 		include : SmallMBottomMotionRightSerif df top rbot fFull
 
-	define [SmallMShortLegHeight top df] : (top - df.mvs) * 0.45
-	define [SmallMSmoothHeight top df] : top - [SmallMSmoothB df] - [HSwToV : Math.abs : TanSlope * df.mvs] - TINY
-
 	glyph-block-export SmallMArches
-	define [SmallMArches df top lbot mbot rbot _mid] : glyph-proc
+	define [SmallMArches df top lbot mbot rbot _mid _ada _adb] : glyph-proc
 		local mid : fallback _mid df.middle
+		local ada : fallback _ada : SmallMSmoothA df
+		local adb : fallback _adb : SmallMSmoothB df
+		include : tagged 'barL' : VBar.l df.leftSB lbot top df.mvs
 		include : SmallMShoulderSpiro
 			left      -- (df.leftSB + [HSwToV : df.mvs - df.shoulderFine])
 			right     -- (mid + [HSwToV : 0.5 * df.mvs])
 			fine      -- df.shoulderFine
 			top       -- top
 			bottom    -- mbot
-			ada       -- [SmallMSmoothA df]
-			adb       -- [SmallMSmoothB df]
+			ada       -- ada
+			adb       -- adb
 			stroke    -- df.mvs
 		include : SmallMShoulderSpiro
 			left      -- (mid + [HSwToV : 0.5 * df.mvs - df.shoulderFine])
@@ -142,26 +142,25 @@ glyph-block Letter-Latin-Lower-M : begin
 			fine      -- df.shoulderFine
 			top       -- top
 			bottom    -- rbot
-			ada       -- [SmallMSmoothA df]
-			adb       -- [SmallMSmoothB df]
+			ada       -- ada
+			adb       -- adb
 			stroke    -- df.mvs
-			leftY0    -- ([SmallMSmoothHeight top df] + O)
-		include : tagged 'barL' : VBar.l df.leftSB lbot top df.mvs
+			leftY0    -- mbot
 
 	glyph-block-export EarlessCornerDoubleArchSmallMShape
-	define [EarlessCornerDoubleArchSmallMShape df top lbot mbot rbot _mid] : glyph-proc
+	define [EarlessCornerDoubleArchSmallMShape df top lbot mbot rbot _mid _ada _adb] : glyph-proc
 		local mid : fallback _mid df.middle
-
+		local ada : fallback _ada : SmallMSmoothA df
+		local adb : fallback _adb : SmallMSmoothB df
 		define [leftKnots sink offset] : begin
 			local xMidBarRightSide : mid + [HSwToV : 0.5 * df.mvs]
 			return : sink
 				widths.rhs df.mvs
 				[if (sink == dispiro) g2 corner] (df.leftSB - offset) (top - DToothlessRise)
 				arch.rhs top (sw -- df.mvs) (blendPre -- {})
-				flat (xMidBarRightSide - offset) [Math.max (top - [SmallMSmoothB df]) (mbot + TINY)] [heading Downward]
+				flat (xMidBarRightSide - offset) [Math.max (top - adb) (mbot + TINY)] [heading Downward]
 				[if (sink == dispiro) curl corner] (xMidBarRightSide - offset) mbot [heading Downward]
 				if (sink == spiro-outline) { [corner (df.leftSB - offset) 0 ] } { }
-
 		define [rightKnots sink] : begin
 			local xMidBarLeftSide : mid - [HSwToV : 0.5 * df.mvs]
 			return : sink
@@ -169,18 +168,18 @@ glyph-block Letter-Latin-Lower-M : begin
 				g2 [mix df.rightSB xMidBarLeftSide 1.5] (top - 2 * DToothlessRise)
 				g2 xMidBarLeftSide (top - DToothlessRise)
 				arch.rhs top (sw -- df.mvs) (blendPre -- {})
-				flat df.rightSB [Math.max (top - [SmallMSmoothB df]) (rbot + TINY)] [heading Downward]
+				flat df.rightSB [Math.max (top - adb) (rbot + TINY)] [heading Downward]
 				curl df.rightSB rbot [heading Downward]
-
+		include : tagged 'barL' : VBar.l df.leftSB lbot (top - DToothlessRise) df.mvs
+		# include : tagged 'barM' : VBar.m mid mbot (top - DToothlessRise) df.mvs
 		include : leftKnots dispiro 0
 		include : difference [rightKnots dispiro] [leftKnots spiro-outline 0.1]
 
-		include : tagged 'barL' : VBar.l df.leftSB lbot (top - DToothlessRise) df.mvs
-		# include : tagged 'barM' : VBar.m mid mbot (top - DToothlessRise) df.mvs
-
 	glyph-block-export EarlessRoundedDoubleArchSmallMShape
-	define [EarlessRoundedDoubleArchSmallMShape df top lbot mbot rbot _mid] : glyph-proc
+	define [EarlessRoundedDoubleArchSmallMShape df top lbot mbot rbot _mid _ada _adb] : glyph-proc
 		local mid : fallback _mid df.middle
+		local ada : fallback _ada : SmallMSmoothA df
+		local adb : fallback _adb : SmallMSmoothB df
 		include : union
 			RevSmallMShoulderSpiro
 				left      -- df.leftSB
@@ -188,8 +187,8 @@ glyph-block Letter-Latin-Lower-M : begin
 				fine      -- (df.mvs * CThin)
 				top       -- top
 				bottom    -- lbot
-				ada       -- [SmallMSmoothA df]
-				adb       -- [SmallMSmoothB df]
+				ada       -- ada
+				adb       -- adb
 				stroke    -- df.mvs
 				rightY0   -- mbot
 			SmallMShoulderSpiro
@@ -198,21 +197,26 @@ glyph-block Letter-Latin-Lower-M : begin
 				fine      -- (df.mvs * CThin)
 				top       -- top
 				bottom    -- rbot
-				ada       -- [SmallMSmoothA df]
-				adb       -- [SmallMSmoothB df]
+				ada       -- ada
+				adb       -- adb
 				stroke    -- df.mvs
 				leftY0    -- mbot
 
-	define [EarlessSingleArchSmallMShape df top lbot mbot rbot _mid] : glyph-proc
+	define [EarlessSingleArchSmallMShape df top lbot mbot rbot _mid _ada _adb] : glyph-proc
 		local mid : fallback _mid df.middle
+		local ada : fallback _ada : SmallMSmoothA df
+		local adb : fallback _adb : SmallMSmoothB df
 		include : tagged 'barL' : VBar.l df.leftSB lbot (top - DToothlessRise) df.mvs
 		include : tagged 'barM' : VBar.m mid mbot (top - 0.25 * df.mvs) df.mvs
 		include : dispiro
 			widths.rhs df.mvs
 			g4 df.leftSB (top - DToothlessRise)
 			arch.rhs top (sw -- df.mvs) (blendPre -- {})
-			flat df.rightSB [Math.max (top - [SmallMSmoothB df]) (rbot + TINY)]
+			flat df.rightSB [Math.max (top - adb) (rbot + TINY)]
 			curl df.rightSB rbot [heading Downward]
+
+	define [SmallMShortLegHeight top df] : mix 0 (top - df.mvs) 0.45
+	define [SmallMSmoothHeight   top df] : top - [SmallMSmoothB df] - TINY - [HSwToV : Math.abs : TanSlope * df.mvs]
 
 	glyph-block-export mShapeBodyImpl
 	define [mShapeBodyImpl df top body earless shortLeg tailed serifs] : glyph-proc
@@ -287,8 +291,8 @@ glyph-block Letter-Latin-Lower-M : begin
 						right  -- df.rightSB
 						ybegin -- (XH / 2)
 						yend   -- (XH / 2 + HalfStroke)
-						ada    -- (SmallArchDepthA * 0.5 * df.adws)
-						adb    -- (SmallArchDepthB * 0.5 * df.adws)
+						ada    -- (ArchDepthA * (2 / df.hPack) * df.adws)
+						adb    -- (ArchDepthB * (2 / df.hPack) * df.adws)
 						sw     -- subDf.mvs
 					include : Serifs subDf XH 0 0 (XH / 2) true false
 					if SLAB : begin
@@ -336,15 +340,16 @@ glyph-block Letter-Latin-Lower-M : begin
 	alias 'cyrl/te/reduced.BGR' null 'cyrl/te.italic'
 	alias 'cyrl/teThreeLeg.italic' null 'cyrl/te.italic'
 
-	derive-composites 'cyrl/teDescender.italic' null 'cyrl/te.italic/descBase' : let [df : dfM]
-		CyrDescender.rSideJut df.rightSB 0 (refSw -- df.mvs)
+	derive-composites 'cyrl/teDescender.italic' null 'cyrl/te.italic/descBase' : let [df : dfM] : CyrDescender.rSideJut
+		x     -- df.rightSB
+		y     -- 0
+		refSw -- df.mvs
 
-	derive-composites 'mPalatalHook' 0x1D86 'm/descBase' : let [df : dfM]
-		PalatalHook.r
-			xLink -- df.rightSB
-			x     -- (df.rightSB + SideJut)
-			y     -- 0
-			refSw -- df.mvs
+	derive-composites 'mPalatalHook' 0x1D86 'm/descBase' : let [df : dfM] : PalatalHook.r
+		xLink -- df.rightSB
+		x     -- (df.rightSB + SideJut)
+		y     -- 0
+		refSw -- df.mvs
 
 	select-variant 'meng' 0x271
 	select-variant 'mCrossedTail' 0xAB3A (follow -- 'meng')

--- a/packages/font-glyphs/src/letter/latin/upper-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-g.ptl
@@ -11,7 +11,7 @@ glyph-block Letter-Latin-Upper-G : begin
 	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors LeaningAnchor
 	glyph-block-import Letter-Shared : CreateTurnedLetter
 	glyph-block-import Letter-Shared-Shapes : SerifedArcStart InwardSlabArcStart TopHook
-	glyph-block-import Letter-Shared-Shapes : ArcStartSerif LetterBarOverlay SerifFrame
+	glyph-block-import Letter-Shared-Shapes : ArcStartSerif LetterBarOverlay
 
 	define TOOTHED            0
 	define TOOTHLESS-CORNER   1
@@ -22,48 +22,56 @@ glyph-block Letter-Latin-Upper-G : begin
 	define CROSSBAR-CAPPED    2
 
 	define SLAB-NONE          0
-	define SLAB-LETTER        1
+	define SLAB-CLASSICAL     1
 	define SLAB-INWARD        2
 
-	define [GShape toothShape slabShape crossBarShape top _ada _adb _hook _yBar] : glyph-proc
+	define [GShape toothShape slabShape crossBarShape top _ada _adb _hook _rise _yBar] : glyph-proc
 		local ada : fallback _ada ArchDepthA
 		local adb : fallback _adb ArchDepthB
 		local hook : fallback _hook Hook
-		local yBar : fallback _yBar (top * 0.52 + QuarterStroke)
+		local rise : fallback _rise : match toothShape
+			[Just TOOTHLESS-CORNER] DToothlessRise
+			__                      ada
+		local yBar : fallback _yBar : [mix 0 top 0.52] + QuarterStroke
 		local fine ShoulderFine
 
 		local knots : match slabShape
-			[Just SLAB-LETTER] : SerifedArcStart.RtlLhs RightSB top Stroke hook
+			[Just SLAB-CLASSICAL] : SerifedArcStart.RtlLhs RightSB top Stroke hook
 			[Just SLAB-INWARD] : InwardSlabArcStart.RtlLhs RightSB top Stroke hook
-			__ : list [widths.lhs] [g4 RightSB (top - hook)] [hookstart top]
+			__ : list
+				widths.lhs
+				g4   RightSB (top - hook)
+				hookstart top
 
 		knots.push [flatside.ld SB 0 top ada adb]
 
 		match toothShape
 			[Just TOOTHED] : knots.push
 				arch.lhs 0 (swAfter -- fine)
-				straight.up.end (RightSB - [HSwToV : Stroke - fine]) ada [widths.lhs.heading fine Upward]
+				straight.up.end (RightSB - [HSwToV : Stroke - fine]) [Math.min rise : yBar - TINY] [widths.lhs.heading fine Upward]
 			[Just TOOTHLESS-CORNER] : knots.push
 				arch.lhs 0 (blendPost -- {})
-				g4   RightSB  DToothlessRise
-			[Just TOOTHLESS-ROUNDED] : knots.push
+				g4   RightSB rise
+			__ : knots.push
 				arch.lhs 0
-				flat RightSB [Math.min ada : yBar - TINY]
+				flat RightSB [Math.min rise : yBar - TINY]
 				curl RightSB yBar [heading Upward]
 
 		include : union
 			dispiro.apply null knots
-			if (slabShape === SLAB-LETTER) [ArcStartSerif.R       RightSB top Stroke hook] [glyph-proc]
-			if (slabShape === SLAB-INWARD) [ArcStartSerif.InwardR RightSB top Stroke hook] [glyph-proc]
+			match slabShape
+				[Just SLAB-CLASSICAL] : ArcStartSerif.R       RightSB top Stroke hook
+				[Just SLAB-INWARD]    : ArcStartSerif.InwardR RightSB top Stroke hook
+				__ : glyph-proc
 			match crossBarShape
 				[Just CROSSBAR-HOOKED] : HBar.t Middle      RightSB              yBar
 				[Just CROSSBAR-CAPPED] : HBar.t Middle [mix RightSB Width 0.625] yBar
 				__ : glyph-proc
 			match toothShape
 				[Just TOOTHED] : union
-					VBar.r RightSB ([Math.min ada : yBar - TINY] + O) yBar
-					VBar.r RightSB ([Math.min ada : yBar - TINY] + 0) 0 [Math.max (Stroke - fine / 2) : AdviceStroke 5]
-				[Just TOOTHLESS-CORNER] : VBar.r RightSB DToothlessRise yBar
+					VBar.r RightSB ([Math.min rise : yBar - TINY] + O) yBar
+					VBar.r RightSB ([Math.min rise : yBar - TINY] + 0) 0 [Math.max (Stroke - fine / 2) : AdviceStroke 5]
+				[Just TOOTHLESS-CORNER] : VBar.r RightSB rise yBar
 				__ : glyph-proc
 
 	create-glyph 'GBarOverlay' : LetterBarOverlay.r.in
@@ -79,7 +87,7 @@ glyph-block Letter-Latin-Upper-G : begin
 			toothlessRounded TOOTHLESS-ROUNDED
 		object
 			serifless        SLAB-NONE
-			serifed          SLAB-LETTER
+			serifed          SLAB-CLASSICAL
 			inwardSerifed    SLAB-INWARD
 		object
 			hookless         CROSSBAR-NONE
@@ -119,22 +127,24 @@ glyph-block Letter-Latin-Upper-G : begin
 	derive-composites 'Gbar' 0x1E4 'G' 'GBarOverlay'
 
 	do "Komi sje"
+		glyph-block-import Letter-Shared-Shapes : SerifFrame
+
 		define Config : object
-			serifless               { SLAB-NONE   }
-			unilateralSerifed       { SLAB-LETTER }
-			unilateralInwardSerifed { SLAB-INWARD }
+			serifless               { SLAB-NONE      }
+			unilateralSerifed       { SLAB-CLASSICAL }
+			unilateralInwardSerifed { SLAB-INWARD    }
 
 		foreach { suffix { slabType } } [Object.entries Config] : begin
 			create-glyph "cyrl/SjeKomi.\(suffix)" : glyph-proc
 				include : MarkSet.capital
-				include : GShape TOOTHLESS-ROUNDED slabType CROSSBAR-NONE CAP ArchDepthA ArchDepthB Hook (CAP / 2 + HalfStroke)
+				include : GShape TOOTHLESS-ROUNDED slabType CROSSBAR-NONE CAP ArchDepthA ArchDepthB Hook ArchDepthA (CAP / 2 + HalfStroke)
 				if SLAB : begin
 					local sf2 : SerifFrame.fromDf [DivFrame 1] (CAP / 2 + HalfStroke) 0
 					include sf2.rt.full
 
 			create-glyph "cyrl/sjeKomi.\(suffix)" : glyph-proc
 				include : MarkSet.e
-				include : GShape TOOTHLESS-ROUNDED slabType CROSSBAR-NONE XH SmallArchDepthA SmallArchDepthB AHook (XH / 2 + HalfStroke)
+				include : GShape TOOTHLESS-ROUNDED slabType CROSSBAR-NONE XH SmallArchDepthA SmallArchDepthB AHook ArchDepthA (XH / 2 + HalfStroke)
 				if SLAB : begin
 					local sf2 : SerifFrame.fromDf [DivFrame 1] (XH / 2 + HalfStroke) 0
 					include sf2.rt.full
@@ -153,7 +163,7 @@ glyph-block Letter-Latin-Upper-G : begin
 		curl (xTerm - offset) yTerm [heading Upward]
 
 	create-glyph 'mathbb/G' 0x1D53E : glyph-proc
-		local yBar : CAP * 0.52 + BBS * 0.25
+		local yBar : [mix 0 CAP 0.52] + BBS * 0.25
 		include : MarkSet.capital
 		include : BBGArcT dispiro 0 CAP ArchDepthA ArchDepthB (RightSB - BBD) yBar
 		include : intersection

--- a/packages/font-glyphs/src/letter/latin/upper-h.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-h.ptl
@@ -27,8 +27,8 @@ glyph-block Letter-Latin-Upper-H : begin
 	define SLAB-ALL-BGR                5
 	define SLAB-TAILED-CYRILLIC-BGR    6
 
-	define [HSerifs slabType t b l r sw] : begin
-		local sf : SerifFrame t b l r (swRef -- [fallback sw Stroke])
+	define [HSerifs slabType l r top _sw] : begin
+		local sf : SerifFrame top 0 l r (swRef -- _sw)
 		return : match slabType
 			[Just SLAB-NONE]                  : glyph-proc
 			[Just SLAB-TOP-LEFT]              : begin          sf.lt.outer
@@ -38,8 +38,8 @@ glyph-block Letter-Latin-Upper-H : begin
 			[Just SLAB-ALL-BGR]               : composite-proc sf.lt.outer sf.rt.inner sf.lb.full sf.rb.full
 			[Just SLAB-TAILED-CYRILLIC-BGR]   : composite-proc sf.lt.outer sf.rt.inner sf.lb.full
 
-	define [LeftHalfHSerifs slabType t b l r sw] : begin
-		local sf : SerifFrame t b l r (swRef -- [fallback sw Stroke])
+	define [LeftHalfHSerifs slabType l r top _sw] : begin
+		local sf : SerifFrame top 0 l r (swRef -- _sw)
 		return : match slabType
 			[Just SLAB-NONE]                  : glyph-proc
 			[Just SLAB-TOP-LEFT]              : begin          sf.lt.outer
@@ -49,8 +49,8 @@ glyph-block Letter-Latin-Upper-H : begin
 			[Just SLAB-ALL-BGR]               : composite-proc sf.lt.outer    sf.lb.fullSide
 			[Just SLAB-TAILED-CYRILLIC-BGR]   : composite-proc sf.lt.outer    sf.lb.fullSide
 
-	define [RightHalfHSerifs slabType t b l r sw] : begin
-		local sf : SerifFrame t b l r (swRef -- [fallback sw Stroke])
+	define [RightHalfHSerifs slabType l r top _sw] : begin
+		local sf : SerifFrame top 0 l r (swRef -- _sw)
 		return : match slabType
 			[Just SLAB-NONE]                  : glyph-proc
 			[Just SLAB-TOP-LEFT]              : glyph-proc
@@ -60,8 +60,8 @@ glyph-block Letter-Latin-Upper-H : begin
 			[Just SLAB-ALL-BGR]               : composite-proc sf.rt.inner    sf.rb.fullSide
 			[Just SLAB-TAILED-CYRILLIC-BGR]   : begin          sf.rt.inner
 
-	define [TurnedHSerifs slabType t b l r sw] : begin
-		local sf : SerifFrame t b l r (swRef -- [fallback sw Stroke])
+	define [TurnedHSerifs slabType l r top _sw] : begin
+		local sf : SerifFrame top 0 l r (swRef -- _sw)
 		return : match slabType
 			[Just SLAB-NONE]                  : glyph-proc
 			[Just SLAB-TOP-LEFT]              : begin          sf.lt.outer
@@ -75,34 +75,34 @@ glyph-block Letter-Latin-Upper-H : begin
 		local sw : fallback _sw Stroke
 		include : tagged 'strokeL' : VBar.l l 0 top sw
 		include : tagged 'strokeR' : VBar.r r 0 top sw
-		include : HBar.m (l - O) (r + O) (top * HBarPos) sw
+		include : tagged 'crossbar' : HBar.m (l - O) (r + O) [mix 0 top HBarPos] sw
 
 	define [TurnedHShape l r top _sw] : glyph-proc
 		local sw : fallback _sw Stroke
-		include : LeaningAnchor.Below.VBar.r r
-		include : tagged 'strokeL' : VBar.l l (top * HBarPos - sw / 2) top sw
+		include : LeaningAnchor.Below.VBar.r r sw
+		include : tagged 'strokeL' : VBar.l l ([mix 0 top HBarPos] - sw / 2) top sw
 		include : tagged 'strokeR' : VBar.r r 0 top sw
-		include : HBar.m (l - O) (r + O) (top * HBarPos) sw
+		include : tagged 'crossbar' : HBar.m (l - O) (r + O) [mix 0 top HBarPos] sw
 
 	define [LeftHalfHShape l r top _sw] : glyph-proc
 		local sw : fallback _sw Stroke
-		include : LeaningAnchor.Above.VBar.l l
-		include : LeaningAnchor.Below.VBar.l l
+		include : LeaningAnchor.Above.VBar.l l sw
+		include : LeaningAnchor.Below.VBar.l l sw
 		include : tagged 'strokeL' : VBar.l l 0 top sw
-		include : HBar.m (l - O) r (top * HBarPos) sw
+		include : tagged 'crossbar' : HBar.m (l - O) r [mix 0 top HBarPos] sw
 
 	define [RightHalfHShape l r top _sw] : glyph-proc
 		local sw : fallback _sw Stroke
-		include : LeaningAnchor.Above.VBar.r r
-		include : LeaningAnchor.Below.VBar.r r
+		include : LeaningAnchor.Above.VBar.r r sw
+		include : LeaningAnchor.Below.VBar.r r sw
 		include : tagged 'strokeR' : VBar.r r 0 top sw
-		include : HBar.m l (r + O) (top * HBarPos) sw
+		include : tagged 'crossbar' : HBar.m l (r + O) [mix 0 top HBarPos] sw
 
 	define [TailedHShape l r top _sw] : glyph-proc
 		local sw : fallback _sw Stroke
 		include : tagged 'strokeL' : VBar.l l 0 top sw
 		include : tagged 'strokeR' : RightwardTailedBar r 0 top (sw -- sw)
-		include : HBar.m (l - O) (r + O) (top * HBarPos) sw
+		include : tagged 'crossbar' : HBar.m (l - O) (r + O) [mix 0 top HBarPos] sw
 
 	define [EnGheShape Body df top slabType vSlab] : glyph-proc
 		local sw : Math.min df.mvs : AdviceStroke 2.75 df.adws
@@ -111,15 +111,16 @@ glyph-block Letter-Latin-Upper-H : begin
 			mix df.leftSB df.rightSB : if (df.adws > 1) (2 / 3) (3 / 4)
 		local xTopBarRightEnd : mix df.width df.rightSB : if vSlab 0.25 0.375
 
-		include : Body df.leftSB xm top sw
+		include : Body             df.leftSB xm top sw
+		include : HSerifs slabType df.leftSB xm top sw
+
 		include : HBar.t (xm - [HSwToV sw] - O) xTopBarRightEnd top sw
 
-		include : HSerifs slabType top 0 df.leftSB xm sw
 		if vSlab : begin
 			local swVJut : Math.min (VJutStroke * (sw / Stroke)) : VSwToH : 0.625 * (xTopBarRightEnd - xm)
 			include : VSerif.dr xTopBarRightEnd top VJut swVJut
 
-	define [HwairShape df top yend slabType] : glyph-proc
+	define [HwairShape df top yend slabType serifMR] : glyph-proc
 		local xm : df.middle + [HSwToV : 0.5 * df.mvs]
 		include : tagged 'strokeL' : VBar.l df.leftSB 0 top df.mvs
 		include : tagged 'strokeR' : UpwardHookShape
@@ -127,22 +128,21 @@ glyph-block Letter-Latin-Upper-H : begin
 			right  -- df.rightSB
 			ybegin -- top
 			yend   -- yend
-			ada    -- (SmallArchDepthA * 0.6 * df.adws)
-			adb    -- (SmallArchDepthB * 0.6 * df.adws)
+			ada    -- (ArchDepthA * (2 / df.hPack) * df.adws)
+			adb    -- (ArchDepthB * (2 / df.hPack) * df.adws)
 			sw     -- df.mvs
-		include : HBar.m (df.leftSB - O) (xm + O) (top * HBarPos) df.mvs
+		include : tagged 'crossbar' : HBar.m (df.leftSB - O) (xm + O) [mix 0 top HBarPos] df.mvs
 
-		include : HSerifs slabType top 0 df.leftSB xm df.mvs
-		if SLAB : begin
+		include : HSerifs slabType df.leftSB xm top df.mvs
+		eject-contour 'serifRB'
+		if serifMR : begin
 			local sf2 : [SerifFrame.fromDf df yend 0].slice 1 2
 			include sf2.rt.full
 
 	define [OverlayStrokeShape top slabType] : begin
-		local yb : top * HBarPos + HalfStroke
+		local yb : [mix 0 top HBarPos] + HalfStroke
 		local yt : top - [if slabType Stroke 0]
-		return : HOverlayBar [mix SB 0 0.7] [mix RightSB Width 0.7]
-			mix yb yt 0.5
-			Math.min OverlayStroke : 0.625 * (yt - yb)
+		return : HOverlayBar [mix SB 0 0.7] [mix RightSB Width 0.7] [mix yb yt 0.5] [Math.min OverlayStroke : 0.625 * (yt - yb)]
 
 	define HConfig : object
 		serifless                        { HShape       TurnedHShape LeftHalfHShape RightHalfHShape SLAB-NONE                  }
@@ -160,11 +160,15 @@ glyph-block Letter-Latin-Upper-H : begin
 		serifless       false
 		topRightSerifed true
 
+	define HwairVConfig : object
+		roundedSerifless false
+		roundedSerifed   true
+
 	foreach { suffix { Body TurnedBody LeftHalfBody RightHalfBody slabType } } [Object.entries HConfig] : do
 		create-glyph "H.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : Body SB RightSB  CAP
-			include : HSerifs slabType CAP 0 SB RightSB
+			include : Body             SB RightSB CAP
+			include : HSerifs slabType SB RightSB CAP
 
 		create-glyph "grek/Eta.\(suffix)" : glyph-proc
 			include [refer-glyph "H.\(suffix)"] AS_BASE ALSO_METRICS
@@ -172,53 +176,53 @@ glyph-block Letter-Latin-Upper-H : begin
 
 		create-glyph "turnH.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : TurnedBody SB RightSB  CAP
-			include : TurnedHSerifs slabType CAP 0 SB RightSB
+			include : TurnedBody             SB RightSB CAP
+			include : TurnedHSerifs slabType SB RightSB CAP
 
 		create-glyph "smcpH.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			include : Body SB RightSB  XH
-			include : HSerifs slabType XH 0 SB RightSB
+			include : Body             SB RightSB XH
+			include : HSerifs slabType SB RightSB XH
 
-		create-glyph "leftHalfH.\(suffix)" : glyph-proc
+		create-glyph "HLeftHalf.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			local xMockLeft : SB * 1.5
+			local xMockLeft : mix 0 SB 1.5
 			local xMockRight : RightSB - [xMidBarShrink (slabType === SLAB-ALL)]
-			local shift : Math.abs : Middle - [mix (xMockLeft - [if (slabType === SLAB-NONE) 0 SideJut]) xMockRight 0.5]
-			local xLeft : xMockLeft + shift
-			local xRight : xMockRight + shift
-			include : LeftHalfBody xLeft xRight CAP
-			include : LeftHalfHSerifs slabType CAP 0 xLeft xRight
+			local xMockMiddle : mix (xMockLeft - [if (slabType === SLAB-NONE) 0 SideJut]) xMockRight 0.5
+			local xLeft  : xMockLeft  + (Middle - xMockMiddle)
+			local xRight : xMockRight + (Middle - xMockMiddle)
+			include : LeftHalfBody             xLeft xRight CAP
+			include : LeftHalfHSerifs slabType xLeft xRight CAP
 
-		create-glyph "rightHalfH.\(suffix)" : glyph-proc
+		create-glyph "HRightHalf.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			local xMockLeft : SB + [xMidBarShrink (slabType === SLAB-ALL)]
-			local xMockRight : Width - SB * 1.5
-			local shift : Math.abs : Middle - [mix xMockLeft (xMockRight + [if (slabType === SLAB-NONE) 0 SideJut]) 0.5]
-			local xLeft : xMockLeft - shift
-			local xRight : xMockRight - shift
-			include : RightHalfBody xLeft xRight CAP
-			include : RightHalfHSerifs slabType CAP 0 xLeft xRight
+			local xMockRight : mix Width RightSB 1.5
+			local xMockMiddle : mix xMockLeft (xMockRight + [if (slabType === SLAB-NONE) 0 SideJut]) 0.5
+			local xLeft  : xMockLeft  + (Middle - xMockMiddle)
+			local xRight : xMockRight + (Middle - xMockMiddle)
+			include : RightHalfBody             xLeft xRight CAP
+			include : RightHalfHSerifs slabType xLeft xRight CAP
 
-		create-glyph "leftHalfSmcpH.\(suffix)" : glyph-proc
+		create-glyph "smcpHLeftHalf.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			local xMockLeft : SB * 1.5
+			local xMockLeft : mix 0 SB 1.5
 			local xMockRight : RightSB - [xMidBarShrink (slabType === SLAB-ALL)]
-			local shift : Math.abs : Middle - [mix (xMockLeft - [if (slabType === SLAB-NONE) 0 SideJut]) xMockRight 0.5]
-			local xLeft : xMockLeft + shift
-			local xRight : xMockRight + shift
-			include : LeftHalfBody xLeft xRight XH
-			include : LeftHalfHSerifs slabType XH 0 xLeft xRight
+			local xMockMiddle : mix (xMockLeft - [if (slabType === SLAB-NONE) 0 SideJut]) xMockRight 0.5
+			local xLeft  : xMockLeft  + (Middle - xMockMiddle)
+			local xRight : xMockRight + (Middle - xMockMiddle)
+			include : LeftHalfBody             xLeft xRight XH
+			include : LeftHalfHSerifs slabType xLeft xRight XH
 
-		create-glyph "rightHalfSmcpH.\(suffix)" : glyph-proc
+		create-glyph "smcpHRightHalf.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			local xMockLeft : SB + [xMidBarShrink (slabType === SLAB-ALL)]
-			local xMockRight : Width - SB * 1.5
-			local shift : Math.abs : Middle - [mix xMockLeft (xMockRight + [if (slabType === SLAB-NONE) 0 SideJut]) 0.5]
-			local xLeft : xMockLeft - shift
-			local xRight : xMockRight - shift
-			include : RightHalfBody xLeft xRight XH
-			include : RightHalfHSerifs slabType XH 0 xLeft xRight
+			local xMockRight : mix Width RightSB 1.5
+			local xMockMiddle : mix xMockLeft (xMockRight + [if (slabType === SLAB-NONE) 0 SideJut]) 0.5
+			local xLeft  : xMockLeft  + (Middle - xMockMiddle)
+			local xRight : xMockRight + (Middle - xMockMiddle)
+			include : RightHalfBody             xLeft xRight XH
+			include : RightHalfHSerifs slabType xLeft xRight XH
 
 		define enGheDf : DivFrame para.advanceScaleM 3
 
@@ -239,25 +243,44 @@ glyph-block Letter-Latin-Upper-H : begin
 		select-variant "cyrl/EnGhe.\(suffix)" (follow -- 'cyrl/EnGhe/GhePart')
 		select-variant "cyrl/enghe.\(suffix)" (follow -- 'cyrl/enghe/ghePart')
 
-		create-glyph "Hwair.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.advanceScaleMM 3
-			include : df.markSet.capital
-			include : HwairShape df CAP XH slabType
+		define hwairDf : DivFrame para.advanceScaleMM 3
+
+		DefineSelectorGlyph "Hwair" suffix hwairDf 'capital'
+
+		foreach { suffixV serifMR } [Object.entries HwairVConfig] : do
+			create-glyph "Hwair.\(suffix).\(suffixV)" : glyph-proc
+				set-width 0
+				set-mark-anchor 'cvDecompose' 0 0
+				include : HwairShape hwairDf CAP XH slabType serifMR
+
+		select-variant "Hwair.\(suffix)" (follow -- 'Hv/v')
 
 		create-glyph "cyrl/NjeKomi.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleMM 3
 			include : df.markSet.capital
-			include : HwairShape df CAP (CAP / 2 + HalfStroke) slabType
+			include : HwairShape df CAP (CAP / 2 + HalfStroke) slabType SLAB
 
 		create-glyph "cyrl/njeKomi.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleMM 3
 			include : df.markSet.e
-			include : HwairShape df XH (XH / 2 + HalfStroke) slabType
+			include : HwairShape df XH (XH / 2 + HalfStroke) slabType SLAB
 
 		create-glyph "HHookLeft.\(suffix)" : glyph-proc
 			include [refer-glyph "H.\(suffix)"] AS_BASE ALSO_METRICS
 			eject-contour "serifLT"
 			include : LeftHook SB CAP
+
+		create-glyph "Heng.\(suffix)" : glyph-proc
+			include : MarkSet.capDesc
+			include [refer-glyph "H.\(suffix)"]
+			eject-contour 'serifRB'
+			include : EngHook RightSB 0 Descender
+
+		create-glyph "smcpHeng.\(suffix)" : glyph-proc
+			include : MarkSet.p
+			include [refer-glyph "smcpH.\(suffix)"]
+			eject-contour 'serifRB'
+			include : EngHook RightSB 0 Descender
 
 		create-glyph "HStroke.\(suffix)" : glyph-proc
 			include [refer-glyph "H.\(suffix)"] AS_BASE ALSO_METRICS
@@ -273,11 +296,9 @@ glyph-block Letter-Latin-Upper-H : begin
 
 			local xm : df.middle + [HSwToV : 0.5 * df.mvs]
 			include : Body df.leftSB xm CAP df.mvs
-			include : difference
-				HSerifs slabType CAP 0 df.leftSB xm df.mvs
-				intersection
-					MaskBelow Stroke
-					MaskRight [mix xm (df.rightSB - [HSwToV df.mvs]) 0.625]
+			include : difference [HSerifs slabType df.leftSB xm CAP df.mvs] : intersection
+				MaskBelow Stroke
+				MaskRight [mix xm (df.rightSB - [HSwToV df.mvs]) 0.625]
 			include : MidHook.m df CAP
 
 		create-glyph "cyrl/enMidHook.\(suffix)" : glyph-proc
@@ -286,26 +307,24 @@ glyph-block Letter-Latin-Upper-H : begin
 
 			local xm : df.middle + [HSwToV : 0.5 * df.mvs]
 			include : Body df.leftSB xm XH df.mvs
-			include : difference
-				HSerifs slabType XH 0 df.leftSB xm df.mvs
-				intersection
-					MaskBelow Stroke
-					MaskRight [mix xm (df.rightSB - [HSwToV df.mvs]) 0.625]
+			include : difference [HSerifs slabType df.leftSB xm XH df.mvs] : intersection
+				MaskBelow Stroke
+				MaskRight [mix xm (df.rightSB - [HSwToV df.mvs]) 0.625]
 			include : MidHook.m df XH
 
 	select-variant 'H' 'H'
 	link-reduced-variant 'H/sansSerif' 'H' MathSansSerif
 	select-variant 'H/descBase' (shapeFrom -- 'H')
 	select-variant 'turnH' 0xA78D (follow -- 'H')
-	select-variant 'leftHalfH' 0x2C75
-	select-variant 'rightHalfH' 0xA7F5
+	select-variant 'HLeftHalf' 0x2C75
+	select-variant 'HRightHalf' 0xA7F5
 
 	select-variant 'grek/Eta' 0x397 (follow -- 'H')
 	link-reduced-variant 'grek/Eta/sansSerif' 'grek/Eta' MathSansSerif (follow -- 'H/sansSerif')
 
 	select-variant 'smcpH' 0x29C (follow -- 'H')
-	select-variant 'leftHalfSmcpH' 0x2C76 (follow -- 'leftHalfH')
-	select-variant 'rightHalfSmcpH' 0xA7F6 (follow -- 'rightHalfH')
+	select-variant 'smcpHLeftHalf' 0x2C76 (follow -- 'HLeftHalf')
+	select-variant 'smcpHRightHalf' 0xA7F6 (follow -- 'HRightHalf')
 
 	select-variant 'cyrl/En' 0x41D (shapeFrom -- 'H')
 	select-variant 'cyrl/En/descBase' (shapeFrom -- 'H')
@@ -314,26 +333,23 @@ glyph-block Letter-Latin-Upper-H : begin
 	select-variant 'cyrl/en/descBase' (shapeFrom -- 'smcpH')
 	select-variant 'cyrl/en.BGR' (shapeFrom -- 'smcpH')
 
-	alias 'grek/Heta' 0x370 'leftHalfH'
-	alias 'grek/heta' 0x371 : if SLAB 'leftHalfSmcpH.topLeftSerifed' 'leftHalfSmcpH.serifless'
-
-	derive-composites 'HDescender' 0x2C67 'H/descBase' [CyrDescender.rSideJut RightSB 0]
-
-	derive-composites 'cyrl/EnDescender' 0x4A2 'cyrl/En/descBase' [CyrDescender.rSideJut RightSB 0]
-	derive-composites 'cyrl/enDescender' 0x4A3 'cyrl/en/descBase' [CyrDescender.rSideJut RightSB 0]
-
-	derive-composites 'cyrl/EnTail' 0x4C9 'cyrl/En/descBase' [CyrTailDescender.rSideJut RightSB 0]
-	derive-composites 'cyrl/enTail' 0x4CA 'cyrl/en/descBase' [CyrTailDescender.rSideJut RightSB 0]
+	alias 'grek/Heta' 0x370 'HLeftHalf'
+	alias 'grek/heta' 0x371 [if SLAB 'smcpHLeftHalf.topLeftSerifed' 'smcpHLeftHalf.serifless']
 
 	CreateSelectorVariants 'cyrl/EnGhe' 0x4A4 [Object.keys HConfig] (follow -- 'cyrl/En')
 	CreateSelectorVariants 'cyrl/enghe' 0x4A5 [Object.keys HConfig] (follow -- 'cyrl/en')
 
-	select-variant 'Hwair' 0x1F6
+	CreateSelectorVariants 'Hwair' 0x1F6 [Object.keys HConfig] (follow -- 'Hv/H')
 
 	select-variant 'HHookLeft' 0xA7AA
 
+	select-variant 'Heng' 0xA726 (follow -- 'H/descBase')
+
 	select-variant 'HStroke' 0x126 (follow -- 'H')
 	select-variant 'smcpHStroke' (follow -- 'H')
+
+	select-variant 'cyrl/EnHook' 0x4C7 (shapeFrom -- 'Heng') (follow -- 'cyrl/En/descBase')
+	select-variant 'cyrl/enHook' 0x4C8 (shapeFrom -- 'smcpHeng') (follow -- 'cyrl/en/descBase')
 
 	select-variant 'cyrl/EnMidHook' 0x0522 (follow -- 'cyrl/En')
 	select-variant 'cyrl/enMidHook' 0x0523 (follow -- 'cyrl/en')
@@ -350,21 +366,13 @@ glyph-block Letter-Latin-Upper-H : begin
 		set-base-anchor 'belowBraceL' (markMiddle + shift - 0.5 * markExtend) belowMarkMid
 		set-base-anchor 'belowBraceR' (markMiddle + shift + 0.5 * markExtend) belowMarkMid
 
-	define [DProcCapitalHeng src sel] : glyph-proc
-		include : MarkSet.capDesc
-		include : refer-glyph src
-		eject-contour 'serifRB'
-		include : EngHook RightSB 0 Descender
+	derive-composites 'HDescender' 0x2C67 'H/descBase' [CyrDescender.rSideJut RightSB 0]
 
-	define [DProcSmallHeng src sel] : glyph-proc
-		include : MarkSet.p
-		include : refer-glyph src
-		eject-contour 'serifRB'
-		include : EngHook RightSB 0 Descender
+	derive-composites 'cyrl/EnDescender' 0x4A2 'cyrl/En/descBase' [CyrDescender.rSideJut RightSB 0]
+	derive-composites 'cyrl/enDescender' 0x4A3 'cyrl/en/descBase' [CyrDescender.rSideJut RightSB 0]
 
-	derive-glyphs 'Heng' 0xA726 'H/descBase' DProcCapitalHeng
-	derive-glyphs 'cyrl/EnHook' 0x4C7 'cyrl/En/descBase' DProcCapitalHeng
-	derive-glyphs 'cyrl/enHook' 0x4C8 'cyrl/en/descBase' DProcSmallHeng
+	derive-composites 'cyrl/EnTail' 0x4C9 'cyrl/En/descBase' [CyrTailDescender.rSideJut RightSB 0]
+	derive-composites 'cyrl/enTail' 0x4CA 'cyrl/en/descBase' [CyrTailDescender.rSideJut RightSB 0]
 
 	derive-glyphs 'cyrl/EnHookLeft' 0x528 'cyrl/En' : lambda [src srl] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
@@ -378,12 +386,12 @@ glyph-block Letter-Latin-Upper-H : begin
 
 	create-glyph 'mathbb/H' 0x210D : glyph-proc
 		include : MarkSet.capital
-		include : VBar.l SB 0 CAP BBS
+		include : VBar.l SB      0 CAP BBS
 		include : VBar.r RightSB 0 CAP BBS
-		include : VBar.l (SB + BBD) 0 CAP BBS
+		include : VBar.l (SB      + BBD) 0 CAP BBS
 		include : VBar.r (RightSB - BBD) 0 CAP BBS
-		include : HBar.m (SB + BBD) (RightSB - BBD) (CAP * HBarPos) BBS
+		include : HBar.m (SB + BBD) (RightSB - BBD) [mix 0 CAP HBarPos] BBS
 		include : HBar.t SB (SB + BBD) CAP BBS
+		include : HBar.b SB (SB + BBD) 0   BBS
 		include : HBar.t (RightSB - BBD) RightSB CAP BBS
-		include : HBar.b SB (SB + BBD) 0 BBS
-		include : HBar.b (RightSB - BBD) RightSB 0 BBS
+		include : HBar.b (RightSB - BBD) RightSB 0   BBS

--- a/packages/font-glyphs/src/letter/latin/upper-t.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-t.ptl
@@ -51,8 +51,8 @@ glyph-block Letter-Latin-Upper-T : begin
 			right  -- right
 			ybegin -- top
 			yend   -- (top / 2 + HalfStroke)
-			ada    -- (SmallArchDepthA * 0.6 * df.adws)
-			adb    -- (SmallArchDepthB * 0.6 * df.adws)
+			ada    -- (ArchDepthA * (2 / df.hPack) * df.adws)
+			adb    -- (ArchDepthB * (2 / df.hPack) * df.adws)
 			sw     -- sw
 
 		if doTopSerifs : begin

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -975,9 +975,9 @@ description = "H without serifs"
 selector.H = "serifless"
 selector."H/sansSerif" = "serifless"
 selector."H/descBase" = "serifless"
-selector.leftHalfH = "serifless"
-selector.rightHalfH = "serifless"
-selector.Hwair = "serifless"
+selector.HLeftHalf = "serifless"
+selector.HRightHalf = "serifless"
+selector."Hv/H" = "serifless"
 selector.HHookLeft = "serifless"
 selector.HHookTop = "serifless"
 
@@ -987,9 +987,9 @@ description = "H with serif only at top left"
 selector.H = "topLeftSerifed"
 selector."H/sansSerif" = "serifless"
 selector."H/descBase" = "topLeftSerifed"
-selector.leftHalfH = "topLeftSerifed"
-selector.rightHalfH = "serifless"
-selector.Hwair = "topLeftSerifed"
+selector.HLeftHalf = "topLeftSerifed"
+selector.HRightHalf = "serifless"
+selector."Hv/H" = "topLeftSerifed"
 selector.HHookLeft = "serifless"
 selector.HHookTop = "serifless"
 
@@ -999,9 +999,9 @@ description = "H with serif only at top left and bottom right"
 selector.H = "topLeftBottomRightSerifed"
 selector."H/sansSerif" = "serifless"
 selector."H/descBase" = "topLeftSerifed"
-selector.leftHalfH = "topLeftSerifed"
-selector.rightHalfH = "topLeftBottomRightSerifed"
-selector.Hwair = "topLeftSerifed"
+selector.HLeftHalf = "topLeftSerifed"
+selector.HRightHalf = "topLeftBottomRightSerifed"
+selector."Hv/H" = "topLeftSerifed"
 selector.HHookLeft = "topLeftBottomRightSerifed"
 selector.HHookTop = "topLeftBottomRightSerifed"
 
@@ -1011,9 +1011,9 @@ description = "H with serifs"
 selector.H = "serifed"
 selector."H/sansSerif" = "serifless"
 selector."H/descBase" = "serifed"
-selector.leftHalfH = "serifed"
-selector.rightHalfH = "serifed"
-selector.Hwair = "serifedExceptBottomRight"
+selector.HLeftHalf = "serifed"
+selector.HRightHalf = "serifed"
+selector."Hv/H" = "serifedExceptBottomRight"
 selector.HHookLeft = "serifed"
 selector.HHookTop = "serifed"
 
@@ -1783,6 +1783,7 @@ descriptionAffix = "straight shape"
 selectorAffix.V = "straight"
 selectorAffix."V/sansSerif" = "straight"
 selectorAffix.VScript = "rounded"
+selectorAffix."Hv/v" = "rounded"
 
 [prime.capital-v.variants-buildup.stages.body.curly]
 rank = 2
@@ -1790,6 +1791,7 @@ descriptionAffix = "curly shape"
 selectorAffix.V = "curly"
 selectorAffix."V/sansSerif" = "curly"
 selectorAffix.VScript = "rounded"
+selectorAffix."Hv/v" = "rounded"
 
 [prime.capital-v.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -1798,6 +1800,7 @@ descriptionJoiner = "without"
 selectorAffix.V = "serifless"
 selectorAffix."V/sansSerif" = "serifless"
 selectorAffix.VScript = "serifless"
+selectorAffix."Hv/v" = "serifless"
 
 [prime.capital-v.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
@@ -1805,6 +1808,7 @@ descriptionAffix = "motion serifs"
 selectorAffix.V = "motionSerifed"
 selectorAffix."V/sansSerif" = "serifless"
 selectorAffix.VScript = "motionSerifed"
+selectorAffix."Hv/v" = "serifless"
 
 [prime.capital-v.variants-buildup.stages.serifs.serifed]
 rank = 3
@@ -1812,6 +1816,7 @@ descriptionAffix = "serifs"
 selectorAffix.V = "serifed"
 selectorAffix."V/sansSerif" = "serifless"
 selectorAffix.VScript = "serifed"
+selectorAffix."Hv/v" = "serifed"
 
 
 
@@ -1947,6 +1952,7 @@ selectorAffix.WHookRight = "curlyFlatTop"
 [prime.capital-w.variants-buildup.stages.body.curly-asymmetric]
 rank = 15
 groupRank = 3
+nonBreakingVariantAdditionPriority = 200
 descriptionAffix = "curly body with asymmetric center"
 selectorAffix.W = "curlyAsymmetric"
 selectorAffix."W/sansSerif" = "curlyAsymmetric"
@@ -1955,7 +1961,7 @@ selectorAffix.WHookRight = "curlyAsymmetric"
 [prime.capital-w.variants-buildup.stages.body.curly-asymmetric-almost-flat-top]
 rank = 16
 groupRank = 3
-nonBreakingVariantAdditionPriority = 100
+nonBreakingVariantAdditionPriority = 200
 descriptionAffix = "curly body with asymmetric center, almost flat top"
 selectorAffix.W = "curlyAsymmetricAlmostFlatTop"
 selectorAffix."W/sansSerif" = "curlyAsymmetricAlmostFlatTop"
@@ -3085,6 +3091,7 @@ selectorAffix."h/descBase" = "straight"
 selectorAffix.hHookTop = "straight"
 selectorAffix.heng = "straight"
 selectorAffix.hengHookTop = "straight"
+selectorAffix."hv/h" = "straight"
 
 [prime.h.variants-buildup.stages.tail.tailed]
 rank = 2
@@ -3095,6 +3102,7 @@ selectorAffix."h/descBase" = "straight"
 selectorAffix.hHookTop = "tailed"
 selectorAffix.heng = "straight"
 selectorAffix.hengHookTop = "straight"
+selectorAffix."hv/h" = "straight"
 
 [prime.h.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -3106,6 +3114,7 @@ selectorAffix."h/descBase" = "serifless"
 selectorAffix.hHookTop = "serifless"
 selectorAffix.heng = "serifless"
 selectorAffix.hengHookTop = "serifless"
+selectorAffix."hv/h" = "serifless"
 
 [prime.h.variants-buildup.stages.serifs.top-left-serifed]
 rank = 2
@@ -3117,6 +3126,7 @@ selectorAffix."h/descBase" = "topLeftSerifed"
 selectorAffix.hHookTop = "serifless"
 selectorAffix.heng = "topLeftSerifed"
 selectorAffix.hengHookTop = "serifless"
+selectorAffix."hv/h" = "topLeftSerifed"
 
 [prime.h.variants-buildup.stages.serifs.motion-serifed]
 rank = 3
@@ -3127,6 +3137,7 @@ selectorAffix."h/descBase" = "topLeftSerifed"
 selectorAffix.hHookTop = { if = [{ tail = "straight" }], then = "motionSerifed", else = "serifless" }
 selectorAffix.heng = "topLeftSerifed"
 selectorAffix.hengHookTop = "serifless"
+selectorAffix."hv/h" = "topLeftSerifed"
 
 [prime.h.variants-buildup.stages.serifs.serifed]
 rank = 4
@@ -3137,6 +3148,7 @@ selectorAffix."h/descBase" = "serifed"
 selectorAffix.hHookTop = "serifed"
 selectorAffix.heng = "serifed"
 selectorAffix.hengHookTop = "serifed"
+selectorAffix."hv/h" = "serifedExceptBottomRight"
 
 
 
@@ -4811,6 +4823,7 @@ descriptionAffix = "straight body"
 selectorAffix.v = "straight"
 selectorAffix."v/sansSerif" = "straight"
 selectorAffix.vScript = "rounded"
+selectorAffix."hv/v" = "rounded"
 selectorAffix.vHookRight = "straight"
 selectorAffix.vLoop = "straight"
 
@@ -4820,6 +4833,7 @@ descriptionAffix = "curly body"
 selectorAffix.v = "curly"
 selectorAffix."v/sansSerif" = "curly"
 selectorAffix.vScript = "rounded"
+selectorAffix."hv/v" = "rounded"
 selectorAffix.vHookRight = "curly"
 selectorAffix.vLoop = "curly"
 
@@ -4829,6 +4843,7 @@ descriptionAffix = "cursive body"
 selectorAffix.v = "cursive"
 selectorAffix."v/sansSerif" = "cursive"
 selectorAffix.vScript = "rounded"
+selectorAffix."hv/v" = "rounded"
 selectorAffix.vHookRight = "straight"
 selectorAffix.vLoop = "straight"
 
@@ -4839,6 +4854,7 @@ descriptionJoiner = "without"
 selectorAffix.v = "serifless"
 selectorAffix."v/sansSerif" = "serifless"
 selectorAffix.vScript = "serifless"
+selectorAffix."hv/v" = "serifless"
 selectorAffix.vHookRight = "serifless"
 selectorAffix.vLoop = "serifless"
 
@@ -4849,6 +4865,7 @@ descriptionAffix = "motion serifs"
 selectorAffix.v = "motionSerifed"
 selectorAffix."v/sansSerif" = "serifless"
 selectorAffix.vScript = "motionSerifed"
+selectorAffix."hv/v" = "serifless"
 selectorAffix.vHookRight = "motionSerifed"
 selectorAffix.vLoop = "serifless"
 
@@ -4858,6 +4875,7 @@ descriptionAffix = "serifs"
 selectorAffix.v = "serifed"
 selectorAffix."v/sansSerif" = "serifless"
 selectorAffix.vScript = {if = [{body = "cursive"}], then = "motionSerifed", else = "serifed"}
+selectorAffix."hv/v" = {if = [{body = "cursive"}], then = "serifless", else = "serifed"}
 selectorAffix.vHookRight = {if = [{body = "cursive"}], then = "motionSerifed", else = "serifed"}
 selectorAffix.vLoop = {if = [{body = "cursive"}], then = "serifless", else = "serifed"}
 
@@ -4995,6 +5013,7 @@ selectorAffix.wHookRight = "curlyFlatTop"
 [prime.w.variants-buildup.stages.body.curly-asymmetric]
 rank = 15
 groupRank = 3
+nonBreakingVariantAdditionPriority = 200
 descriptionAffix = "curly body with asymmetric center"
 selectorAffix.w = "curlyAsymmetric"
 selectorAffix."w/sansSerif" = "curlyAsymmetric"
@@ -5003,7 +5022,7 @@ selectorAffix.wHookRight = "curlyAsymmetric"
 [prime.w.variants-buildup.stages.body.curly-asymmetric-almost-flat-top]
 rank = 16
 groupRank = 3
-nonBreakingVariantAdditionPriority = 100
+nonBreakingVariantAdditionPriority = 200
 descriptionAffix = "curly body with asymmetric center, almost flat top"
 selectorAffix.w = "curlyAsymmetricAlmostFlatTop"
 selectorAffix."w/sansSerif" = "curlyAsymmetricAlmostFlatTop"
@@ -5016,7 +5035,6 @@ descriptionAffix = "cursive shape"
 selectorAffix.w = "cursive"
 selectorAffix."w/sansSerif" = "cursive"
 selectorAffix.wHookRight = "cursive"
-
 
 [prime.w.variants-buildup.stages.serifs.serifless]
 rank = 1


### PR DESCRIPTION
This basically makes all the Komi letters have the same arch depth as each other for their `UpwardHookShape` instances, using
`(2 / [DivFrame].hPack) * [DivFrame].adws` as the scalar for the arch depths under monospace — usually evaluating to `1` under Quasi Proportional, but not always, with Tje (`Ԏ`, `ԏ`) being an exception, but this is fine because it doesn't fully expand out enough to actually _need_ to evaluate to `1`.

Also make Hwair (`Ƕ`, `ƕ`) respond to (serif) variants of `V`/`v` (`cv31`, `cv76`) as it is also simultaneously an Hv/hv ligature. This does not include distinguishing between straight/curly body variants.

`HǶhƕ ԀԂԁԃ ЗԄзԅ НԊнԋ ЛԈлԉ СԌсԍ ТԎтԏ`

Sans Monospace:
<img width="1119" height="1124" alt="image" src="https://github.com/user-attachments/assets/5634c8d2-409a-4c8c-b39c-a61556574e6a" />
Slab Monospace:
<img width="1129" height="1132" alt="image" src="https://github.com/user-attachments/assets/c96e6728-ed11-4549-adba-a7c0c64a116b" />
Aile:
<img width="1483" height="1126" alt="image" src="https://github.com/user-attachments/assets/85e416e0-d5a5-4735-ab8b-80c102b8379f" />
Etoile:
<img width="1500" height="1125" alt="image" src="https://github.com/user-attachments/assets/3bac2aa1-56a2-4f54-924d-fa22cadc9836" />
