### PR TITLE
Flat Hook `5`

### DIFF
--- a/changes/34.0.0.md
+++ b/changes/34.0.0.md
@@ -2,6 +2,7 @@
 * Add characters:
   - UNCERTAINTY SIGN (`U+2BD1`) (#2976).
 * Add `straight-vertical-sides-almost-flat-top` and `rounded-vertical-sides-almost-flat-top` variants for `W` and `w`.
+* Add `flat-hook` variants for `5`.
 * Refine shape of the following characters:
   - LATIN CAPITAL LETTER GHA (`U+01A2`).
   - LATIN SMALL LETTER GHA (`U+01A3`).

--- a/packages/font-glyphs/src/letter/shared/arc-hook.ptl
+++ b/packages/font-glyphs/src/letter/shared/arc-hook.ptl
@@ -193,7 +193,7 @@ glyph-block Letter-Arc-Hook : begin
 		export : define [hookEndR] : begin
 			return : list
 				hookend box.b (sw -- sw)
-				g4 box.r (box.b + hook) [heading Upward]
+				g4 box.r (box.b + hook) # Rounded hooks only end with non-level terminal for EndR
 
 		export : define [serifStartL] : return : glyph-proc
 		export : define [serifStartR] : return : glyph-proc
@@ -227,42 +227,42 @@ glyph-block Letter-Arc-Hook : begin
 		export : define [arcStartL] : begin
 			return : list
 				corner xLArc box.t [widths.rhs.heading sw Rightward]
-				curl [arch.adjust-x.top (midX + midShift) sw] box.t
+				curl [Math.max (xLArc + TanSlope * sw) : arch.adjust-x.top (midX + midShift) sw] box.t [heading Rightward]
 				archv
 		export : define [arcStartR] : begin
 			return : list
 				corner xRArc box.t [widths.lhs.heading sw Leftward]
-				curl [arch.adjust-x.top (midX - midShift) sw] box.t
+				curl [Math.min (xRArc - TanSlope * sw) : arch.adjust-x.top (midX - midShift) sw] box.t [heading Leftward]
 				archv
 		export : define [arcEndL] : begin
 			return : list
 				arcvh
-				flat [arch.adjust-x.bot (midX + midShift) sw] box.b [widths.rhs sw]
+				flat [Math.max (xLArc + TanSlope * sw) : arch.adjust-x.bot (midX + midShift) sw] box.b [widths.rhs.heading sw Leftward]
 				corner xLArc box.b [heading Leftward]
 		export : define [arcEndR] : begin
 			return : list
 				arcvh
-				flat [arch.adjust-x.bot (midX - midShift) sw] box.b [widths.lhs sw]
+				flat [Math.min (xRArc - TanSlope * sw) : arch.adjust-x.bot (midX - midShift) sw] box.b [widths.lhs.heading sw Rightward]
 				corner xRArc box.b [heading Rightward]
 		export : define [hookStartL] : begin
 			return : list
 				corner xLHook box.t [widths.rhs sw]
-				curl [arch.adjust-x.top (midX + midShift) sw] box.t
+				curl [Math.max (xLHook + TanSlope * sw) : arch.adjust-x.top (midX + midShift) sw] box.t [heading Rightward]
 				archv.superness DesignParameters.tightHookSuperness
 		export : define [hookStartR] : begin
 			return : list
 				corner xRHook box.t [widths.lhs sw]
-				curl [arch.adjust-x.top (midX - midShift) sw] box.t
+				curl [Math.min (xRHook - TanSlope * sw) : arch.adjust-x.top (midX - midShift) sw] box.t [heading Leftward]
 				archv.superness DesignParameters.tightHookSuperness
 		export : define [hookEndL] : begin
 			return : list
 				arcvh.superness DesignParameters.tightHookSuperness
-				flat [arch.adjust-x.bot (midX + midShift) sw] box.b [widths.rhs sw]
+				flat [Math.max (xLHook + TanSlope * sw) : arch.adjust-x.bot (midX + midShift) sw] box.b [widths.rhs.heading sw Leftward]
 				corner xLHook box.b
 		export : define [hookEndR] : begin
 			return : list
 				arcvh.superness DesignParameters.tightHookSuperness
-				flat [arch.adjust-x.bot (midX - midShift) sw] box.b [widths.lhs sw]
+				flat [Math.min (xRHook - TanSlope * sw) : arch.adjust-x.bot (midX - midShift) sw] box.b [widths.lhs.heading sw Rightward]
 				corner xRHook box.b
 
 		export : define [serifStartL] : begin

--- a/packages/font-glyphs/src/letter/shared/shoulder-bowl.ptl
+++ b/packages/font-glyphs/src/letter/shared/shoulder-bowl.ptl
@@ -11,6 +11,8 @@ glyph-block Letter-Shoulder-Bowl : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Arc-Hook : ArcStartSerifWidth
 
+	glyph-block-export BowlT ShoulderT
+
 	define flex-params [BowlT] : namespace
 		local-parameter : arcCStart
 		local-parameter : arcCEnd
@@ -21,13 +23,14 @@ glyph-block Letter-Shoulder-Bowl : begin
 		local-parameter : sw    -- Stroke
 
 		local-parameter : barSw -- [ArcStartSerifWidth sw]
+		local-parameter : hook  -- Hook
 		local-parameter : ox    -- OX
 
 
 		define realAda : ArchDepthAClamped box.t box.b ada adb
 		define realAdb : ArchDepthBClamped box.t box.b ada adb
-		export : define ArcStart : arcCStart box (ada -- realAda) (adb -- realAdb) (sw -- sw) (barSw -- barSw)
-		export : define ArcEnd   : arcCEnd   box (ada -- realAda) (adb -- realAdb) (sw -- sw) (barSw -- barSw)
+		export : define ArcStart : arcCStart box (ada -- realAda) (adb -- realAdb) (sw -- sw) (barSw -- barSw) (hook -- hook)
+		export : define ArcEnd   : arcCEnd   box (ada -- realAda) (adb -- realAdb) (sw -- sw) (barSw -- barSw) (hook -- hook)
 
 		export : define shape : namespace
 			export : define [arcL] : dispiro
@@ -74,8 +77,9 @@ glyph-block Letter-Shoulder-Bowl : begin
 		local-parameter : sw    -- Stroke
 
 		local-parameter : barSw -- [ArcStartSerifWidth sw]
+		local-parameter : hook  -- Hook
 
-		export : define Arc : arcC box (ada -- ada) (adb -- adb) (sw -- sw) (barSw -- barSw)
+		export : define Arc : arcC box (ada -- ada) (adb -- adb) (sw -- sw) (barSw -- barSw) (hook -- hook)
 
 		export : define shape : namespace
 			export : define [arcLT] : dispiro

--- a/packages/font-glyphs/src/number/5.ptl
+++ b/packages/font-glyphs/src/number/5.ptl
@@ -2,6 +2,7 @@ $$include '../meta/macros.ptl'
 
 import [mix linreg clamp fallback SuffixCfg] from "@iosevka/util"
 import [MathSansSerif] from "@iosevka/glyph/relation"
+import [Box] from "@iosevka/geometry/box"
 
 glyph-module
 
@@ -9,34 +10,11 @@ glyph-block Digits-Five : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Digits-Shared : OnumMarks ShiftDown CodeLnum CodeOnum
-
-	define [FiveFlatStroke xLeft archTop pShapeHeight sw] : dispiro
-		widths.rhs sw
-		flat (xLeft + [HSwToV sw]) archTop
-		curl [Math.max (xLeft + TINY) [arch.adjust-x.top Middle sw]] archTop
-		archv
-		g4 (RightSB - OX) [YSmoothMidR archTop 0 ArchDepthA ArchDepthB]
-		hookend 0 (sw -- sw)
-		g4 SB (Hook * pShapeHeight)
-
-	define [FiveArcStroke xLeft archTop pShapeHeight sw] : dispiro
-		widths.rhs sw
-		g4 xLeft (archTop - AHook * pShapeHeight)
-		hookstart archTop (sw -- sw)
-		g4 (RightSB - OX) [YSmoothMidR archTop 0 ArchDepthA ArchDepthB]
-		hookend 0 (sw -- sw)
-		g4 SB (Hook * pShapeHeight)
-
-	define [FiveArcStrokeMask xLeft archTop pShapeHeight sw] : spiro-outline
-		g4 (xLeft + 1) (archTop - AHook * pShapeHeight)
-		hookstart (archTop - 1) (sw -- sw)
-		g4 (RightSB - OX - 1) [YSmoothMidR archTop 0 ArchDepthA ArchDepthB]
-		hookend 1 (sw -- sw)
-		g4 (SB + 1) (Hook * pShapeHeight)
+	glyph-block-import Letter-Arc-Hook : Toothed Toothless Rounded Flat
 
 	define [FiveShape] : with-params [
 			top bp pBarPosSwAdj [sw Stroke] [bbd 0] [obl 0] [zt 0]
-			[bottomShape FiveArcStroke] [pXLeft 0.025] [slab SLAB]
+			[bowlTopArcC Rounded] [bowlBotArcC Rounded] [pXLeft 0.025] [slab SLAB]
 		] : glyph-proc
 		local t1 : (top * bp + sw * pBarPosSwAdj) * 0.8
 		local t2 : (top * bp + sw * pBarPosSwAdj) * 1.0
@@ -45,13 +23,21 @@ glyph-block Digits-Five : begin
 
 		local kGap : 0.144 - 0.1 * sw / t2
 
+		local boxTop : new Box t2 0 xLeft RightSB
+		local boxBot : new Box t2 0 SB RightSB
+		local ArcTop : bowlTopArcC boxTop (sw -- sw) (barSw -- sw) (hook -- AHook * (top / CAP)) (xShrink -- [HSwToV : 0.5 * sw])
+		local ArcBot : bowlBotArcC boxBot (sw -- sw) (barSw -- sw) (hook --  Hook * (top / CAP))
+
 		include : difference
 			glyph-proc
-				local fiveStroke : include : bottomShape xLeft t2 (top / CAP) sw
+				local fiveStroke : include : dispiro
+					ArcTop.hookStartL
+					g4 (RightSB - OX) [YSmoothMidR t2 0 ArchDepthA ArchDepthB]
+					ArcBot.hookEndL
 				local firstKnot fiveStroke.rhsKnots.0
 
 				local oblCor : Math.hypot 1 obl
-				local xVBar : firstKnot.x - oblCor * [HSwToV sw]
+				local xVBar : firstKnot.x - oblCor * [HSwToV sw] + [if (bowlTopArcC === Flat) [HSwToV : 0.5 * sw] 0]
 				local xVBarOffset : (top - firstKnot.y) * obl
 				include : HBar.t [if zt SB (xVBar + xVBarOffset)] xRight top sw
 				include : union
@@ -62,7 +48,16 @@ glyph-block Digits-Five : begin
 						flat xVBar firstKnot.y [widths.rhs.heading (oblCor * sw) Upward]
 						flat (xVBar + xVBarOffset) top [heading Upward]
 
-				if bbd : let [mask : FiveArcStrokeMask xLeft t2 (top / CAP) sw] : begin
+				if bbd : begin
+					local boxTop2 : boxTop.pad TINY
+					local boxBot2 : boxBot.pad TINY
+					local ArcTop2 : bowlTopArcC boxTop2 (sw -- sw) (barSw -- sw) (hook -- AHook * (top / CAP)) (xShrink -- [HSwToV : 0.5 * sw])
+					local ArcBot2 : bowlBotArcC boxBot2 (sw -- sw) (barSw -- sw) (hook --  Hook * (top / CAP))
+
+					local mask : spiro-outline
+						ArcTop2.hookStartL
+						g4 (boxTop2.r - OX) [YSmoothMidR t2 0 ArchDepthA ArchDepthB]
+						ArcBot2.hookEndL
 					include : intersection mask [VBar.r (RightSB - OX - bbd) 0 CAP sw]
 					include : difference [VBar.r (firstKnot.x + bbd) 0 CAP sw] mask [Rect (t2 / 2) 0 0 Width]
 
@@ -74,30 +69,31 @@ glyph-block Digits-Five : begin
 		object # upper-left-bar
 			"upright" 0
 			"oblique" (1 / 12)
-		object # middle
-			"arched"  { FiveArcStroke  DesignParameters.fiveBarPos           0     0.025 }
-			"flat"    { FiveFlatStroke (7 / 8 * DesignParameters.fiveBarPos) (1/3) 0.05  }
+		object # arcs
+			"arched"    { Rounded Rounded DesignParameters.fiveBarPos           0     0.025 }
+			"flat"      { Flat    Rounded (7 / 8 * DesignParameters.fiveBarPos) (1/3) 0.05  }
+			"flat-hook" { Flat    Flat    (7 / 8 * DesignParameters.fiveBarPos) (1/3) 0.05  }
 		object # serifs
 			"serifless" false
 			"serifed"   true
 
-	foreach { suffix { obl { bottomShape pBarPos pBarPosSwAdj pXLeft } slab } } [pairs-of FiveConfig] : do
+	foreach { suffix { obl { bowlTopArcC bowlBotArcC pBarPos pBarPosSwAdj pXLeft } slab } } [pairs-of FiveConfig] : do
 		create-glyph "five.lnum.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : FiveShape CAP pBarPos pBarPosSwAdj (bottomShape -- bottomShape) (obl -- obl) (pXLeft -- pXLeft) (slab -- slab)
+			include : FiveShape CAP pBarPos pBarPosSwAdj (bowlTopArcC -- bowlTopArcC) (bowlBotArcC -- bowlBotArcC) (obl -- obl) (pXLeft -- pXLeft) (slab -- slab)
 
 		create-glyph "five.onum.\(suffix)" : glyph-proc
 			include : OnumMarks.p
-			include : FiveShape CAP pBarPos pBarPosSwAdj (bottomShape -- bottomShape) (obl -- obl) (pXLeft -- pXLeft) (slab -- slab)
+			include : FiveShape CAP pBarPos pBarPosSwAdj (bowlTopArcC -- bowlTopArcC) (bowlBotArcC -- bowlBotArcC) (obl -- obl) (pXLeft -- pXLeft) (slab -- slab)
 			include : ShiftDown
 
 		create-glyph "zhuangToneFive.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : FiveShape CAP pBarPos pBarPosSwAdj (bottomShape -- bottomShape) (zt -- ((RightSB - SB) * 0.05)) (pXLeft -- pXLeft) (slab -- slab)
+			include : FiveShape CAP pBarPos pBarPosSwAdj (bowlTopArcC -- bowlTopArcC) (bowlBotArcC -- bowlBotArcC) (zt -- ((RightSB - SB) * 0.05)) (pXLeft -- pXLeft) (slab -- slab)
 
 		create-glyph "zhuangtonefive.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			include : FiveShape XH pBarPos pBarPosSwAdj (bottomShape -- bottomShape) (zt -- ((RightSB - SB) * 0.05)) (pXLeft -- pXLeft) (slab -- slab)
+			include : FiveShape XH pBarPos pBarPosSwAdj (bowlTopArcC -- bowlTopArcC) (bowlBotArcC -- bowlBotArcC) (zt -- ((RightSB - SB) * 0.05)) (pXLeft -- pXLeft) (slab -- slab)
 
 	select-variant 'five.lnum' [CodeLnum '5'] (follow -- 'five')
 	select-variant 'five.onum' [CodeOnum '5'] (follow -- 'five')

--- a/packages/geometry/src/box.mjs
+++ b/packages/geometry/src/box.mjs
@@ -33,7 +33,7 @@ export class Box {
 	}
 
 	pad(d) {
-		return new Box(this.top - d, this.bottom + d, this.left - d, this.right + d);
+		return new Box(this.top - d, this.bottom + d, this.left + d, this.right - d);
 	}
 	padLeft(d) {
 		return new Box(this.top, this.bottom, this.left + d, this.right);

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -203,7 +203,7 @@ entry = "upper-left-bar"
 descriptionLeader = "`5`"
 
 [prime.five.variants-buildup.stages.upper-left-bar."*"]
-next = "middle"
+next = "arcs"
 
 [prime.five.variants-buildup.stages.upper-left-bar.upright]
 rank = 1
@@ -219,22 +219,29 @@ selectorAffix.five = "oblique"
 selectorAffix."five/sansSerif" = "oblique"
 selectorAffix.zhuangToneFive = "upright"
 
-[prime.five.variants-buildup.stages.middle."*"]
+[prime.five.variants-buildup.stages.arcs."*"]
 next = "serifs"
 
-[prime.five.variants-buildup.stages.middle.arched]
+[prime.five.variants-buildup.stages.arcs.arched]
 rank = 1
 descriptionAffix = "arched middle part"
 selectorAffix.five = "arched"
 selectorAffix."five/sansSerif" = "arched"
 selectorAffix.zhuangToneFive = "arched"
 
-[prime.five.variants-buildup.stages.middle.flat]
+[prime.five.variants-buildup.stages.arcs.flat]
 rank = 2
 descriptionAffix = "flat middle part"
 selectorAffix.five = "flat"
 selectorAffix."five/sansSerif" = "flat"
 selectorAffix.zhuangToneFive = "flat"
+
+[prime.five.variants-buildup.stages.arcs.flat-hook]
+rank = 3
+descriptionAffix = "flat middle part and hook"
+selectorAffix.five = "flat-hook"
+selectorAffix."five/sansSerif" = "flat-hook"
+selectorAffix.zhuangToneFive = "flat-hook"
 
 [prime.five.variants-buildup.stages.serifs.serifless]
 rank = 1


### PR DESCRIPTION
Partially resolves #1287.

`5Ƽƽ𝟝⁵₅` (Bottom 3 lines are before build)
<img width="1260" height="270" alt="screenshot" src="https://github.com/user-attachments/assets/22b99d6c-dc8f-40df-9471-a6efdb75f2e6" />

This PR tries to add flat-hook `5` variants, which is the easiest case out of the 3 mentioned in that issue. `ec` are much more involved and would probably be a draft PR for another time (especially since those changes kinda conflicted with #2972 or something else).

Changes made in Arc-Hook/Bowl-Shoulder/other code:
- Added `hook` override in Bowl/ShoulderT.
	- Ideally we might want a more comprehensive override system on these, something like `arcStartParams` `arcEndParams` (with appropriate defaults) that get passed down to the corresponding Arc constructors. I've no idea how to implement these (it's not as simple as `$-flex-params` i think)
	- (This is not used now)
- Minor modification on `Flat` arcs to (try to) handle potential breaks in crowded spaces + slope.
- Fixed some logic on `box.pad()`.

`5` Variants:
- Modified `5.ptl` to use Arc-Hook. Didn't use BowlT since it had too many special cases or problems.
- Renamed `middle` variant stage to `arcs`, with a new `flat-hook` variant, which has flat middle + hook.
	- Theoretically `arched` middle + `flat` hook is possible but it doesn't look right (<img height="50" alt="Pasted image 20251208045732" src="https://github.com/user-attachments/assets/6b76e25e-1347-421e-845b-1bacfe2869f3" />).
	- Other possible middle/hook arcs:
		- Toothed/Toothless middles (by extension): Probably will look even worse than arched middle.
		- Flat-serifed, Toothless-serifed, Toothed hooks: The kind of serifed-hooks I mentioned in #2085. Probably better to handle them if/when we do serifed digits.
		- Toothless-nonserifed: _This would actually provide the "humanist open hooks" requested in #1287,_ if that's allowed.
- Some minor change in how the flat middle variant is handled. This is required to fix some broken shapes in max slant heavy.