### PR TITLE
Reorganize `W`/`w` variants in `params/variants.toml`.

### DIFF
--- a/packages/font-glyphs/src/letter/latin/w.ptl
+++ b/packages/font-glyphs/src/letter/latin/w.ptl
@@ -393,10 +393,10 @@ glyph-block Letter-Latin-W : begin
 		# Body
 		object
 			straight                           { WShapeImpl   WHookRightShape   FORM-STRAIGHT         MIDH-OTHER      para.advanceScaleM  para.advanceScaleM  }
-			straightAsymmetric                 { WShapeImpl   WHookRightShape   FORM-ASYMMETRIC      MIDH-TOP        para.advanceScaleM  para.advanceScaleT  }
-			straightDoubleV                    { WShapeImpl   WHookRightShape   FORM-DOUBLE-V        MIDH-TOP        para.advanceScaleM  para.advanceScaleT  }
 			straightAlmostFlatTop              { WShapeImpl   WHookRightShape   FORM-STRAIGHT         MIDH-ALMOST-TOP para.advanceScaleMM para.advanceScaleM  }
 			straightFlatTop                    { WShapeImpl   WHookRightShape   FORM-STRAIGHT         MIDH-TOP        para.advanceScaleMM para.advanceScaleM  }
+			straightAsymmetric                 { WShapeImpl   WHookRightShape   FORM-ASYMMETRIC       MIDH-TOP        para.advanceScaleM  para.advanceScaleT  }
+			straightDoubleV                    { WShapeImpl   WHookRightShape   FORM-DOUBLE-V         MIDH-TOP        para.advanceScaleM  para.advanceScaleT  }
 			straightVerticalSides              { WVertSides   WVSHookRightShape FORM-VERTICAL         MIDH-OTHER      para.advanceScaleM  para.advanceScaleT  }
 			straightVerticalSidesAlmostFlatTop { WVertSides   WVSHookRightShape FORM-VERTICAL         MIDH-ALMOST-TOP para.advanceScaleM  para.advanceScaleT  }
 			straightVerticalSidesFlatTop       { WVertSides   WVSHookRightShape FORM-VERTICAL         MIDH-TOP        para.advanceScaleM  para.advanceScaleT  }
@@ -407,10 +407,8 @@ glyph-block Letter-Latin-W : begin
 			curlyAlmostFlatTop                 { WShapeImpl   WHookRightShape   FORM-CURLY            MIDH-ALMOST-TOP para.advanceScaleMM para.advanceScaleM  }
 			curlyFlatTop                       { WShapeImpl   WHookRightShape   FORM-CURLY            MIDH-TOP        para.advanceScaleMM para.advanceScaleM  }
 			curlyAsymmetric                    { WShapeImpl   WHookRightShape   FORM-CURLY-ASYMMETRIC MIDH-TOP        para.advanceScaleM  para.advanceScaleT  }
-			curlyAsymmetricAlmostFlatTop       { WShapeImpl   WHookRightShape   FORM-CURLY-ASYMMETRIC MIDH-ALMOST-TOP para.advanceScaleMM para.advanceScaleM  }
 			cursive                            { WCursiveImpl WHookRightCursive FORM-CURSIVE          MIDH-OTHER      para.advanceScaleMM para.advanceScaleM  }
 			cyrlOmega                          { WShapeImpl   WHookRightShape   FORM-CYRL-OMEGA       MIDH-OTHER      para.advanceScaleMM para.advanceScaleM  }
-
 
 		# Serifs
 		function [body] : if (body == 'cyrlOmega')
@@ -421,7 +419,6 @@ glyph-block Letter-Latin-W : begin
 				serifed     : match body
 					[Just 'straightAsymmetric']           SERIFS-ALL-ASYMMETRIC
 					[Just 'curlyAsymmetric']              SERIFS-ALL-ASYMMETRIC
-					[Just 'curlyAsymmetricAlmostFlatTop'] SERIFS-ALL-ASYMMETRIC
 					[Just 'straightDoubleV']              SERIFS-ALL-OUTER
 					[Just 'straightFlatTop']              SERIFS-ALL-OUTER
 					[Just 'straightVerticalSidesFlatTop'] SERIFS-ALL-OUTER

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -203,7 +203,7 @@ entry = "upper-left-bar"
 descriptionLeader = "`5`"
 
 [prime.five.variants-buildup.stages.upper-left-bar."*"]
-next = "arcs"
+next = "arc"
 
 [prime.five.variants-buildup.stages.upper-left-bar.upright]
 rank = 1
@@ -219,24 +219,24 @@ selectorAffix.five = "oblique"
 selectorAffix."five/sansSerif" = "oblique"
 selectorAffix.zhuangToneFive = "upright"
 
-[prime.five.variants-buildup.stages.arcs."*"]
+[prime.five.variants-buildup.stages.arc."*"]
 next = "serifs"
 
-[prime.five.variants-buildup.stages.arcs.arched]
+[prime.five.variants-buildup.stages.arc.arched]
 rank = 1
 descriptionAffix = "arched middle part"
 selectorAffix.five = "arched"
 selectorAffix."five/sansSerif" = "arched"
 selectorAffix.zhuangToneFive = "arched"
 
-[prime.five.variants-buildup.stages.arcs.flat]
+[prime.five.variants-buildup.stages.arc.flat]
 rank = 2
 descriptionAffix = "flat middle part"
 selectorAffix.five = "flat"
 selectorAffix."five/sansSerif" = "flat"
 selectorAffix.zhuangToneFive = "flat"
 
-[prime.five.variants-buildup.stages.arcs.flat-hook]
+[prime.five.variants-buildup.stages.arc.flat-hook]
 rank = 3
 descriptionAffix = "flat middle part and hook"
 selectorAffix.five = "flat-hook"
@@ -1836,143 +1836,79 @@ entry = "body"
 descriptionLeader = "`W`"
 
 [prime.capital-w.variants-buildup.stages.body."*"]
-next = "serifs"
+next = "center"
 
 [prime.capital-w.variants-buildup.stages.body.straight]
 rank = 1
 groupRank = 1
-descriptionAffix = "standard, straight body"
+descriptionAffix = "straight body shape"
 selectorAffix.W = "straight"
 selectorAffix."W/sansSerif" = "straight"
 selectorAffix.WHookRight = "straight"
 
-[prime.capital-w.variants-buildup.stages.body.straight-almost-flat-top]
-rank = 2
-groupRank = 1
-descriptionAffix = "straight body shape that the middle is almost aligned to the top"
-selectorAffix.W = "straightAlmostFlatTop"
-selectorAffix."W/sansSerif" = "straightFlatTop"
-selectorAffix.WHookRight = "straightAlmostFlatTop"
-
-[prime.capital-w.variants-buildup.stages.body.straight-flat-top]
-rank = 3
-groupRank = 1
-descriptionAffix = "straight body shape that the middle is forced to be aligned to the top"
-selectorAffix.W = "straightFlatTop"
-selectorAffix."W/sansSerif" = "straightFlatTop"
-selectorAffix.WHookRight = "straightFlatTop"
-
-[prime.capital-w.variants-buildup.stages.body.straight-double-v]
-rank = 4
-groupRank = 2
-descriptionAffix = "body shape like double V"
-selectorAffix.W = "straightDoubleV"
-selectorAffix."W/sansSerif" = "straightDoubleV"
-selectorAffix.WHookRight = "straightDoubleV"
-
-[prime.capital-w.variants-buildup.stages.body.straight-asymmetric]
-rank = 5
-groupRank = 2
-descriptionAffix = "asymmetric shape"
-selectorAffix.W = "straightAsymmetric"
-selectorAffix."W/sansSerif" = "straightAsymmetric"
-selectorAffix.WHookRight = "straightAsymmetric"
-
 [prime.capital-w.variants-buildup.stages.body.straight-vertical-sides]
-rank = 6
-groupRank = 3
+rank = 2
+groupRank = 2
 descriptionAffix = "straight body shape with vertical sides"
 selectorAffix.W = "straightVerticalSides"
 selectorAffix."W/sansSerif" = "straightVerticalSides"
 selectorAffix.WHookRight = "straightVerticalSides"
 
-[prime.capital-w.variants-buildup.stages.body.straight-vertical-sides-almost-flat-top]
-rank = 7
-groupRank = 3
-nonBreakingVariantAdditionPriority = 200
-descriptionAffix = "straight body shape with vertical sides, and a middle stem aligned to the top"
-selectorAffix.W = "straightVerticalSidesAlmostFlatTop"
-selectorAffix."W/sansSerif" = "straightVerticalSidesFlatTop"
-selectorAffix.WHookRight = "straightVerticalSidesAlmostFlatTop"
-
-[prime.capital-w.variants-buildup.stages.body.straight-vertical-sides-flat-top]
-rank = 8
-groupRank = 3
-nonBreakingVariantAdditionPriority = 100
-descriptionAffix = "straight body shape with vertical sides, and a middle stem aligned to the top"
-selectorAffix.W = "straightVerticalSidesFlatTop"
-selectorAffix."W/sansSerif" = "straightVerticalSidesFlatTop"
-selectorAffix.WHookRight = "straightVerticalSidesFlatTop"
-
 [prime.capital-w.variants-buildup.stages.body.rounded-vertical-sides]
-rank = 9
-groupRank = 3
+rank = 3
+groupRank = 2
 descriptionAffix = "rounded body shape with vertical sides"
 selectorAffix.W = "roundedVerticalSides"
 selectorAffix."W/sansSerif" = "roundedVerticalSides"
 selectorAffix.WHookRight = "roundedVerticalSides"
 
-[prime.capital-w.variants-buildup.stages.body.rounded-vertical-sides-almost-flat-top]
-rank = 10
-groupRank = 3
-nonBreakingVariantAdditionPriority = 200
-descriptionAffix = "rounded body shape with vertical sides, and a middle stem almost aligned to the top"
-selectorAffix.W = "roundedVerticalSidesAlmostFlatTop"
-selectorAffix."W/sansSerif" = "roundedVerticalSidesFlatTop"
-selectorAffix.WHookRight = "roundedVerticalSidesAlmostFlatTop"
-
-[prime.capital-w.variants-buildup.stages.body.rounded-vertical-sides-flat-top]
-rank = 11
-groupRank = 3
-nonBreakingVariantAdditionPriority = 100
-descriptionAffix = "rounded body shape with vertical sides, and a middle stem aligned to the top"
-selectorAffix.W = "roundedVerticalSidesFlatTop"
-selectorAffix."W/sansSerif" = "roundedVerticalSidesFlatTop"
-selectorAffix.WHookRight = "roundedVerticalSidesFlatTop"
-
 [prime.capital-w.variants-buildup.stages.body.curly]
-rank = 12
+rank = 4
 groupRank = 3
-descriptionAffix = "curly body"
+descriptionAffix = "curly body shape"
 selectorAffix.W = "curly"
 selectorAffix."W/sansSerif" = "curly"
 selectorAffix.WHookRight = "curly"
 
-[prime.capital-w.variants-buildup.stages.body.curly-almost-flat-top]
-rank = 13
-groupRank = 3
-nonBreakingVariantAdditionPriority = 100
-descriptionAffix = "curly body with a middle stem almost aligned to the top"
-selectorAffix.W = "curlyAlmostFlatTop"
-selectorAffix."W/sansSerif" = "curlyFlatTop"
-selectorAffix.WHookRight = "curlyAlmostFlatTop"
+[prime.capital-w.variants-buildup.stages.center."*"]
+next = "serifs"
 
-[prime.capital-w.variants-buildup.stages.body.curly-flat-top]
-rank = 14
-groupRank = 3
-nonBreakingVariantAdditionPriority = 100
-descriptionAffix = "curly body with a middle stem aligned to the top"
-selectorAffix.W = "curlyFlatTop"
-selectorAffix."W/sansSerif" = "curlyFlatTop"
-selectorAffix.WHookRight = "curlyFlatTop"
+[prime.capital-w.variants-buildup.stages.center.standard]
+rank = 1
+keyAffix = ""
+selectorAffix.W = ""
+selectorAffix."W/sansSerif" = ""
+selectorAffix.WHookRight = ""
 
-[prime.capital-w.variants-buildup.stages.body.curly-asymmetric]
-rank = 15
-groupRank = 3
-nonBreakingVariantAdditionPriority = 200
-descriptionAffix = "curly body with asymmetric center"
-selectorAffix.W = "curlyAsymmetric"
-selectorAffix."W/sansSerif" = "curlyAsymmetric"
-selectorAffix.WHookRight = "curlyAsymmetric"
+[prime.capital-w.variants-buildup.stages.center.almost-flat-top]
+rank = 2
+descriptionAffix = "a middle stem almost aligned to the top"
+selectorAffix.W = "almostFlatTop"
+selectorAffix."W/sansSerif" = "flatTop"
+selectorAffix.WHookRight = "almostFlatTop"
 
-[prime.capital-w.variants-buildup.stages.body.curly-asymmetric-almost-flat-top]
-rank = 16
-groupRank = 3
-nonBreakingVariantAdditionPriority = 200
-descriptionAffix = "curly body with asymmetric center, almost flat top"
-selectorAffix.W = "curlyAsymmetricAlmostFlatTop"
-selectorAffix."W/sansSerif" = "curlyAsymmetricAlmostFlatTop"
-selectorAffix.WHookRight = "curlyAsymmetricAlmostFlatTop"
+[prime.capital-w.variants-buildup.stages.center.flat-top]
+rank = 3
+descriptionAffix = "a middle stem aligned to the top"
+selectorAffix.W = "flatTop"
+selectorAffix."W/sansSerif" = "flatTop"
+selectorAffix.WHookRight = "flatTop"
+
+[prime.capital-w.variants-buildup.stages.center.asymmetric]
+rank = 4
+enableIf = [{ body = "straight" }, { body = "curly" }]
+descriptionAffix = "asymmetric center"
+selectorAffix.W = "asymmetric"
+selectorAffix."W/sansSerif" = "asymmetric"
+selectorAffix.WHookRight = "asymmetric"
+
+[prime.capital-w.variants-buildup.stages.center.double-v]
+rank = 5
+enableIf = [{ body = "straight" }]
+descriptionAffix = "crossing center, like double V"
+selectorAffix.W = "doubleV"
+selectorAffix."W/sansSerif" = "doubleV"
+selectorAffix.WHookRight = "doubleV"
 
 [prime.capital-w.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -1994,7 +1930,7 @@ rank = 3
 descriptionAffix = "serifs"
 selectorAffix.W = "serifed"
 selectorAffix."W/sansSerif" = "serifless"
-selectorAffix.WHookRight = { if = [{ body = "straight-double-v" }, { body = "straight-asymmetric" }], then = "motionSerifed", else = "serifed" }
+selectorAffix.WHookRight = { if = [{ center = "flat-top" }, { center = "asymmetric" }, { center = "double-v" }], then = "motionSerifed", else = "serifed" }
 
 
 
@@ -3447,7 +3383,7 @@ selectorAffix.kDescender = "topLeftSerifed"
 
 [prime.k.variants-buildup.stages.serifs.bottom-right-serifed]
 rank = 3
-disableIf = [ { body = "diagonal-tailed-cursive" } ]
+disableIf = [{ body = "diagonal-tailed-cursive" }]
 descriptionAffix = "serifs at bottom right"
 selectorAffix.k = "bottomRightSerifed"
 selectorAffix."k/sansSerif" = "serifless"
@@ -3457,7 +3393,7 @@ selectorAffix.kDescender = "serifless"
 
 [prime.k.variants-buildup.stages.serifs.top-left-and-bottom-right-serifed]
 rank = 4
-disableIf = [ { body = "diagonal-tailed-cursive" } ]
+disableIf = [{ body = "diagonal-tailed-cursive" }]
 descriptionAffix = "serifs at top left and bottom right"
 selectorAffix.k = "topLeftAndBottomRightSerifed"
 selectorAffix."k/sansSerif" = "serifless"
@@ -3468,7 +3404,7 @@ selectorAffix.kDescender = "topLeftSerifed"
 [prime.k.variants-buildup.stages.serifs.top-right-serifed]
 rank = 5
 nonBreakingVariantAdditionPriority = 100
-disableIf = [ { body = "cursive" }, { body = "diagonal-tailed-cursive" } ]
+disableIf = [{ body = "cursive" }, { body = "diagonal-tailed-cursive" }]
 descriptionAffix = "serifs at top right"
 selectorAffix.k = "topRightSerifed"
 selectorAffix."k/sansSerif" = "serifless"
@@ -3479,7 +3415,7 @@ selectorAffix.kDescender = "topRightSerifed"
 [prime.k.variants-buildup.stages.serifs.tri-serifed]
 rank = 6
 nonBreakingVariantAdditionPriority = 100
-disableIf = [ { body = "cursive" }, { body = "diagonal-tailed-cursive" } ]
+disableIf = [{ body = "cursive" }, { body = "diagonal-tailed-cursive" }]
 descriptionAffix = "serifs at top left and both legs"
 selectorAffix.k = "triSerifed"
 selectorAffix."k/sansSerif" = "serifless"
@@ -3489,7 +3425,7 @@ selectorAffix.kDescender = "topLeftAndTopRightSerifed"
 
 [prime.k.variants-buildup.stages.serifs.serifed]
 rank = 7
-disableIf = [ { body = "diagonal-tailed-cursive" } ]
+disableIf = [{ body = "diagonal-tailed-cursive" }]
 descriptionAffix = "serifs"
 selectorAffix.k = "serifed"
 selectorAffix."k/sansSerif" = "serifless"
@@ -3500,7 +3436,7 @@ selectorAffix.kDescender = "serifed"
 [prime.k.variants-buildup.stages.serifs.full-serifed]
 rank = 8
 nonBreakingVariantAdditionPriority = 100
-disableIf = [ { body = "diagonal-tailed-cursive" } ]
+disableIf = [{ body = "diagonal-tailed-cursive" }]
 descriptionAffix = "full serifs at legs"
 selectorAffix.k = "fullSerifed"
 selectorAffix."k/sansSerif" = "serifless"
@@ -3801,7 +3737,7 @@ selectorAffix.meng = ""
 
 [prime.m.variants-buildup.stages.leg.short-leg]
 rank = 2
-groupRank = {if = [{body = "eared"}], then = 2, else = 1}
+groupRank = { if = [{ body = "eared" }], then = 2, else = 1 }
 descriptionAffix = "shorter middle leg (like Ubuntu Mono)"
 selectorAffix.m = "shortLeg"
 selectorAffix."m/sansSerif" = "shortLeg"
@@ -3863,7 +3799,7 @@ selectorAffix.meng = "serifless"
 [prime.m.variants-buildup.stages.serifs.top-left-serifed]
 rank = 2
 descriptionAffix = "serif at top left"
-disableIf = [ { body = "NOT eared" } ]
+disableIf = [{ body = "NOT eared" }]
 selectorAffix.m = "topLeftSerifed"
 selectorAffix."m/sansSerif" = "serifless"
 selectorAffix."m/descBase" = "topLeftSerifed"
@@ -3878,7 +3814,7 @@ selectorAffix.meng = "topLeftSerifed"
 [prime.m.variants-buildup.stages.serifs.top-left-and-bottom-right-serifed]
 rank = 3
 descriptionAffix = "serifs at top left and bottom right"
-disableIf = [ { body = "NOT eared" }, { tail = "tailed" } ]
+disableIf = [{ body = "NOT eared" }, { tail = "tailed" }]
 selectorAffix.m = "topLeftAndBottomRightSerifed"
 selectorAffix."m/sansSerif" = "serifless"
 selectorAffix."m/descBase" = "topLeftSerifed"
@@ -3893,7 +3829,7 @@ selectorAffix.meng = "topLeftSerifed"
 [prime.m.variants-buildup.stages.serifs.bottom-right-serifed]
 rank = 3
 descriptionAffix = "serifs at bottom right"
-disableIf = [ { body = "eared" }, { tail = "tailed" } ]
+disableIf = [{ body = "eared" }, { tail = "tailed" }]
 selectorAffix.m = "bottomRightSerifed"
 selectorAffix."m/sansSerif" = "serifless"
 selectorAffix."m/descBase" = "serifless"
@@ -4029,7 +3965,7 @@ selectorAffix."cyrl/yat.italic/base/cursive" = "serifless"
 [prime.n.variants-buildup.stages.serifs.top-left-serifed]
 rank = 2
 descriptionAffix = "serif at top left"
-enableIf = [ { body = "eared", terminal = "NOT tailed" } ]
+enableIf = [{ body = "eared", terminal = "NOT tailed" }]
 selectorAffix.n = "topLeftSerifed"
 selectorAffix."n/sansSerif" = "serifless"
 selectorAffix."n/descBase" = "topLeftSerifed"
@@ -4045,7 +3981,7 @@ selectorAffix."cyrl/yat.italic/base/cursive" = "topLeftSerifed"
 [prime.n.variants-buildup.stages.serifs.motion-serifed]
 rank = 3
 descriptionAffix = "serif at top left and bottom right"
-disableIf = [ { body = "NOT eared", terminal = "tailed" } ]
+disableIf = [{ body = "NOT eared", terminal = "tailed" }]
 selectorAffix.n = "motionSerifed"
 selectorAffix."n/sansSerif" = "serifless"
 selectorAffix."n/descBase" = { if = [{ body = "eared" }], then = "topLeftSerifed", else = "serifless" }
@@ -4354,7 +4290,7 @@ selectorAffix."rFlap" = "serifless"
 
 [prime.r.variants-buildup.stages.serifs.top-serifed]
 rank = 2
-disableIf = [ { body = "earless-corner" }, { body = "earless-rounded" } ]
+disableIf = [{ body = "earless-corner" }, { body = "earless-rounded" }]
 descriptionAffix = "serif at top"
 selectorAffix.r = "topSerifed"
 selectorAffix."r/sansSerif" = "serifless"
@@ -4364,7 +4300,7 @@ selectorAffix."rFlap" = "serifless"
 
 [prime.r.variants-buildup.stages.serifs.base-serifed]
 rank = 3
-disableIf = [ { body = "earless-corner" }, { body = "earless-rounded" } ]
+disableIf = [{ body = "earless-corner" }, { body = "earless-rounded" }]
 descriptionAffix = "serif at bottom"
 selectorAffix.r = "baseSerifed"
 selectorAffix."r/sansSerif" = "serifless"
@@ -4377,7 +4313,7 @@ rank = 4
 descriptionAffix = "serifs"
 selectorAffix.r = "serifed"
 selectorAffix."r/sansSerif" = "serifless"
-selectorAffix.rRTail = {if =  [{body="earless-corner"}, {body="earless-rounded"}], then = "serifless", else = "topSerifed"}
+selectorAffix.rRTail = { if =  [{ body = "earless-corner" }, { body = "earless-rounded" }], then = "serifless", else = "topSerifed" }
 selectorAffix."r/ascBase" = "serifed"
 selectorAffix."rFlap" = "serifed"
 
@@ -4465,7 +4401,7 @@ selectorAffix."t/compLigRight" = "bentHook"
 selectorAffix.tHookTop = "bentHook"
 selectorAffix.tHookTopRTail = "hookless"
 selectorAffix.tRTail = "hookless"
-selectorAffix.tCurlyTail = {if = [{symmetry = "asymmetric"}], then = "flatHook", else = "bentHook"}
+selectorAffix.tCurlyTail = { if = [{ symmetry = "asymmetric" }], then = "flatHook", else = "bentHook" }
 selectorAffix."tsLig/upperHalf" = "bentHook"
 
 [prime.t.variants-buildup.stages.body.flat-hook]
@@ -4491,7 +4427,7 @@ selectorAffix."t/compLigRight" = "diagonalTailed"
 selectorAffix.tHookTop = "diagonalTailed"
 selectorAffix.tHookTopRTail = "hookless"
 selectorAffix.tRTail = "hookless"
-selectorAffix.tCurlyTail = {if = [{symmetry = "asymmetric"}], then = "flatHook", else = "bentHook"}
+selectorAffix.tCurlyTail = { if = [{ symmetry = "asymmetric" }], then = "flatHook", else = "bentHook" }
 selectorAffix."tsLig/upperHalf" = "bentHook"
 
 [prime.t.variants-buildup.stages.body.hookless]
@@ -4505,7 +4441,7 @@ selectorAffix."t/compLigRight" = "hookless"
 selectorAffix.tHookTop = "hookless"
 selectorAffix.tHookTopRTail = "hookless"
 selectorAffix.tRTail = "hookless"
-selectorAffix.tCurlyTail = {if = [{symmetry = "asymmetric"}], then = "flatHook", else = "hookless"}
+selectorAffix.tCurlyTail = { if = [{ symmetry = "asymmetric" }], then = "flatHook", else = "hookless" }
 selectorAffix."tsLig/upperHalf" = "bentHook"
 
 [prime.t.variants-buildup.stages.symmetry."*"]
@@ -4764,7 +4700,7 @@ selectorAffix.u = "motionSerifed"
 selectorAffix."u/sansSerif" = "serifless"
 selectorAffix."u/descBase" = "motionSerifed"
 selectorAffix.uShortLeg = "motionSerifed"
-selectorAffix.uHookLeft = {if = [{body = "toothed"}], then = "bottomRightSerifed", else = "serifless"}
+selectorAffix.uHookLeft = { if = [{ body = "toothed" }], then = "bottomRightSerifed", else = "serifless" }
 selectorAffix.turnh = "motionSerifed"
 selectorAffix.turnhHookLeft = "bottomRightSerifed"
 selectorAffix.turnhHookLeftRTail = "serifless"
@@ -4782,7 +4718,7 @@ selectorAffix."cyrl/dzhe.italic" = "motionSerifed"
 selectorAffix."cyrl/tse.italic" = "motionSerifed"
 selectorAffix."cyrl/tseRev.italic" = "motionSerifed"
 selectorAffix."ue/u" = "serifed"
-selectorAffix."au/u" = {if = [{body = "toothed"}], then = "bottomRightSerifed", else = "serifless"}
+selectorAffix."au/u" = { if = [{ body = "toothed" }], then = "bottomRightSerifed", else = "serifless" }
 
 [prime.u.variants-buildup.stages.serifs.serifed]
 rank = 4
@@ -4881,10 +4817,10 @@ rank = 3
 descriptionAffix = "serifs"
 selectorAffix.v = "serifed"
 selectorAffix."v/sansSerif" = "serifless"
-selectorAffix.vScript = {if = [{body = "cursive"}], then = "motionSerifed", else = "serifed"}
-selectorAffix."hv/v" = {if = [{body = "cursive"}], then = "serifless", else = "serifed"}
-selectorAffix.vHookRight = {if = [{body = "cursive"}], then = "motionSerifed", else = "serifed"}
-selectorAffix.vLoop = {if = [{body = "cursive"}], then = "serifless", else = "serifed"}
+selectorAffix.vScript = { if = [{ body = "cursive" }], then = "motionSerifed", else = "serifed" }
+selectorAffix."hv/v" = { if = [{ body = "cursive" }], then = "serifless", else = "serifed" }
+selectorAffix.vHookRight = { if = [{ body = "cursive" }], then = "motionSerifed", else = "serifed" }
+selectorAffix.vLoop = { if = [{ body = "cursive" }], then = "serifless", else = "serifed" }
 
 
 
@@ -4897,151 +4833,88 @@ entry = "body"
 descriptionLeader = "`w`"
 
 [prime.w.variants-buildup.stages.body."*"]
-next = "serifs"
+next = "center"
 
 [prime.w.variants-buildup.stages.body.straight]
 rank = 1
 groupRank = 1
-descriptionAffix = "standard, straight body"
+descriptionAffix = "straight body shape"
 selectorAffix.w = "straight"
 selectorAffix."w/sansSerif" = "straight"
 selectorAffix.wHookRight = "straight"
 
-[prime.w.variants-buildup.stages.body.straight-almost-flat-top]
-rank = 2
-groupRank = 1
-descriptionAffix = "straight body shape that the middle is almost aligned to the top"
-selectorAffix.w = "straightAlmostFlatTop"
-selectorAffix."w/sansSerif" = "straightFlatTop"
-selectorAffix.wHookRight = "straightAlmostFlatTop"
-
-[prime.w.variants-buildup.stages.body.straight-flat-top]
-rank = 3
-groupRank = 1
-descriptionAffix = "straight body shape that the middle is forced to be aligned to the top"
-selectorAffix.w = "straightFlatTop"
-selectorAffix."w/sansSerif" = "straightFlatTop"
-selectorAffix.wHookRight = "straightFlatTop"
-
-[prime.w.variants-buildup.stages.body.straight-double-v]
-rank = 4
-groupRank = 2
-descriptionAffix = "body shape like double V"
-selectorAffix.w = "straightDoubleV"
-selectorAffix."w/sansSerif" = "straightDoubleV"
-selectorAffix.wHookRight = "straightDoubleV"
-
-[prime.w.variants-buildup.stages.body.straight-asymmetric]
-rank = 5
-groupRank = 2
-descriptionAffix = "asymmetric shape"
-selectorAffix.w = "straightAsymmetric"
-selectorAffix."w/sansSerif" = "straightAsymmetric"
-selectorAffix.wHookRight = "straightAsymmetric"
-
 [prime.w.variants-buildup.stages.body.straight-vertical-sides]
-rank = 6
-groupRank = 3
+rank = 2
+groupRank = 2
 descriptionAffix = "straight body shape with vertical sides"
 selectorAffix.w = "straightVerticalSides"
 selectorAffix."w/sansSerif" = "straightVerticalSides"
 selectorAffix.wHookRight = "straightVerticalSides"
 
-[prime.w.variants-buildup.stages.body.straight-vertical-sides-almost-flat-top]
-rank = 7
-groupRank = 3
-nonBreakingVariantAdditionPriority = 200
-descriptionAffix = "straight body shape with vertical sides, and a middle stem almost aligned to the top"
-selectorAffix.w = "straightVerticalSidesAlmostFlatTop"
-selectorAffix."w/sansSerif" = "straightVerticalSidesFlatTop"
-selectorAffix.wHookRight = "straightVerticalSidesAlmostFlatTop"
-
-[prime.w.variants-buildup.stages.body.straight-vertical-sides-flat-top]
-rank = 8
-groupRank = 3
-nonBreakingVariantAdditionPriority = 100
-descriptionAffix = "straight body shape with vertical sides, and a middle stem aligned to the top"
-selectorAffix.w = "straightVerticalSidesFlatTop"
-selectorAffix."w/sansSerif" = "straightVerticalSidesFlatTop"
-selectorAffix.wHookRight = "straightVerticalSidesFlatTop"
-
 [prime.w.variants-buildup.stages.body.rounded-vertical-sides]
-rank = 9
-groupRank = 3
+rank = 3
+groupRank = 2
 descriptionAffix = "rounded body shape with vertical sides"
 selectorAffix.w = "roundedVerticalSides"
 selectorAffix."w/sansSerif" = "roundedVerticalSides"
 selectorAffix.wHookRight = "roundedVerticalSides"
 
-[prime.w.variants-buildup.stages.body.rounded-vertical-sides-almost-flat-top]
-rank = 10
-groupRank = 3
-nonBreakingVariantAdditionPriority = 200
-descriptionAffix = "rounded body shape with vertical sides, and a middle stem almost aligned to the top"
-selectorAffix.w = "roundedVerticalSidesAlmostFlatTop"
-selectorAffix."w/sansSerif" = "roundedVerticalSidesFlatTop"
-selectorAffix.wHookRight = "roundedVerticalSidesAlmostFlatTop"
-
-[prime.w.variants-buildup.stages.body.rounded-vertical-sides-flat-top]
-rank = 11
-groupRank = 3
-nonBreakingVariantAdditionPriority = 100
-descriptionAffix = "rounded body shape with vertical sides, and a middle stem aligned to the top"
-selectorAffix.w = "roundedVerticalSidesFlatTop"
-selectorAffix."w/sansSerif" = "roundedVerticalSidesFlatTop"
-selectorAffix.wHookRight = "roundedVerticalSidesFlatTop"
-
 [prime.w.variants-buildup.stages.body.curly]
-rank = 12
+rank = 4
 groupRank = 3
-descriptionAffix = "curly body"
+descriptionAffix = "curly body shape"
 selectorAffix.w = "curly"
 selectorAffix."w/sansSerif" = "curly"
 selectorAffix.wHookRight = "curly"
 
-[prime.w.variants-buildup.stages.body.curly-almost-flat-top]
-rank = 13
-groupRank = 3
-nonBreakingVariantAdditionPriority = 100
-descriptionAffix = "curly body with a middle stem almost aligned to the top"
-selectorAffix.w = "curlyAlmostFlatTop"
-selectorAffix."w/sansSerif" = "curlyFlatTop"
-selectorAffix.wHookRight = "curlyAlmostFlatTop"
-
-[prime.w.variants-buildup.stages.body.curly-flat-top]
-rank = 14
-groupRank = 3
-nonBreakingVariantAdditionPriority = 100
-descriptionAffix = "curly body with a middle stem aligned to the top"
-selectorAffix.w = "curlyFlatTop"
-selectorAffix."w/sansSerif" = "curlyFlatTop"
-selectorAffix.wHookRight = "curlyFlatTop"
-
-[prime.w.variants-buildup.stages.body.curly-asymmetric]
-rank = 15
-groupRank = 3
-nonBreakingVariantAdditionPriority = 200
-descriptionAffix = "curly body with asymmetric center"
-selectorAffix.w = "curlyAsymmetric"
-selectorAffix."w/sansSerif" = "curlyAsymmetric"
-selectorAffix.wHookRight = "curlyAsymmetric"
-
-[prime.w.variants-buildup.stages.body.curly-asymmetric-almost-flat-top]
-rank = 16
-groupRank = 3
-nonBreakingVariantAdditionPriority = 200
-descriptionAffix = "curly body with asymmetric center, almost flat top"
-selectorAffix.w = "curlyAsymmetricAlmostFlatTop"
-selectorAffix."w/sansSerif" = "curlyAsymmetricAlmostFlatTop"
-selectorAffix.wHookRight = "curlyAsymmetricAlmostFlatTop"
-
 [prime.w.variants-buildup.stages.body.cursive]
-rank = 17
+rank = 5
 groupRank = 4
+next = "serifs"
 descriptionAffix = "cursive shape"
 selectorAffix.w = "cursive"
 selectorAffix."w/sansSerif" = "cursive"
 selectorAffix.wHookRight = "cursive"
+
+[prime.w.variants-buildup.stages.center."*"]
+next = "serifs"
+
+[prime.w.variants-buildup.stages.center.standard]
+rank = 1
+keyAffix = ""
+selectorAffix.w = ""
+selectorAffix."w/sansSerif" = ""
+selectorAffix.wHookRight = ""
+
+[prime.w.variants-buildup.stages.center.almost-flat-top]
+rank = 2
+descriptionAffix = "a middle stem almost aligned to the top"
+selectorAffix.w = "almostFlatTop"
+selectorAffix."w/sansSerif" = "flatTop"
+selectorAffix.wHookRight = "almostFlatTop"
+
+[prime.w.variants-buildup.stages.center.flat-top]
+rank = 3
+descriptionAffix = "a middle stem aligned to the top"
+selectorAffix.w = "flatTop"
+selectorAffix."w/sansSerif" = "flatTop"
+selectorAffix.wHookRight = "flatTop"
+
+[prime.w.variants-buildup.stages.center.asymmetric]
+rank = 4
+enableIf = [{ body = "straight" }, { body = "curly" }]
+descriptionAffix = "asymmetric center"
+selectorAffix.w = "asymmetric"
+selectorAffix."w/sansSerif" = "asymmetric"
+selectorAffix.wHookRight = "asymmetric"
+
+[prime.w.variants-buildup.stages.center.double-v]
+rank = 5
+enableIf = [{ body = "straight" }]
+descriptionAffix = "crossing center, like double V"
+selectorAffix.w = "doubleV"
+selectorAffix."w/sansSerif" = "doubleV"
+selectorAffix.wHookRight = "doubleV"
 
 [prime.w.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -5053,7 +4926,7 @@ selectorAffix.wHookRight = "serifless"
 
 [prime.w.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
-disableIf = [{ body = "cursive" }]
+enableIf = [{ body = "NOT cursive" }]
 descriptionAffix = "motion serifs"
 selectorAffix.w = "motionSerifed"
 selectorAffix."w/sansSerif" = "serifless"
@@ -5064,7 +4937,7 @@ rank = 3
 descriptionAffix = "serifs"
 selectorAffix.w = "serifed"
 selectorAffix."w/sansSerif" = "serifless"
-selectorAffix.wHookRight = { if = [{ body = "straight-double-v" }, { body = "straight-asymmetric" }], then = "motionSerifed", else = "serifed" }
+selectorAffix.wHookRight = { if = [{ center = "flat-top" }, { center = "asymmetric" }, { center = "double-v" }], then = "motionSerifed", else = "serifed" }
 
 
 
@@ -5140,7 +5013,7 @@ selectorAffix."cyrl/rha/right" = "serifless"
 
 [prime.x.variants-buildup.stages.serifs.unilateral-motion-serifed]
 rank = 2
-disableIf = [{body = "semi-chancery-straight"}, {body = "semi-chancery-curly"}]
+disableIf = [{ body = "semi-chancery-straight" }, { body = "semi-chancery-curly" }]
 descriptionAffix = "motion serifs at top-left"
 selectorAffix.x = "unilateralMotionSerifed"
 selectorAffix."x/sansSerif" = "serifless"
@@ -5149,7 +5022,7 @@ selectorAffix."cyrl/rha/right" = "serifless"
 
 [prime.x.variants-buildup.stages.serifs.bilateral-motion-serifed]
 rank = 3
-disableIf = [{body = "semi-chancery-straight"}, {body = "semi-chancery-curly"}]
+disableIf = [{ body = "semi-chancery-straight" }, { body = "semi-chancery-curly" }]
 descriptionAffix = "motion serifs at top-left and bottom-right"
 selectorAffix.x = "bilateralMotionSerifed"
 selectorAffix."x/sansSerif" = "serifless"
@@ -5652,26 +5525,26 @@ selectorAffix.eszet = { if = [{ body = "traditional" }, { body = "traditional-fl
 
 [prime.eszet.variants-buildup.stages.serifs.middle-serifed-xh]
 rank = 3
-enableIf = [{body = "sulzbacher"}, {body = "longs-s-lig"}]
+enableIf = [{ body = "sulzbacher" }, { body = "longs-s-lig" }]
 descriptionAffix = "serif at middle at x-height"
 selectorAffix.eszet = "middleSerifedXH"
 
 [prime.eszet.variants-buildup.stages.serifs.bottom-serifed]
-enableIf = [{terminal = "non-descending"}]
+enableIf = [{ terminal = "non-descending" }]
 rank = 4
 descriptionAffix = "serif at bottom"
 selectorAffix.eszet = "bottomSerifed"
 
 [prime.eszet.variants-buildup.stages.serifs.dual-serifed]
-enableIf = [{terminal = "non-descending"}]
+enableIf = [{ terminal = "non-descending" }]
 rank = 5
 descriptionAffix = "serif at middle and bottom"
 selectorAffix.eszet = { if = [{ body = "traditional" }, { body = "traditional-flat-hook" }], then = "dualSerifedXH", else = "dualSerifed" }
 
 [prime.eszet.variants-buildup.stages.serifs.dual-serifed-xh]
 enableIf = [
-	{terminal = "non-descending", body = "sulzbacher"},
-	{terminal = "non-descending", body = "longs-s-lig"}
+	{ terminal = "non-descending", body = "sulzbacher" },
+	{ terminal = "non-descending", body = "longs-s-lig" }
 ]
 rank = 6
 descriptionAffix = "serif at middle (x-height) and bottom"
@@ -6029,7 +5902,7 @@ selectorAffix."grek/eta/sansSerif" = "serifless"
 [prime.lower-eta.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
 descriptionAffix = "serif at top left"
-enableIf = [ { body = "eared" } ]
+enableIf = [{ body = "eared" }]
 selectorAffix."grek/eta" = "topLeftSerifed"
 selectorAffix."grek/eta/sansSerif" = "serifless"
 
@@ -6632,21 +6505,21 @@ selectorAffix."grek/chi/sansSerif" = "serifless"
 
 [prime.lower-chi.variants-buildup.stages.serifs.unilateral-motion-serifed]
 rank = 2
-disableIf = [{body = "semi-chancery-straight"}, {body = "semi-chancery-curly"}]
+disableIf = [{ body = "semi-chancery-straight" }, { body = "semi-chancery-curly" }]
 descriptionAffix = "motion serifs at top-left"
 selectorAffix."grek/chi" = "unilateralMotionSerifed"
 selectorAffix."grek/chi/sansSerif" = "serifless"
 
 [prime.lower-chi.variants-buildup.stages.serifs.bilateral-motion-serifed]
 rank = 3
-disableIf = [{body = "semi-chancery-straight"}, {body = "semi-chancery-curly"}]
+disableIf = [{ body = "semi-chancery-straight" }, { body = "semi-chancery-curly" }]
 descriptionAffix = "motion serifs at top-left and bottom-right"
 selectorAffix."grek/chi" = "bilateralMotionSerifed"
 selectorAffix."grek/chi/sansSerif" = "serifless"
 
 [prime.lower-chi.variants-buildup.stages.serifs.serifed__normal]
 rank = 4
-disableIf = [{body = "semi-chancery-straight"}, {body = "semi-chancery-curly"}]
+disableIf = [{ body = "semi-chancery-straight" }, { body = "semi-chancery-curly" }]
 keyAffix = "serifed"
 descriptionAffix = "serifs"
 selectorAffix."grek/chi" = "grekLowerChiSerifed"
@@ -6654,7 +6527,7 @@ selectorAffix."grek/chi/sansSerif" = "serifless"
 
 [prime.lower-chi.variants-buildup.stages.serifs.serifed__semi-chancery]
 rank = 4
-disableIf = [{body = "straight"}, {body = "curly"}]
+disableIf = [{ body = "straight" }, { body = "curly" }]
 keyAffix = "serifed"
 descriptionAffix = "serifs"
 selectorAffix."grek/chi" = "serifed"


### PR DESCRIPTION
This basically re-categorizes `almost-flat-top`, `flat-top`, `asymmetric`, and `double-v` variants as another "variant buildup" layer called `center`, placed between `body` and `serifs` buildup layers.

The `curly-asymmetric-almost-flat-top` variants added by #2993 (not yet in the release version) are the only variants not included, as a sort of casualty; However, they may have possibly been added with the assumption that there existed some kind of `straight-asymmetric-almost-flat-top` variants as precedent for the curly forms, which there are currently no such variants in place. The normal `curly-asymmetric` variants with a flat top are retained, however, which have existing `straight-asymmetric` counterparts.

In a perfect world, I'd like to rename `double-v` to `crossing`, but I'd rather not implement further breaking changes when I don't need to.