### PR TITLE
Add `straight-serifed` and `curly-serifed` variants for Greek Lower Nu (`ν`) to complete the set.

### DIFF
--- a/changes/34.0.0.md
+++ b/changes/34.0.0.md
@@ -6,7 +6,7 @@
   - Z NOTATION SCHEMA PROJECTION (`U+2A21`).
 * Add `straight-vertical-sides-almost-flat-top` and `rounded-vertical-sides-almost-flat-top` variants for `W` and `w`.
 * Add `flat-hook` variants for `5`.
-* Add serifed casual variant for Greek lowercase nu (`U+03BD`) (#2721).
+* Add serifed variants for Greek lowercase nu (`U+03BD`) (#2721).
 * Refine shape of the following characters:
   - LATIN CAPITAL LETTER THORN (`U+00DF`).
   - LATIN CAPITAL LETTER GHA (`U+01A2`).

--- a/packages/font-glyphs/src/letter/greek/lower-nu.ptl
+++ b/packages/font-glyphs/src/letter/greek/lower-nu.ptl
@@ -1,40 +1,46 @@
 $$include '../../meta/macros.ptl'
 
 import [mix linreg clamp fallback] from "@iosevka/util"
+import [MathSansSerif] from "@iosevka/glyph/relation"
 
 glyph-module
 
 glyph-block Letter-Greek-Lower-Nu : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : SerifFrame
 
-	alias 'grek/nu.straight' null 'v.straightSerifless'
-	alias 'grek/nu.curly'    null 'v.curlySerifless'
+	alias 'grek/nu.straightSerifless' null 'v.straightSerifless'
+	alias 'grek/nu.straightSerifed'   null 'v.straightMotionSerifed'
 
-	define [NuCoreShape df k ltOvershoot] : glyph-proc
+	alias 'grek/nu.curlySerifless' null 'v.curlySerifless'
+	alias 'grek/nu.curlySerifed'   null 'v.curlyMotionSerifed'
+
+	define [NuBaseShape df k ltOvershoot] : glyph-proc
 		local xmid : df.middle + 0.375 * Stroke
 		include : dispiro
-			g4 (df.leftSB + [HSwToV : k * Stroke]) (XH - ltOvershoot) [widths.rhs]
+			widths.rhs
+			g4 (df.leftSB + [HSwToV : k * Stroke]) (XH - ltOvershoot)
 			bezControls 0.33 0.2 1 0.76 6 important
 			g4.down.end xmid 0 [heading Downward]
 		include : dispiro
 			widths.rhs
-			flat df.rightSB XH [heading Downward]
-			curl df.rightSB (XH * 0.9) [heading Downward]
+			flat df.rightSB      XH        [heading Downward]
+			curl df.rightSB [mix XH 0 0.1] [heading Downward]
 			quadControls 0 0.35 6
 			g4   xmid 0
 
-	create-glyph 'grek/nu.casual' : glyph-proc
+	create-glyph 'grek/nu.casualSerifless' : glyph-proc
 		local df : include : DivFrame 1
 		include : df.markSet.e
-		include : NuCoreShape df 0.4 O
+		include : NuBaseShape df 0.4 O
 
 	create-glyph 'grek/nu.casualSerifed' : glyph-proc
 		local df : include : DivFrame 1
 		include : df.markSet.e
 		include : difference
-			NuCoreShape df 0.75 0
-			Rect XH (XH - Stroke) 0 (df.leftSB + [HSwToV : 0.5 * Stroke])
-		include : HSerif.lt (df.leftSB + [HSwToV : 0.25 * Stroke]) XH (SideJut + [HSwToV : 0.25 * Stroke])
+			NuBaseShape df 0.75 0
+			Rect XH (XH - Stroke) 0 (df.leftSB + [HSwToV HalfStroke])
+		include : HSerif.lt (df.leftSB + [HSwToV QuarterStroke]) XH (SideJut + [HSwToV QuarterStroke])
+
 	select-variant 'grek/nu' 0x3BD
+	link-reduced-variant 'grek/nu/sansSerif' 'grek/nu' MathSansSerif

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -6293,25 +6293,42 @@ sampler = "ν"
 samplerExplain = "Greek lower Nu"
 tagKind = "letter"
 
-[prime.lower-nu.variants.straight]
+[prime.lower-nu.variants-buildup]
+entry = "body"
+descriptionLeader = "Greek lower Nu (`ν`)"
+
+[prime.lower-nu.variants-buildup.stages.body."*"]
+next = "serifs"
+
+[prime.lower-nu.variants-buildup.stages.body.straight]
 rank = 1
-description = "Greek lower Nu (`ν`) with straight shape"
-selector."grek/nu" = "straight"
+descriptionAffix = "straight shape"
+selectorAffix."grek/nu" = "straight"
+selectorAffix."grek/nu/sansSerif" = "straight"
 
-[prime.lower-nu.variants.curly]
+[prime.lower-nu.variants-buildup.stages.body.curly]
 rank = 2
-description = "Greek lower Nu (`ν`) with curly shape"
-selector."grek/nu" = "curly"
+descriptionAffix = "curly shape"
+selectorAffix."grek/nu" = "curly"
+selectorAffix."grek/nu/sansSerif" = "curly"
 
-[prime.lower-nu.variants.casual]
+[prime.lower-nu.variants-buildup.stages.body.casual]
 rank = 3
-description = "Greek lower Nu (`ν`) with casual shape"
-selector."grek/nu" = "casual"
+descriptionAffix = "casual shape"
+selectorAffix."grek/nu" = "casual"
+selectorAffix."grek/nu/sansSerif" = "casual"
 
-[prime.lower-nu.variants.casual-serifed]
-rank = 4
-description = "Greek lower Nu (`ν`) with casual shape and serifs"
-selector."grek/nu" = "casualSerifed"
+[prime.lower-nu.variants-buildup.stages.serifs.serifless]
+rank = 1
+keyAffix = ""
+selectorAffix."grek/nu" = "serifless"
+selectorAffix."grek/nu/sansSerif" = "serifless"
+
+[prime.lower-nu.variants-buildup.stages.serifs.serifed]
+rank = 2
+descriptionAffix = "serifs"
+selectorAffix."grek/nu" = "serifed"
+selectorAffix."grek/nu/sansSerif" = "serifless"
 
 
 
@@ -10698,7 +10715,7 @@ cyrl-a = "double-storey-toothless-corner"
 cyrl-u = "straight-serifless"
 one = "base-flat-top-serif"
 four = "closed-serifless"
-five = "upright-flat-serifless"
+five = "upright-flat-hook-serifless"
 six = "straight-bar"
 seven = "straight-serifless"
 eight = "two-circles"
@@ -10758,7 +10775,7 @@ cyrl-ka = "symmetric-connected-serifed"
 cyrl-capital-u = "straight-serifed"
 cyrl-u = "straight-serifed"
 four = "closed-serifed"
-five = "upright-flat-serifed"
+five = "upright-flat-hook-serifed"
 seven = "straight-serifed"
 micro-sign = "toothless-rounded-serifed"
 
@@ -11267,12 +11284,14 @@ y = "straight-turn-serifless"
 capital-eszet = "corner-serifless"
 long-s = "flat-hook-double-serifed-xh"
 eszet = "traditional-flat-hook-serifless"
+lower-gamma = "straight"
 lower-delta = "flat-top"
 lower-eta = "motion-serifed"
 lower-theta = "oval"
 lower-iota = "serifed-flat-tailed"
 lower-kappa = "straight-top-right-serifed"
 lower-lambda = "tailed-turn"
+lower-nu = "straight-serifed"
 lower-tau = "flat-tailed"
 lower-upsilon = "straight-serifless"
 lower-chi = "semi-chancery-straight-serifless"
@@ -11323,8 +11342,10 @@ x = "cursive"
 y = "cursive-serifless"
 z = "cursive"
 long-s = "flat-hook-diagonal-tailed-middle-serifed-xh"
+lower-gamma = "casual"
 lower-theta = "cursive"
 lower-iota = "serifed-diagonal-tailed"
+lower-nu = "casual-serifed"
 lower-tau = "diagonal-tailed"
 cyrl-a = "single-storey-tailed"
 cyrl-zhe = "cursive"
@@ -11560,6 +11581,7 @@ lower-theta = "capsule"
 lower-iota = "serifed-flat-tailed"
 lower-kappa = "straight-serifless"
 lower-lambda = "tailed-turn"
+lower-nu = "casual-serifed"
 lower-tau = "flat-tailed"
 lower-chi = "semi-chancery-straight-serifless"
 partial-derivative = "straight-bar"


### PR DESCRIPTION
Using a variant buildup mechanism with `keyAffix = ""`  on serifless variants in `params/variants.toml` to preserve the existing variant names for serifless variants while still adding new separately named `serifed` variants.

Also implement `MathSansSerif` form for nu.

```
ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ
abc.def.ghi.jkl.mno.pqrs.tuv.wxyz
!iIlL17|¦ ¢coO08BDQ $5SZ2zs ∂96µm
float il1[]={1-2/3.4,5+6=7/8%90};
1234567890 ,._-+= >< «¯-¬_» ~–÷+×
{*}[]()<>`+-=$/#_%^@\&|~?'" !,.;:
g9q¶ Þẞðþſß ΓΔΛαβγδηθικλμνξπτυφχψ
ЖЗКНРУЭЯавжзклмнруфчьыэя <= != ==
```

`ss15` upright:
<img width="1911" height="1146" alt="image" src="https://github.com/user-attachments/assets/36c95dcf-6e02-44bd-828b-fb44f8a61a9e" />
`ss15` italic:
<img width="1896" height="1127" alt="image" src="https://github.com/user-attachments/assets/be7e117f-6b48-46b1-9ff5-dcf707f3b618" />
`ss17` upright:
<img width="1900" height="1122" alt="image" src="https://github.com/user-attachments/assets/5c1a25b0-2858-4f63-bd05-63fc325cf367" />
`ss17` italic:
<img width="1912" height="1134" alt="image" src="https://github.com/user-attachments/assets/4155b1be-013f-4ae1-a9e9-64dfe3d02495" />
