### PR TITLE
Add IPA localization form for Modifier Small Capital H with Stroke (`ꟸ`).

### DIFF
--- a/changes/34.0.0.md
+++ b/changes/34.0.0.md
@@ -7,6 +7,7 @@
 * Add `straight-vertical-sides-almost-flat-top` and `rounded-vertical-sides-almost-flat-top` variants for `W` and `w`.
 * Add `flat-hook` variants for `5`.
 * Add serifed variants for Greek lowercase nu (`U+03BD`) (#2721).
+* Add IPA localization form for MODIFIER LETTER CAPITAL H WITH STROKE (`U+A7F8`).
 * Refine shape of the following characters:
   - LATIN CAPITAL LETTER THORN (`U+00DF`).
   - LATIN CAPITAL LETTER GHA (`U+01A2`).

--- a/packages/font-glyphs/src/letter/greek/orthography.ptl
+++ b/packages/font-glyphs/src/letter/greek/orthography.ptl
@@ -52,6 +52,8 @@ glyph-block Letter-Greek-Orthography : begin
 	link-gr LocalizedForm.IPPH 'gAcute'              'gAcute/doubleStorey'
 	link-gr LocalizedForm.IPPH 'gMacron'             'gMacron/doubleStorey'
 
+	link-gr LocalizedForm.IPPH 'smcpHStroke'         'smcpHFaucal'
+
 	link-gr LocalizedForm.IPPH 'grek/beta'           'latn/beta'
 	link-gr LocalizedForm.IPPH 'grek/theta'          'grek/theta/nonCursive'
 	link-gr LocalizedForm.IPPH 'grek/chi'            'latn/chi'

--- a/packages/font-glyphs/src/letter/latin/upper-h.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-h.ptl
@@ -120,7 +120,7 @@ glyph-block Letter-Latin-Upper-H : begin
 			local swVJut : Math.min (VJutStroke * (sw / Stroke)) : VSwToH : 0.625 * (xTopBarRightEnd - xm)
 			include : VSerif.dr xTopBarRightEnd top VJut swVJut
 
-	define [HwairShape df top yend slabType serifMR] : glyph-proc
+	define [HwairShape df top yend slabType serifTR] : glyph-proc
 		local xm : df.middle + [HSwToV : 0.5 * df.mvs]
 		include : tagged 'strokeL' : VBar.l df.leftSB 0 top df.mvs
 		include : tagged 'strokeR' : UpwardHookShape
@@ -135,7 +135,7 @@ glyph-block Letter-Latin-Upper-H : begin
 
 		include : HSerifs slabType df.leftSB xm top df.mvs
 		eject-contour 'serifRB'
-		if serifMR : begin
+		if serifTR : begin
 			local sf2 : [SerifFrame.fromDf df yend 0].slice 1 2
 			include sf2.rt.full
 
@@ -247,11 +247,11 @@ glyph-block Letter-Latin-Upper-H : begin
 
 		DefineSelectorGlyph "Hwair" suffix hwairDf 'capital'
 
-		foreach { suffixV serifMR } [Object.entries HwairVConfig] : do
+		foreach { suffixV serifTR } [Object.entries HwairVConfig] : do
 			create-glyph "Hwair.\(suffix).\(suffixV)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
-				include : HwairShape hwairDf CAP XH slabType serifMR
+				include : HwairShape hwairDf CAP XH slabType serifTR
 
 		select-variant "Hwair.\(suffix)" (follow -- 'Hv/v')
 
@@ -289,6 +289,17 @@ glyph-block Letter-Latin-Upper-H : begin
 		create-glyph "smcpHStroke.\(suffix)" : glyph-proc
 			include [refer-glyph "smcpH.\(suffix)"] AS_BASE ALSO_METRICS
 			include : OverlayStrokeShape XH slabType
+
+		create-glyph "smcpHFaucal.\(suffix)" : glyph-proc
+			include [refer-glyph "smcpH.\(suffix)"] AS_BASE ALSO_METRICS
+			eject-contour 'crossbar'
+			local bp1 : mix 0 XH : HBarPos + 0.05
+			local bp2 : mix 0 XH : HBarPos - 0.05
+			local barSw : Math.min OverlayStroke
+				0.625 * ((XH - [if (slabType === SLAB-ALL) Stroke 0]) - bp1)
+				0.625 * (bp2 - [if (slabType === SLAB-ALL) Stroke 0])
+			include : HBar.b (SB - O) (RightSB + O) bp1 barSw
+			include : HBar.t (SB - O) (RightSB + O) bp2 barSw
 
 		create-glyph "cyrl/EnMidHook.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleMM 3
@@ -347,6 +358,7 @@ glyph-block Letter-Latin-Upper-H : begin
 
 	select-variant 'HStroke' 0x126 (follow -- 'H')
 	select-variant 'smcpHStroke' (follow -- 'H')
+	select-variant 'smcpHFaucal' (follow -- 'H')
 
 	select-variant 'cyrl/EnHook' 0x4C7 (shapeFrom -- 'Heng') (follow -- 'cyrl/En/descBase')
 	select-variant 'cyrl/enHook' 0x4C8 (shapeFrom -- 'smcpHeng') (follow -- 'cyrl/en/descBase')


### PR DESCRIPTION
This is how this character appears in the [official Voice Quality Symbols (ExtIPA) chart](https://upload.wikimedia.org/wikipedia/commons/c/c4/VOQS_chart_%282016%29.pdf) but not the [Unicode charts](https://www.unicode.org/charts/PDF/UA720.pdf) so I have elected to implement this as an `IPPH` override in order to cause the least possible disruption.

[According to Wikipedia](https://en.wikipedia.org/wiki/Voice_Quality_Symbols#Phonation_types), this different glyph is supposed to be "iconic of narrowing of faucal pillars"

It also appears this way in the sample image in the [Wiktionary article for this character](https://en.wiktionary.org/wiki/%EA%9F%B8).

`DFLT: Vꟸ <span lang="und-fonipa">IPPH: Vꟸ</span>`

Sans:
<img width="2085" height="879" alt="image" src="https://github.com/user-attachments/assets/87fbc6bc-f201-4da4-9763-71737752b78b" />
Slab:
<img width="2069" height="847" alt="image" src="https://github.com/user-attachments/assets/b6810dc1-3245-4945-b342-b205d2604a6f" />
Compared to Gentium:
<img width="1933" height="824" alt="image" src="https://github.com/user-attachments/assets/c2ba9ea4-5b54-43f4-9fd5-3544d3c65d53" />
Compared to Andika:
<img width="2114" height="1037" alt="image" src="https://github.com/user-attachments/assets/77c4bc9a-b6c0-4ada-8635-52aa1b12814f" />
Compared to Charis:
<img width="2084" height="871" alt="image" src="https://github.com/user-attachments/assets/390c646b-edf8-4177-9724-8bff70f4075c" />
Compared to Doulos SIL:
<img width="2128" height="957" alt="image" src="https://github.com/user-attachments/assets/debdfe26-5197-45c8-b543-f2b016df8ca9" />
