### PR TITLE
Tighten quasi-proportional punctuation spacing

### DIFF
--- a/changes/34.1.0.md
+++ b/changes/34.1.0.md
@@ -1,0 +1,1 @@
+* Tighten quasi-proportional spacing for simple punctuation marks (e.g. `.`, `,`, `:`, `;`, `!`).

--- a/packages/font-glyphs/src/symbol/punctuation/ellipsis.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/ellipsis.ptl
@@ -34,13 +34,13 @@ glyph-block Symbol-Punctuation-Ellipsis : begin
 	for-width-kinds WideWidth1 "Ellipsis"
 		foreach { suffix { DrawAt kDotRadius overshoot } } [Object.entries DotVariants] : do
 			create-glyph "\[MangleName 'oneDotLeader'].\(suffix)" : glyph-proc
-				local width : MosaicWidth * [mix para.advanceScaleF para.advanceScaleII (MosaicWidthScalar - 1)]
+				local width : MosaicWidth * [mix para.advanceScaleI para.advanceScaleII (MosaicWidthScalar - 1)]
 				set-width width
 				local radius : [EllipsisDotRadius 2 MosaicWidth] * kDotRadius
 				include : DrawAt (width / 2) radius (radius - overshoot)
 
 			create-glyph "\[MangleName 'twoDotsLeader'].\(suffix)" : glyph-proc
-				local width : MosaicWidth * [mix 1 para.advanceScaleF (MosaicWidthScalar - 1)]
+				local width : MosaicWidth * [mix 1 para.advanceScaleI (MosaicWidthScalar - 1)]
 				set-width width
 				local radius : [EllipsisDotRadius 2 MosaicWidth] * kDotRadius
 				local left : mix 0 width (1 / 4)
@@ -92,11 +92,11 @@ glyph-block Symbol-Punctuation-Ellipsis : begin
 			include : VThreeDotsShape DrawAt radius overshoot 0 df.width 0 (SymbolMid - XH / 2) (SymbolMid + XH / 2)
 
 		create-glyph "quadColon.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.advanceScaleF
+			local df : include : DivFrame para.advanceScaleI
 			include : VFourDotShape DrawAt radius overshoot df.middle (-XH / 6) (XH * 7 / 6)
 
 		create-glyph "mathQuadColon.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.advanceScaleF
+			local df : include : DivFrame para.advanceScaleI
 			include : VFourDotShape DrawAt radius overshoot df.middle (SymbolMid - XH * 2 / 3) (SymbolMid + XH * 2 / 3)
 
 		create-glyph "vSixDots.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/symbol/punctuation/emotion.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/emotion.ptl
@@ -16,7 +16,7 @@ glyph-block Symbol-Punctuation-Emotion : begin
 		foreach { suffix { DrawAt kdr overshoot } } [Object.entries DotVariants] : do
 			local dr : DotRadius * kdr
 			create-glyph "exclam.\(suffix)" : glyph-proc
-				local df : include : DivFrame para.advanceScaleF
+				local df : include : DivFrame para.advanceScaleI
 				include : df.markSet.capital
 				include : VBar.m df.middle [clamp 0 (CAP * 0.4) (emotionBottom * 1.18)] CAP
 				include : DrawAt df.middle dr (dr - overshoot)
@@ -32,16 +32,16 @@ glyph-block Symbol-Punctuation-Emotion : begin
 				set-mark-anchor 'cvDecompose' (0 - Width) 0
 
 		select-variant 'exclam' '!' (follow -- 'punctuationDot')
-		turned         'exclamDown' 0xA1 'exclam' [DivFrame para.advanceScaleF].middle (XH / 2)
+		turned         'exclamDown' 0xA1 'exclam' [DivFrame para.advanceScaleI].middle (XH / 2)
 
 		select-variant 'question/dotPart' (follow -- 'punctuationDot')
 		select-variant 'questionDown/dotPart' (follow -- 'punctuationDot')
 
 		alias  'alveolarClick'     0x1C3 'exclam'
-		turned 'alveolarPercussive' null 'exclam' [DivFrame para.advanceScaleF].middle (CAP / 2)
+		turned 'alveolarPercussive' null 'exclam' [DivFrame para.advanceScaleI].middle (CAP / 2)
 
 		derive-glyphs 'retroflexClick' 0x1DF0A 'exclam' : function [src sel] : glyph-proc
-			local df : DivFrame para.advanceScaleF
+			local df : DivFrame para.advanceScaleI
 			include : df.markSet.capDesc
 			include : refer-glyph src
 			include : RetroflexHook.m

--- a/packages/font-glyphs/src/symbol/punctuation/interpuncts.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/interpuncts.ptl
@@ -12,7 +12,7 @@ glyph-block Symbol-Punctuation-Interpuncts : begin
 
 	foreach { suffix { DrawAt kDotRadius overshoot } } [Object.entries DotVariants] : do
 		create-glyph "interpunct.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.advanceScaleF
+			local df : include : DivFrame para.advanceScaleI
 			include : DrawAt df.middle SymbolMid (PeriodRadius * kDotRadius - overshoot)
 
 	select-variant 'interpunct' 0xB7 (follow -- 'punctuationDot')

--- a/packages/font-glyphs/src/symbol/punctuation/small.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/small.ptl
@@ -13,16 +13,16 @@ glyph-block Symbol-Punctuation-Small : begin
 
 	foreach { suffix { DrawAt kDotRadius overshoot } } [Object.entries DotVariants] : do
 		create-glyph "period.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.advanceScaleF
+			local df : include : DivFrame para.advanceScaleI
 			include : DrawAt df.middle (PeriodRadius * kDotRadius) (PeriodRadius * kDotRadius - overshoot)
 		create-glyph "halfXhPeriod.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.advanceScaleF
+			local df : include : DivFrame para.advanceScaleI
 			include : DrawAt df.middle (XH / 2) (PeriodRadius * kDotRadius - overshoot)
 		create-glyph "xhPeriod.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.advanceScaleF
+			local df : include : DivFrame para.advanceScaleI
 			include : DrawAt df.middle (XH - PeriodRadius * kDotRadius) (PeriodRadius * kDotRadius - overshoot)
 		create-glyph "capPeriod.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.advanceScaleF
+			local df : include : DivFrame para.advanceScaleI
 			include : DrawAt df.middle (CAP - PeriodRadius * kDotRadius) (PeriodRadius * kDotRadius - overshoot)
 
 		create-glyph "smallPeriod.\(suffix)"        : DrawAt Middle (DotRadius * kDotRadius)       (DotRadius * kDotRadius - overshoot)
@@ -40,7 +40,7 @@ glyph-block Symbol-Punctuation-Small : begin
 		include : Translate (mx1) (my1)
 
 	create-glyph 'comma.round' : glyph-proc
-		local df : include : DivFrame para.advanceScaleF
+		local df : include : DivFrame para.advanceScaleI
 		include : CommaShapeT df.middle 0 : glyph-proc
 			local r : PeriodRadius + 0
 			local ro : PeriodRadius - O
@@ -73,7 +73,7 @@ glyph-block Symbol-Punctuation-Small : begin
 					g4 (-commaOverflow + Descender * TanSlope) Descender [widths.rhs swEnd]
 
 	create-glyph 'comma.square' : glyph-proc
-		local df : include : DivFrame para.advanceScaleF
+		local df : include : DivFrame para.advanceScaleI
 		include : with-transform [Translate df.middle 0] : glyph-proc
 			local r : PeriodRadius * DesignParameters.squareDotScalar + 0
 			local sw : Math.min [AdviceStroke 4] (PeriodSize * DesignParameters.squareDotScalar * 0.4)
@@ -90,7 +90,7 @@ glyph-block Symbol-Punctuation-Small : begin
 
 
 	create-glyph 'revComma.round' : glyph-proc
-		local df : include : DivFrame para.advanceScaleF
+		local df : include : DivFrame para.advanceScaleI
 		include : CommaShapeT df.middle 0 : glyph-proc
 			local r : PeriodRadius + 0
 			local ro : PeriodRadius - O
@@ -123,7 +123,7 @@ glyph-block Symbol-Punctuation-Small : begin
 					g4 (commaOverflow + Descender * TanSlope) Descender [widths.lhs swEnd]
 
 	create-glyph 'revComma.square' : glyph-proc
-		local df : include : DivFrame para.advanceScaleF
+		local df : include : DivFrame para.advanceScaleI
 		include : with-transform [Translate df.middle 0] : glyph-proc
 			local r : PeriodRadius * DesignParameters.squareDotScalar + 0
 			local sw : Math.min [AdviceStroke 4] (PeriodSize * DesignParameters.squareDotScalar * 0.4)
@@ -142,8 +142,8 @@ glyph-block Symbol-Punctuation-Small : begin
 	select-variant 'comma' ',' (follow -- 'punctuationDot')
 	select-variant 'revComma' 0x2E41 (follow -- 'punctuationDot')
 
-	turned "turnComma.round"  null "comma.round"  [DivFrame para.advanceScaleF].middle PeriodRadius
-	turned "turnComma.square" null "comma.square" [DivFrame para.advanceScaleF].middle (PeriodRadius * DesignParameters.squareDotScalar)
+	turned "turnComma.round"  null "comma.round"  [DivFrame para.advanceScaleI].middle PeriodRadius
+	turned "turnComma.square" null "comma.square" [DivFrame para.advanceScaleI].middle (PeriodRadius * DesignParameters.squareDotScalar)
 	select-variant 'turnComma' 0x2E32 (follow -- 'punctuationDot')
 
 	derive-composites 'raisedPeriod.round'  null 'period.round'  [ApparentTranslate 0 (XH / 2 - PeriodRadius)]
@@ -297,7 +297,7 @@ glyph-block Symbol-Punctuation-Small : begin
 	alias 'grek/question' 0x37E 'semicolon'
 	alias 'armn/fullstop' 0x589 'colon'
 
-	turned 'turnSemiColon' 0x2E35 'semicolon' [DivFrame para.advanceScaleF].middle (XH / 2)
+	turned 'turnSemiColon' 0x2E35 'semicolon' [DivFrame para.advanceScaleI].middle (XH / 2)
 
 	# Hollow (no CV)
 
@@ -324,14 +324,14 @@ glyph-block Symbol-Punctuation-Small : begin
 			curl (mx - rad * k2x) (d - rad * k2y)
 
 	create-glyph 'hollowColon' 0x2982 : glyph-proc
-		local df : include : DivFrame para.advanceScaleF
+		local df : include : DivFrame para.advanceScaleI
 		define sw : AdviceStroke 5
 		define dotRadius : Math.max PeriodRadius (XH / 8)
 		include : RingStrokeAt df.middle (XH - dotRadius) (dotRadius + sw / 2 - O) sw
 		include : RingStrokeAt df.middle dotRadius (dotRadius + sw / 2 - O) sw
 
 	create-glyph 'zNotationSchemaComposition' 0x2A1F : glyph-proc
-		local df : include : DivFrame para.advanceScaleF
+		local df : include : DivFrame para.advanceScaleI
 		define sw : AdviceStroke 5
 		define dotRadius : Math.max PeriodRadius (XH / 8)
 		include : RingStrokeAt df.middle (XH - dotRadius) (dotRadius + sw / 2 - O) sw
@@ -340,7 +340,7 @@ glyph-block Symbol-Punctuation-Small : begin
 			RingCommaStroke df.middle dotRadius (dotRadius + sw / 2 - O) sw 0.75 0 1 3
 
 	create-glyph 'zNotationRelationalComposition' 0x2A3E : glyph-proc
-		local df : include : DivFrame para.advanceScaleF
+		local df : include : DivFrame para.advanceScaleI
 		define sw : AdviceStroke 6.5
 		define dotRadius : 0.625 * [Math.max PeriodRadius (XH / 8)]
 		include : RingStrokeAt df.middle (0.625 * XH - dotRadius) (dotRadius + sw / 2 - O) sw


### PR DESCRIPTION
## Summary
- tighten quasi-proportional punctuation spacing by switching punctuation modules to `advanceScaleI`
- keep ellipsis and math dot operators at regular width via `advanceScaleF` in `packages/font-glyphs/src/symbol/punctuation/ellipsis.ptl`
- list adjusted codepoints in `doc/adjusted-punctuation-chars.txt`

## Adjusted chars
```
U+0021 !
U+0022 "
U+0027 '
U+002C ,
U+002E .
U+003A :
U+003B ;
U+003F ?
U+0060 `
U+00A1 ¡
U+00B7 ·
U+00BF ¿
U+01C3 ǃ
U+02B9 ʹ
U+02BA ʺ
U+02BB ʻ
U+02BC ʼ
U+02BD ʽ
U+02BE ʾ
U+02BF ʿ
U+02C8 ˈ
U+02CC ˌ
U+02EE ˮ
U+02F8 ˸
U+0374 ʹ
U+0375 ͵
U+037E ;
U+0387 ·
U+055C ՜
U+055E ՞
U+0589 ։
U+10FB ჻
U+2018 ‘
U+2019 ’
U+201A ‚
U+201B ‛
U+201C “
U+201D ”
U+201E „
U+201F ‟
U+2024 ․
U+2025 ‥
U+2027 ‧
U+2032 ′
U+2033 ″
U+2034 ‴
U+2035 ‵
U+2036 ‶
U+2037 ‷
U+203D ‽
U+204F ⁏
U+2056 ⁖
U+2057 ⁗
U+2058 ⁘
U+2059 ⁙
U+205A ⁚
U+205B ⁛
U+205C ⁜
U+205D ⁝
U+205E ⁞
U+22EE ⋮
U+2426 ␦
U+2982 ⦂
U+2999 ⦙
U+2A1F ⨟
U+2A3E ⨾
U+2AF6 ⫶
U+2E12 ⸒
U+2E18 ⸘
U+2E2A ⸪
U+2E2B ⸫
U+2E2C ⸬
U+2E2D ⸭
U+2E2E ⸮
U+2E31 ⸱
U+2E32 ⸲
U+2E33 ⸳
U+2E34 ⸴
U+2E35 ⸵
U+2E3D ⸽
U+2E41 ⹁
U+2E42 ⹂
U+2E44 ⹄
U+2E49 ⹉
U+A789 ꞉
U+A78B Ꞌ
U+A78C ꞌ
U+A78F ꞏ
U+1DF0A 𝼊
```

## Testing
- not run (not built in this repo)
