### PR TITLE
Add IPA localization form for Triple Vertical Bar Delimiter (`⦀`).

### DIFF
--- a/changes/34.1.0.md
+++ b/changes/34.1.0.md
@@ -1,4 +1,5 @@
 * Add IPA localization forms for letters with caron (e.g. {`ď`, `Ľ`, `ľ`, `ť`} → {`d͏̌`, `L͏̌`, `l͏̌`, `t͏̌`}).
+* Add IPA localization form for TRIPLE VERTICAL BAR DELIMITER (`U+2980`).
 * Add characters:
   - MUSICAL SYMBOL BREATH MARK (`U+1D112`).
 * Refine shape of the following characters:

--- a/packages/font-glyphs/src/auto-build/transformed-jobs-data.ptl
+++ b/packages/font-glyphs/src/auto-build/transformed-jobs-data.ptl
@@ -189,7 +189,7 @@ export : define Superscript : list
 	list 0x107B6 'dentalClick'
 	list 0x107B7 'lateralClick'
 	list 0x107B8 'palatalClick'
-	list 0x107B9 'retroflexClick'
+	list 0x107B9 'alveolarClickRTail'
 	list 0x107BA 'sCurlyTail'
 	list 0x1E030 'cyrl/a'
 	list 0x1E031 'cyrl/be'

--- a/packages/font-glyphs/src/orthography/index.ptl
+++ b/packages/font-glyphs/src/orthography/index.ptl
@@ -11,22 +11,22 @@ glyph-block Orthography : begin
 	########## Latin letters
 
 	# Link localization forms
-	link-gr LocalizedForm.PLK 'CAcute'               'CAcute.PLK'
-	link-gr LocalizedForm.PLK 'cAcute'               'cAcute.PLK'
-	link-gr LocalizedForm.PLK 'NAcute'               'NAcute.PLK'
-	link-gr LocalizedForm.PLK 'nAcute'               'nAcute.PLK'
-	link-gr LocalizedForm.PLK 'OAcute'               'OAcute.PLK'
-	link-gr LocalizedForm.PLK 'oAcute'               'oAcute.PLK'
-	link-gr LocalizedForm.PLK 'SAcute'               'SAcute.PLK'
-	link-gr LocalizedForm.PLK 'sAcute'               'sAcute.PLK'
-	link-gr LocalizedForm.PLK 'Z'                    'Z.PLK'
-	link-gr LocalizedForm.PLK 'z'                    'z.PLK'
-	link-gr LocalizedForm.PLK 'ZAcute'               'ZAcute.PLK'
-	link-gr LocalizedForm.PLK 'zAcute'               'zAcute.PLK'
-	link-gr LocalizedForm.PLK 'ZDot'                 'ZDot.PLK'
-	link-gr LocalizedForm.PLK 'zDot'                 'zDot.PLK'
+	link-gr LocalizedForm.PLK  'CAcute'              'CAcute.PLK'
+	link-gr LocalizedForm.PLK  'cAcute'              'cAcute.PLK'
+	link-gr LocalizedForm.PLK  'NAcute'              'NAcute.PLK'
+	link-gr LocalizedForm.PLK  'nAcute'              'nAcute.PLK'
+	link-gr LocalizedForm.PLK  'OAcute'              'OAcute.PLK'
+	link-gr LocalizedForm.PLK  'oAcute'              'oAcute.PLK'
+	link-gr LocalizedForm.PLK  'SAcute'              'SAcute.PLK'
+	link-gr LocalizedForm.PLK  'sAcute'              'sAcute.PLK'
+	link-gr LocalizedForm.PLK  'Z'                   'Z.PLK'
+	link-gr LocalizedForm.PLK  'z'                   'z.PLK'
+	link-gr LocalizedForm.PLK  'ZAcute'              'ZAcute.PLK'
+	link-gr LocalizedForm.PLK  'zAcute'              'zAcute.PLK'
+	link-gr LocalizedForm.PLK  'ZDot'                'ZDot.PLK'
+	link-gr LocalizedForm.PLK  'zDot'                'zDot.PLK'
 
-	link-gr LocalizedForm.TRK 'i'                    'i.TRK'
+	link-gr LocalizedForm.TRK  'i'                   'i.TRK'
 
 	link-gr LocalizedForm.IPPH 'a'                   'a/doubleStorey'
 	link-gr LocalizedForm.IPPH 'aGrave'              'aGrave/doubleStorey'
@@ -74,6 +74,8 @@ glyph-block Orthography : begin
 	link-gr LocalizedForm.IPPH 'LCaron'              'LWedge'
 	link-gr LocalizedForm.IPPH 'lCaron'              'lWedge'
 	link-gr LocalizedForm.IPPH 'tCaron'              'tWedge'
+	link-gr LocalizedForm.IPPH 'exclamDown'          'alveolarPercussive'
+	link-gr LocalizedForm.IPPH 'tripleBar'           'retroflexClick'
 
 	########## Greek letters
 

--- a/packages/font-glyphs/src/symbol/punctuation/bar.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/bar.ptl
@@ -88,7 +88,7 @@ glyph-block Symbol-Punctuation-Bar : begin
 		: else : begin
 			set-base-anchor 'above' x top
 			set-base-anchor 'below' x bot
-		local fine : [AdviceStroke 4.25] * ([fallback _sw Stroke] / Stroke)
+		local fine : [AdviceStroke 5.25] * ([fallback _sw Stroke] / Stroke)
 		include : VBar.m (x - Width / 4) bot top fine
 		include : VBar.m  x              bot top fine
 		include : VBar.m (x + Width / 4) bot top fine
@@ -117,6 +117,9 @@ glyph-block Symbol-Punctuation-Bar : begin
 	create-glyph 'lateralClick' 0x1C1 : glyph-proc
 		local df : include : DivFrame 1
 		include : DoubleBarShape df.middle Ascender Descender df.mvs [df.markSet.bp]
+	create-glyph 'retroflexClick' : glyph-proc
+		local df : include : DivFrame 1
+		include : TripleBarShape df.middle Ascender Descender df.mvs [df.markSet.bp]
 	create-glyph 'palatalClick' 0x1C2 : glyph-proc
 		local df : include : DivFrame para.advanceScaleF
 		include : BarShape df.middle Ascender Descender df.mvs [df.markSet.bp]

--- a/packages/font-glyphs/src/symbol/punctuation/emotion.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/emotion.ptl
@@ -41,9 +41,9 @@ glyph-block Symbol-Punctuation-Emotion : begin
 		select-variant 'questionDown/dotPart' (follow -- 'punctuationDot')
 
 		select-variant 'alveolarClick' 0x1C3 (follow -- 'diacriticDot')
-		CreateTurnedLetter 'alveolarPercussive' null 'alveolarClick' HalfAdvance (CAP / 2)
+		CreateTurnedLetter 'alveolarPercussive' null 'alveolarClick' HalfAdvance (XH / 2)
 
-		derive-glyphs 'retroflexClick' 0x1DF0A 'alveolarClick' : function [src sel] : glyph-proc
+		derive-glyphs 'alveolarClickRTail' 0x1DF0A 'alveolarClick' : function [src sel] : glyph-proc
 			local df : include : DivFrame para.advanceScaleI
 			include : df.markSet.capDesc
 			include : refer-glyph src


### PR DESCRIPTION
This symbol ([Wiktionary](https://en.wiktionary.org/wiki/%E2%A6%80)) is often used as an additional [click letter](https://en.wikipedia.org/wiki/Click_letter#Multiple_systems). Some sources use it for a secondary [lateral click](https://en.wikipedia.org/wiki/Lateral_click) (`ǁ`) while others list it as a historic [retroflex click](https://en.wikipedia.org/wiki/Retroflex_click) (`𝼊`).

SIL fonts use this form by default, and group it with clicks in their [OpenType feature set](https://software.sil.org/gentium/features/)([s](https://software.sil.org/charis/features/)), however, I have elected to put this behind a localization form because this character has uses outside of phonetics as well, hence its placement in a mathematical block. This implementation is also made possible by #3059 .

`[ᵏǀl̪ə] [ᵏǁl̩] [ᵏ⦀l̠ə]~[k𝼊𐞷l𐞧ə] [ᵑǂ¡ʎə]~[ŋǂꜞlʲə]`

<img width="2225" height="677" alt="image" src="https://github.com/user-attachments/assets/fbbea514-f099-4dee-8a37-a7569d8e77dc" />
Compared to Gentium:
<img width="1671" height="637" alt="image" src="https://github.com/user-attachments/assets/30c9dae7-992e-4bf7-affc-f738bb5aa41d" />
Compared to Charis:
<img width="2033" height="685" alt="image" src="https://github.com/user-attachments/assets/5fa69577-094e-4e4b-89bd-557af4ab3996" />
