### PR TITLE
Improve vertical alignment of diagonal stroke for Cyrillic I (`И`, `и`) under slab and stroke width of hook of Upper Eng (`Ŋ`) under heavy.

### DIFF
--- a/packages/font-glyphs/src/letter/latin/upper-n.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-n.ptl
@@ -24,9 +24,17 @@ glyph-block Letter-Latin-Upper-N : begin
 	define SLAB-CYRL-I  4
 	define SLAB-DIGAMMA 5
 
+	define pInkTrap 0.4
+
 	define [NShape] : with-params [bodyType slabType top left right [crowd 2] [crDiag 4]] : glyph-proc
 		local swDiag : AdviceStroke crDiag
 		local stroke : AdviceStroke crowd
+		local swEnd : match bodyType
+			[Just BODY-SYMMETRIC]    swDiag
+			__                       stroke
+		local swStart : match bodyType
+			[Just BODY-SYMMETRIC]    swDiag
+			__                       stroke
 		local xEnd   : right - swDiag
 		local xStart : left  + swDiag
 		local yEnd : match bodyType
@@ -35,24 +43,18 @@ glyph-block Letter-Latin-Upper-N : begin
 		local yStart : match bodyType
 			[Just BODY-ASYMMETRIC]   top
 			__                     : top - yEnd
-		local swEnd : match bodyType
-			[Just BODY-SYMMETRIC]    swDiag
-			__                       stroke
-		local swStart : match bodyType
-			[Just BODY-SYMMETRIC]    swDiag
-			__                       stroke
 
 		include : union
 			match bodyType
 				[Just BODY-SYMMETRIC] : dispiro
 					flat left 0 [widths.rhs.heading stroke Upward]
-					curl left [mix 0 top 0.4] [heading Upward]
+					curl left [mix 0 top pInkTrap] [heading Upward]
 					straight.up.end left top [widths.rhs.heading swStart Upward]
 				__ : VBar.l left 0 top swStart
 			match bodyType
 				[Just BODY-SYMMETRIC] : dispiro
 					flat right top [widths.rhs.heading stroke Downward]
-					curl right [mix top 0 0.4] [heading Downward]
+					curl right [mix top 0 pInkTrap] [heading Downward]
 					straight.down.end right 0 [widths.rhs.heading swEnd Downward]
 				__ : VBar.r right 0 top swEnd
 			intersection [Rect top 0 left right]
@@ -70,11 +72,17 @@ glyph-block Letter-Latin-Upper-N : begin
 	define [RevNShape] : with-params [bodyType slabType top left right [crowd 2] [crDiag 4]] : glyph-proc
 		local swDiag : AdviceStroke crDiag
 		local stroke : AdviceStroke crowd
+		local swEnd : match bodyType
+			[Just BODY-SYMMETRIC]    swDiag
+			__                       stroke
+		local swStart : match bodyType
+			[Just BODY-SYMMETRIC]    swDiag
+			__                       stroke
 		local xEnd : match bodyType
-			[Just BODY-COMPRESSED] : left + [HSwToV stroke]
+			[Just BODY-COMPRESSED] : left + [HSwToV swEnd]
 			__                     : left + swDiag
 		local xStart : match bodyType
-			[Just BODY-COMPRESSED] : right - [HSwToV stroke]
+			[Just BODY-COMPRESSED] : right - [HSwToV swStart]
 			__                     : right - swDiag
 		local yEnd : match bodyType
 			[Just BODY-COMPRESSED] : if SLAB stroke 0
@@ -83,26 +91,20 @@ glyph-block Letter-Latin-Upper-N : begin
 		local yStart : match bodyType
 			[Just BODY-ASYMMETRIC]   top
 			__                     : top - yEnd
-		local swEnd : match bodyType
-			[Just BODY-SYMMETRIC]    swDiag
-			__                       stroke
-		local swStart : match bodyType
-			[Just BODY-SYMMETRIC]    swDiag
-			__                       stroke
 
 		include : union
 			match bodyType
 				[Just BODY-SYMMETRIC] : dispiro
-					flat left top [widths.lhs.heading stroke Downward]
-					curl left [mix top 0 0.4] [heading Downward]
-					straight.down.end left 0 [widths.lhs.heading swEnd Downward]
-				__ : VBar.l left 0 top swEnd
-			match bodyType
-				[Just BODY-SYMMETRIC] : dispiro
 					flat right 0 [widths.lhs.heading stroke Upward]
-					curl right [mix 0 top 0.4] [heading Upward]
+					curl right [mix 0 top pInkTrap] [heading Upward]
 					straight.up.end right top [widths.lhs.heading swStart Upward]
 				__ : VBar.r right 0 top swStart
+			match bodyType
+				[Just BODY-SYMMETRIC] : dispiro
+					flat left top [widths.lhs.heading stroke Downward]
+					curl left [mix top 0 pInkTrap] [heading Downward]
+					straight.down.end left 0 [widths.lhs.heading swEnd Downward]
+				__ : VBar.l left 0 top swEnd
 			intersection [Rect top 0 left right] : match bodyType
 				[Just BODY-COMPRESSED] : dispiro
 					corner xStart yStart [widths.lhs swDiag]


### PR DESCRIPTION
Basically, Cyrillic I (under slab) should have a diagonal stroke that shifts from `lhs` to `rhs` and terminate on the vertical bars in order to exactly align to the serifs (and not overshoot/undershoot the desired points), instead of the old method before of trying to approximate it by shifting a `center` stroke by a multiple of its width (which is always changing in real space based on the diagonal angle due to `HVContrast` being partially applied, and is therefore unreliable).

Furthermore, based on this knowledge, the stroke width of the hook part of Eng can be exactly tuned using `DiagCor` in order to hard-limit it to 1× + the actual extra width added by the diagonal stroke when `N` is symmetrical (unchanged when it's asymmetric), but no more than `Stroke` and no less than `swEnd`, instead of the old method before of using a "magic number" that may not exactly line up in extreme cases or under italic/oblique.

For each row in the screenshot below, left column is standard width (500), right column is "extended" width.

`ŊŋИи`

<img width="622" height="1231" alt="image" src="https://github.com/user-attachments/assets/ca8ced31-63ff-45e1-b322-c6c855cb62db" />
