### PR TITLE
Optimize arch depths of Eszet (`ẞ`, `ß`).

### DIFF
--- a/packages/font-glyphs/src/letter/latin-ext/eszet.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/eszet.ptl
@@ -26,44 +26,44 @@ glyph-block Letter-Latin-Lower-Eszet : begin
 	define SERIF-DUAL-XH : SERIF-BOT + SERIF-MID-XH
 
 	define [EszetSerifs df fTraditional slab] : glyph-proc
-		local sf : SerifFrame.fromDf [DivFrame 1] fbar 0
-		local lb : if fTraditional sf.lb.full sf.lb.outer
-		if [maskBits slab SERIF-BOT] : include lb
+		local sf : SerifFrame.fromDf df fbar 0
+		if [maskBits slab SERIF-BOT] : include : if fTraditional sf.lb.full sf.lb.outer
 		if [maskBits slab SERIF-MID] : include sf.lt.outer
 
-		local sfXH : SerifFrame.fromDf [DivFrame 1] XH 0
-		if [maskBits slab SERIF-MID-XH] : include sfXH.lt.outer
+		if [maskBits slab SERIF-MID-XH] : begin
+			local sfXH : SerifFrame.fromDf df XH 0
+			include sfXH.lt.outer
 
 	define [Traditional fFlathook] : function [slab tail] : glyph-proc
 		include : MarkSet.bp
-		local l : SB * 1
 		local xHook : [mix SB RightSB 0.75] + [HSwToV HalfStroke]
 		local hd : FlatHookDepth [DivFrame 1]
 		if fFlathook
 		: then : include : dispiro
-			flat xHook Ascender [widths.lhs]
-			curl (l + hd.x) Ascender
+			widths.lhs
+			flat xHook Ascender
+			curl (SB + hd.x) Ascender
 			archv
-			flat l (Ascender - hd.y)
-			curl l 0 [heading Downward]
+			flat SB (Ascender - hd.y)
+			curl SB 0 [heading Downward]
 		: else : include : dispiro
 			widths.lhs
-			g4 xHook (Ascender - Hook)
+			g4   xHook (Ascender - Hook)
 			hookstart Ascender
-			flat l XH
-			curl l 0 [heading Downward]
+			flat SB XH
+			curl SB 0 [heading Downward]
 		local t : mix 0 Ascender 0.7
 		local tm : [mix Descender t 0.625] + HalfStroke
-		local tl : [mix l RightSB 0.35] + [HSwToV HalfStroke]
-		include : HBar.t (l + 1) (RightSB - HalfStroke * 1.2 - OX) t
+		local tl : [mix SB RightSB 0.35] + [HSwToV HalfStroke]
+		include : HBar.t (SB + 1) (RightSB - HalfStroke * 1.2 - OX) t
 		include : dispiro
 			widths.rhs
 			flat tl tm [heading Rightward]
 			curl (tl + 1) tm [heading Rightward]
-			g2 (RightSB - OX * 1.5) [mix Descender tm 0.70]
-			g2 (RightSB - OX * 1.5) [mix Descender tm 0.67]
+			g2   (RightSB - OX * 1.5) [mix Descender tm 0.70]
+			g2   (RightSB - OX * 1.5) [mix Descender tm 0.67]
 			alsoThru 0.5 0.75
-			g4 ([mix SB RightSB 0.35] + [if tail 0.625 0] * [HSwToV Stroke]) Descender
+			g4   ([mix SB RightSB 0.35] + [if tail 0.625 0] * [HSwToV Stroke]) Descender
 		include : dispiro
 			widths.center (Stroke * 1.1)
 			corner tl (tm - Stroke) [heading Upward]
@@ -71,35 +71,38 @@ glyph-block Letter-Latin-Lower-Eszet : begin
 
 		include : EszetSerifs [DivFrame 1] true slab
 		include : match tail
-			[Just DESCENDING] : VBar.l l Descender 0
-			[Just TAILED] : PalatalHook.lExt l 0
+			[Just DESCENDING] : VBar.l SB Descender 0
+			[Just TAILED]     : PalatalHook.lExt SB 0
 			__ : glyph-proc
 
 
 	define [Sulzbacher slab tail] : glyph-proc
-		define ymiddle : mix 0 Ascender 0.5
+		include : MarkSet.b
+
+		define yMiddle : mix 0 Ascender 0.5
 		define xFinal : Math.max
 			mix (SB + [HSwToV Stroke]) RightSB 0.1
 			mix SB RightSB 0.3
-		define xMiddle : Math.max xFinal (SB + [HSwToV : 1.2 * Stroke]) (RightSB - ymiddle / 2 - HalfStroke)
-		define xMiddleBot : Math.max xMiddle (xFinal + TINY + TanSlope * Stroke)
+		define xMiddle : Math.max xFinal
+			SB + [HSwToV : 1.2 * Stroke]
+			RightSB - (yMiddle / 2 + HalfStroke)
+		define xMiddleBot : Math.max xMiddle : (xFinal + TINY) + [Math.abs : TanSlope * Stroke]
 
 		define ada : ArchDepthAOf (0.75 * ArchDepth) (0.5 * Width)
 		define adb : ArchDepthBOf (0.75 * ArchDepth) (0.5 * Width)
 
-		include : MarkSet.b
 		include : dispiro
 			widths.rhs
 			flat SB 0 [heading Upward]
-			curl SB XH
+			curl SB [Math.max XH : Ascender - SmallArchDepthA]
 			arch.rhs Ascender
-			g4 (RightSB + O * 2) [YSmoothMidR Ascender (ymiddle - HalfStroke) ada adb]
-			g4.left.end xMiddle (ymiddle - HalfStroke) [heading Leftward]
+			g4   (RightSB + O * 2) [YSmoothMidR Ascender (yMiddle - HalfStroke) ada adb]
+			g4.left.end xMiddle (yMiddle - HalfStroke) [heading Leftward]
 		include : dispiro
 			widths.rhs
-			g4.right.start xMiddle (ymiddle + HalfStroke) [heading Rightward]
+			g4.right.start xMiddle (yMiddle + HalfStroke) [heading Rightward]
 			archv
-			g4   (RightSB - O) [YSmoothMidR (ymiddle + HalfStroke) 0 ada adb]
+			g4   (RightSB - O) [YSmoothMidR (yMiddle + HalfStroke) 0 ada adb]
 			arcvh
 			flat xMiddleBot 0 [heading Leftward]
 			curl xFinal 0 [heading Leftward]
@@ -107,7 +110,7 @@ glyph-block Letter-Latin-Lower-Eszet : begin
 		include : EszetSerifs [DivFrame 1] false slab
 		include : match tail
 			[Just DESCENDING] : VBar.l SB Descender 0
-			[Just TAILED] : PalatalHook.lExt SB 0
+			[Just TAILED]     : PalatalHook.lExt SB 0
 			__ : glyph-proc
 
 
@@ -130,7 +133,6 @@ glyph-block Letter-Latin-Lower-Eszet : begin
 		define archDepthBTop : ArchDepthBOf (ArchDepth * (sTopHookX - SB - swInner * 0.5) / (RightSB - SB)) (Width - (RightSB - sTopHookX))
 		define innerSmoothB : 1 * archDepthBTop # ArchDepthBOf (0.5 * swInner + (widthInner / Width) * [AdviceSArchDepth XH (-1) swInner]) widthInner
 
-
 		include : dispiro
 			widths.rhs swOuter
 			flat SB 0 [heading Upward]
@@ -141,23 +143,23 @@ glyph-block Letter-Latin-Lower-Eszet : begin
 				swAfter -- swInner
 			g4.down.mid sTopHookX (Ascender - archDepthBTop + TanSlope * swInner) [widths.rhs.heading swInner Downward]
 			alsoThru.g2 0.5 0.50 [widths.center swInner]
-			g4 sTurnX [mix innerSmoothB (Ascender - archDepthBTop) 0.5] [widths.lhs.heading swInner Downward]
+			g4   sTurnX [mix innerSmoothB (Ascender - archDepthBTop) 0.5] [widths.lhs.heading swInner Downward]
 			alsoThru.g2 0.5 0.50 [widths.center swInner]
-			g4 (RightSB - OX) (innerSmoothB - 2 * TanSlope * swInner) [widths.rhs.heading swInner Downward]
+			g4   (RightSB - OX) (innerSmoothB - 2 * TanSlope * swInner) [widths.rhs.heading swInner Downward]
 			arcvh
-			flat [arch.adjust-x.bot ([Math.max (sEndX + TINY + TanSlope * swInner) : Math.min (RightSB - innerSmoothB) [mix sEndX RightSB 0.375]] + TanSlope * swInner) (swInner / 2)] 0
+			flat [arch.adjust-x.bot ([Math.max (sEndX + TINY + TanSlope * swInner) : Math.min (RightSB - innerSmoothB) : mix sEndX RightSB 0.375] + TanSlope * swInner) (swInner / 2)] 0
 			curl sEndX 0 [heading Leftward]
 
 		include : EszetSerifs [DivFrame 1] false slab
 		include : match tail
 			[Just DESCENDING] : VBar.l SB Descender 0 swOuter
-			[Just TAILED] : PalatalHook.lExt SB 0 (sw -- swOuter)
+			[Just TAILED]     : PalatalHook.lExt SB 0 (sw -- swOuter)
 			__ : no-shape
 
 	define EszetConfig : SuffixCfg.weave
 		object # body
-			traditional           : Traditional false
-			traditionalFlatHook   : Traditional true
+			traditional             [Traditional false]
+			traditionalFlatHook     [Traditional true]
 			sulzbacher              Sulzbacher
 			longSSLig               LongSSLig
 		object # terminal
@@ -194,96 +196,91 @@ glyph-block Letter-Latin-Upper-Eszet : begin
 	define [EszetRoundedShape slab] : glyph-proc
 		include : MarkSet.capital
 
-		define ymiddle : mix 0 CAP 0.5
-		define ymiddleCap : [mix 0 CAP 0.5] + HalfStroke
+		define yMiddle : mix 0 CAP 0.5
+		define yMiddleCap : mix 0 CAP 0.54
 		define xFinal : Math.max
 			mix (SB + [HSwToV Stroke]) RightSB 0.1
 			mix SB RightSB 0.3
-		define xMiddle : Math.max xFinal (SB + [HSwToV : 1.2 * Stroke]) (RightSB - ymiddle / 2 - HalfStroke)
-		define xMiddleBot : Math.max xMiddle (xFinal + TINY + TanSlope * Stroke)
-		define rightTopX : RightSB + O
+		define xMiddle : Math.max xFinal
+			SB + [HSwToV : 1.2 * Stroke]
+			RightSB - (yMiddle / 2 + HalfStroke)
+		define xMiddleBot : Math.max xMiddle : (xFinal + TINY) + [Math.abs : TanSlope * Stroke]
 
 		include : dispiro
-			widths.lhs
-			g4 rightTopX (CAP - ArchDepthB)
-			hookstart CAP
-			flat SB XH
-			curl SB 0 [heading Downward]
+			widths.rhs
+			flat SB 0 [heading Upward]
+			curl SB [Math.max XH : CAP - ArchDepthA]
+			arch.rhs CAP (blendPost -- {})
+			g4   (RightSB + O) (CAP - DToothlessRise)
+		include : ExtLineRhsToLhs (RightSB + O) (CAP - DToothlessRise) xMiddle (yMiddleCap + HalfStroke)
 		include : dispiro
 			widths.rhs
-			g4   xMiddle ymiddleCap [heading Rightward]
+			g4   xMiddle (yMiddleCap + HalfStroke) [heading Rightward]
 			archv
-			g4   (RightSB - O * 2) [YSmoothMidR ymiddleCap 0]
+			g4   (RightSB - O * 2) [YSmoothMidR (yMiddleCap + HalfStroke) 0 ArchDepthA ArchDepthB]
 			arcvh
 			flat xMiddleBot 0
 			curl xFinal 0 [heading Leftward]
-		include : dispiro
-			widths.rhs
-			g4 rightTopX (CAP - ArchDepthB)
-			g4 xMiddle ymiddleCap [widths.lhs Stroke]
 
 		include : CapitalEszetSerifs slab
 
 	define [EszetFlatTopShape slab] : glyph-proc
 		include : MarkSet.capital
 
-		define ymiddle : mix 0 CAP 0.5
-		define ymiddleCap : [mix 0 CAP 0.54] + HalfStroke
+		define yMiddle : mix 0 CAP 0.5
+		define yMiddleCap : mix 0 CAP 0.54
 		define xFinal : Math.max
 			mix (SB + [HSwToV Stroke]) RightSB 0.1
 			mix SB RightSB 0.3
-		define xMiddle : Math.max xFinal (SB + [HSwToV : 1.2 * Stroke]) (RightSB - ymiddle / 2 - HalfStroke)
-		define xMiddleBot : Math.max xMiddle (xFinal + TINY + TanSlope * Stroke)
-		define rightTopX : RightSB + O
+		define xMiddle : Math.max xFinal
+			SB + [HSwToV : 1.2 * Stroke]
+			RightSB - (yMiddle / 2 + HalfStroke)
+		define xMiddleBot : Math.max xMiddle : (xFinal + TINY) + [Math.abs : TanSlope * Stroke]
 
 		include : dispiro
-			widths.lhs
-			flat rightTopX CAP [heading Leftward]
-			curl Middle CAP
-			archv
-			flat SB XH
-			curl SB 0 [heading Downward]
+			widths.rhs
+			flat SB 0 [heading Upward]
+			curl SB [Math.max XH : CAP - ArchDepthA]
+			arcvh
+			flat Middle CAP
+			curl (RightSB + O) CAP [heading Rightward]
+		include : ExtLineRhsToLhs (RightSB + O) (CAP - Stroke) xMiddle (yMiddleCap + HalfStroke)
 		include : dispiro
 			widths.rhs
-			g4   xMiddle ymiddleCap [heading Rightward]
+			g4   xMiddle (yMiddleCap + HalfStroke) [heading Rightward]
 			archv
-			g4   (RightSB - O * 2) [YSmoothMidR ymiddleCap 0]
+			g4   (RightSB - O * 2) [YSmoothMidR (yMiddleCap + HalfStroke) 0 ArchDepthA ArchDepthB]
 			arcvh
 			flat xMiddleBot 0
 			curl xFinal 0 [heading Leftward]
-		include : dispiro
-			widths.rhs
-			g4 rightTopX (CAP - Stroke)
-			g4 xMiddle ymiddleCap [widths.lhs Stroke]
 
 		include : CapitalEszetSerifs slab
 
 	define [EszetCornerShape slab] : glyph-proc
 		include : MarkSet.capital
 
-		define ymiddle : mix 0 CAP 0.5
-		define ymiddleCap : [mix 0 CAP 0.54] + HalfStroke
+		define yMiddle : mix 0 CAP 0.5
+		define yMiddleCap : mix 0 CAP 0.54
 		define xFinal : Math.max
 			mix (SB + [HSwToV Stroke]) RightSB 0.1
 			mix SB RightSB 0.3
-		define xMiddle : Math.max xFinal (SB + [HSwToV : 1.2 * Stroke]) (RightSB - ymiddle / 2 - HalfStroke)
-		define xMiddleBot : Math.max xMiddle (xFinal + TINY + TanSlope * Stroke)
-		define rightTopX : RightSB + O
+		define xMiddle : Math.max xFinal
+			SB + [HSwToV : 1.2 * Stroke]
+			RightSB - (yMiddle / 2 + HalfStroke)
+		define xMiddleBot : Math.max xMiddle : (xFinal + TINY) + [Math.abs : TanSlope * Stroke]
 
-		include : VBar.l SB 0 CAP
-		include : HBar.t SB rightTopX CAP
+		include : union
+			VBar.l SB 0 CAP
+			HBar.t (SB + 1) (RightSB + O) CAP
+		include : ExtLineRhsToLhs (RightSB + O) (CAP - Stroke) xMiddle (yMiddleCap + HalfStroke)
 		include : dispiro
 			widths.rhs
-			g4   xMiddle ymiddleCap [heading Rightward]
+			g4   xMiddle (yMiddleCap + HalfStroke) [heading Rightward]
 			archv
-			g4   (RightSB - O * 2) [YSmoothMidR ymiddleCap 0]
+			g4   (RightSB - O * 2) [YSmoothMidR (yMiddleCap + HalfStroke) 0 ArchDepthA ArchDepthB]
 			arcvh
 			flat xMiddleBot 0
 			curl xFinal 0 [heading Leftward]
-		include : dispiro
-			widths.rhs
-			g4 rightTopX (CAP - Stroke)
-			g4 xMiddle ymiddleCap [widths.lhs Stroke]
 
 		include : CapitalEszetSerifs slab
 


### PR DESCRIPTION
Basically, instead of having the arches at `XH`, they are at `[Math.max XH (`{`CAP`|`Ascender`}` - `{`Small`}`ArchDepthA)]` for better optical correction under italics while still limiting it to a minimum value of `XH` to leave room for the middle/dual serifed variants. For the lowercase, this only affects the `sulzbacher` style.

Also redo the right arch depth of the `rounded` variant of the capital (`'cv61'1`) to use `DToothlessRise`. In my opinion, this looks much better, and much more like how the majority of fonts draw this style. It also helps disambiguate from the lowercase at smaller optical sizes. I would prefer if this was _not_ treated as a separate variant from the previous design, as it's really just a refinement of the existing shape.

`ẞß`
`'cv61'1`:
<img width="754" height="1227" alt="image" src="https://github.com/user-attachments/assets/c32f1b48-4591-4620-a2f8-391af8e374d4" />
`'cv61'3`:
<img width="753" height="1229" alt="image" src="https://github.com/user-attachments/assets/abdf99fc-64bf-488c-a9fe-d4f13bd5a9df" />
`'cv61'5` (for sanity):
<img width="747" height="1227" alt="image" src="https://github.com/user-attachments/assets/205a4c15-a607-402d-836d-555f2ff6e28b" />
