### PR TITLE
Cleanup of #3070 .

### DIFF
--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -22,19 +22,23 @@ glyph-block Letter-Latin-Lower-E : begin
 	define SLAB-CLASSICAL  1
 	define SLAB-INWARD     2
 
-	define [SmallESerifedTerminalShape df top stroke hook tailSlab isStart] : match tailSlab
-		[Just SLAB-CLASSICAL] : SerifedArcEnd.LtrLhs df.rightSB 0 stroke hook
-		[Just SLAB-INWARD] : InwardSlabArcEnd.LtrLhs df.rightSB 0 stroke hook
-		__ : list
-			hookend 0 (sw -- stroke) (suppressSwash -- isStart)
-			g4 (df.rightSB - [if (!isStart && para.isItalic && (para.slopeAngle > 0)) 0 0.5] * OX) [SmallEHook top stroke hook (!isStart && para.isItalic && (para.slopeAngle > 0))]
+	define [SmallESerifedTerminalShape df top stroke hook tailSlab isStart] : begin
+		local doSwash : !isStart && para.isItalic && (para.slopeAngle > 0)
+		return : match tailSlab
+			[Just SLAB-CLASSICAL] : SerifedArcEnd.LtrLhs df.rightSB 0 stroke hook
+			[Just SLAB-INWARD] : InwardSlabArcEnd.LtrLhs df.rightSB 0 stroke hook
+			__ : list
+				hookend 0 (sw -- stroke) (suppressSwash -- isStart)
+				g4 (df.rightSB - [if doSwash 0 0.5] * OX) [SmallEHook top stroke hook doSwash]
 
-	define [RevSmallESerifedTerminalShape df top stroke hook tailSlab isStart] : match tailSlab
-		[Just SLAB-CLASSICAL] : SerifedArcEnd.RtlRhs df.leftSB 0 stroke hook
-		[Just SLAB-INWARD] : InwardSlabArcEnd.RtlRhs df.leftSB 0 stroke hook
-		__ : list
-			hookend 0 (sw -- stroke) (suppressSwash -- isStart)
-			g4 (df.leftSB + [if (!isStart && para.isItalic && (para.slopeAngle < 0)) 0 0.5] * OX) [SmallEHook top stroke hook (!isStart && para.isItalic && (para.slopeAngle < 0))]
+	define [RevSmallESerifedTerminalShape df top stroke hook tailSlab isStart] : begin
+		local doSwash : !isStart && para.isItalic && (para.slopeAngle < 0)
+		return : match tailSlab
+			[Just SLAB-CLASSICAL] : SerifedArcEnd.RtlRhs df.leftSB 0 stroke hook
+			[Just SLAB-INWARD] : InwardSlabArcEnd.RtlRhs df.leftSB 0 stroke hook
+			__ : list
+				hookend 0 (sw -- stroke) (suppressSwash -- isStart)
+				g4 (df.leftSB + [if doSwash 0 0.5] * OX) [SmallEHook top stroke hook doSwash]
 
 	define [SmallETerminalSerif df top stroke hook tailSlab isStart] : match tailSlab
 		[Just SLAB-CLASSICAL] : ArcEndSerif.R       df.rightSB 0 stroke hook
@@ -128,10 +132,10 @@ glyph-block Letter-Latin-Lower-E : begin
 		local adb2 : ArchDepthBOf : (1 - DesignParameters.eBarPos) * SmallArchDepth
 		local path : include : dispiro
 			widths.lhs stroke
-			[if para.isItalic g2 flat] xStart yBarBottom
-			virt [mix xStart df.rightSB (0.475 + 0.1 * TanSlope)] yBarBottom
+			[if para.isItalic g2   flat]      xStart                                      yBarBottom
+			[if para.isItalic virt curl] [mix xStart df.rightSB (0.475 + 0.1 * TanSlope)] yBarBottom [if para.isItalic null [heading Rightward]]
 			archv
-			g4 (df.rightSB - OX - 0.5 * extraCurliness) [YSmoothMidR top yBarBottom ada2 adb2]
+			g4 ((df.rightSB - OX) - 0.5 * (df.width / HalfUPM) * extraCurliness) [YSmoothMidR top yBarBottom ada2 adb2]
 			arch.lhs top (sw -- stroke)
 			flatside.ld df.leftSB 0 top ada adb
 			SmallESerifedTerminalShape df top stroke hook tailSlab cw
@@ -163,9 +167,9 @@ glyph-block Letter-Latin-Lower-E : begin
 		local adb2 : ArchDepthBOf : (1 - DesignParameters.eBarPos) * SmallArchDepth
 		include : dispiro
 			widths.rhs stroke
-			[if para.isItalic g2 flat] xStart (yBarBottom + (2/3) * extraCurliness)
-			[if para.isItalic g2.left.mid curl] [mix xStart df.leftSB (0.475 - 0.1 * TanSlope)] (yBarBottom - (1/3) * extraCurliness) [if (para.isItalic && (para.slopeAngle < 0)) null [heading Leftward]]
-			if (para.isItalic && (para.slopeAngle < 0)) {} { [archv] }
+			[if para.isItalic g2          flat]      xStart                                     (yBarBottom + (2/3) * extraCurliness)
+			[if para.isItalic g2.left.mid curl] [mix xStart df.leftSB (0.475 - 0.1 * TanSlope)] (yBarBottom - (1/3) * extraCurliness) [heading Leftward]
+			archv
 			g4 (df.leftSB + OX) [YSmoothMidL top yBarBottom ada2 adb2]
 			arch.rhs top (sw -- stroke)
 			flatside.rd df.rightSB 0 top ada adb


### PR DESCRIPTION
The variable `extraCurlyness` has nothing to do with the width the character cell, which may cause problems in the `e` part in composite characters (ex: `æ`, `œ`) or in derived builds (superscript, boxed, etc.), so therefore the 'x'-coordinate:
`(df.rightSB - OX - 0.5 * extraCurliness)`
should instead be written as:
(`df.rightSB - OX - 0.5 * (df.width / HalfUPM) * extraCurliness)`.
This also incidentally affects expanded width (and by extension Quasi-Proportional) but this should not really cause any problems (or it may actually be better this way) as it just subtracts a proportionally adjusted slice off the side relative to the change in width.

Also use old form when rounded `e` is used when the font is upright, since the upright form for the form added by #3070 appears to be untested. In the images below, both upright and italic use the `rounded` variant to demonstrate this, as the "straight" variant is unchanged.

Also, drop the code (specifically my code) for making reversed e (`ɘ`) resemble normal `e` in the rare "back-italics" (a trait of left&shy;handed handwriting) since the text explanation in #3070 appears to make a good argument to have it be based on the actual writing direction of the Latin script (in cursive) when it's read back, which does not change just because a person writes it with their left hand (in other words, it does not magically become Arabic).

`EeƎɘƎǝ ƏəӘәЭэ Ҽҽ øꬿœꭢᶕɚ œꭀᴔæꬱᴂ`

Monospace:
<img width="1949" height="1018" alt="image" src="https://github.com/user-attachments/assets/770ac811-7ad6-4c5d-b77c-cd5930c83917" />

Aile:
<img width="2363" height="1007" alt="image" src="https://github.com/user-attachments/assets/df359d5d-85d1-4568-a7e8-45d37bb5cdb3" />
