### PR TITLE
Continuation of #3083 for Latin Lower F (`f`).

### DIFF
--- a/packages/font-glyphs/src/letter/latin-ext/long-s.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/long-s.ptl
@@ -54,20 +54,20 @@ glyph-block Letter-Latin-Long-S : begin
 		LongSUpperHalf (-1) Middle top [mix top bottom 0.5] hookx hooky fine
 		LongSLowerHalf (-1) Middle [mix top bottom 0.5] bottom hookx hooky fine
 
-	define [IFishHookShape top bottom fSlab] : glyph-proc
+	define [IFishHookShape top bottom fSlab _kSerif] : glyph-proc
 		local balance : IBalance2 : DivFrame 1
-		include : with-transform [Translate balance 0] : glyph-proc
-			include : VBar.m Middle bottom (top - Hook)
-			include : VerticalHook.m Middle (top - Hook) ((-LongJut) + balance) ((-Hook) + HalfStroke)
-			if fSlab : begin
-				local serifLength : 1 * MidJutCenter
-				local xSerifPos : Middle + OX
-				include : HSerif.mb xSerifPos bottom serifLength
+		local m : Middle + balance
+		include : VBar.m m bottom (top - Hook)
+		include : VerticalHook.m m (top - Hook) ((-LongJut) + balance) ((-Hook) + HalfStroke)
+		if fSlab : begin
+			local serifLength : Math.max Jut : mix [HSwToV HalfStroke] MidJutCenter : fallback _kSerif 1
+			local xSerifPos : m - [IBalance : DivFrame 1]
+			include : HSerif.mb xSerifPos bottom serifLength
 
-	define [StandardSerifs m0 fSlab] : glyph-proc
+	define [StandardSerifs m0 fSlab _kSerif] : glyph-proc
 		local m : m0 + [HSwToV HalfStroke]
-		local serifLength : 1 * MidJutCenter
-		local xSerifPos : m + (Middle - m) / Width * serifLength
+		local serifLength : Math.max Jut : mix [HSwToV HalfStroke] MidJutCenter : fallback _kSerif 1
+		local xSerifPos : mix m Middle (serifLength / Width)
 		if [maskBits fSlab SLAB_BOTTOM] : begin
 			include : tagged "serifLB" : HSerif.mb xSerifPos 0 serifLength
 		if [maskBits fSlab SLAB_MIDDLE] : begin
@@ -79,7 +79,7 @@ glyph-block Letter-Latin-Long-S : begin
 				MaskLeft (m + TINY)
 				HSerif.mt xSerifPos XH serifLength
 
-	define [LongSBentHookBase y0 m fSlab] : glyph-proc
+	define [LongSBentHookBase y0 m fSlab _kSerif] : glyph-proc
 		local xTerminal : RightSB + RBalance2 + [Math.max 0 : m - [StdSmallFBarLeftPos0]]
 		include : dispiro
 			widths.lhs
@@ -88,22 +88,22 @@ glyph-block Letter-Latin-Long-S : begin
 			flat m (Ascender - ArchDepthA)
 			curl m 0 [heading Downward]
 		include : LeaningAnchor.Above.Hook m xTerminal
-		set-base-anchor "overlay" (m + [HSwToV : 0.65 * Stroke]) (Ascender * OverlayPos)
-		include : StandardSerifs m fSlab
+		set-base-anchor "overlay" (m + [HSwToV : 0.65 * Stroke]) [mix 0 Ascender OverlayPos]
+		include : StandardSerifs m fSlab _kSerif
 
 	define [LongSBentHookOverlayBar m] : LetterBarOverlay.m.in
 		x   -- (m + [HSwToV HalfStroke])
-		bot -- (0.75 * XH - Stroke)
+		bot -- ([mix 0 XH 0.75] - Stroke)
 		top -- (Ascender - Stroke)
 		py  -- OverlayPos
 
 	define [LongSSymmetricOverlayBar m] : LetterBarOverlay.m.in
 		x   -- m
-		bot -- (0.75 * XH - Stroke)
+		bot -- ([mix 0 XH 0.75] - Stroke)
 		top -- (Ascender - Stroke)
 		py  -- OverlayPos
 
-	define [LongSFlatHookNoTailShape m yBot fSlab] : glyph-proc
+	define [LongSFlatHookNoTailShape m yBot fSlab _kSerif] : glyph-proc
 		local hd : FlatHookDepth [DivFrame 1]
 		include : dispiro
 			widths.lhs
@@ -113,8 +113,8 @@ glyph-block Letter-Latin-Long-S : begin
 			flat m (Ascender - hd.y)
 			curl m yBot [heading Downward]
 		include : LeaningAnchor.Above.Hook m RightSB
-		set-base-anchor "overlay" (m + [HSwToV : 0.65 * Stroke]) (Ascender * OverlayPos)
-		include : StandardSerifs m fSlab
+		set-base-anchor "overlay" (m + [HSwToV : 0.65 * Stroke]) [mix 0 Ascender OverlayPos]
+		include : StandardSerifs m fSlab _kSerif
 
 	# Non-descending variants
 	define SerifSuffixes : object
@@ -140,7 +140,7 @@ glyph-block Letter-Latin-Long-S : begin
 
 		create-glyph "longs.flatHookExt\(suffix)" : glyph-proc
 			include [refer-glyph "longs.flatHook\(suffix)"] AS_BASE ALSO_METRICS
-			include : HBar.t RightSB (2 * Width) Ascender
+			include : HBar.t RightSB [mix 0 Width 2] Ascender
 
 	# Descending and Tailed variants
 	define SerifSuffixesDescending : object
@@ -158,7 +158,7 @@ glyph-block Letter-Latin-Long-S : begin
 
 		create-glyph "longs.flatHookExtDescending\(suffix)" : glyph-proc
 			include [refer-glyph "longs.flatHookDescending\(suffix)"] AS_BASE ALSO_METRICS
-			include : HBar.t RightSB (2 * Width) Ascender
+			include : HBar.t RightSB [mix 0 Width 2] Ascender
 
 		create-glyph "longs.flatHookTailed\(suffix)" : glyph-proc
 			include : MarkSet.bp
@@ -169,7 +169,7 @@ glyph-block Letter-Latin-Long-S : begin
 
 		create-glyph "longs.flatHookExtTailed\(suffix)" : glyph-proc
 			include [refer-glyph "longs.flatHookTailed\(suffix)"] AS_BASE ALSO_METRICS
-			include : HBar.t (Middle + HookX + (0.25 - TanSlope) * Stroke) (2 * Width) Ascender
+			include : HBar.t (Middle + HookX + (0.25 - TanSlope) * Stroke) [mix 0 Width 2] Ascender
 
 		create-glyph "longs.flatHookDiagonalTailed\(suffix)" : glyph-proc
 			include : MarkSet.bp
@@ -183,7 +183,7 @@ glyph-block Letter-Latin-Long-S : begin
 
 		create-glyph "longs.flatHookExtDiagonalTailed\(suffix)" : glyph-proc
 			include [refer-glyph "longs.flatHookDiagonalTailed\(suffix)"] AS_BASE ALSO_METRICS
-			include : HBar.t (Middle + HookX + (0.25 - TanSlope) * Stroke) (2 * Width) Ascender
+			include : HBar.t (Middle + HookX + (0.25 - TanSlope) * Stroke) [mix 0 Width 2] Ascender
 
 		create-glyph "longs.bentHookDescending\(suffix)" : glyph-proc
 			include : MarkSet.bp
@@ -244,17 +244,14 @@ glyph-block Letter-Latin-Long-S : begin
 	create-glyph "eshCurlyTail" 0x286 : glyph-proc
 		include : MarkSet.bp
 		local fine : AdviceStroke 3.5
-		# local rinner : LongJut / 2 - fine / 2
-		local m : Middle + [HSwToV HalfStroke] - FBalance
-		# local x2 : mix RightSB m 0.25
-		# local y2 : Descender + O
+		local m : Middle - FBalance
 		include : union
-			LongSUpperHalf (+1) (Middle - FBalance) Ascender 0 (HookX + QuarterStroke) Hook
+			LongSUpperHalf (+1) m Ascender 0 (HookX + QuarterStroke) Hook
 			dispiro
 				widths.rhs
-				flat m (-O) [heading Downward]
-				curl m (Descender + LongJut)
-				CurlyTail.n fine Descender (m - LongJut - [HSwToV Stroke])
+				flat (m + [HSwToV HalfStroke]) (-O) [heading Downward]
+				curl (m + [HSwToV HalfStroke]) (Descender + LongJut)
+				CurlyTail.n fine Descender ((m - [HSwToV HalfStroke]) - LongJut)
 					x2 -- (RightSB + [HSwToV : 0.5 * fine])
 					y2 -- (Descender + 0.5 * fine)
 

--- a/packages/font-glyphs/src/letter/latin/lower-f.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-f.ptl
@@ -16,16 +16,20 @@ glyph-block Letter-Latin-Lower-F : begin
 		set-base-anchor 'palatalHookPos' (barLeft + [HSwToV : Stroke + [Math.max VJutStroke : Width / 12]]) 0
 
 	glyph-block-export fbar
-	define fbar : XH * DesignParameters.fBarPosToXH + Stroke * DesignParameters.fbarStrokeAdj
+	define fbar : [mix 0 XH DesignParameters.fBarPosToXH] + Stroke * DesignParameters.fbarStrokeAdj
 	define [SmallFBottomSerif df] : glyph-proc
 		local l : [mix df.leftSB df.rightSB 0.020] + HalfStroke * TanSlope
 		local r : [mix df.leftSB df.rightSB 0.875] + HalfStroke * TanSlope
-		include : dispiro [widths.lhs] [flat l 0] [curl r 0]
+		include : dispiro
+			widths.lhs
+			flat l 0
+			curl r 0
 		set-base-anchor 'palatalHookPos' r 0
 
 	define [NarrowBottomSerif df] : glyph-proc
-		include : HSerif.mb df.middle 0 (LongJut * df.adws)
-		set-base-anchor 'palatalHookPos' (df.middle + LongJut * df.adws + HalfStroke * TanSlope) 0
+		local jut : Math.max MidJutCenter : mix [HSwToV HalfStroke] LongJut df.adws
+		include : HSerif.mb df.middle 0 jut
+		set-base-anchor 'palatalHookPos' (df.middle + jut + HalfStroke * TanSlope) 0
 
 	define [StdFShapeT sink df offset barleft sw] : sink
 		widths.lhs sw
@@ -33,9 +37,9 @@ glyph-block Letter-Latin-Lower-F : begin
 		hookstart (Ascender - offset) (sw -- sw)
 		flat (barleft + offset) (Ascender - ArchDepthA * 0.8)
 		[if offset corner curl] (barleft + offset) 0 [heading Downward]
-		if offset {[corner (df.rightSB + RBalance2 - (OX - O) - offset) 0]} {}
+		if offset { [corner (df.rightSB + RBalance2 - (OX - O) - offset) 0] } {}
 
-	define [SmallFDownExtension barLeft] : VBar.l barLeft 0.1 (Descender * 0.9)
+	define [SmallFDownExtension barLeft] : VBar.l barLeft 0.1 [mix 0 Descender 0.9]
 
 	define [SmallFDownHook df barRight counterHookLeft] : begin
 		local hd : FlatHookDepth df
@@ -51,7 +55,8 @@ glyph-block Letter-Latin-Lower-F : begin
 	define [SmallFDiagonalTail df barLeft] : begin
 		local xBarMiddle : barLeft + [HSwToV HalfStroke]
 		return : dispiro
-			flat xBarMiddle TINY [widths.center.heading Stroke Downward]
+			widths.center
+			flat xBarMiddle TINY [heading Downward]
 			DiagTail.L xBarMiddle Descender [DiagTail.StdDepth df Stroke] Stroke
 
 	glyph-block-export StdSmallFBarLeftPos
@@ -178,7 +183,7 @@ glyph-block Letter-Latin-Lower-F : begin
 	select-variant 'f' 'f'
 	link-reduced-variant 'f/sansSerif' 'f' MathSansSerif
 	select-variant 'fLenis' 0xAB35 (shapeFrom -- 'f')
-	select-variant 'fLTail' 0x192  (shapeFrom -- 'f')
+	select-variant 'fHookBottom' 0x192 (shapeFrom -- 'f')
 	select-variant 'f/compLigLeft1' (shapeFrom -- 'f')
 	select-variant 'f/compLigLeft2' (shapeFrom -- 'f')
 	select-variant 'f/compLigLeft3' (shapeFrom -- 'f')

--- a/packages/font-glyphs/src/letter/latin/lower-il.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-il.ptl
@@ -23,7 +23,7 @@ glyph-block Letter-Latin-Lower-I : begin
 	define MODE-I  0 # 'i'-like letters
 	define MODE-L  1 # 'l'-like letters
 
-	define [XMiddle mode] : namespace
+	define [XMiddleT mode] : namespace
 		define [HookyImpl df doST doSB] : df.middle + ([if doST 1 0] - [if doSB 1 0]) * [IBalance2 df]
 		define [FlatTailedImpl df doST] : HookyImpl df (doST && mode !== MODE-L) true
 		define [TailedImpl df doST] : mix df.leftSB df.rightSB ([StrokeWidthBlend 0.42 0.46] - [TailedDotlessIShift df])
@@ -142,8 +142,8 @@ glyph-block Letter-Latin-Lower-I : begin
 
 	define ILJut : namespace
 		export : define [None         df top xMiddle] : HSwToV : 0.5 * df.mvs
-		export : define [Hooky        df top xMiddle] : Math.max Jut :  mix [None df top xMiddle] LongJut df.adws
-		export : define [Serifed      df top xMiddle] : Math.max Jut : [mix [None df top xMiddle] LongJut df.adws] - (xMiddle - df.middle)
+		export : define [Hooky        df top xMiddle] : Math.max Jut  [mix [None df top xMiddle] LongJut df.adws]
+		export : define [Serifed      df top xMiddle] : Math.max Jut ([mix [None df top xMiddle] LongJut df.adws] - (xMiddle - df.middle))
 		export : define [HookyShort   df top xMiddle] : mix Jut [Hooky   df top xMiddle] 0.5
 		export : define [SerifedShort df top xMiddle] : mix Jut [Serifed df top xMiddle] 0.5
 
@@ -169,49 +169,49 @@ glyph-block Letter-Latin-Lower-I : begin
 
 	define [SmallILConfig mode] : object
 		# Normal
-		'serifless'             { ILBody.Serifless     ILSerifs.None          ILMarks.Serifless  [XMiddle mode].Center             para.advanceScaleII  0      }
-		'hooky'                 { ILBody.Serifless     ILSerifs.Hooky         ILMarks.Serifed    [XMiddle mode].Hooky              para.advanceScaleI   0      }
-		'hookyBottom'           { ILBody.HookyBottom   ILSerifs.None          ILMarks.Serifless  [XMiddle mode].HookyBottom        para.advanceScaleI   Stroke }
-		'zshaped'               { ILBody.HookyBottom   ILSerifs.Hooky         ILMarks.Serifed    [XMiddle mode].ZShaped            para.advanceScaleI   Stroke }
-		'zshapedAsymmetric'     { ILBody.HookyBottom   ILSerifs.HookyShort    ILMarks.Serifed    [XMiddle mode].ZShaped            para.advanceScaleI   Stroke }
-		'serifed'               { ILBody.Serifed       ILSerifs.Serifed       ILMarks.Serifed    [XMiddle mode].Serifed            para.advanceScaleI   Stroke }
-		'serifedAsymmetric'     { ILBody.Serifed       ILSerifs.SerifedShort  ILMarks.Serifed    [XMiddle mode].Serifed            para.advanceScaleI   Stroke }
-		'tailed'                { ILBody.Tailed        ILSerifs.None          ILMarks.Serifless  [XMiddle mode].Tailed             para.advanceScaleI   Stroke }
-		'tailedSerifed'         { ILBody.Tailed        ILSerifs.Hooky         ILMarks.Serifed    [XMiddle mode].TailedSerifed      para.advanceScaleI   Stroke }
-		'diagonalTailed'        { ILBody.DiagTailed    ILSerifs.None          ILMarks.Serifless  [XMiddle mode].Tailed             para.advanceScaleI   Stroke }
-		'serifedDiagonalTailed' { ILBody.DiagTailed    ILSerifs.Hooky         ILMarks.Serifed    [XMiddle mode].TailedSerifed      para.advanceScaleI   Stroke }
-		'flatTailed'            { ILBody.FlatTailed    ILSerifs.None          ILMarks.Serifless  [XMiddle mode].FlatTailed         para.advanceScaleI   Stroke }
-		'serifedFlatTailed'     { ILBody.FlatTailed    ILSerifs.Hooky         ILMarks.Serifed    [XMiddle mode].SerifedFlatTailed  para.advanceScaleI   Stroke }
-		'semiTailed'            { ILBody.SemiTailed    ILSerifs.None          ILMarks.Serifless  [XMiddle mode].FlatTailed         para.advanceScaleI   Stroke }
-		'serifedSemiTailed'     { ILBody.SemiTailed    ILSerifs.Hooky         ILMarks.Serifed    [XMiddle mode].SerifedFlatTailed  para.advanceScaleI   Stroke }
+		'serifless'             { ILBody.Serifless     ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].Center             para.advanceScaleII  0      }
+		'hooky'                 { ILBody.Serifless     ILSerifs.Hooky         ILMarks.Serifed    [XMiddleT mode].Hooky              para.advanceScaleI   0      }
+		'hookyBottom'           { ILBody.HookyBottom   ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].HookyBottom        para.advanceScaleI   Stroke }
+		'zshaped'               { ILBody.HookyBottom   ILSerifs.Hooky         ILMarks.Serifed    [XMiddleT mode].ZShaped            para.advanceScaleI   Stroke }
+		'zshapedAsymmetric'     { ILBody.HookyBottom   ILSerifs.HookyShort    ILMarks.Serifed    [XMiddleT mode].ZShaped            para.advanceScaleI   Stroke }
+		'serifed'               { ILBody.Serifed       ILSerifs.Serifed       ILMarks.Serifed    [XMiddleT mode].Serifed            para.advanceScaleI   Stroke }
+		'serifedAsymmetric'     { ILBody.Serifed       ILSerifs.SerifedShort  ILMarks.Serifed    [XMiddleT mode].Serifed            para.advanceScaleI   Stroke }
+		'tailed'                { ILBody.Tailed        ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].Tailed             para.advanceScaleI   Stroke }
+		'tailedSerifed'         { ILBody.Tailed        ILSerifs.Hooky         ILMarks.Serifed    [XMiddleT mode].TailedSerifed      para.advanceScaleI   Stroke }
+		'diagonalTailed'        { ILBody.DiagTailed    ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].Tailed             para.advanceScaleI   Stroke }
+		'serifedDiagonalTailed' { ILBody.DiagTailed    ILSerifs.Hooky         ILMarks.Serifed    [XMiddleT mode].TailedSerifed      para.advanceScaleI   Stroke }
+		'flatTailed'            { ILBody.FlatTailed    ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].FlatTailed         para.advanceScaleI   Stroke }
+		'serifedFlatTailed'     { ILBody.FlatTailed    ILSerifs.Hooky         ILMarks.Serifed    [XMiddleT mode].SerifedFlatTailed  para.advanceScaleI   Stroke }
+		'semiTailed'            { ILBody.SemiTailed    ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].FlatTailed         para.advanceScaleI   Stroke }
+		'serifedSemiTailed'     { ILBody.SemiTailed    ILSerifs.Hooky         ILMarks.Serifed    [XMiddleT mode].SerifedFlatTailed  para.advanceScaleI   Stroke }
 		# Decompressed
-		'hookyDec'              { ILBody.Serifless     ILSerifs.Hooky         ILMarks.Serifed    [XMiddle mode].Hooky              para.advanceScaleI   0      }
-		'seriflessDec'          { ILBody.Serifless     ILSerifs.None          ILMarks.Serifless  [XMiddle mode].Center             para.advanceScaleI   0      }
-		'tailedDec'             { ILBody.Tailed        ILSerifs.None          ILMarks.Serifless  [XMiddle mode].Tailed             para.advanceScaleI   Stroke }
-		'diagonalTailedDec'     { ILBody.DiagTailed    ILSerifs.None          ILMarks.Serifless  [XMiddle mode].Tailed             para.advanceScaleI   Stroke }
-		'flatTailedDec'         { ILBody.FlatTailed    ILSerifs.None          ILMarks.Serifless  [XMiddle mode].FlatTailed         para.advanceScaleI   Stroke }
-		'semiTailedDec'         { ILBody.SemiTailed    ILSerifs.None          ILMarks.Serifless  [XMiddle mode].FlatTailed         para.advanceScaleI   Stroke }
-		'hookyBottomDec'        { ILBody.HookyBottom   ILSerifs.None          ILMarks.Serifless  [XMiddle mode].HookyBottom        para.advanceScaleI   Stroke }
+		'hookyDec'              { ILBody.Serifless     ILSerifs.Hooky         ILMarks.Serifed    [XMiddleT mode].Hooky              para.advanceScaleI   0      }
+		'seriflessDec'          { ILBody.Serifless     ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].Center             para.advanceScaleI   0      }
+		'tailedDec'             { ILBody.Tailed        ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].Tailed             para.advanceScaleI   Stroke }
+		'diagonalTailedDec'     { ILBody.DiagTailed    ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].Tailed             para.advanceScaleI   Stroke }
+		'flatTailedDec'         { ILBody.FlatTailed    ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].FlatTailed         para.advanceScaleI   Stroke }
+		'semiTailedDec'         { ILBody.SemiTailed    ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].FlatTailed         para.advanceScaleI   Stroke }
+		'hookyBottomDec'        { ILBody.HookyBottom   ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].HookyBottom        para.advanceScaleI   Stroke }
 		# R Tail
-		'hookyRTail'            { ILBody.Serifless     ILSerifs.Hooky         ILMarks.Serifed    [XMiddle mode].Center             para.advanceScaleI   0      }
-		'seriflessRTail'        { ILBody.Serifless     ILSerifs.None          ILMarks.Serifless  [XMiddle mode].HookyBottom        para.advanceScaleI   0      }
+		'hookyRTail'            { ILBody.Serifless     ILSerifs.Hooky         ILMarks.Serifed    [XMiddleT mode].Center             para.advanceScaleI   0      }
+		'seriflessRTail'        { ILBody.Serifless     ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].HookyBottom        para.advanceScaleI   0      }
 		# R Tail + Decompress
-		'hookyRTailDec'         { ILBody.Serifless     ILSerifs.Hooky         ILMarks.Serifed    [XMiddle mode].Center             para.advanceScaleI   0      }
-		'seriflessRTailDec'     { ILBody.Serifless     ILSerifs.None          ILMarks.Serifless  [XMiddle mode].HookyBottom        para.advanceScaleI   0      }
+		'hookyRTailDec'         { ILBody.Serifless     ILSerifs.Hooky         ILMarks.Serifed    [XMiddleT mode].Center             para.advanceScaleI   0      }
+		'seriflessRTailDec'     { ILBody.Serifless     ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].HookyBottom        para.advanceScaleI   0      }
 		#
-		'hookyPL'               { ILBody.PhoneticLeft  ILSerifs.Hooky         ILMarks.Serifed    [XMiddle mode].PhoneticLeft       1                    0      }
-		'seriflessPL'           { ILBody.PhoneticLeft  ILSerifs.None          ILMarks.Serifless  [XMiddle mode].PhoneticLeft       1                    0      }
+		'hookyPL'               { ILBody.PhoneticLeft  ILSerifs.Hooky         ILMarks.Serifed    [XMiddleT mode].PhoneticLeft       1                    0      }
+		'seriflessPL'           { ILBody.PhoneticLeft  ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].PhoneticLeft       1                    0      }
 		# Special variants for Tau (which is built using dotlessi)
-		'tau/tailless'          { ILBody.Serifless     ILSerifs.None          ILMarks.Serifless  [XMiddle mode].Center             1                    0      }
-		'tau/tailed'            { ILBody.Tailed        ILSerifs.None          ILMarks.Serifless  [XMiddle mode].Tailed             1                    Stroke }
-		'tau/diagonalTailed'    { ILBody.DiagTailed    ILSerifs.None          ILMarks.Serifless  [XMiddle mode].Tailed             1                    Stroke }
-		'tau/flatTailed'        { ILBody.FlatTailed    ILSerifs.None          ILMarks.Serifless  [XMiddle mode].FlatTailed         1                    Stroke }
-		'tau/semiTailed'        { ILBody.SemiTailed    ILSerifs.None          ILMarks.Serifless  [XMiddle mode].FlatTailed         1                    Stroke }
-		'tau/shortTailed'       { ILBody.ShortTailed   ILSerifs.None          ILMarks.Serifless  [XMiddle mode].Center             1                    Stroke }
+		'tau/tailless'          { ILBody.Serifless     ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].Center             1                    0      }
+		'tau/tailed'            { ILBody.Tailed        ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].Tailed             1                    Stroke }
+		'tau/diagonalTailed'    { ILBody.DiagTailed    ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].Tailed             1                    Stroke }
+		'tau/flatTailed'        { ILBody.FlatTailed    ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].FlatTailed         1                    Stroke }
+		'tau/semiTailed'        { ILBody.SemiTailed    ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].FlatTailed         1                    Stroke }
+		'tau/shortTailed'       { ILBody.ShortTailed   ILSerifs.None          ILMarks.Serifless  [XMiddleT mode].Center             1                    Stroke }
 
 	# 'i'-like letters
 	do : foreach { suffix { Body Serifs Marks xMiddleTMono adws y0R } } [Object.entries [SmallILConfig MODE-I]] : begin
-		define xMiddleTCenter [XMiddle MODE-I].Center
+		define xMiddleTCenter [XMiddleT MODE-I].Center
 		define xMiddleT : if (para.isQuasiProportional && Body !== ILBody.PhoneticLeft) xMiddleTCenter xMiddleTMono
 
 		create-glyph "dotlessi.\(suffix)" : glyph-proc
@@ -266,7 +266,7 @@ glyph-block Letter-Latin-Lower-I : begin
 
 	# 'l'-like letters
 	do : foreach { suffix { Body Serifs Marks xMiddleTMono adws y0R } } [Object.entries [SmallILConfig MODE-L]] : begin
-		define xMiddleTCenter [XMiddle MODE-L].Center
+		define xMiddleTCenter [XMiddleT MODE-L].Center
 		define xMiddleT : if (para.isQuasiProportional && Body !== ILBody.PhoneticLeft) xMiddleTCenter xMiddleTMono
 
 		create-glyph "l.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/upper-f.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-f.ptl
@@ -104,7 +104,7 @@ glyph-block Letter-Latin-Upper-F : begin
 	CreateTurnedLetter 'turnF' 0x2132 'F'     HalfAdvance (CAP / 2)
 	CreateTurnedLetter 'turnf' 0x214E 'smcpF' HalfAdvance (XH  / 2)
 
-	derive-glyphs 'FLTail' 0x191 'F' : lambda [src gr] : glyph-proc
+	derive-glyphs 'FHookBottom' 0x191 'F' : lambda [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
 		eject-contour 'serifLB'
 		include : PalatalHook.lExt xFBarLeft 0

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2745,7 +2745,7 @@ selectorAffix."f/compLigLeft4" = "flatHookCLC4"
 selectorAffix."f/phoneticLeft" = ""
 selectorAffix."f/tailless" = ""
 selectorAffix.fLenis = ""
-selectorAffix.fLTail = ""
+selectorAffix.fHookBottom = ""
 
 [prime.f.variants-buildup.stages.hook.flat-hook]
 rank = 2
@@ -2759,7 +2759,7 @@ selectorAffix."f/compLigLeft4" = "flatHookCLC4"
 selectorAffix."f/phoneticLeft" = "flatHook"
 selectorAffix."f/tailless" = "flatHook"
 selectorAffix.fLenis = "flatHook"
-selectorAffix.fLTail = "flatHook"
+selectorAffix.fHookBottom = "flatHook"
 
 [prime.f.variants-buildup.stages.tail."*"]
 next = "crossbar"
@@ -2777,7 +2777,7 @@ selectorAffix."f/compLigLeft4" = "serifless"
 selectorAffix."f/phoneticLeft" = "serifless"
 selectorAffix."f/tailless" = "serifless"
 selectorAffix.fLenis = "serifless"
-selectorAffix.fLTail = "tailed"
+selectorAffix.fHookBottom = "tailed"
 
 [prime.f.variants-buildup.stages.tail.serifed]
 rank = 2
@@ -2791,7 +2791,7 @@ selectorAffix."f/compLigLeft4" = "serifed"
 selectorAffix."f/phoneticLeft" = "serifed"
 selectorAffix."f/tailless" = "serifed"
 selectorAffix.fLenis = "serifless"
-selectorAffix.fLTail = "tailed"
+selectorAffix.fHookBottom = "tailed"
 
 [prime.f.variants-buildup.stages.tail.extended]
 rank = 3
@@ -2805,7 +2805,7 @@ selectorAffix."f/compLigLeft4" = "extended"
 selectorAffix."f/phoneticLeft" = "extended"
 selectorAffix."f/tailless" = "serifless"
 selectorAffix.fLenis = "serifless"
-selectorAffix.fLTail = "tailed"
+selectorAffix.fHookBottom = "tailed"
 
 [prime.f.variants-buildup.stages.tail.tailed]
 rank = 4
@@ -2819,7 +2819,7 @@ selectorAffix."f/compLigLeft4" = "tailed"
 selectorAffix."f/phoneticLeft" = "tailed"
 selectorAffix."f/tailless" = "serifless"
 selectorAffix.fLenis = "serifless"
-selectorAffix.fLTail = "tailed"
+selectorAffix.fHookBottom = "tailed"
 
 [prime.f.variants-buildup.stages.tail.diagonal-tailed]
 rank = 5
@@ -2833,7 +2833,7 @@ selectorAffix."f/compLigLeft4" = "diagonalTailed"
 selectorAffix."f/phoneticLeft" = "diagonalTailed"
 selectorAffix."f/tailless" = "serifless"
 selectorAffix.fLenis = "serifless"
-selectorAffix.fLTail = "tailed"
+selectorAffix.fHookBottom = "tailed"
 
 [prime.f.variants-buildup.stages.crossbar.standard]
 rank = 1
@@ -2847,7 +2847,7 @@ selectorAffix."f/compLigLeft4" = ""
 selectorAffix."f/phoneticLeft" = "crossbarAtXHeight"
 selectorAffix."f/tailless" = ""
 selectorAffix.fLenis = ""
-selectorAffix.fLTail = ""
+selectorAffix.fHookBottom = ""
 
 [prime.f.variants-buildup.stages.crossbar.crossbar-at-x-height]
 rank = 1
@@ -2861,7 +2861,7 @@ selectorAffix."f/compLigLeft4" = "crossbarAtXHeight"
 selectorAffix."f/phoneticLeft" = "crossbarAtXHeight"
 selectorAffix."f/tailless" = "crossbarAtXHeight"
 selectorAffix.fLenis = "crossbarAtXHeight"
-selectorAffix.fLTail = "crossbarAtXHeight"
+selectorAffix.fHookBottom = "crossbarAtXHeight"
 
 
 
@@ -11591,9 +11591,14 @@ cyrl-capital-ze = "unilateral-inward-serifed"
 cyrl-ze = "serifless"
 cyrl-capital-ka = "symmetric-connected-bottom-right-serifed"
 cyrl-ka = "symmetric-connected-serifless"
+cyrl-el = "straight"
+cyrl-en = "serifless"
 cyrl-capital-er = "closed-motion-serifed"
 cyrl-capital-u = "straight-turn-serifless"
 cyrl-u = "straight-turn-serifless"
+cyrl-che = "standard"
+cyrl-yeri = "corner"
+cyrl-yery = "corner"
 cyrl-capital-e = "unilateral-inward-serifed"
 cyrl-e = "serifless"
 cyrl-capital-ya = "straight-motion-serifed"
@@ -11648,9 +11653,14 @@ lower-kappa = "straight-bottom-right-serifed"
 cyrl-a = "single-storey-tailed"
 cyrl-ze = "unilateral-bottom-inward-serifed"
 cyrl-ka = "symmetric-connected-bottom-right-serifed"
+cyrl-el = "tailed"
+cyrl-en = "tailed-serifless"
 cyrl-u = "cursive-serifless"
+cyrl-che = "tailed"
+cyrl-yeri = "cursive"
+cyrl-yery = "cursive-tailed"
 cyrl-e = "unilateral-bottom-inward-serifed"
-cyrl-ya = "straight-motion-serifed"
+cyrl-ya = "straight-tailed-motion-serifed"
 
 [composite.ss17.slab-override.design]
 capital-b = "standard-bilateral-serifed"
@@ -11691,6 +11701,7 @@ cyrl-a = "double-storey-hook-inward-serifed-tailed"
 cyrl-ze = "unilateral-inward-serifed"
 cyrl-capital-ka = "symmetric-connected-serifed"
 cyrl-ka = "symmetric-connected-serifed"
+cyrl-en = "serifed"
 cyrl-capital-er = "closed-serifed"
 cyrl-capital-u = "straight-turn-serifed"
 cyrl-u = "straight-turn-serifed"
@@ -11723,8 +11734,10 @@ lower-kappa = "straight-top-left-and-bottom-right-serifed"
 cyrl-a = "single-storey-tailed"
 cyrl-ze = "unilateral-bottom-inward-serifed"
 cyrl-ka = "symmetric-connected-top-left-and-bottom-right-serifed"
+cyrl-en = "tailed-top-left-serifed"
 cyrl-u = "cursive-motion-serifed"
 cyrl-e = "unilateral-bottom-inward-serifed"
+cyrl-ya = "straight-tailed-serifed"
 micro-sign = "tailed-motion-serifed"
 
 


### PR DESCRIPTION
Basically, in the same manner as what I did earlier for `I`/`i`/`l`, when scaling `LongJut` by `[DivFrame].adws`, make it start at `[HSwToV : 0.5 * [DivFrame].mvs]` instead of `0`, because a hypothetical `adws` of `0` would make the serif have an effective length of 0 as it then becomes flush with the vertical bar (that is to say in principle, and ignoring `FBalance`/`RBalance2`) .

`letter/latin-ext/long-s.ptl` has code added to match — in theory — but it's inactive since all characters that would be affected don't touch the `_kSerif` parameter I added since they all use an `adws` of `1`, which is the number that `kSerif` falls back to.

Shown below is under Etoile, which is the only default family where it changes. Other stylistic sets using `f.flatHookSerifed` are unchanged under monospace, and `f.bentHookSerifed` is unchanged everywhere.

In this case, the words "before" and "after" are also incidentally affected under the custom build.

`Ff Ƒƒ Ꞙꞙ ᶂ`

<img width="575" height="1089" alt="image" src="https://github.com/user-attachments/assets/d133dd43-ab57-4074-a5ec-d61efbaa7a46" />
