### PR TITLE
Improve glyph for Latin Upper Eng (`Ŋ`), add locales for Sámi languages using existing Eng glyph.

### DIFF
--- a/changes/34.2.0.md
+++ b/changes/34.2.0.md
@@ -1,4 +1,6 @@
+* Add Latin localization forms for Sámi languages.
 * Refine shape of the following characters:
+  - LATIN CAPITAL LETTER ENG (`U+014A`).
   - LATIN LETTER SMALL CAPITAL G (`U+0262`).
   - LATIN LETTER SMALL CAPITAL G WITH HOOK (`U+029B`).
   - LATIN SMALL LETTER LS DIGRAPH (`U+02AA`) ... LATIN SMALL LETTER LZ DIGRAPH (`U+02AB`).

--- a/packages/font-glyphs/src/letter/latin/lower-n.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-n.ptl
@@ -12,7 +12,7 @@ glyph-block Letter-Latin-Lower-N : begin
 	glyph-block-import Letter-Shared : CreateAccentedComposition
 	glyph-block-import Letter-Shared-Shapes : CurlyTail nShoulder RightwardTailedBar
 	glyph-block-import Letter-Shared-Shapes : MidHook CyrDescender PalatalHook RetroflexHook
-	glyph-block-import Letter-Shared-Shapes : EngHook SerifFrame
+	glyph-block-import Letter-Shared-Shapes : VerticalHook EngHook SerifFrame
 
 	define [AdjustTrailingAnchor] : glyph-proc
 		define trAnchor currentGlyph.baseAnchors.trailing
@@ -154,6 +154,17 @@ glyph-block Letter-Latin-Lower-N : begin
 			if sLB : include : sLB [DivFrame 1] 0
 			if sRB : include : sRB [DivFrame 1] 0
 
+		if (!tailed) : create-glyph "Eng.\(suffix)" : glyph-proc
+			include : MarkSet.capital
+			include : Body CAP SB RightSB (O + Hook + HalfStroke) Stroke ArchDepthA ArchDepthB
+			include : VerticalHook.r
+				x      -- RightSB
+				y      -- (O + Hook + HalfStroke)
+				xDepth -- [Math.max ((Middle + [HSwToV HalfStroke]) - RightSB) ((-1.2) * HookX)]
+				yDepth -- Hook
+			if sLT : include : sLT [DivFrame 1] CAP
+			if sLB : include : sLB [DivFrame 1] 0
+
 		if (!tailed) : create-glyph "eng.\(suffix)" : glyph-proc
 			include : MarkSet.p
 			include : Body XH SB RightSB 0 Stroke
@@ -195,7 +206,7 @@ glyph-block Letter-Latin-Lower-N : begin
 		create-glyph "latn/Eta.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
 			include : LeaningAnchor.Below.VBar.r RightSB
-			include : Body CAP SB RightSB [if tailed (CAP - SmallArchDepthB + O) Descender] Stroke
+			include : Body CAP SB RightSB [if tailed (CAP - SmallArchDepthB + O) Descender] Stroke ArchDepthA ArchDepthB
 			if tailed : include : EndingTail RightSB Descender (CAP - SmallArchDepthB) Stroke
 			if sLT : include : sLT [DivFrame 1] CAP
 			if sLB : include : sLB [DivFrame 1] 0
@@ -249,22 +260,22 @@ glyph-block Letter-Latin-Lower-N : begin
 		if (!tailed) : create-glyph "engPalatalHook.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleM 1
 			include : df.markSet.p
-			local dfSub : DivFrame (0.75 * para.advanceScaleM) 2
-			include : Body XH dfSub.leftSB dfSub.rightSB 0 dfSub.mvs dfSub.smallArchDepthA dfSub.smallArchDepthB
-			include : EngHook dfSub.rightSB 0 Descender (sw -- dfSub.mvs)
-			if sLT : include : sLT dfSub XH
-			if sLB : include : sLB dfSub 0
+			local subDf : DivFrame (0.75 * para.advanceScaleM) 2
+			include : Body XH subDf.leftSB subDf.rightSB 0 subDf.mvs subDf.smallArchDepthA subDf.smallArchDepthB
+			include : EngHook subDf.rightSB 0 Descender (sw -- subDf.mvs)
+			if sLT : include : sLT subDf XH
+			if sLB : include : sLB subDf 0
 			include : PalatalHook.r
 				x -- df.rightSB
 				y -- 0
-				xLink -- dfSub.rightSB
-				refSw -- dfSub.mvs
-				maskOut -- [intersection [MaskBelow 0] [MaskLeft dfSub.rightSB]]
+				xLink -- subDf.rightSB
+				refSw -- subDf.mvs
+				maskOut -- [intersection [MaskBelow 0] [MaskLeft subDf.rightSB]]
 
 		if (!tailed && !sRB) : create-glyph "RInsular.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
 			include : LeaningAnchor.Below.VBar.l SB
-			include : Body CAP SB RightSB (-Descender) Stroke
+			include : Body CAP SB RightSB (-Descender) Stroke ArchDepthA ArchDepthB
 			include : RetroflexHook.rExt RightSB (-Descender)
 			include : VBar.l SB Descender 0
 			if sLT : include : sLT [DivFrame 1] CAP
@@ -281,12 +292,12 @@ glyph-block Letter-Latin-Lower-N : begin
 			local df : include : DivFrame para.advanceScaleMM 3
 			include : df.markSet.p
 
-			local dfHalf : df.slice 3 2
-			include : Body XH dfHalf.leftSB dfHalf.rightSB [if tailed (XH - dfHalf.smallArchDepthB + O) 0] dfHalf.mvs dfHalf.smallArchDepthA dfHalf.smallArchDepthB
-			if tailed : include : EndingTail dfHalf.rightSB 0 (XH - dfHalf.smallArchDepthB) dfHalf.mvs
-			if sLT : include : sLT dfHalf XH
-			if sLB : include : sLB dfHalf 0
-			if sRB : include : sRB dfHalf 0
+			local subDf : df.slice 3 2
+			include : Body XH subDf.leftSB subDf.rightSB [if tailed (XH - subDf.smallArchDepthB + O) 0] df.mvs subDf.smallArchDepthA subDf.smallArchDepthB
+			if tailed : include : EndingTail subDf.rightSB 0 (XH - subDf.smallArchDepthB) df.mvs
+			if sLT : include : sLT subDf XH
+			if sLB : include : sLB subDf 0
+			if sRB : include : sRB subDf 0
 
 			include : MidHook.m df XH
 
@@ -308,6 +319,7 @@ glyph-block Letter-Latin-Lower-N : begin
 	select-variant 'cyrl/pe.italic/descBase' (shapeFrom -- 'n')
 	alias 'cyrl/pe.BGR' null 'cyrl/pe.italic'
 
+	select-variant 'Eng' 0x14A (follow -- 'eng')
 	select-variant 'eng' 0x14B
 	link-reduced-variant 'eng/phoneticRight' 'eng'
 	select-variant 'nHookLeft' 0x272
@@ -338,11 +350,13 @@ glyph-block Letter-Latin-Lower-N : begin
 	CreateAccentedComposition 'nAcute.PLK' null 'n' 'kreskaAbove'
 
 	do "n with Apostrophe"
-		derive-glyphs 'nApostrophe/comma' null 'commaAbove/asPunctuation' : function [src gr] : glyph-proc
-			include : with-transform [Translate (Middle + SB) 0]
+		glyph-block-import Mark-Shared-Metrics : markMiddle
+
+		derive-glyphs 'nApostrophe/commaTL' null 'commaAbove/asPunctuation' : function [src gr] : glyph-proc
+			include : with-transform [Translate (SB - markMiddle) 0]
 				refer-glyph src
 
-		derive-composites 'nApostrophe' 0x149 'n' 'nApostrophe/comma'
+		derive-composites 'nApostrophe' 0x149 'n' 'nApostrophe/commaTL'
 
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarLeft
 	create-glyph 'mathbb/n' 0x1D55F : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/upper-n.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-n.ptl
@@ -139,7 +139,7 @@ glyph-block Letter-Latin-Upper-N : begin
 			include : MarkSet.capital
 			include : RevNShape [DivFrame 1] CAP bodyType slabType (swDiag -- [AdviceStroke crDiag])
 
-		create-glyph "Eng.\(suffix)" : glyph-proc
+		create-glyph "Eng.NSM.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
 			local dim : include : NShape [DivFrame 1] CAP bodyType slabType (swDiag -- [AdviceStroke crDiag])
 			local cor : HSwToV : DiagCor (dim.yEnd - dim.yStart) (dim.xEnd - dim.xStart)
@@ -165,23 +165,22 @@ glyph-block Letter-Latin-Upper-N : begin
 
 	select-variant 'N' 'N'
 	link-reduced-variant 'N/sansSerif' 'N' MathSansSerif
+	select-variant 'smcpN' 0x274 (follow -- 'N')
 	select-variant 'revN' (follow -- 'N')
+	select-variant 'revSmcpN' 0x1D0E (follow -- 'N')
 
 	alias 'grek/Nu' 0x39D 'N'
 	alias-reduced-variant 'grek/Nu/sansSerif' 'grek/Nu' 'N/sansSerif' MathSansSerif
+
+	select-variant 'Eng.NSM' (follow -- 'N')
+	select-variant 'NHookLeft' 0x19D (follow -- 'N')
+
+	select-variant 'currency/nairaSign/base' (follow -- 'N')
 
 	derive-composites 'NDescender' 0xA790 'N' [CyrDescender.rSideJut RightSB 0]
 
 	CreateAccentedComposition 'NAcute'    0x143 'N' 'acuteAbove'
 	CreateAccentedComposition 'NAcute.PLK' null 'N' 'kreskaAbove'
-
-	select-variant 'Eng'       0x14A (follow -- 'N')
-	select-variant 'NHookLeft' 0x19D (follow -- 'N')
-
-	select-variant 'smcpN'    0x274  (follow -- 'N')
-	select-variant 'revSmcpN' 0x1D0E (follow -- 'N')
-
-	select-variant 'currency/nairaSign/base' (follow -- 'N')
 
 	create-glyph 'cyrl/I' 0x418 : glyph-proc
 		include : MarkSet.capital

--- a/packages/font-otl/src/gsub-locl.ptl
+++ b/packages/font-otl/src/gsub-locl.ptl
@@ -16,6 +16,13 @@ export : define [buildLOCL gsub para glyphStore] : begin
 	define cyrlBGR  : gsub.copyLanguage 'cyrl_BGR ' 'cyrl_DFLT'
 	define cyrlBSH  : gsub.copyLanguage 'cyrl_BSH ' 'cyrl_DFLT'
 	define cyrlCHU  : gsub.copyLanguage 'cyrl_CHU ' 'cyrl_DFLT'
+	define latnNSM  : gsub.copyLanguage 'latn_NSM ' 'latn_DFLT'
+	define latnISM  : gsub.copyLanguage 'latn_ISM ' 'latn_DFLT'
+	define latnLSM  : gsub.copyLanguage 'latn_LSM ' 'latn_DFLT'
+	define latnSJE  : gsub.copyLanguage 'latn_SJE ' 'latn_DFLT'
+	define latnSJU  : gsub.copyLanguage 'latn_SJU ' 'latn_DFLT'
+	define latnSKS  : gsub.copyLanguage 'latn_SKS ' 'latn_DFLT'
+	define latnSSM  : gsub.copyLanguage 'latn_SSM ' 'latn_DFLT'
 	define latnPLK  : gsub.copyLanguage 'latn_PLK ' 'latn_DFLT'
 	define latnROM  : gsub.copyLanguage 'latn_ROM ' 'latn_DFLT'
 	define latnMOL  : gsub.copyLanguage 'latn_MOL ' 'latn_DFLT'
@@ -57,6 +64,20 @@ export : define [buildLOCL gsub para glyphStore] : begin
 	# CHU
 	define loclCHU : cyrlCHU.addFeature : gsub.createFeature 'locl'
 	loclCHU.addLookup : createGsubLookupFromGr gsub glyphStore LocalizedForm.CHU
+
+	# NSM
+	define loclNSM : gsub.createFeature 'locl'
+	latnNSM.addFeature loclNSM
+	latnISM.addFeature loclNSM
+	latnLSM.addFeature loclNSM
+	latnSJE.addFeature loclNSM
+	latnSJU.addFeature loclNSM
+	latnSKS.addFeature loclNSM
+	latnSSM.addFeature loclNSM
+	loclNSM.addLookup : gsub.createLookup
+		.type 'gsub_single'
+		.substitutions : object
+			'Eng' : glyphStore.ensureExists 'Eng.NSM'
 
 	# PLK
 	define loclPLK : latnPLK.addFeature : gsub.createFeature 'locl'

--- a/tools/generate-samples/src/templates/languages.mjs
+++ b/tools/generate-samples/src/templates/languages.mjs
@@ -34,6 +34,7 @@ const languages = [
     { lang: 'Portuguese',    sample: 'Luís argüia à Júlia que «brações, fé, chá, óxido, pôr, zângão» eram palavras do português.' },
     { lang: 'Romanian',      sample: 'Înjurând pițigăiat, zoofobul comandă vexat whisky și tequila.', localeId :'ro' },
     { lang: 'Russian',       sample: 'Широкая электрификация южных губерний даст мощный толчок подъёму сельского хозяйства.' },
+    { lang: 'Northern Sámi', sample: 'Vuol Ruoŧa geđggiid leat máŋga luosa ja čuovžža.', localeId :'se' },
     { lang: 'Serbian',       sample: 'Ајшо, лепото и чежњо, за љубав срца мога дођи у Хаџиће на кафу.', localeId: 'sr' },
     { lang: 'Slovak',        sample: 'Kŕdeľ šťastných ďatľov učí pri ústí Váhu mĺkveho koňa obhrýzať kôru a žrať čerstvé mäso.' },
     { lang: 'Slovenian',     sample: 'V kožuščku hudobnega fanta stopiclja mizar.' },


### PR DESCRIPTION
In September 2024, I raised [this issue](https://github.com/MicrosoftDocs/typography-issues/issues/1175) in Microsoft's official OpenType specification issue tracker on GitHub, and in the following December that same year, they added the two locales I requested in it to complete the set of language tags for (living) Sámi languages using the Latin script.
Fonts like [this project, which extends Inconsolata's Unicode coverage](https://github.com/MihailJP/Inconsolata-LGC) currently make use of them.

Basically, there are [far more languages](https://en.wikipedia.org/wiki/Eng_(letter)#Usage) — and far more speakers of said languages — in western Africa which use `Ŋ` in its "enlarged lowercase" `n` form.
Sámi languages, on the other hand — a Uralic language family in northern Norway, Sweden, Finland, and European Russia — use the ordinary capital `N` form as shown in the Unicode charts.
Unicode also tries to make it clear that the glyphs in the charts are not necessarily always prescriptive, and [the notes in the charts](https://www.unicode.org/charts/PDF/U0100.pdf) imply that _both the ordinary capital `N` form or the enlarged lowercase `n` form_ are acceptable graphical variants, even if only one is shown in the samples.

The existing capital `N` form (already used by the font) is therefore allocated to a new `NSM` locale ([Northern Sámi](https://en.wikipedia.org/wiki/Northern_S%C3%A1mi), the Sámi language with the most speakers) as well as other related Sámi locales routed through it. This is exhaustive [of all Sámi languages using the Latin script](https://en.wikipedia.org/wiki/S%C3%A1mi_orthography), whereas ones using the Cyrillic script, chiefly [Kildin Sámi](https://en.wikipedia.org/wiki/Kildin_S%C3%A1mi_orthography), are omitted.

```
Vuol Ruoŧa geđggiid leat máŋga luosa ja čuovžža.
VUOL RUOŦA GEĐGGIID LEAT MÁŊGA LUOSA JA ČUOVŽŽA.
```

Sans:
<img width="2123" height="1190" alt="image" src="https://github.com/user-attachments/assets/f02cd5eb-692e-411f-81a5-f680c772fb74" />
Slab:
<img width="2138" height="1184" alt="image" src="https://github.com/user-attachments/assets/e670514b-2806-4528-a005-9c3f88be585c" />
