### PR TITLE
Simplify glyph of enlarged minuscule eng (`Ŋ`) by making its hook descend below the baseline like the lowercase.

### DIFF
--- a/packages/font-glyphs/src/letter/latin/lower-n.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-n.ptl
@@ -12,7 +12,7 @@ glyph-block Letter-Latin-Lower-N : begin
 	glyph-block-import Letter-Shared : CreateAccentedComposition
 	glyph-block-import Letter-Shared-Shapes : CurlyTail nShoulder RightwardTailedBar
 	glyph-block-import Letter-Shared-Shapes : MidHook CyrDescender PalatalHook RetroflexHook
-	glyph-block-import Letter-Shared-Shapes : VerticalHook EngHook SerifFrame
+	glyph-block-import Letter-Shared-Shapes : EngHook SerifFrame
 
 	define [AdjustTrailingAnchor] : glyph-proc
 		define trAnchor currentGlyph.baseAnchors.trailing
@@ -144,7 +144,7 @@ glyph-block Letter-Latin-Lower-N : begin
 				begin NBottomLeftYatSerif
 				begin nothing
 
-	foreach { suffix { Body tailed {sLT sLB sRB} } } [Object.entries NConfig] : do
+	foreach { suffix { Body tailed { sLT sLB sRB } } } [Object.entries NConfig] : do
 		create-glyph "n.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			set-base-anchor 'trailing' RightSB 0
@@ -155,13 +155,9 @@ glyph-block Letter-Latin-Lower-N : begin
 			if sRB : include : sRB [DivFrame 1] 0
 
 		if (!tailed) : create-glyph "Eng.\(suffix)" : glyph-proc
-			include : MarkSet.capital
-			include : Body CAP SB RightSB (O + Hook + HalfStroke) Stroke ArchDepthA ArchDepthB
-			include : VerticalHook.r
-				x      -- RightSB
-				y      -- (O + Hook + HalfStroke)
-				xDepth -- [Math.max ((Middle + [HSwToV HalfStroke]) - RightSB) ((-1.2) * HookX)]
-				yDepth -- Hook
+			include : MarkSet.capDesc
+			include : Body CAP SB RightSB 0 Stroke ArchDepthA ArchDepthB
+			include : EngHook RightSB 0 Descender
 			if sLT : include : sLT [DivFrame 1] CAP
 			if sLB : include : sLB [DivFrame 1] 0
 
@@ -351,7 +347,6 @@ glyph-block Letter-Latin-Lower-N : begin
 
 	do "n with Apostrophe"
 		glyph-block-import Mark-Shared-Metrics : markMiddle
-
 		derive-glyphs 'nApostrophe/commaTL' null 'commaAbove/asPunctuation' : function [src gr] : glyph-proc
 			include : with-transform [Translate (SB - markMiddle) 0]
 				refer-glyph src


### PR DESCRIPTION
Addendum to #3093 .
This is actually even _more_ correct for West African typography to use as a default. Fonts that have an `'NSM '` override (examples below) tend to use this descending version of the enlarged minuscule form as their `'DFLT'` form.

```
Vuol Ruoŧa geđggiid leat máŋga luosa ja čuovžža.
VUOL RUOŦA GEĐGGIID LEAT MÁŊGA LUOSA JA ČUOVŽŽA.
```

Sans:
<img width="2129" height="1191" alt="image" src="https://github.com/user-attachments/assets/1a3d0231-dc84-4682-82cf-b0da691fb35b" />
Slab:
<img width="2134" height="1182" alt="image" src="https://github.com/user-attachments/assets/21f11001-2798-4988-a156-b15cab3e0a39" />
Compared to Merriweather:
<img width="2529" height="1197" alt="image" src="https://github.com/user-attachments/assets/f90b9c25-22cc-412e-a061-e493ad6c38ce" />
Compared to DejaVu Serif:
<img width="2450" height="1073" alt="image" src="https://github.com/user-attachments/assets/fc8a9897-e5bf-4966-a41d-ba6e3b9e9485" />
