### PR TITLE
Make Upper Turned M (`Ɯ`) base its arch depth on full `ArchDepth`.

### DIFF
--- a/changes/34.2.0.md
+++ b/changes/34.2.0.md
@@ -2,6 +2,7 @@
 * Add IPA localization forms for Lower B and D with stroke (`ƀ`, `đ`).
 * Refine shape of the following characters:
   - LATIN CAPITAL LETTER ENG (`U+014A`).
+  - LATIN CAPITAL LETTER TURNED M (`U+019C`).
   - LATIN CAPITAL LETTER N WITH LONG RIGHT LEG (`U+0220`).
   - LATIN CAPITAL LETTER SMALL Q WITH HOOK TAIL (`U+024A`).
   - LATIN LETTER SMALL CAPITAL G (`U+0262`).

--- a/packages/font-glyphs/src/letter/cyrillic/sha.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/sha.ptl
@@ -50,7 +50,7 @@ glyph-block Letter-Cyrillic-Sha : begin
 		include : df.markSet.e
 		include : CyrShaShape df XH 0 (doSerif -- SLAB) (fInv -- true)
 
-	create-glyph 'turnSmcpM' 0xA7FA : glyph-proc
+	create-glyph 'turnSmcpmCap' 0xA7FA : glyph-proc
 		local df : include : DivFrame para.advanceScaleM 3
 		include : df.markSet.e
 		include : CyrShaShape df XH 0 (doSerif -- SLAB)

--- a/packages/font-glyphs/src/letter/latin/lower-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-m.ptl
@@ -13,8 +13,11 @@ glyph-block Letter-Latin-Lower-M : begin
 	glyph-block-import Letter-Shared-Shapes : MidHook CyrDescender CyrCurlDescender PalatalHook EngHook
 	glyph-block-import Letter-Shared-Shapes : UpwardHookShape SerifFrame
 
-	define [SmallMSmoothA df] [df.slice 3 2].smallArchDepthA
-	define [SmallMSmoothB df] [df.slice 3 2].smallArchDepthB
+	define [dfM] : DivFrame para.advanceScaleMM 3
+
+	define [SmallMSmoothA df _ad] : [df.slice 3 2].archDepthAOf [fallback _ad SmallArchDepth]
+	define [SmallMSmoothB df _ad] : [df.slice 3 2].archDepthBOf [fallback _ad SmallArchDepth]
+
 	define [SmallMShoulderSpiro] : with-params [left right fine top bottom ada adb stroke leftY0] : glyph-proc
 		local fix : HSwToV : TanSlope * stroke
 		include : spiro-outline
@@ -63,15 +66,15 @@ glyph-block Letter-Latin-Lower-M : begin
 
 	define [SmallMBottomMotionLeftSerif df top lbot fFull] : begin
 		local sf : SerifFrame.fromDf df top lbot
-		return : if fFull sf.lb.inner [no-shape]
+		return : if fFull sf.lb.inner : no-shape
 
-	define [SmallMBottomMiddleSerif df top mbot fFull mid] : begin
+	define [SmallMBottomMiddleSerif df top mbot fFull] : begin
 		local sf : SerifFrame.fromDf df top mbot
-		return : if fFull [sf.mb.fullAt mid] [no-shape]
+		return : if fFull sf.mb.full : no-shape
 
-	define [SmallMBottomMotionMiddleSerif df top mbot fFull mid] : begin
+	define [SmallMBottomMotionMiddleSerif df top mbot fFull] : begin
 		local sf : SerifFrame.fromDf df top mbot
-		return : if fFull [sf.mb.rightAt mid] [no-shape]
+		return : if fFull sf.mb.right : no-shape
 
 	define [SmallMBottomRightSerif df top rbot fFull] : begin
 		local sf : SerifFrame.fromDf df top rbot
@@ -81,55 +84,49 @@ glyph-block Letter-Latin-Lower-M : begin
 		local sf : SerifFrame.fromDf df top rbot
 		return sf.rb.outer
 
-	define [dfM] : DivFrame para.advanceScaleMM 3
-
-	define [MEnoughSpaceForFullSerifs _df _mid] : begin
-		local df : fallback _df : dfM
-		local mid : fallback _mid df.middle
+	define [MEnoughSpaceForFullSerifs df] : begin
 		local ink : HSwToV df.mvs
-		local gap : [Math.min (mid - df.leftSB) (df.rightSB - mid)] - 1.5 * ink
+		local gap : (df.rightSB - df.leftSB) / 2 - 1.5 * ink
 		return : 0.5 * ink + 0.375 * gap > para.refJut
 
-	define [FullSerifs df top lbot mbot rbot tailed earless _mid] : glyph-proc
-		local mid : fallback _mid df.middle
-		local fFull : MEnoughSpaceForFullSerifs df mid
+	define [FullSerifs df top lbot mbot rbot tailed earless] : glyph-proc
+		local fFull : MEnoughSpaceForFullSerifs df
 		if [not earless] : include : SmallMTopLeftSerif df top lbot fFull
 		include : SmallMBottomLeftSerif df top lbot fFull
-		include : SmallMBottomMiddleSerif df top mbot fFull mid
+		include : SmallMBottomMiddleSerif df top mbot fFull
 		if [not tailed] : include : SmallMBottomRightSerif df top rbot fFull
 
-	define [FullTurnMSerifs df top lbot mbot rbot tailed earless _mid] : glyph-proc
-		local mid : fallback _mid df.middle
+	define [FullTurnMSerifs df top lbot mbot rbot tailed earless] : glyph-proc
 		if [not earless] : include : SmallMTopLeftSerif df top lbot true
 		include : SmallMBottomMotionLeftSerif df top lbot true
-		include : SmallMBottomMotionMiddleSerif df top mbot true mid
+		include : SmallMBottomMotionMiddleSerif df top mbot true
 		if [not tailed] : include : SmallMBottomMotionRightSerif df top rbot true
 
-	define [AutoSerifs df top lbot mbot rbot tailed earless _mid] : begin
-		if SLAB [FullSerifs df top lbot mbot rbot tailed earless _mid] [no-shape]
+	define [AutoSerifs df top lbot mbot rbot tailed earless] : if SLAB
+		FullSerifs df top lbot mbot rbot tailed earless
+		no-shape
 
-	define [LtSerifs df top lbot mbot rbot tailed earless _mid] : glyph-proc
-		local fFull : MEnoughSpaceForFullSerifs df : fallback _mid df.middle
+	define [LtSerifs df top lbot mbot rbot tailed earless] : glyph-proc
+		local fFull : MEnoughSpaceForFullSerifs df
 		include : SmallMTopLeftSerif df top lbot fFull
 
-	define [LtRbSerifs df top lbot mbot rbot tailed earless _mid] : glyph-proc
-		local fFull : MEnoughSpaceForFullSerifs df : fallback _mid df.middle
+	define [LtRbSerifs df top lbot mbot rbot tailed earless] : glyph-proc
+		local fFull : MEnoughSpaceForFullSerifs df
 		include : SmallMTopLeftSerif df top lbot fFull
 		include : SmallMBottomMotionRightSerif df top rbot fFull
 
-	define [RbSerifs df top lbot mbot rbot tailed earless _mid] : glyph-proc
-		local fFull : MEnoughSpaceForFullSerifs df : fallback _mid df.middle
+	define [RbSerifs df top lbot mbot rbot tailed earless] : glyph-proc
+		local fFull : MEnoughSpaceForFullSerifs df
 		include : SmallMBottomMotionRightSerif df top rbot fFull
 
 	glyph-block-export SmallMArches
-	define [SmallMArches df top lbot mbot rbot _mid _ada _adb] : glyph-proc
-		local mid : fallback _mid df.middle
+	define [SmallMArches df top lbot mbot rbot _ada _adb] : glyph-proc
 		local ada : fallback _ada : SmallMSmoothA df
 		local adb : fallback _adb : SmallMSmoothB df
 		include : tagged 'barL' : VBar.l df.leftSB lbot top df.mvs
 		include : SmallMShoulderSpiro
 			left      -- (df.leftSB + [HSwToV : df.mvs - df.shoulderFine])
-			right     -- (mid + [HSwToV : 0.5 * df.mvs])
+			right     -- (df.middle + [HSwToV : 0.5 * df.mvs])
 			fine      -- df.shoulderFine
 			top       -- top
 			bottom    -- mbot
@@ -137,7 +134,7 @@ glyph-block Letter-Latin-Lower-M : begin
 			adb       -- adb
 			stroke    -- df.mvs
 		include : SmallMShoulderSpiro
-			left      -- (mid + [HSwToV : 0.5 * df.mvs - df.shoulderFine])
+			left      -- (df.middle + [HSwToV : 0.5 * df.mvs - df.shoulderFine])
 			right     -- df.rightSB
 			fine      -- df.shoulderFine
 			top       -- top
@@ -148,12 +145,11 @@ glyph-block Letter-Latin-Lower-M : begin
 			leftY0    -- mbot
 
 	glyph-block-export EarlessCornerDoubleArchSmallMShape
-	define [EarlessCornerDoubleArchSmallMShape df top lbot mbot rbot _mid _ada _adb] : glyph-proc
-		local mid : fallback _mid df.middle
+	define [EarlessCornerDoubleArchSmallMShape df top lbot mbot rbot _ada _adb] : glyph-proc
 		local ada : fallback _ada : SmallMSmoothA df
 		local adb : fallback _adb : SmallMSmoothB df
 		define [leftKnots sink offset] : begin
-			local xMidBarRightSide : mid + [HSwToV : 0.5 * df.mvs]
+			local xMidBarRightSide : df.middle + [HSwToV : 0.5 * df.mvs]
 			return : sink
 				widths.rhs df.mvs
 				[if (sink == dispiro) g2 corner] (df.leftSB - offset) (top - DToothlessRise)
@@ -162,7 +158,7 @@ glyph-block Letter-Latin-Lower-M : begin
 				[if (sink == dispiro) curl corner] (xMidBarRightSide - offset) mbot [heading Downward]
 				if (sink == spiro-outline) { [corner (df.leftSB - offset) 0 ] } { }
 		define [rightKnots sink] : begin
-			local xMidBarLeftSide : mid - [HSwToV : 0.5 * df.mvs]
+			local xMidBarLeftSide : df.middle - [HSwToV : 0.5 * df.mvs]
 			return : sink
 				widths.rhs df.mvs
 				g2 [mix df.rightSB xMidBarLeftSide 1.5] (top - 2 * DToothlessRise)
@@ -171,19 +167,18 @@ glyph-block Letter-Latin-Lower-M : begin
 				flat df.rightSB [Math.max (top - adb) (rbot + TINY)] [heading Downward]
 				curl df.rightSB rbot [heading Downward]
 		include : tagged 'barL' : VBar.l df.leftSB lbot (top - DToothlessRise) df.mvs
-		# include : tagged 'barM' : VBar.m mid mbot (top - DToothlessRise) df.mvs
+		# include : tagged 'barM' : VBar.m df.middle mbot (top - DToothlessRise) df.mvs
 		include : leftKnots dispiro 0
 		include : difference [rightKnots dispiro] [leftKnots spiro-outline 0.1]
 
 	glyph-block-export EarlessRoundedDoubleArchSmallMShape
-	define [EarlessRoundedDoubleArchSmallMShape df top lbot mbot rbot _mid _ada _adb] : glyph-proc
-		local mid : fallback _mid df.middle
+	define [EarlessRoundedDoubleArchSmallMShape df top lbot mbot rbot _ada _adb] : glyph-proc
 		local ada : fallback _ada : SmallMSmoothA df
 		local adb : fallback _adb : SmallMSmoothB df
 		include : union
 			RevSmallMShoulderSpiro
 				left      -- df.leftSB
-				right     -- (mid - [HSwToV : (0.5 - CThin) * df.mvs])
+				right     -- (df.middle - [HSwToV : (0.5 - CThin) * df.mvs])
 				fine      -- (df.mvs * CThin)
 				top       -- top
 				bottom    -- lbot
@@ -192,7 +187,7 @@ glyph-block Letter-Latin-Lower-M : begin
 				stroke    -- df.mvs
 				rightY0   -- mbot
 			SmallMShoulderSpiro
-				left      -- (mid + [HSwToV : (0.5 - CThin) * df.mvs])
+				left      -- (df.middle + [HSwToV : (0.5 - CThin) * df.mvs])
 				right     -- df.rightSB
 				fine      -- (df.mvs * CThin)
 				top       -- top
@@ -202,12 +197,11 @@ glyph-block Letter-Latin-Lower-M : begin
 				stroke    -- df.mvs
 				leftY0    -- mbot
 
-	define [EarlessSingleArchSmallMShape df top lbot mbot rbot _mid _ada _adb] : glyph-proc
-		local mid : fallback _mid df.middle
+	define [EarlessSingleArchSmallMShape df top lbot mbot rbot _ada _adb] : glyph-proc
 		local ada : fallback _ada : SmallMSmoothA df
 		local adb : fallback _adb : SmallMSmoothB df
 		include : tagged 'barL' : VBar.l df.leftSB lbot (top - DToothlessRise) df.mvs
-		include : tagged 'barM' : VBar.m mid mbot (top - 0.25 * df.mvs) df.mvs
+		include : tagged 'barM' : VBar.m df.middle mbot (top - 0.25 * df.mvs) df.mvs
 		include : dispiro
 			widths.rhs df.mvs
 			g4 df.leftSB (top - DToothlessRise)
@@ -215,14 +209,14 @@ glyph-block Letter-Latin-Lower-M : begin
 			flat df.rightSB [Math.max (top - adb) (rbot + TINY)]
 			curl df.rightSB rbot [heading Downward]
 
-	define [SmallMShortLegHeight top df] : mix 0 (top - df.mvs) 0.45
-	define [SmallMSmoothHeight   top df] : top - [SmallMSmoothB df] - TINY - [HSwToV : Math.abs : TanSlope * df.mvs]
+	define [SmallMShortLegHeight df top _ada _adb] : mix 0 (top - df.mvs) 0.45
+	define [SmallMSmoothHeight   df top _ada _adb] : top - [fallback _adb : SmallMSmoothB df] - TINY - [HSwToV : Math.abs : TanSlope * df.mvs]
 
 	glyph-block-export mShapeBodyImpl
-	define [mShapeBodyImpl df top body earless shortLeg tailed serifs] : glyph-proc
-		include : body df top 0 [if shortLeg [SmallMShortLegHeight top df] 0] [if tailed ([SmallMSmoothHeight top df] + O) 0]
-		if tailed : include : RightwardTailedBar df.rightSB 0 [SmallMSmoothHeight top df] (sw -- df.mvs)
-		include : serifs df top 0 [if shortLeg [SmallMShortLegHeight top df] 0] 0 tailed earless
+	define [mShapeBodyImpl df top body earless shortLeg tailed serifs _ada _adb] : glyph-proc
+		include : body df top 0 [if shortLeg [SmallMShortLegHeight df top _ada _adb] 0] [if tailed ([SmallMSmoothHeight df top _ada _adb] + O) 0] _ada _adb
+		if tailed : include : RightwardTailedBar df.rightSB 0 [SmallMSmoothHeight df top _ada _adb] (sw -- df.mvs)
+		include : serifs df top 0 [if shortLeg [SmallMShortLegHeight df top _ada _adb] 0] 0 tailed earless
 
 	glyph-block-export SmallMConfig
 	define SmallMConfig : SuffixCfg.weave
@@ -245,8 +239,8 @@ glyph-block Letter-Latin-Lower-M : begin
 			"topLeftAndBottomRightSerifed" { LtRbSerifs }
 
 	foreach { suffix { {Body earless} {shortLeg} {tailed} {Serifs} } } [pairs-of SmallMConfig] : do
-		define [mShapeBody df top] : begin
-			return : mShapeBodyImpl df top Body earless shortLeg tailed Serifs
+		define [mShapeBody df top _ada _adb] : begin
+			return : mShapeBodyImpl df top Body earless shortLeg tailed Serifs _ada _adb
 
 		create-glyph "m.\(suffix)" : glyph-proc
 			local df : include : dfM
@@ -272,12 +266,12 @@ glyph-block Letter-Latin-Lower-M : begin
 				local m2 : df.leftSB + gap * 2 - [HSwToV : 0.25 * fine]
 				local x2 : df.rightSB + SideJut
 				local y2 : rinner * 2 + fine - O
-				include : Body df XH 0 [if shortLeg [SmallMShortLegHeight XH df] 0] (y2 + O)
+				include : Body df XH 0 [if shortLeg [SmallMShortLegHeight df XH] 0] (y2 + O)
 				include : dispiro
 					straight.down.start df.rightSB y2 [widths.rhs.heading df.mvs Downward]
 					CurlyTail.f fine 0 m2 x2 (swBefore -- df.mvs)
 
-				include : Serifs df XH 0 [if shortLeg [SmallMShortLegHeight XH df] 0] 0 true earless
+				include : Serifs df XH 0 [if shortLeg [SmallMShortLegHeight df XH] 0] 0 true earless
 
 		if (Body === SmallMArches && !shortLeg) : begin
 			if (!tailed) : begin
@@ -354,8 +348,8 @@ glyph-block Letter-Latin-Lower-M : begin
 	select-variant 'meng' 0x271
 	select-variant 'mCrossedTail' 0xAB3A (follow -- 'meng')
 
-	define [turnMShapeBodyImpl df top body toothless tailed serifs] : glyph-proc
-		include : body df top 0 0 0
+	define [turnMShapeBodyImpl df top body toothless tailed serifs _ada _adb] : glyph-proc
+		include : body df top 0 0 0 _ada _adb
 		include : serifs df top 0 0 0 0 toothless
 		include : FlipAround df.middle (top / 2)
 		if tailed : begin
@@ -378,8 +372,8 @@ glyph-block Letter-Latin-Lower-M : begin
 				__               { RbSerifs   } # The name-shaping mapping is swapped by design
 
 	foreach { suffix { {Body toothless tailed} {Serifs} } } [pairs-of TurnMConfig] : do
-		define [turnMShapeBody df top] : glyph-proc
-			include : turnMShapeBodyImpl df top Body toothless tailed Serifs
+		define [turnMShapeBody df top _ada _adb] : glyph-proc
+			include : turnMShapeBodyImpl df top Body toothless tailed Serifs _ada _adb
 
 		create-glyph "turnm.\(suffix)" : glyph-proc
 			local df : include : dfM
@@ -390,6 +384,8 @@ glyph-block Letter-Latin-Lower-M : begin
 			local df : include : dfM
 			include : df.markSet.capital
 			include : turnMShapeBody df CAP
+				SmallMSmoothA df ArchDepth
+				SmallMSmoothB df ArchDepth
 
 		if (!tailed) : begin
 			create-glyph "turnmLeg.\(suffix)" : glyph-proc
@@ -427,23 +423,23 @@ glyph-block Letter-Latin-Lower-M : begin
 				eject-contour 'serifLT'
 				include : CyrCurlDescender.rSideJut df.rightSB 0 (refSw -- df.mvs)
 
-	select-variant 'turnm' 0x26F (follow -- [conditional-follow [MEnoughSpaceForFullSerifs] 'turnm/full' 'turnm/reduced'])
+	select-variant 'turnm' 0x26F (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'turnm/full' 'turnm/reduced'])
 	select-variant 'turnm/reduced' (shapeFrom -- 'turnm')
 
-	select-variant 'turnmCap' 0x19C (follow -- [conditional-follow [MEnoughSpaceForFullSerifs] 'turnm/full' 'turnm/reduced'])
+	select-variant 'turnmCap' 0x19C (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'turnm/full' 'turnm/reduced'])
 
-	select-variant 'turnmLeg' 0x270 (follow -- [conditional-follow [MEnoughSpaceForFullSerifs] 'turnmLeg/full' 'turnmLeg/reduced'])
+	select-variant 'turnmLeg' 0x270 (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'turnmLeg/full' 'turnmLeg/reduced'])
 	select-variant 'turnmLeg/reduced' (shapeFrom -- 'turnmLeg')
 
-	select-variant 'turnmSideways' 0x1D1F (follow -- [conditional-follow [MEnoughSpaceForFullSerifs] 'turnm/full' 'turnm/reduced'])
+	select-variant 'turnmSideways' 0x1D1F (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'turnm/full' 'turnm/reduced'])
 
-	select-variant 'cyrl/sha.italic' (shapeFrom -- 'turnm') (follow -- [conditional-follow [MEnoughSpaceForFullSerifs] 'cyrl/sha.italic/full' 'cyrl/sha.italic/reduced'])
+	select-variant 'cyrl/sha.italic' (shapeFrom -- 'turnm') (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'cyrl/sha.italic/full' 'cyrl/sha.italic/reduced'])
 	select-variant 'cyrl/sha/reduced.italic' (shapeFrom -- 'turnm') (follow -- 'cyrl/sha.italic/reduced')
 
-	select-variant 'cyrl/shcha.italic' (follow -- [conditional-follow [MEnoughSpaceForFullSerifs] 'cyrl/shcha.italic/full' 'cyrl/shcha.italic/reduced'])
+	select-variant 'cyrl/shcha.italic' (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'cyrl/shcha.italic/full' 'cyrl/shcha.italic/reduced'])
 	select-variant 'cyrl/shcha/reduced.italic' (shapeFrom -- 'cyrl/shcha.italic') (follow -- 'cyrl/shcha.italic/reduced')
 
-	select-variant 'cyrl/shwe.italic' (follow -- [conditional-follow [MEnoughSpaceForFullSerifs] 'cyrl/shcha.italic/full' 'cyrl/shcha.italic/reduced'])
+	select-variant 'cyrl/shwe.italic' (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'cyrl/shcha.italic/full' 'cyrl/shcha.italic/reduced'])
 
 	alias 'cyrl/sha.BGR'         null 'cyrl/sha.italic'
 	alias 'cyrl/sha/reduced.BGR' null 'cyrl/sha/reduced.italic'


### PR DESCRIPTION
Continuation of #3096 but a little bit more involved to set up.

Also drop the code for an arbitrary `mid` value for `m` serifs, because it never ended up getting used (it was originally implemented for `ꬺ` by #1989 before changes were requested of it).

`UƜꝠAꜲꜴꜶꙖuɯꝡaꜳꜵꜷꙗ`
Sans Monospace:
<img width="1157" height="1142" alt="image" src="https://github.com/user-attachments/assets/582e5356-e65e-4361-bfa1-6fb1b6732b98" />
Slab Monospace:
<img width="1149" height="1133" alt="image" src="https://github.com/user-attachments/assets/8686da00-d121-4a83-883c-acf824ee1264" />
Aile:
<img width="1667" height="1137" alt="image" src="https://github.com/user-attachments/assets/866d7c4a-2e35-47ec-99b7-84426dc55fe5" />
Etoile:
<img width="1661" height="1134" alt="image" src="https://github.com/user-attachments/assets/9209b40b-5586-488f-9748-2a142b5f1f4a" />
