### PR TITLE
Cleanup of rounded variants of Cyrillic Yeri (`Ь`, `ь`) and composites thereof.

### DIFF
--- a/packages/font-glyphs/src/letter/cyrillic/be.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/be.ptl
@@ -10,7 +10,7 @@ glyph-block Letter-Cyrillic-Be : begin
 	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared-Shapes : UpwardHookShape SerifFrame
 	glyph-block-import Letter-Latin-Upper-F : EFVJutLength
-	glyph-block-import Letter-Cyrillic-Yeri : YeriBarPos Yeri RevYeri
+	glyph-block-import Letter-Cyrillic-Yeri : YeriBarPos YeriUpper RevYeriUpper
 
 	define BeConfig : object
 		standardSerifless         { false false }
@@ -23,47 +23,47 @@ glyph-block Letter-Cyrillic-Be : begin
 		create-glyph "cyrl/Be.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			local stroke : AdviceStroke2 2 3 CAP
-			include : Yeri.UprightShape CAP SB RightSB stroke (fSlab -- false)
+			include : YeriUpper.Shape CAP SB RightSB stroke (fSlab -- false)
 			include : HBar.t (SB - O) [mix SB RightSB 0.9] CAP
 			if doST : begin
-				include : tagged 'serifTL' : HSerif.lt SB CAP SideJut stroke
+				include : tagged 'serifLT' : HSerif.lt SB CAP SideJut stroke
 				local { jutTop jutBot jutMid } : EFVJutLength CAP YeriBarPos stroke
 				local swVJut : VJutStroke * (stroke / Stroke)
-				include : tagged 'serifTR' : VSerif.dr [mix SB RightSB 0.9] CAP jutTop swVJut
-			if doSB : include : tagged 'serifBL' : HSerif.lb SB 0 SideJut stroke
+				include : tagged 'serifRT' : VSerif.dr [mix SB RightSB 0.9] CAP jutTop swVJut
+			if doSB : include : tagged 'serifLB' : HSerif.lb SB 0 SideJut stroke
 
 		create-glyph "cyrl/BeRev.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			local stroke : AdviceStroke2 2 3 CAP
-			include : RevYeri.Shape CAP SB RightSB stroke (fSlab -- false)
+			include : RevYeriUpper.Shape CAP SB RightSB stroke (fSlab -- false)
 			include : HBar.t [mix SB RightSB 0.1] (RightSB + O) CAP
 			if doST : begin
-				include : tagged 'serifTR' : HSerif.rt RightSB CAP SideJut stroke
+				include : tagged 'serifRT' : HSerif.rt RightSB CAP SideJut stroke
 				local { jutTop jutBot jutMid } : EFVJutLength CAP YeriBarPos stroke
 				local swVJut : VJutStroke * (stroke / Stroke)
-				include : tagged 'serifTL' : VSerif.dl [mix SB RightSB 0.1] CAP jutTop swVJut
-			if doSB : include : tagged 'serifBR' : HSerif.rb RightSB 0 SideJut stroke
+				include : tagged 'serifLT' : VSerif.dl [mix SB RightSB 0.1] CAP jutTop swVJut
+			if doSB : include : tagged 'serifRB' : HSerif.rb RightSB 0 SideJut stroke
 
 		create-glyph "cyrl/DeKomi.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			local stroke : AdviceStroke2 2 3 CAP
 			include : LeaningAnchor.Above.VBar.r RightSB stroke
-			include : RevYeri.Shape CAP SB RightSB stroke (fSlab -- false)
-			if doST : include : tagged 'serifTR' : if fMotion
+			include : RevYeriUpper.Shape CAP SB RightSB stroke (fSlab -- false)
+			if doST : include : tagged 'serifRT' : if fMotion
 				HSerif.lt (RightSB - [HSwToV stroke]) CAP SideJut stroke
 				HSerif.mt (RightSB - [HSwToV : 0.5 * stroke]) CAP (Jut - [HSwToV : 0.5 * (Stroke - stroke)]) stroke
-			if doSB : include : tagged 'serifBR' : HSerif.rb RightSB 0 SideJut stroke
+			if doSB : include : tagged 'serifRB' : HSerif.rb RightSB 0 SideJut stroke
 
 		create-glyph "cyrl/DjeKomi.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleMM 3
 			include : df.markSet.capital
 
-			include : RevYeri.RoundShape CAP
+			include : RevYeriUpper.RoundShape CAP
 				left   -- df.leftSB
 				right  -- (df.middle + [HSwToV : 0.5 * df.mvs])
 				stroke -- df.mvs
 				fSlab  -- false
-			if doST : include : tagged 'serifTR' : if fMotion
+			if doST : include : tagged 'serifRT' : if fMotion
 				HSerif.lt (df.middle - [HSwToV : 0.5 * df.mvs]) CAP SideJut df.mvs
 				HSerif.mt df.middle CAP (Jut - [HSwToV : 0.5 * (Stroke - df.mvs)]) df.mvs
 			include : UpwardHookShape

--- a/packages/font-glyphs/src/letter/cyrillic/lje.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/lje.ptl
@@ -12,23 +12,26 @@ glyph-block Letter-Cyrillic-Lje : begin
 	glyph-block-import Letter-Cyrillic-Yeri : YeriConfig
 
 	define [CyrLjeShape Yeri df top] : glyph-proc
+		local sw : Math.min df.mvs : AdviceStroke2 3 3 top df.adws
 		local xTopLeft : mix df.leftSB df.rightSB 0.025
-		local jut : Math.min (Jut - [HSwToV : 0.5 * (Stroke - df.mvs)]) : mix [HSwToV : 0.5 * df.mvs] Jut : (2/3) * df.adws
+		local xBotLeft : mix df.leftSB 0 [if SLAB 1.00 0.75]
+		local jut : Math.min
+			Jut - [HSwToV : 0.5 * (Stroke - sw)]
+			mix [HSwToV : 0.5 * sw] Jut ((2 / df.hPack) * df.adws)
 		include : LegShape
 			ztop -- [Point.fromXY Point.Type.Corner xTopLeft top]
-			zbot -- [Point.fromXY Point.Type.Corner [mix df.leftSB 0 : if SLAB 1 0.75] 0]
+			zbot -- [Point.fromXY Point.Type.Corner xBotLeft 0]
 			xb   -- xTopLeft
-			fine -- df.mvs
+			fine -- sw
 		include : Yeri top
-			left   -- (df.middle - [HSwToV : 0.5 * df.mvs])
+			left   -- (df.middle - [HSwToV : 0.5 * sw])
 			right  -- (df.rightSB - O)
-			stroke -- df.mvs
+			stroke -- sw
 			jut    -- jut
-		include : HBar.t xTopLeft df.middle top df.mvs
-		if SLAB : begin
-			include : HSerif.lt xTopLeft top (jut - [HSwToV : 0.5 * df.mvs]) df.mvs
+		include : HBar.t xTopLeft df.middle top sw
+		if SLAB : include : HSerif.lt xTopLeft top (jut - [HSwToV : 0.5 * sw]) sw
 
-	foreach { suffix { Uc Lc } } [Object.entries YeriConfig] : do
+	foreach { suffix { Uc Lc BGRc } } [Object.entries YeriConfig] : do
 		create-glyph "cyrl/Lje.\(suffix)"  : glyph-proc
 			local df : include : DivFrame para.advanceScaleMM 3
 			include : df.markSet.capital

--- a/packages/font-glyphs/src/letter/cyrillic/nje.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/nje.ptl
@@ -18,14 +18,18 @@ glyph-block Letter-Cyrillic-Nje : begin
 	define SLAB-TAILED-CYRILLIC        3
 	define SLAB-ALL                    4
 
-	define [LeftHalf slabType df top] : glyph-proc
-		local dfSub : df.slice 3 2
-		include : VBar.l dfSub.leftSB 0 top dfSub.mvs
-		include : HBar.m dfSub.leftSB dfSub.rightSB (top * HBarPos) dfSub.mvs
+	define [CyrNjeStroke df top] : Math.min df.mvs : AdviceStroke2 3 3 top df.adws
 
-		local sf : SerifFrame.fromDf dfSub top 0
+	define [LeftHalf slabType df top] : glyph-proc
+		local sw : CyrNjeStroke df top
+
+		local subDf : df.slice 3 2
+		include : VBar.l subDf.leftSB 0 top sw
+		include : HBar.m subDf.leftSB subDf.rightSB [mix 0 top HBarPos] sw
+
+		local sf : SerifFrame.fromDf subDf top 0 (swRef -- sw)
 		include : match slabType
-			[Just SLAB-NONE]   : glyph-proc
+			[Just SLAB-NONE]     : glyph-proc
 			[Just SLAB-TOP-LEFT] : begin sf.lt.outer
 			[Just SLAB-TOP-LEFT-BOTTOM-RIGHT] : composite-proc sf.lt.outer sf.rb.outer
 			[Just SLAB-TAILED-CYRILLIC] : if sf.enoughSpaceForFullSerifs
@@ -36,15 +40,12 @@ glyph-block Letter-Cyrillic-Nje : begin
 				composite-proc sf.lt.outer sf.rt.outer sf.lb.outer
 
 	define [RightHalf Yeri df top] : glyph-proc
+		local sw : CyrNjeStroke df top
 		include : Yeri top
-			left   -- (df.middle - [HSwToV : 0.5 * df.mvs])
+			left   -- (df.middle - [HSwToV : 0.5 * sw])
 			right  -- (df.rightSB - O)
-			stroke -- df.mvs
-		eject-contour 'serifYeriLT'
-		eject-contour 'serifYeriLB'
-
-	define NjeReduction : object
-		serifed 'serifedExceptBottomRight'
+			stroke -- sw
+			fSlab  -- false
 
 	define LeftHalfConfig : object
 		serifless                        { SLAB-NONE                  }
@@ -64,7 +65,7 @@ glyph-block Letter-Cyrillic-Nje : begin
 			include : df.markSet.e
 			include : LeftHalf slabType df XH
 
-	foreach { suffix { Uc Lc } } [Object.entries YeriConfig] : do
+	foreach { suffix { Uc Lc BGRc } } [Object.entries YeriConfig] : do
 		create-glyph "cyrl/Nje/rightHalf.\(suffix)"  : glyph-proc
 			local df : include : DivFrame para.advanceScaleMM 3
 			include : df.markSet.capital

--- a/packages/font-glyphs/src/letter/cyrillic/shha.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/shha.ptl
@@ -61,8 +61,8 @@ glyph-block Letter-Cyrillic-Shha : begin
 			eject-contour 'serifLT'
 			include : TopHook.toRight.lBarInner SB 0 CAP
 
-	select-variant 'cyrl/Shha' 0x4BA (follow -- 'H')
-	select-variant 'cyrl/Shha/descBase' (shapeFrom -- 'cyrl/Shha') (follow -- 'H/descBase')
-	select-variant 'cyrl/Hwe' 0xA694 (follow -- 'HHookTop')
+	select-variant 'cyrl/Shha' 0x4BA (follow -- 'hCap')
+	select-variant 'cyrl/Hwe' 0xA694 (follow -- 'hCapHookTop')
 
+	select-variant 'cyrl/Shha/descBase' (shapeFrom -- 'cyrl/Shha') (follow -- 'hCap/descBase')
 	derive-composites 'cyrl/ShhaDescender' 0x526 'cyrl/Shha/descBase' [CyrDescender.rSideJut RightSB 0]

--- a/packages/font-glyphs/src/letter/cyrillic/te-midhook.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/te-midhook.ptl
@@ -35,9 +35,11 @@ glyph-block Letter-Cyrillic-Te-MidHook : begin
 			include : VSerif.dl  xTopBarLeft top VJut swVJut
 			include : VSerif.dr xTopBarRight top VJut swVJut
 
-		if slabBot : include : intersection
-			MaskLeft : mix (left + [HSwToV sw]) (right - [HSwToV sw]) 0.625
-			HSerif.mb (left + [HSwToV : 0.5 * sw]) 0 ([Math.max Jut : MidJutCenter * (6 / 7) * df.adws] - [HSwToV : 0.5 * (Stroke - sw)]) sw
+		if slabBot : begin
+			local jut : Math.max Jut : mix [HSwToV HalfStroke] MidJutCenter ((6 / 7) * df.adws)
+			include : intersection
+				MaskLeft : mix (left + [HSwToV sw]) (right - [HSwToV sw]) 0.625
+				HSerif.mb (left + [HSwToV : 0.5 * sw]) 0 (jut - [HSwToV : 0.5 * (Stroke - sw)]) sw
 
 	foreach { suffix { adws doST doSB } } [Object.entries TConfig] : do
 		create-glyph "cyrl/TeMidHook.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/letter/cyrillic/tje.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/tje.ptl
@@ -13,14 +13,14 @@ glyph-block Letter-Cyrillic-Tje : begin
 	glyph-block-import Letter-Latin-Upper-T : TConfig
 	glyph-block-import Letter-Cyrillic-Yeri : YeriConfig YeriBarPos
 
-	define [xMidBarLeft df] : [mix df.leftSB df.rightSB 0.3] + OX
-	define [xBowlRight df] : df.rightSB - OX
+	define [xTeMidBarLeft  df] : [mix df.leftSB df.rightSB 0.3] + OX
+	define [xYeriBowlRight df] : df.rightSB - OX
 
-	define [CyrTjeStroke df] : Math.min df.mvs : AdviceStroke 2.75 df.adws
+	define [CyrTjeStroke df top] : Math.min df.mvs : AdviceStroke2 2.75 3 top df.adws
 
 	define [LeftHalf df top sw slabTop slabBot] : glyph-proc
-		local left : xMidBarLeft df
-		local right : xBowlRight df
+		local left  : xTeMidBarLeft  df
+		local right : xYeriBowlRight df
 
 		local xTopBarLeft : df.leftSB - SideJut
 		local xTopBarRight : Math.max
@@ -34,42 +34,45 @@ glyph-block Letter-Cyrillic-Tje : begin
 			include : VSerif.dl xTopBarLeft  top jutTop swVJut
 			include : VSerif.dr xTopBarRight top jutTop swVJut
 
-		if slabBot : include : HSerif.lb left 0 ([Math.max Jut : MidJutCenter * (6 / 7) * df.adws] - [HSwToV HalfStroke]) sw
+		if slabBot : begin
+			local jut : Math.max Jut : mix [HSwToV HalfStroke] MidJutCenter ((6 / 7) * df.adws)
+			include : HSerif.lb left 0 (jut - [HSwToV HalfStroke]) sw
 
 	define [RightHalf Yeri df top sw] : glyph-proc
 		include : Yeri top
-			left   -- [xMidBarLeft df]
-			right  -- [xBowlRight df]
+			left   -- [xTeMidBarLeft  df]
+			right  -- [xYeriBowlRight df]
 			stroke -- sw
-		eject-contour 'serifYeriLT'
-		eject-contour 'serifYeriLB'
+			fSlab  -- false
 
 	foreach { suffix { adws doST doSB } } [Object.entries TConfig] : do
 		create-glyph "cyrl/Tje/leftHalf.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleT 3
 			include : df.markSet.capital
 			local subDf : DivFrame adws 3
-			include : with-transform [ApparentTranslate ([xMidBarLeft df] - [xMidBarLeft subDf]) 0]
-				LeftHalf subDf CAP [CyrTjeStroke df] doST doSB
+			local xOffsetMid : [xTeMidBarLeft df] - [xTeMidBarLeft subDf]
+			include : with-transform [ApparentTranslate xOffsetMid 0]
+				LeftHalf subDf CAP [CyrTjeStroke df CAP] doST doSB
 
 		create-glyph "cyrl/tje.upright/leftHalf.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleT 3
 			include : df.markSet.e
 			local subDf : DivFrame adws 3
-			include : with-transform [ApparentTranslate ([xMidBarLeft df] - [xMidBarLeft subDf]) 0]
-				LeftHalf subDf XH [CyrTjeStroke df] doST doSB
+			local xOffsetMid : [xTeMidBarLeft df] - [xTeMidBarLeft subDf]
+			include : with-transform [ApparentTranslate xOffsetMid 0]
+				LeftHalf subDf XH [CyrTjeStroke df XH] doST doSB
 
-	foreach { suffix { Uc Lc } } [Object.entries YeriConfig] : do
+	foreach { suffix { Uc Lc BGRc } } [Object.entries YeriConfig] : do
 		create-glyph "cyrl/Tje/rightHalf.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleT 3
 			include : df.markSet.capital
-			include : RightHalf Uc df CAP [CyrTjeStroke df]
+			include : RightHalf Uc df CAP [CyrTjeStroke df CAP]
 			DependentSelector.set currentGlyph : if (suffix === "corner") 'full' 'reduced'
 
 		create-glyph "cyrl/tje.upright/rightHalf.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleT 3
 			include : df.markSet.e
-			include : RightHalf Lc df XH [CyrTjeStroke df]
+			include : RightHalf Lc df XH [CyrTjeStroke df XH]
 			DependentSelector.set currentGlyph : if (suffix === "corner") 'full' 'reduced'
 
 	select-variant 'cyrl/Tje/leftHalf/full'

--- a/packages/font-glyphs/src/letter/cyrillic/yat.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/yat.ptl
@@ -81,20 +81,27 @@ glyph-block Letter-Cyrillic-Yat : begin
 
 		include : with-transform [ApparentTranslate shift 0] : Yat
 
-		include : Iotified.[if fCapital 'full' 'ascender'] df top 0 (fCapital -- fCapital) (swRef -- stroke)
+		include : Iotified.[if fCapital 'full' 'ascender'] df top 0
+			fCapital -- fCapital
+			swRef    -- stroke
 
 	define [SakhaYatShape Yeri df top] : glyph-proc
+		local jut : Math.min
+			Jut - [HSwToV : 0.5 * (Stroke - df.mvs)]
+			mix [HSwToV : 0.5 * df.mvs] Jut ((2 / df.hPack) * df.adws)
 		include : Yeri top
 			left   -- (df.middle - [HSwToV : 0.5 * df.mvs])
 			right  -- df.rightSB
 			stroke -- df.mvs
-			jut    -- [Math.min (Jut - [HSwToV : 0.5 * (Stroke - df.mvs)]) : mix [HSwToV : 0.5 * df.mvs] Jut : (2/3) * df.adws]
+			jut    -- jut
 
 		local fEnoughSpaceForFullSerifs : df.width > 7 * para.refJut
 		if [not fEnoughSpaceForFullSerifs] : eject-contour 'serifYeriLB'
-		include : Iotified.[if fEnoughSpaceForFullSerifs 'full' 'outer'] df top (df.middle + [HSwToV : 0.5 * df.mvs]) (top - df.mvs / 2)
+		include : Iotified.[if fEnoughSpaceForFullSerifs 'full' 'outer'] df top
+			hBarRight -- (df.middle + [HSwToV : 0.5 * df.mvs])
+			hBarY     -- (top - df.mvs / 2)
 
-	foreach { suffix { Uc Lc } } [pairs-of YeriConfig] : do
+	foreach { suffix { Uc Lc BGRc } } [pairs-of YeriConfig] : do
 		create-glyph "cyrl/Yat.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleT 2
 			include : df.markSet.capital
@@ -147,12 +154,12 @@ glyph-block Letter-Cyrillic-Yat : begin
 			local df : include : DivFrame para.advanceScaleMM 3
 			include : df.markSet.e
 
-			local dfSub : df.slice 3 2
-			local xMidBarLeft : dfSub.rightSB - [HSwToV df.mvs]
+			local subDf : df.slice 3 2
+			local xMidBarLeft : subDf.rightSB - [HSwToV df.mvs]
 
 			include : Lc XH xMidBarLeft df.rightSB
 				stroke -- df.mvs
-				yStart -- (XH - dfSub.smallArchDepthB)
+				yStart -- (XH - subDf.smallArchDepthB)
 			eject-contour 'serifYeriLT'
 			eject-contour 'serifYeriLB'
 
@@ -162,12 +169,12 @@ glyph-block Letter-Cyrillic-Yat : begin
 			local df : include : DivFrame [mix 1 para.advanceScaleMM 2] 4
 			include : df.markSet.e
 
-			local dfSub : df.slice 4 3 0
-			local xMidBarLeft : dfSub.rightSB - [HSwToV df.mvs]
+			local subDf : df.slice 4 3 0
+			local xMidBarLeft : subDf.rightSB - [HSwToV df.mvs]
 
 			include : Lc XH xMidBarLeft df.rightSB
 				stroke -- df.mvs
-				yStart -- (XH - SmallArchDepthB * 0.5 * df.adws)
+				yStart -- (XH - SmallArchDepthB * (2 / df.hPack) * df.adws)
 			eject-contour 'serifYeriLT'
 			eject-contour 'serifYeriLB'
 

--- a/packages/font-glyphs/src/letter/cyrillic/yer.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/yer.ptl
@@ -92,7 +92,7 @@ glyph-block Letter-Cyrillic-Yer : begin
 		local fine : Math.min stroke : AdviceStroke 5.5 (mockWidth / Width)
 		include : ExtLineLhs xYeriLeft top xTopBarLeft yTopBarLeft fine
 
-	foreach { suffix { Uc Lc } } [Object.entries YeriConfig] : do
+	foreach { suffix { Uc Lc BGRc } } [Object.entries YeriConfig] : do
 		create-glyph "cyrl/Yer.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleT 2
 			include : df.markSet.capital
@@ -104,6 +104,13 @@ glyph-block Letter-Cyrillic-Yer : begin
 			local df : include : DivFrame para.advanceScaleT 2
 			include : df.markSet.e
 			include : CyrYerShape Lc XH
+				left   -- df.leftSB
+				right  -- df.rightSB
+				stroke -- [df.adviceStroke2 2.75 3 XH]
+		create-glyph "cyrl/yer.BGR.\(suffix)" : glyph-proc
+			local df : include : DivFrame para.advanceScaleT 2
+			include : df.markSet.e
+			include : CyrYerShape BGRc XH
 				left   -- df.leftSB
 				right  -- df.rightSB
 				stroke -- [df.adviceStroke2 2.75 3 XH]
@@ -146,7 +153,7 @@ glyph-block Letter-Cyrillic-Yer : begin
 
 	select-variant 'cyrl/Yer' 0x42A
 	select-variant 'cyrl/yer' 0x44A
-	select-variant 'cyrl/yer.BGR' (shapeFrom -- 'cyrl/yer')
+	select-variant 'cyrl/yer.BGR'
 	select-variant 'cyrl/yerTall' 0x1C86 (follow -- 'cyrl/yer')
 
 	select-variant 'cyrl/YerNeutral' 0xA64E (follow -- 'cyrl/Yer')

--- a/packages/font-glyphs/src/letter/cyrillic/yeri.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/yeri.ptl
@@ -13,9 +13,10 @@ glyph-block Letter-Cyrillic-Yeri : begin
 	glyph-block-export YeriBarPos
 	define YeriBarPos 0.55
 
-	glyph-block-export Yeri
-	define Yeri : namespace
-		define flex-params [CornerCommon] : glyph-proc
+	define [YeriShapeGroup fCapital fBGR] : namespace
+		define useFullSerifs : fCapital || !(para.isItalic || fBGR)
+
+		export : define flex-params [Shape] : glyph-proc
 			local-parameter : top
 			local-parameter : left   -- SB
 			local-parameter : right  -- RightSB
@@ -25,57 +26,35 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			local-parameter : yStart -- top
 			local-parameter : fSlab  -- SLAB
 
-			local bowl : [mix 0 top pBar] + stroke / 2
-			local turnRadius : BowlXDepth bowl 0 left right stroke
-			local ada : ArchDepthAOf ArchDepth : (right - left) + SB * 2
-			local adb : ArchDepthBOf ArchDepth : (right - left) + SB * 2
+			local bowlTop : [mix 0 top pBar] + stroke / 2
+			local turnRadius : BowlXDepth bowlTop 0 left right stroke
 			local fine : ShoulderFine * (stroke / Stroke)
 
-			local yTurnBottomL : YSmoothMidL bowl 0 ada adb
-			local yTurnBottomR : YSmoothMidR bowl 0 ada adb
+			local mockWidth : (right - left) + SB * 2
+			local archDepth : Math.max (ArchDepth * (mockWidth / Width)) (stroke * 1.125)
+			local ada : ArchDepthAOf archDepth mockWidth
+			local adb : ArchDepthBOf archDepth mockWidth
+			local yTurnBottomL : YSmoothMidL bowlTop 0 ada adb
+			local yTurnBottomR : YSmoothMidR bowlTop 0 ada adb
 
 			include : union [VBar.l left 0 yStart stroke] : dispiro
 				widths.lhs stroke
-				flat (left + Stroke * 0.2) 0 [heading Rightward]
-				curl [arch.adjust-x.bot [Math.max ((left + Stroke * 0.2) + TINY + [Math.abs : stroke * TanSlope]) (right - turnRadius)] (sw -- stroke)] 0
+				flat (left - O) 0 [heading Rightward]
+				curl [arch.adjust-x.bot [Math.max (right - turnRadius) : mix left right 0.5] (sw -- stroke)] 0
 				archv 8
 				g4   (right - OX) yTurnBottomR
 				arcvh 8
-				flat [arch.adjust-x.top [Math.max ((left + Stroke * 0.2) + TINY + [Math.abs : stroke * TanSlope]) (right - turnRadius)] (sw -- stroke)] bowl
-				curl (left + Stroke * 0.2) bowl [heading Leftward]
+				flat [arch.adjust-x.top [Math.max (right - turnRadius) : mix left right 0.5] (sw -- stroke)] bowlTop
+				curl (left - O) bowlTop [heading Leftward]
 
-		export : define flex-params [UprightShape] : glyph-proc
-			local-parameter : top
-			local-parameter : left   -- SB
-			local-parameter : right  -- RightSB
-			local-parameter : stroke -- Stroke
-			local-parameter : jut    -- (Jut - [HSwToV : 0.5 * (Stroke - stroke)])
-			local-parameter : pBar   -- YeriBarPos
-			local-parameter : yStart -- top
-			local-parameter : fSlab  -- SLAB
-
-			include : CornerCommon.apply null $-flex-arguments
 			if fSlab : include : composite-proc
-				tagged 'serifYeriLB' : HSerif.lb left 0 (jut - [HSwToV : 0.5 * stroke]) stroke
-				tagged 'serifYeriLT' : HSerif.mt (left + [HSwToV : 0.5 * stroke]) top jut stroke
-
-		export : define flex-params [ItalicShape] : glyph-proc
-			local-parameter : top
-			local-parameter : left   -- SB
-			local-parameter : right  -- RightSB
-			local-parameter : stroke -- Stroke
-			local-parameter : jut    -- (Jut - [HSwToV : 0.5 * (Stroke - stroke)])
-			local-parameter : pBar   -- YeriBarPos
-			local-parameter : yStart -- top
-			local-parameter : fSlab  -- SLAB
-
-			include : CornerCommon.apply null $-flex-arguments
-			if fSlab : include : tagged 'serifYeriLT' : HSerif.lt left top (jut - [HSwToV : 0.5 * stroke]) stroke
-
-		export : define flex-params [AutoItalicShape] : begin
-			if para.isItalic
-			: then : ItalicShape.apply  null $-flex-arguments
-			: else : UprightShape.apply null $-flex-arguments
+				tagged 'serifYeriLB' : if useFullSerifs
+					HSerif.lb left 0 (jut - [HSwToV : 0.5 * stroke]) stroke
+					no-shape
+				tagged 'serifYeriLT' : if useFullSerifs
+					HSerif.mt (left + [HSwToV : 0.5 * stroke]) top jut stroke
+					HSerif.lt left top (jut - [HSwToV : 0.5 * stroke]) stroke
+		set Shape.useFullSerifs useFullSerifs
 
 		export : define flex-params [RoundShape] : glyph-proc
 			local-parameter : top
@@ -87,26 +66,31 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			local-parameter : yStart -- top
 			local-parameter : fSlab  -- SLAB
 
-			local bowl : [mix 0 top pBar] + stroke / 2
-			local turnRadius : BowlXDepth bowl 0 left right stroke
-			local ada : ArchDepthAOf ArchDepth : (right - left) + SB * 2
-			local adb : ArchDepthBOf ArchDepth : (right - left) + SB * 2
+			local bowlTop : [mix 0 top pBar] + stroke / 2
+			local turnRadius : BowlXDepth bowlTop 0 left right stroke
 			local fine : ShoulderFine * (stroke / Stroke)
 
-			local yTurnBottomL : YSmoothMidL bowl 0 ada adb
-			local yTurnBottomR : YSmoothMidR bowl 0 ada adb
+			local mockWidth : (right - left) + SB * 2
+			local archDepth : Math.max (ArchDepth * (mockWidth / Width)) (stroke * 1.125)
+			local ada : ArchDepthAOf archDepth mockWidth
+			local adb : ArchDepthBOf archDepth mockWidth
+			local yTurnBottomL : YSmoothMidL bowlTop 0 ada adb
+			local yTurnBottomR : YSmoothMidR bowlTop 0 ada adb
 
 			include : dispiro
 				widths.lhs stroke
 				flat left yStart [heading Downward]
-				curl left [Math.min (yStart - TINY) yTurnBottomL]
+				curl left [Math.min (yStart - TINY) (0 + adb) yTurnBottomL]
 				arch.lhs 0 (sw -- stroke)
 				g4   (right - OX) yTurnBottomR
-				arcvh
-				flat [arch.adjust-x.top [mix left right 0.5] (sw -- stroke)] bowl
-				curl (left + Stroke * 0.2) bowl [heading Leftward]
+				arcvh 8
+				flat [arch.adjust-x.top [Math.max (right - turnRadius) : mix left right 0.5] (sw -- stroke)] bowlTop
+				curl (left - O) bowlTop [heading Leftward]
 
-			if fSlab : include : tagged 'serifYeriLT' : HSerif.lt left top (jut - [HSwToV : 0.5 * stroke]) stroke
+			if fSlab : include : tagged 'serifYeriLT' : if useFullSerifs
+				HSerif.mt (left + [HSwToV : 0.5 * stroke]) top jut stroke
+				HSerif.lt left top (jut - [HSwToV : 0.5 * stroke]) stroke
+		set RoundShape.useFullSerifs useFullSerifs
 
 		export : define flex-params [CursiveShape] : glyph-proc
 			local-parameter : top
@@ -118,28 +102,38 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			local-parameter : yStart -- top
 			local-parameter : fSlab  -- SLAB
 
-			local bowl : [mix 0 top pBar] + stroke / 2
-			local turnRadius : BowlXDepth bowl 0 left right stroke
-			local ada : ArchDepthAOf ArchDepth : (right - left) + SB * 2
-			local adb : ArchDepthBOf ArchDepth : (right - left) + SB * 2
+			local bowlTop : [mix 0 top pBar] + stroke / 2
+			local turnRadius : BowlXDepth bowlTop 0 left right stroke
 			local fine : ShoulderFine * (stroke / Stroke)
 
-			local yTurnBottomL : YSmoothMidL bowl 0 ada adb
-			local yTurnBottomR : YSmoothMidR bowl 0 ada adb
+			local mockWidth : (right - left) + SB * 2
+			local archDepth : Math.max (ArchDepth * (mockWidth / Width)) (stroke * 1.125)
+			local ada : ArchDepthAOf archDepth mockWidth
+			local adb : ArchDepthBOf archDepth mockWidth
+			local yTurnBottomL : YSmoothMidL bowlTop 0 ada adb
+			local yTurnBottomR : YSmoothMidR bowlTop 0 ada adb
 
 			include : dispiro
 				widths.lhs stroke
 				flat left yStart [heading Downward]
-				curl left [Math.min (yStart - TINY) yTurnBottomL]
+				curl left [Math.min (yStart - TINY) (0 + adb) yTurnBottomL]
 				arch.lhs 0 (sw -- stroke)
 				g4   (right - OX) yTurnBottomR
-				arch.lhs bowl (sw -- stroke) (swAfter -- fine)
-				g4.down.end (left + [HSwToV : stroke - fine]) yTurnBottomL [widths.lhs.heading fine Downward]
+				arch.lhs bowlTop (sw -- stroke) (swAfter -- fine)
+				g4.down.end (left + [HSwToV : stroke - fine]) [Math.max (bowlTop - ada) yTurnBottomL] [widths.lhs.heading fine Downward]
 
-			if fSlab : include : tagged 'serifYeriLT' : HSerif.lt left top (jut - [HSwToV : 0.5 * stroke]) stroke
+			if fSlab : include : tagged 'serifYeriLT' : if useFullSerifs
+				HSerif.mt (left + [HSwToV : 0.5 * stroke]) top jut stroke
+				HSerif.lt left top (jut - [HSwToV : 0.5 * stroke]) stroke
+		set CursiveShape.useFullSerifs useFullSerifs
 
-	glyph-block-export RevYeri
-	define RevYeri : namespace
+	glyph-block-export YeriUpper YeriLower
+	define YeriUpper    : YeriShapeGroup true  false
+	define YeriLower    : YeriShapeGroup false false
+	define YeriLowerBGR : YeriShapeGroup false true
+
+	glyph-block-export RevYeriUpper
+	define RevYeriUpper : namespace
 		export : define flex-params [Shape] : glyph-proc
 			local-parameter : top
 			local-parameter : left   -- SB
@@ -150,24 +144,26 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			local-parameter : yStart -- top
 			local-parameter : fSlab  -- SLAB
 
-			local bowl : [mix 0 top pBar] + stroke / 2
-			local turnRadius : BowlXDepth bowl 0 left right stroke
-			local ada : ArchDepthAOf ArchDepth : (right - left) + SB * 2
-			local adb : ArchDepthBOf ArchDepth : (right - left) + SB * 2
+			local bowlTop : [mix 0 top pBar] + stroke / 2
+			local turnRadius : BowlXDepth bowlTop 0 left right stroke
 			local fine : ShoulderFine * (stroke / Stroke)
 
-			local yTurnBottomL : YSmoothMidL bowl 0 ada adb
-			local yTurnBottomR : YSmoothMidR bowl 0 ada adb
+			local mockWidth : (right - left) + SB * 2
+			local archDepth : Math.max (ArchDepth * (mockWidth / Width)) (stroke * 1.125)
+			local ada : ArchDepthAOf archDepth mockWidth
+			local adb : ArchDepthBOf archDepth mockWidth
+			local yTurnBottomL : YSmoothMidL bowlTop 0 ada adb
+			local yTurnBottomR : YSmoothMidR bowlTop 0 ada adb
 
 			include : union [VBar.r right 0 yStart stroke] : dispiro
 				widths.rhs stroke
-				flat (right - Stroke * 0.2) 0 [heading Leftward]
-				curl [arch.adjust-x.bot [Math.min ((right - Stroke * 0.2) - TINY - [Math.abs : stroke * TanSlope]) (left + turnRadius)] (sw -- stroke)] 0
+				flat (right + O) 0 [heading Leftward]
+				curl [arch.adjust-x.bot [Math.min (left + turnRadius) : mix left right 0.5] (sw -- stroke)] 0
 				archv 8
 				g4   (left + OX) yTurnBottomL
 				arcvh 8
-				flat [arch.adjust-x.top [Math.min ((right - Stroke * 0.2) - TINY - [Math.abs : stroke * TanSlope]) (left + turnRadius)] (sw -- stroke)] bowl
-				curl (right - Stroke * 0.2) bowl [heading Rightward]
+				flat [arch.adjust-x.top [Math.min (left + turnRadius) : mix left right 0.5] (sw -- stroke)] bowlTop
+				curl (right + O) bowlTop [heading Rightward]
 
 			if fSlab : include : composite-proc
 				tagged 'serifYeriRB' : HSerif.rb right 0 (jut - [HSwToV : 0.5 * stroke]) stroke
@@ -183,34 +179,36 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			local-parameter : yStart -- top
 			local-parameter : fSlab  -- SLAB
 
-			local bowl : [mix 0 top pBar] + stroke / 2
-			local turnRadius : BowlXDepth bowl 0 left right stroke
-			local ada : ArchDepthAOf ArchDepth : (right - left) + SB * 2
-			local adb : ArchDepthBOf ArchDepth : (right - left) + SB * 2
+			local bowlTop : [mix 0 top pBar] + stroke / 2
+			local turnRadius : BowlXDepth bowlTop 0 left right stroke
 			local fine : ShoulderFine * (stroke / Stroke)
 
-			local yTurnBottomL : YSmoothMidL bowl 0 ada adb
-			local yTurnBottomR : YSmoothMidR bowl 0 ada adb
+			local mockWidth : (right - left) + SB * 2
+			local archDepth : Math.max (ArchDepth * (mockWidth / Width)) (stroke * 1.125)
+			local ada : ArchDepthAOf archDepth mockWidth
+			local adb : ArchDepthBOf archDepth mockWidth
+			local yTurnBottomL : YSmoothMidL bowlTop 0 ada adb
+			local yTurnBottomR : YSmoothMidR bowlTop 0 ada adb
 
 			include : dispiro
 				widths.rhs stroke
 				flat right yStart [heading Downward]
-				curl right [Math.min (yStart - TINY) yTurnBottomR]
+				curl right [Math.min (yStart - TINY) (0 + ada) yTurnBottomR]
 				arch.rhs 0 (sw -- stroke)
 				g4   (left + OX) yTurnBottomL
-				arcvh
-				flat [arch.adjust-x.top [mix left right 0.5] (sw -- stroke)] bowl
-				curl (right - Stroke * 0.2) bowl [heading Rightward]
+				arcvh 8
+				flat [arch.adjust-x.top [Math.min (left + turnRadius) : mix left right 0.5] (sw -- stroke)] bowlTop
+				curl (right + O) bowlTop [heading Rightward]
 
 			if fSlab : include : tagged 'serifYeriRT' : HSerif.mt (right - [HSwToV : 0.5 * stroke]) top jut stroke
 
 	glyph-block-export YeriConfig
 	define YeriConfig : object
-		corner        { Yeri.UprightShape Yeri.AutoItalicShape }
-		round         { Yeri.RoundShape   Yeri.RoundShape      }
-		cursive       { Yeri.CursiveShape Yeri.CursiveShape    }
+		corner        { YeriUpper.Shape        YeriLower.Shape        YeriLowerBGR.Shape        }
+		round         { YeriUpper.RoundShape   YeriLower.RoundShape   YeriLowerBGR.RoundShape   }
+		cursive       { YeriUpper.CursiveShape YeriLower.CursiveShape YeriLowerBGR.CursiveShape }
 
-	foreach { suffix { Uc Lc } } [Object.entries YeriConfig] : do
+	foreach { suffix { Uc Lc BGRc } } [Object.entries YeriConfig] : do
 		create-glyph "cyrl/Yeri.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			local stroke : AdviceStroke2 2 3 CAP
@@ -227,9 +225,14 @@ glyph-block Letter-Cyrillic-Yeri : begin
 				x   -- SB
 				bot -- ([mix 0 XH YeriBarPos] + stroke / 2)
 				top -- (XH - [if SLAB stroke 0])
+		create-glyph "cyrl/yeri.BGR.\(suffix)" : glyph-proc
+			include : MarkSet.e
+			local stroke : AdviceStroke2 2 3 XH
+			include : BGRc XH SB RightSB stroke
 
 	select-variant 'cyrl/Yeri' 0x42C
 	select-variant 'cyrl/yeri' 0x44C
-	select-variant 'cyrl/yeri.BGR' (shapeFrom -- 'cyrl/yeri')
+	select-variant 'cyrl/yeri.BGR'
+
 	select-variant 'cyrl/YeriBar' 0x48C (follow -- 'cyrl/Yeri')
 	select-variant 'cyrl/yeriBar' 0x48D (follow -- 'cyrl/yeri')

--- a/packages/font-glyphs/src/letter/cyrillic/yery.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/yery.ptl
@@ -8,26 +8,27 @@ glyph-block Letter-Cyrillic-Yery : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Shapes : RightwardTailedBar
-	glyph-block-import Letter-Cyrillic-Yeri : Yeri
+	glyph-block-import Letter-Cyrillic-Yeri : YeriUpper YeriLower
 	glyph-block-import Letter-Cyrillic-Yer : CyrYerShape
 
-	define [CyrYeryShape fBackYer] : function [Base df top fTailed] : glyph-proc
+	define [CyrYeryShape fBackYer] : function [Yeri df top fTailed] : glyph-proc
 		local stroke : Math.min df.mvs : if fBackYer
 			AdviceStroke2 2.75 3 top : df.adws * (7 / 9)
 			AdviceStroke2 2.00 3 top : df.adws * (3 / 4)
 		local jut : Jut - [HSwToV : 0.5 * (Stroke - stroke)]
 
 		local xMiddleSym : mix 0 df.width : if fBackYer (5 / 9) (1 / 2)
-		local xMiddle : Math.min (df.leftSB + ([mix Width df.width : if fBackYer (1 / 3) 0] - SB * 2))
+		local xMiddle : Math.min
+			df.leftSB + ([mix Width df.width : if fBackYer (1 / 3) 0] - SB * 2)
 			mix (xMiddleSym + [HSwToV : 0.5 * stroke]) (df.rightSB - [HSwToV stroke]) 0.25
 
 		include : if fBackYer
-			CyrYerShape Base top
+			CyrYerShape Yeri top
 				left   -- df.leftSB
 				right  -- xMiddle
 				stroke -- stroke
 				jut    -- jut
-			Base top
+			Yeri top
 				left   -- df.leftSB
 				right  -- xMiddle
 				stroke -- stroke
@@ -37,19 +38,20 @@ glyph-block Letter-Cyrillic-Yery : begin
 			RightwardTailedBar df.rightSB 0 top stroke
 			VBar.r             df.rightSB 0 top stroke
 
-		if SLAB : begin
-			local useFullSerifs : Base === Yeri.UprightShape || (Base === Yeri.AutoItalicShape && [not para.isItalic])
-
-			if useFullSerifs : include : tagged 'serifRT' : HSerif.mt (df.rightSB - [HSwToV : 0.5 * stroke]) top jut stroke
-			if [not fTailed] : include : tagged 'serifRB' : if useFullSerifs
-				HSerif.mb (df.rightSB - [HSwToV : 0.5 * stroke]) 0 jut stroke
-				HSerif.rb df.rightSB 0 (jut - [HSwToV : 0.5 * stroke]) stroke
+		if SLAB : include : composite-proc
+			tagged 'serifRT' : piecewise
+				Yeri.useFullSerifs : HSerif.mt (df.rightSB - [HSwToV : 0.5 * stroke]) top jut stroke
+				true               : no-shape
+			tagged 'serifRB' : piecewise
+				fTailed            : no-shape
+				Yeri.useFullSerifs : HSerif.mb (df.rightSB - [HSwToV : 0.5 * stroke]) 0 jut stroke
+				true               : HSerif.rb df.rightSB 0 (jut - [HSwToV : 0.5 * stroke]) stroke
 
 	define YeryConfig : SuffixCfg.weave
 		object # Yeri
-			corner        { Yeri.UprightShape Yeri.AutoItalicShape }
-			round         { Yeri.RoundShape   Yeri.RoundShape      }
-			cursive       { Yeri.CursiveShape Yeri.CursiveShape    }
+			corner        { YeriUpper.Shape        YeriLower.Shape        }
+			round         { YeriUpper.RoundShape   YeriLower.RoundShape   }
+			cursive       { YeriUpper.CursiveShape YeriLower.CursiveShape }
 		object # Tail
 			""            false
 			tailed        true

--- a/packages/font-glyphs/src/letter/latin/lower-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-m.ptl
@@ -273,9 +273,8 @@ glyph-block Letter-Latin-Lower-M : begin
 				local fine : [AdviceStroke 4] * (df.mvs / Stroke)
 				local rinner : XH * 0.15 - fine * 0.75
 				local sw : [AdviceStroke 3] * (df.mvs / Stroke)
-				local gap : (df.rightSB - df.leftSB - [HSwToV fine]) / 3
 				local m2 : Math.max
-					df.leftSB + gap * 2 - [HSwToV : 0.25 * fine]
+					[mix df.leftSB (df.rightSB - [HSwToV fine]) (2 / 3)] - [HSwToV : 0.25 * fine]
 					df.rightSB - (RightSB - SB) / 2 - [HSwToV : 0.5 * fine]
 				local x2 : df.rightSB + SideJut
 				local y2 : rinner * 2 + fine - O
@@ -310,7 +309,7 @@ glyph-block Letter-Latin-Lower-M : begin
 					local df : include : DivFrame [mix 1 para.advanceScaleMM 2] 4
 					include : df.markSet.e
 					local subDf : df.slice 4 3 0
-					include : Body   subDf XH 0 0 (XH - SmallArchDepthB * 0.5 * df.adws - TINY)
+					include : Body   subDf XH 0 0 (XH - SmallArchDepthB * (2 / df.hPack) * df.adws - TINY)
 					include : Serifs subDf XH 0 0 0 false false
 
 				create-glyph "cyrl/tje.italic/base/cursive.\(suffix)" : glyph-proc
@@ -469,8 +468,8 @@ glyph-block Letter-Latin-Lower-M : begin
 		local df : include : DivFrame 1 3
 		include : df.markSet.e
 
-		local bbs : AdviceStroke 8
-		local bbd : BBD * [Math.min (3 / 4) (bbs / BBS)]
+		local bbs : Math.min BBS : AdviceStroke 8
+		local bbd : BBD * [Math.min 0.75 : bbs / BBS]
 		define xMid : mix (df.leftSB + bbd + [HSwToV bbs]) df.rightSB 0.5
 
 		include : BBBarLeft df.leftSB 0 XH (bbd -- bbd) (bbs -- bbs)

--- a/packages/font-glyphs/src/letter/latin/lower-n.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-n.ptl
@@ -301,12 +301,12 @@ glyph-block Letter-Latin-Lower-N : begin
 			local df : include : DivFrame para.advanceScaleMM 3
 			include : df.markSet.e
 
-			local dfSub : df.slice 3 2
-			include : Body XH dfSub.leftSB dfSub.rightSB (XH - dfSub.smallArchDepthB - TINY) dfSub.mvs dfSub.smallArchDepthA dfSub.smallArchDepthB
+			local subDf : df.slice 3 2
+			include : Body XH subDf.leftSB subDf.rightSB (XH - subDf.smallArchDepthB - TINY) subDf.mvs subDf.smallArchDepthA subDf.smallArchDepthB
 
-			if sLT : include : sLT dfSub XH
-			if sLB : include : sLB dfSub 0
-			if sRB : include : sRB dfSub 0
+			if sLT : include : sLT subDf XH
+			if sLB : include : sLB subDf 0
+			if sRB : include : sRB subDf 0
 
 	select-variant 'n' 'n'
 	link-reduced-variant 'n/sansSerif' 'n' MathSansSerif

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1005,7 +1005,9 @@ selector.HLeftHalf = "serifless"
 selector.HRightHalf = "serifless"
 selector."Hv/H" = "serifless"
 selector.HHookLeft = "serifless"
-selector.HHookTop = "serifless"
+selector.hCap = "serifless"
+selector."hCap/descBase" = "serifless"
+selector.hCapHookTop = "serifless"
 
 [prime.capital-h.variants.top-left-serifed]
 rank = 2
@@ -1017,7 +1019,9 @@ selector.HLeftHalf = "topLeftSerifed"
 selector.HRightHalf = "serifless"
 selector."Hv/H" = "topLeftSerifed"
 selector.HHookLeft = "serifless"
-selector.HHookTop = "serifless"
+selector.hCap = "topLeftSerifed"
+selector."hCap/descBase" = "topLeftSerifed"
+selector.hCapHookTop = "serifless"
 
 [prime.capital-h.variants.top-left-bottom-right-serifed]
 rank = 3
@@ -1029,7 +1033,9 @@ selector.HLeftHalf = "topLeftSerifed"
 selector.HRightHalf = "topLeftBottomRightSerifed"
 selector."Hv/H" = "topLeftSerifed"
 selector.HHookLeft = "topLeftBottomRightSerifed"
-selector.HHookTop = "topLeftBottomRightSerifed"
+selector.hCap = "topLeftBottomRightSerifed"
+selector."hCap/descBase" = "topLeftSerifed"
+selector.hCapHookTop = "topLeftBottomRightSerifed"
 
 [prime.capital-h.variants.serifed]
 rank = 4
@@ -1041,7 +1047,9 @@ selector.HLeftHalf = "serifed"
 selector.HRightHalf = "serifed"
 selector."Hv/H" = "serifedExceptBottomRight"
 selector.HHookLeft = "serifed"
-selector.HHookTop = "serifed"
+selector.hCap = "serifed"
+selector."hCap/descBase" = "serifed"
+selector.hCapHookTop = "serifed"
 
 
 


### PR DESCRIPTION
* Continuation of #3116 for Cyrillic Lje/Nje/Tje (`Љ`, `љ`, `Њ`, `њ`, `Ᲊ`, `ᲊ`).
* Continuation of #3083 and #3086 for Cyrillic Tje (`Ᲊ`, `ᲊ`) and Te with Middle Hook (`Ꚋ`, `ꚋ`).
* Optimize arch depth and turn radius of rounded variants Cyrillic Yeri/Yer/etc., especially in composites.
* Let rounded/cursive variants of cyrillic Yeri/Yer/Yery/etc. use full (upright) serifs under slab when upright, except under Bulgarian locale where Yeri/Yer in particular remain the same as before (Italics under `'DFLT'` are also unchanged in this regard).

`БЬԀƋ ԀԂ ЬꙎƄЪᲆъƅꙏь ꙐЫыꙑ ЉљЊњᲉᲊ ꙒѢᲇѣꙓ`

Sans Monospace under `'VAAF'2,'VAAG'3;`:
<img width="2539" height="1138" alt="image" src="https://github.com/user-attachments/assets/806ce9d3-45a9-4543-bc06-63b007604471" />
Slab Monospace under `'VAAF'2,'VAAG'3;`:
<img width="2535" height="1130" alt="image" src="https://github.com/user-attachments/assets/9120c48d-565e-4a76-9731-5d9791e73f82" />
Aile under `'VAAF'2,'VAAG'3;`:
<img width="2534" height="894" alt="image" src="https://github.com/user-attachments/assets/f6daf5ef-2c7e-4af6-a571-bc8f7cdd2d1a" />
Etoile under `'VAAF'2,'VAAG'3;`:
<img width="2531" height="897" alt="image" src="https://github.com/user-attachments/assets/5fe0368d-dd13-4fa7-aa2e-82abdccc46db" />
