### PR TITLE
Move "generic" `RDiagTailedBar` shape function from `letter/latin/lower-q.ptl` to `letter/shared.ptl`.

### DIFF
--- a/packages/font-glyphs/src/letter/latin-ext/gha.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/gha.ptl
@@ -8,8 +8,7 @@ glyph-module
 glyph-block Letter-Latin-Gha : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : RightwardTailedBar
-	glyph-block-import Letter-Latin-Lower-Q : RDiagTailedBar
+	glyph-block-import Letter-Shared-Shapes : RightwardTailedBar RightwardDiagTailedBar
 	glyph-block-import Mark-Adjustment : LeaningAnchor
 
 	define TERMINAL-NORMAL  0
@@ -25,9 +24,9 @@ glyph-block Letter-Latin-Gha : begin
 		local adb : [fallback _adb SmallArchDepthB] * 0.75 * df.adws
 		include : OShape top 0 subDf.leftSB subDf.rightSB sw ada adb
 		include : match terminal
-			[Just TERMINAL-TAILED] : RightwardTailedBar (df.rightSB - OX) bot top sw
-			[Just TERMINAL-DIAG]   : RDiagTailedBar     (df.rightSB - OX) bot top sw
-			__                     : VBar.r             (df.rightSB - OX) bot top sw
+			[Just TERMINAL-TAILED] : RightwardTailedBar     (df.rightSB - OX) bot top sw
+			[Just TERMINAL-DIAG]   : RightwardDiagTailedBar (df.rightSB - OX) bot top sw
+			__                     : VBar.r                 (df.rightSB - OX) bot top sw
 		include : dispiro
 			widths.lhs sw
 			flat ((subDf.rightSB - OX) - [HSwToV : 0.5 * sw])        (top - adb) [heading Rightward]
@@ -42,8 +41,8 @@ glyph-block Letter-Latin-Gha : begin
 		include : LeaningAnchor.Below.VBar.r (df.rightSB - OX) sw
 
 	define GhaConfig : object
-		straightSerifless       { TERMINAL-NORMAL false }
-		straightBottomSerifed   { TERMINAL-NORMAL true  }
+		serifless               { TERMINAL-NORMAL false }
+		bottomSerifed           { TERMINAL-NORMAL true  }
 		tailedSerifless         { TERMINAL-TAILED false }
 		diagonalTailedSerifless { TERMINAL-DIAG   false }
 

--- a/packages/font-glyphs/src/letter/latin/lower-b.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-b.ptl
@@ -38,7 +38,7 @@ glyph-block Letter-Latin-Lower-B : begin
 
 	define BConfig : SuffixCfg.weave
 		object # body
-			toothed           ToothedBody
+			""                ToothedBody
 			toothlessCorner   ToothlessCornerBody
 			toothlessRounded  ToothlessRoundedBody
 			bottomCut         BottomCutBody
@@ -48,7 +48,7 @@ glyph-block Letter-Latin-Lower-B : begin
 			bottomSerifed   { LBSerifs   false  }
 			serifed         { FullSerifs true   }
 
-	foreach { suffix { Body {Serifs doST} }} [Object.entries BConfig] : do
+	foreach { suffix { Body { Serifs doST } } } [Object.entries BConfig] : do
 		local yOverlay : mix XH (Ascender - [if doST Stroke 0]) 0.5
 		create-glyph "b.\(suffix)" : glyph-proc
 			include : MarkSet.b
@@ -89,11 +89,11 @@ glyph-block Letter-Latin-Lower-B : begin
 	select-variant 'b' 'b'
 	link-reduced-variant 'b/sansSerif' 'b' MathSansSerif
 
-	select-variant 'bStroke' 0x180  (follow -- 'b')
+	select-variant 'bStroke' 0x180 (follow -- 'b')
 	CreateAccentedComposition 'bBar' null 'b' 'hStrike'
 
-	select-variant 'bSlash'  0x2422 (follow -- 'b')
-	select-variant 'latn/be' 0x183  (follow -- 'b')
+	select-variant 'bSlash' 0x2422 (follow -- 'b')
+	select-variant 'latn/be' 0x183 (follow -- 'b')
 
 	select-variant 'bHookTop' 0x253
 

--- a/packages/font-glyphs/src/letter/latin/lower-q.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-q.ptl
@@ -10,20 +10,12 @@ glyph-block Letter-Latin-Lower-Q : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Shared-Metrics : markHalfStroke
 	glyph-block-import Mark-Adjustment : LeaningAnchor
-	glyph-block-import Letter-Shared-Shapes : OBarRight RightwardTailedBar
-	glyph-block-import Letter-Shared-Shapes : DiagTail TopHook RetroflexHook
+	glyph-block-import Letter-Shared-Shapes : RightwardTailedBar RightwardDiagTailedBar
+	glyph-block-import Letter-Shared-Shapes : OBarRight TopHook RetroflexHook
 
 	define TERMINAL-NORMAL  0
 	define TERMINAL-TAILED  1
 	define TERMINAL-DIAG    2
-
-	glyph-block-export RDiagTailedBar
-	define [RDiagTailedBar x0 yb yt _sw] : begin
-		local sw : fallback _sw Stroke
-		return : dispiro
-			widths.center sw
-			flat       (x0 - [HSwToV : 0.5 * sw]) yt [heading Downward]
-			DiagTail.R (x0 - [HSwToV : 0.5 * sw]) yb (0.875 * Hook - 0.375 * sw) sw
 
 	define [EaredBody terminal top bottom _ada _adb] : glyph-proc
 		local ada : fallback _ada SmallArchDepthA
@@ -34,9 +26,9 @@ glyph-block Letter-Latin-Lower-Q : begin
 			ada -- ada
 			adb -- adb
 		include : match terminal
-			[Just TERMINAL-TAILED] : RightwardTailedBar RightSB bottom top
-			[Just TERMINAL-DIAG]   : RDiagTailedBar     RightSB bottom top
-			__                     : VBar.r             RightSB bottom top
+			[Just TERMINAL-TAILED] : RightwardTailedBar     RightSB bottom top
+			[Just TERMINAL-DIAG]   : RightwardDiagTailedBar RightSB bottom top
+			__                     : VBar.r                 RightSB bottom top
 
 	define [TopCutBody terminal top bottom _ada _adb] : glyph-proc
 		local ada : fallback _ada SmallArchDepthA
@@ -47,9 +39,9 @@ glyph-block Letter-Latin-Lower-Q : begin
 			ada -- ada
 			adb -- adb
 		include : match terminal
-			[Just TERMINAL-TAILED] : RightwardTailedBar RightSB bottom (top - HalfStroke)
-			[Just TERMINAL-DIAG]   : RDiagTailedBar     RightSB bottom (top - HalfStroke)
-			__                     : VBar.r             RightSB bottom (top - HalfStroke)
+			[Just TERMINAL-TAILED] : RightwardTailedBar     RightSB bottom (top - HalfStroke)
+			[Just TERMINAL-DIAG]   : RightwardDiagTailedBar RightSB bottom (top - HalfStroke)
+			__                     : VBar.r                 RightSB bottom (top - HalfStroke)
 		include : spiro-outline
 			corner  RightSB                     top
 			corner  RightSB                    (top - HalfStroke)
@@ -66,9 +58,9 @@ glyph-block Letter-Latin-Lower-Q : begin
 			rise -- DToothlessRise
 			mBlend -- DMBlend
 		include : match terminal
-			[Just TERMINAL-TAILED] : RightwardTailedBar RightSB bottom (top - DToothlessRise)
-			[Just TERMINAL-DIAG]   : RDiagTailedBar     RightSB bottom (top - DToothlessRise)
-			__                     : VBar.r             RightSB bottom (top - DToothlessRise)
+			[Just TERMINAL-TAILED] : RightwardTailedBar     RightSB bottom (top - DToothlessRise)
+			[Just TERMINAL-DIAG]   : RightwardDiagTailedBar RightSB bottom (top - DToothlessRise)
+			__                     : VBar.r                 RightSB bottom (top - DToothlessRise)
 
 	define [EarlessRoundedBody terminal top bottom _ada _adb] : glyph-proc
 		local ada : fallback _ada SmallArchDepthA
@@ -80,9 +72,9 @@ glyph-block Letter-Latin-Lower-Q : begin
 			adb -- adb
 			yTerminal -- ada
 		include : match terminal
-			[Just TERMINAL-TAILED] : RightwardTailedBar RightSB bottom (top - adb)
-			[Just TERMINAL-DIAG]   : RDiagTailedBar     RightSB bottom (top - adb)
-			__                     : VBar.r             RightSB bottom (top - adb)
+			[Just TERMINAL-TAILED] : RightwardTailedBar     RightSB bottom (top - adb)
+			[Just TERMINAL-DIAG]   : RightwardDiagTailedBar RightSB bottom (top - adb)
+			__                     : VBar.r                 RightSB bottom (top - adb)
 
 	define [RtSerif y] : tagged 'serifRT' : HSerif.rt RightSB y SideJut
 	define [RbSerif y] : tagged 'serifRB' : union
@@ -98,7 +90,7 @@ glyph-block Letter-Latin-Lower-Q : begin
 			earlessRounded       EarlessRoundedBody
 			topCut               TopCutBody
 		object # tail
-			straight             TERMINAL-NORMAL
+			""                   TERMINAL-NORMAL
 			tailed               TERMINAL-TAILED
 			diagonalTailed       TERMINAL-DIAG
 		object # serifs

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -140,25 +140,31 @@ glyph-block Letter-Shared-Shapes : begin
 	define [RightwardTailedBar] : with-params [x low high [sw Stroke]] : begin
 		local hookDepth : Math.max SideJut [AdviceStroke 8] (SB * 0.625)
 		local hookTurn  : Math.max [AdviceStroke 16] (hookDepth - [AdviceStroke 16])
-		local overshoot : O * 1
 		return : dispiro
-			flat (x - [HSwToV sw]) high [widths.lhs.heading sw Downward]
-			curl (x - [HSwToV sw]) (low + overshoot + sw + hookTurn) [heading Downward]
+			widths.lhs sw
+			flat (x - [HSwToV sw]) high [heading Downward]
+			curl (x - [HSwToV sw]) (low + O + sw + hookTurn) [heading Downward]
 			arcvh
-			flat (x + hookTurn)  (low + overshoot) [heading Rightward]
-			curl (x + hookDepth + sw * TanSlope) (low + overshoot)
+			flat (x + hookTurn) (low + O) [heading Rightward]
+			curl (x + hookDepth + sw * TanSlope) (low + O)
 
 	glyph-block-export InvRightwardTailedBar
 	define [InvRightwardTailedBar] : with-params [x low high [sw Stroke]] : begin
 		local hookDepth : Math.max SideJut [AdviceStroke 8] (SB * 0.625)
 		local hookTurn  : Math.max [AdviceStroke 16] (hookDepth - [AdviceStroke 16])
-		local overshoot : O * 1
 		return : dispiro
-			flat (x - [HSwToV sw]) low [widths.rhs.heading sw Upward]
-			curl (x - [HSwToV sw]) (high - overshoot - sw - hookTurn) [heading Upward]
+			widths.rhs sw
+			flat (x - [HSwToV sw]) low [heading Upward]
+			curl (x - [HSwToV sw]) (high - O - sw - hookTurn) [heading Upward]
 			arcvh
-			flat (x + hookTurn)  (high - overshoot) [heading Rightward]
-			curl (x + hookDepth + sw * TanSlope) (high - overshoot)
+			flat (x + hookTurn) (high - O) [heading Rightward]
+			curl (x + hookDepth + sw * TanSlope) (high - O)
+
+	glyph-block-export RightwardDiagTailedBar
+	define [RightwardDiagTailedBar] : with-params [x low high [sw Stroke]] : dispiro
+		widths.center sw
+		flat       (x - [HSwToV : 0.5 * sw]) high [heading Downward]
+		DiagTail.R (x - [HSwToV : 0.5 * sw]) low (0.875 * Hook - 0.375 * sw) sw
 
 	glyph-block-export CurlyTail
 	define CurlyTail : namespace

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2462,9 +2462,9 @@ next = "serifs"
 [prime.b.variants-buildup.stages.body.toothed]
 rank = 1
 descriptionAffix = "toothed shape"
-selectorAffix.b = "toothed"
-selectorAffix."b/sansSerif" = "toothed"
-selectorAffix.bHookTop = "toothed"
+selectorAffix.b = ""
+selectorAffix."b/sansSerif" = ""
+selectorAffix.bHookTop = ""
 
 [prime.b.variants-buildup.stages.body.bottom-cut]
 rank = 2
@@ -4159,11 +4159,11 @@ next = "serifs"
 [prime.q.variants-buildup.stages.terminal.straight]
 rank = 1
 descriptionAffix = "straight terminal"
-selectorAffix.q = "straight"
-selectorAffix."q/sansSerif" = "straight"
-selectorAffix."q/hookTopBase" = "straight"
-selectorAffix.qRTail = "straight"
-selectorAffix.gha = "straight"
+selectorAffix.q = ""
+selectorAffix."q/sansSerif" = ""
+selectorAffix."q/hookTopBase" = ""
+selectorAffix.qRTail = ""
+selectorAffix.gha = ""
 
 [prime.q.variants-buildup.stages.terminal.tailed]
 rank = 2
@@ -4171,7 +4171,7 @@ descriptionAffix = "tailed terminal"
 selectorAffix.q = "tailed"
 selectorAffix."q/sansSerif" = "tailed"
 selectorAffix."q/hookTopBase" = "tailed"
-selectorAffix.qRTail = "straight"
+selectorAffix.qRTail = ""
 selectorAffix.gha = "tailed"
 
 [prime.q.variants-buildup.stages.terminal.diagonal-tailed]
@@ -4180,7 +4180,7 @@ descriptionAffix = "diagonally tailed terminal"
 selectorAffix.q = "diagonalTailed"
 selectorAffix."q/sansSerif" = "diagonalTailed"
 selectorAffix."q/hookTopBase" = "diagonalTailed"
-selectorAffix.qRTail = "straight"
+selectorAffix.qRTail = ""
 selectorAffix.gha = "diagonalTailed"
 
 [prime.q.variants-buildup.stages.serifs.serifless]


### PR DESCRIPTION
This groups it with `RightwardTailedBar` for better organization, for when specific parameters for fine-tuning the diagonal tail are not necessary, such as in lower `q` and related characters.

This could perhaps open up possibilities to use this shape function in more files, including ones compiled _before_ `letter/latin/lower-q.ptl` in the queue.

Nothing is otherwise visually changed.