### PR TITLE
Add `motion-bottom-serifed` variants for `q`.

### DIFF
--- a/changes/34.3.0.md
+++ b/changes/34.3.0.md
@@ -1,4 +1,5 @@
 * Add `crossbar-at-half-ascender-height` variants for `f`.
+* Add `motion-bottom-serifed` variants for `q`.
 * Add `middle-serifed-half-ascender` variants for long-s (`ſ`) and lower eszett (`ß`).
 * Refine shape of the following characters:
   - CYRILLIC CAPITAL LETTER PSI (`U+0470`).

--- a/packages/font-glyphs/src/letter/latin-ext/gha.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/gha.ptl
@@ -15,7 +15,11 @@ glyph-block Letter-Latin-Gha : begin
 	define TERMINAL-TAILED  1
 	define TERMINAL-DIAG    2
 
-	define [GhaShape df terminal top bot _ada _adb fSlab] : glyph-proc
+	define SLAB-NONE        0
+	define SLAB-OUTER       1
+	define SLAB-FULL        2
+
+	define [GhaShape df terminal top bot _ada _adb slabType] : glyph-proc
 		local sw : Math.min df.mvs : AdviceStroke 2 (0.75 * df.adws)
 		local gap : 0.375 * (df.rightSB - df.leftSB) - [HSwToV : 0.25 * sw] + sw / 16
 		local subDf : DivFrame [Math.min ((df.width - gap) / Width) (0.75 * df.adws)] 2
@@ -34,28 +38,32 @@ glyph-block Letter-Latin-Gha : begin
 			alsoThru 0.5 0.15
 			g4   ((df.rightSB - OX) - [HSwToV sw]) top [widths.rhs sw]
 
-		if fSlab : include : tagged 'serifRB' : union
-			HSerif.rb ((df.rightSB - OX) - [HSwToV : 0.5 * sw]) bot (Jut        - [HSwToV : 0.5 * (Stroke - sw)]) sw
-			HSerif.lb ((df.rightSB - OX) - [HSwToV : 0.5 * sw]) bot (MidJutSide - [HSwToV : 0.5 * (Stroke - sw)]) sw
+		include : tagged 'serifRB' : match slabType
+			[Just SLAB-OUTER] : HSerif.rb (df.rightSB - OX) bot SideJut sw
+			[Just SLAB-FULL]  : union
+				HSerif.rb ((df.rightSB - OX) - [HSwToV : 0.5 * sw]) bot (Jut        - [HSwToV : 0.5 * (Stroke - sw)]) sw
+				HSerif.lb ((df.rightSB - OX) - [HSwToV : 0.5 * sw]) bot (MidJutSide - [HSwToV : 0.5 * (Stroke - sw)]) sw
+			__                : no-shape
 
 		include : LeaningAnchor.Below.VBar.r (df.rightSB - OX) sw
 
 	define GhaConfig : object
-		serifless               { TERMINAL-NORMAL false }
-		bottomSerifed           { TERMINAL-NORMAL true  }
-		tailedSerifless         { TERMINAL-TAILED false }
-		diagonalTailedSerifless { TERMINAL-DIAG   false }
+		serifless               { TERMINAL-NORMAL  SLAB-NONE  }
+		motionBottomSerifed     { TERMINAL-NORMAL  SLAB-OUTER }
+		bottomSerifed           { TERMINAL-NORMAL  SLAB-FULL  }
+		tailedSerifless         { TERMINAL-TAILED  SLAB-NONE  }
+		diagonalTailedSerifless { TERMINAL-DIAG    SLAB-NONE  }
 
-	foreach { suffix { terminal doSB } } [Object.entries GhaConfig] : do
+	foreach { suffix { terminal slabType } } [Object.entries GhaConfig] : do
 		create-glyph "Gha.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleM 3
 			include : df.markSet.capDesc
-			include : GhaShape df terminal CAP Descender ArchDepthA ArchDepthB doSB
+			include : GhaShape df terminal CAP Descender ArchDepthA ArchDepthB slabType
 
 		create-glyph "gha.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleM 3
 			include : df.markSet.p
-			include : GhaShape df terminal XH Descender SmallArchDepthA SmallArchDepthB doSB
+			include : GhaShape df terminal XH Descender SmallArchDepthA SmallArchDepthB slabType
 
 	select-variant 'Gha' 0x1A2 (follow -- 'gha')
 	select-variant 'gha' 0x1A3

--- a/packages/font-glyphs/src/letter/latin/lower-q.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-q.ptl
@@ -80,24 +80,26 @@ glyph-block Letter-Latin-Lower-Q : begin
 	define [RbSerif y] : tagged 'serifRB' : union
 		HSerif.lb (RightSB - [HSwToV HalfStroke]) y MidJutSide
 		HSerif.rb (RightSB - [HSwToV HalfStroke]) y Jut
+	define [RbSerifOuter y] : tagged 'serifRB' : HSerif.rb RightSB y SideJut
 	define [RtSerifAuto y] : NeedSlab SLAB : RtSerif y
 	define [RbSerifAuto y] : NeedSlab SLAB : RbSerif y
 
 	define QConfig : SuffixCfg.weave
 		object # body
-			""                   EaredBody
-			earlessCorner        EarlessCornerBody
-			earlessRounded       EarlessRoundedBody
-			topCut               TopCutBody
+			""                    EaredBody
+			earlessCorner         EarlessCornerBody
+			earlessRounded        EarlessRoundedBody
+			topCut                TopCutBody
 		object # tail
-			""                   TERMINAL-NORMAL
-			tailed               TERMINAL-TAILED
-			diagonalTailed       TERMINAL-DIAG
+			""                    TERMINAL-NORMAL
+			tailed                TERMINAL-TAILED
+			diagonalTailed        TERMINAL-DIAG
 		object # serifs
-			serifless          { null    null    }
-			motionSerifed      { RtSerif null    }
-			bottomSerifed      { null    RbSerif }
-			serifed            { RtSerif RbSerif }
+			serifless           { null        null         }
+			motionSerifed       { RtSerif     null         }
+			bottomSerifed       { null        RbSerif      }
+			motionBottomSerifed { null        RbSerifOuter }
+			serifed             { RtSerif     RbSerif      }
 
 	foreach { suffix { Body terminal { sRT sRB } } } [Object.entries QConfig] : do
 		create-glyph "q.\(suffix)" : glyph-proc

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -4218,9 +4218,10 @@ selectorAffix."q/hookTopBase" = "bottomSerifed"
 selectorAffix.qRTail = "serifless"
 selectorAffix.gha = "bottomSerifed"
 
-[prime.q.variants-buildup.stages.serifs.motion-serifed]
+[prime.q.variants-buildup.stages.serifs.motion-serifed__eared]
 rank = 3
 enableIf = [{ body = "eared" }]
+keyAffix = "motion-serifed"
 descriptionAffix = "motion serifs"
 selectorAffix.q = "motionSerifed"
 selectorAffix."q/sansSerif" = "serifless"
@@ -4228,8 +4229,31 @@ selectorAffix."q/hookTopBase" = "serifless"
 selectorAffix.qRTail = "motionSerifed"
 selectorAffix.gha = "serifless"
 
-[prime.q.variants-buildup.stages.serifs.serifed__eared]
+[prime.q.variants-buildup.stages.serifs.motion-serifed__earless]
+rank = 3
+nonBreakingVariantAdditionPriority = 100
+enableIf = [{ body = "NOT eared", terminal = "straight" }]
+keyAffix = "motion-serifed"
+descriptionAffix = "motion serifs at terminal (bottom-right)"
+selectorAffix.q = "motionBottomSerifed"
+selectorAffix."q/sansSerif" = "serifless"
+selectorAffix."q/hookTopBase" = "motionBottomSerifed"
+selectorAffix.qRTail = "serifless"
+selectorAffix.gha = "motionBottomSerifed"
+
+[prime.q.variants-buildup.stages.serifs.motion-bottom-serifed]
 rank = 4
+nonBreakingVariantAdditionPriority = 100
+enableIf = [{ body = "eared", terminal = "straight" }]
+descriptionAffix = "motion serifs at terminal (bottom-right)"
+selectorAffix.q = "motionBottomSerifed"
+selectorAffix."q/sansSerif" = "serifless"
+selectorAffix."q/hookTopBase" = "motionBottomSerifed"
+selectorAffix.qRTail = "serifless"
+selectorAffix.gha = "motionBottomSerifed"
+
+[prime.q.variants-buildup.stages.serifs.serifed__eared]
+rank = 5
 enableIf = [{ body = "eared", terminal = "straight" }]
 keyAffix = "serifed"
 descriptionAffix = "serifs"
@@ -4239,8 +4263,8 @@ selectorAffix."q/hookTopBase" = "bottomSerifed"
 selectorAffix.qRTail = "motionSerifed"
 selectorAffix.gha = "bottomSerifed"
 
-[prime.q.variants-buildup.stages.serifs.serifed__eareless]
-rank = 4
+[prime.q.variants-buildup.stages.serifs.serifed__earless]
+rank = 5
 enableIf = [{ body = "NOT eared", terminal = "straight" }]
 keyAffix = "serifed"
 descriptionAffix = "serifs"


### PR DESCRIPTION
These are mainly for custom Italic Slab builds. Actual default build plans are unchanged.

The below images are examples using my own `private-build-plans.toml` appended with the following text:
```
[buildPlans.IosevkaCustomSlab.variants.italic]
p = "eared-motion-serifed"
q = "straight-motion-bottom-serifed"
lower-thorn = "motion-serifed"
cyrl-er = "eared-motion-serifed"
```
The rest of the character variants not shown in the block above otherwise follow the default build plans exactly.

For earless variants, the name shaping tree uses the available `motion-serifed` key.
For eared variants, it uses `motion-bottom-serifed` because the `motion-serifed` key is already taken.

This yields four-total new selectable `q` variants:
  * `straight-motion-bottom-serifed`.
  * `top-cut-straight-motion-serifed`.
  * `earless-corner-straight-motion-serifed`.
  * `earless-rounded-straight-motion-serifed`.

-----

```
ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ
abc.def.ghi.jkl.mno.pqrs.tuv.wxyz
!iIlL17|¦ ¢coO08BDQ $5SZ2zs ∂96µm
float il1[]={1-2/3.4,5+6=7/8%90};
1234567890 ,._-+= >< «¯-¬_» ~–÷+×
{*}[]()<>`+-=$/#_%^@\&|~?'" !,.;:
g9q¶ Þẞðþſß ΓΔΛαβγδηθικλμνξπτυφχψ
ЖЗКНРУЭЯавжзклмнруфчьыэя <= != ==
```

Slab Default Upright:
<img width="1564" height="944" alt="image" src="https://github.com/user-attachments/assets/8947eb01-7937-407d-9b35-3b60466eb3ae" />
Slab Italic under `'cv50'2,'cv51'21,'cv66'2,'VAAA'2;`:
<img width="1578" height="948" alt="image" src="https://github.com/user-attachments/assets/5dd292a1-8d52-43da-b425-0833dcc9aa1a" />
Etoile Default Upright:
<img width="1903" height="946" alt="image" src="https://github.com/user-attachments/assets/2354423a-efb4-4829-99d7-a5fd616b3128" />
Etoile Italic under `'cv50'2,'cv51'21,'cv66'2,'VAAA'2;`:
<img width="1904" height="954" alt="image" src="https://github.com/user-attachments/assets/2825c314-12f3-462b-9b17-416a14c9ba7e" />
