### PR TITLE
Make Armenian lowercase letters' bottom serifs (on descenders) respond to italics, to match `p`/`q`/etc.

### DIFF
--- a/packages/font-glyphs/src/letter/armenian.ptl
+++ b/packages/font-glyphs/src/letter/armenian.ptl
@@ -21,6 +21,7 @@ export : define [apply] : begin
 	run-glyph-module "./armenian/upper-cheh.mjs"
 	run-glyph-module "./armenian/upper-yi.mjs"
 	run-glyph-module "./armenian/lower-sha-group.mjs"
+	run-glyph-module "./armenian/lower-rra.mjs"
 	run-glyph-module "./armenian/upper-co.mjs"
 	run-glyph-module "./armenian/keh.mjs"
 	run-glyph-module "./armenian/feh.mjs"

--- a/packages/font-glyphs/src/letter/armenian/feh.ptl
+++ b/packages/font-glyphs/src/letter/armenian/feh.ptl
@@ -49,6 +49,6 @@ glyph-block Letter-Armenian-Feh : begin
 		local adb : df.archDepthBOf SmallArchDepth sw
 		include : FehBody df Ascender 0 sw Hook ada adb
 		include : VBar.m df.middle Descender Ascender sw
-		if SLAB : begin
+		if (SLAB && [not para.isItalic]) : begin
 			local sf : SerifFrame.fromDf df Ascender Descender (swSerif -- sw)
 			include sf.mb.fullCenter

--- a/packages/font-glyphs/src/letter/armenian/keh.ptl
+++ b/packages/font-glyphs/src/letter/armenian/keh.ptl
@@ -19,11 +19,11 @@ glyph-block Letter-Armenian-Keh : begin
 		create-glyph 'armn/Keh' 0x554 : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.capital
-			local ostroke : OverlayStroke * (df.mvs / Stroke)
-			local bot : CAP * HBarPos - df.mvs / 2
+			local barSw : OverlayStroke * (df.mvs / Stroke)
+			local oBot : CAP * HBarPos - df.mvs / 2
 			include : OBarLeft.earlessRounded
 				top   -- CAP
-				bot   -- bot
+				bot   -- oBot
 				left  -- df.leftSB
 				right -- df.rightSB
 				sw    -- df.mvs
@@ -31,11 +31,9 @@ glyph-block Letter-Armenian-Keh : begin
 				ada   -- ArchDepthA
 				adb   -- ArchDepthB
 				yTerminal -- 0
-			include : HBar.m
-				df.leftSB - jut + [HSwToV : 0.5 * df.mvs]
-				df.rightSB + 0
-				mix [if SLAB df.mvs 0] bot 0.5
-				Math.min ostroke : 0.5 * (bot - [if SLAB df.mvs 0])
+			include : HBar.m (df.leftSB + [HSwToV : 0.5 * df.mvs] - jut) df.rightSB
+				mix [if SLAB df.mvs 0] oBot 0.5
+				Math.min barSw : 0.5 * (oBot - [if SLAB df.mvs 0])
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df CAP 0
 				include sf.lb.full
@@ -43,11 +41,11 @@ glyph-block Letter-Armenian-Keh : begin
 		create-glyph 'armn/keh' 0x584 : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.p
-			local ostroke : OverlayStroke * (df.mvs / Stroke)
-			local bot : Math.max (0.1 * (XH - Descender)) (ostroke + 0.5 * df.mvs)
+			local barSw : OverlayStroke * (df.mvs / Stroke)
+			local oBot : Math.max (0.1 * (XH - Descender)) (barSw + 0.5 * df.mvs)
 			include : OBarLeft.shape
 				top   -- XH
-				bot   -- bot
+				bot   -- oBot
 				left  -- df.leftSB
 				right -- df.rightSB
 				sw    -- df.mvs
@@ -55,11 +53,8 @@ glyph-block Letter-Armenian-Keh : begin
 				ada   -- SmallArchDepthA
 				adb   -- SmallArchDepthB
 			include : VBar.l df.leftSB Descender XH df.mvs
-			include : HBar.b
-				df.leftSB - jut + [HSwToV : 0.5 * df.mvs]
-				df.rightSB + 0
-				XH - highBarPos
-				1 * ostroke
+			include : HBar.b (df.leftSB + [HSwToV : 0.5 * df.mvs] - jut) df.rightSB 0 barSw
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH Descender
-				include : composite-proc sf.lt.outer sf.lb.fullSide
+				include sf.lt.outer
+				if [not para.isItalic] : include sf.lb.fullSide

--- a/packages/font-glyphs/src/letter/armenian/lower-dza-cheh.ptl
+++ b/packages/font-glyphs/src/letter/armenian/lower-dza-cheh.ptl
@@ -27,7 +27,7 @@ glyph-block Letter-Armenian-Lower-Dza-Cheh : begin
 				straight.down.start x1 Ascender [heading Downward]
 				arcvh
 				flat df.middle y2
-				curl x2 y2 [heading Rightward]
+				curl x2        y2 [heading Rightward]
 
 			define [knots] : list
 				straight.left.start x2 (y2 + 0.5 * df.mvs) [heading Leftward]
@@ -43,14 +43,14 @@ glyph-block Letter-Armenian-Lower-Dza-Cheh : begin
 				spiro-outline
 					knots
 					corner df.leftSB 0
-					corner VERY-FAR 0
-					corner VERY-FAR (y2 + 0.5 * df.mvs)
+					corner VERY-FAR  0
+					corner VERY-FAR  (y2 + 0.5 * df.mvs)
 				dispiro
 					widths.rhs df.mvs
 					flat df.leftSB XH
 					curl df.middle XH [heading Rightward]
 					archv
-					flat df.rightSB (XH - SmallArchDepthB)
+					flat df.rightSB [Math.max (XH - SmallArchDepthB) (0 + TINY)]
 					curl df.rightSB 0 [heading Downward]
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df Ascender 0
@@ -63,19 +63,19 @@ glyph-block Letter-Armenian-Lower-Dza-Cheh : begin
 			local x1 : mix df.leftSB df.rightSB 0.75
 			include : dispiro
 				widths.lhs df.mvs
-				flat x1 Ascender
+				flat x1        Ascender
 				curl df.middle Ascender [heading Leftward]
 				archv
 				flat df.leftSB (Ascender - SmallArchDepthA)
-				curl df.leftSB (0 + SmallArchDepthB) [heading Downward]
+				curl df.leftSB (0        + SmallArchDepthB) [heading Downward]
 				arch.lhs 0 (sw -- df.mvs) (swAfter -- df.shoulderFine)
 				straight.up.end (df.rightSB - [HSwToV : df.mvs - df.shoulderFine]) (0 + SmallArchDepthA) [widths.lhs df.shoulderFine]
 			include : dispiro
 				widths.rhs df.mvs
-				flat (df.leftSB - jut + [HSwToV : 0.5 * df.mvs]) highBarPos
-				curl df.middle highBarPos [heading Rightward]
+				flat (df.leftSB + [HSwToV : 0.5 * df.mvs] - jut) highBarPos
+				curl df.middle                                   highBarPos [heading Rightward]
 				archv
-				flat df.rightSB (highBarPos - SmallArchDepthB)
+				flat df.rightSB [Math.max (highBarPos - SmallArchDepthB) (0 + TINY)]
 				curl df.rightSB 0 [heading Downward]
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df Ascender 0

--- a/packages/font-glyphs/src/letter/armenian/lower-gim-za.ptl
+++ b/packages/font-glyphs/src/letter/armenian/lower-gim-za.ptl
@@ -15,21 +15,36 @@ glyph-block Letter-Armenian-Lower-Gim-Za : begin
 		create-glyph 'armn/gim' 0x563 : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.p
-			include : OBarRight.shape (top -- XH)
-			include : VBar.r df.rightSB Descender XH
+			include : OBarRight.shape
+				top   -- XH
+				bot   -- 0
+				left  -- df.leftSB
+				right -- df.rightSB
+				sw    -- df.mvs
+				fine  -- df.shoulderFine
+				ada   -- SmallArchDepthA
+				adb   -- SmallArchDepthB
+			include : VBar.r df.rightSB Descender XH df.mvs
 			include : [ArmHBar.right df].base
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH Descender
-				include sf.rb.fullSide
-				if [not para.isItalic] : begin
-					include sf.rt.outer
+				include : if para.isItalic sf.rb.outer
+					composite-proc sf.rt.outer sf.rb.fullSide
 
 	do "Za"
 		create-glyph 'armn/za' 0x566 : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.p
-			include : OBarRight.shape (top -- XH)
-			include : VBar.r df.rightSB Descender XH
+			include : OBarRight.shape
+				top   -- XH
+				bot   -- 0
+				left  -- df.leftSB
+				right -- df.rightSB
+				sw    -- df.mvs
+				fine  -- df.shoulderFine
+				ada   -- SmallArchDepthA
+				adb   -- SmallArchDepthB
+			include : VBar.r df.rightSB Descender XH df.mvs
 			include : [ArmHBar.right df].desc
 			if (SLAB && [not para.isItalic]) : begin
 				local sf : SerifFrame.fromDf df XH Descender

--- a/packages/font-glyphs/src/letter/armenian/lower-rra.ptl
+++ b/packages/font-glyphs/src/letter/armenian/lower-rra.ptl
@@ -1,0 +1,52 @@
+$$include '../../meta/macros.ptl'
+
+import [mix linreg clamp fallback] from "@iosevka/util"
+import [DependentSelector] from "@iosevka/glyph/relation"
+
+glyph-module
+
+glyph-block Letter-Armenian-Lower-Rra : begin
+	glyph-block-import CommonShapes
+	glyph-block-import Common-Derivatives
+	glyph-block-import Letter-Shared-Shapes : SerifFrame # nShoulder
+	# glyph-block-import Letter-Armenian-Shared-Shapes : ArmHBar
+	glyph-block-import Letter-Armenian-Lower-Sha-Group : TwoNeck
+
+	# Common Params
+	define barPos : XH / 2
+	define highBarPos XH
+	define jut Jut
+
+	do "Rra"
+		create-glyph 'armn/rra' 0x57C : glyph-proc
+			local df : include : DivFrame 1
+			include : df.markSet.e
+			include : VBar.l df.leftSB 0 XH df.mvs
+
+			# Combination of nShoulder and straight '2' shape
+			local left : Math.max df.middle : (df.rightSB - [HSwToV df.mvs]) - jut
+			include : dispiro
+				widths.rhs df.shoulderFine
+				flat (df.leftSB + [HSwToV : df.mvs - df.shoulderFine]) (XH - SmallArchDepthA - TINY)
+				curl (df.leftSB + [HSwToV : df.mvs - df.shoulderFine]) (XH - SmallArchDepthA)
+				arch.rhs XH (sw -- df.mvs) (swBefore -- df.shoulderFine)
+				TwoNeck df XH 0 left
+			include : HBar.b left ((left + [HSwToV df.mvs]) + jut) 0 df.mvs
+			if SLAB : begin
+				local sf : SerifFrame.fromDf df XH 0
+				include sf.lt.outer
+				if [not para.isItalic] : include sf.lb.outer
+
+			# Alternate straight 'n' form
+			# include : nShoulder.shape
+			# 	top    -- XH
+			# 	bottom -- 0
+			# 	left   -- (df.leftSB + [HSwToV df.mvs])
+			# 	right  -- df.rightSB
+			# 	stroke -- df.mvs
+			# 	fine   -- df.shoulderFine
+			# include : [ArmHBar.right df].base
+			# if SLAB : begin
+			# 	local sf : SerifFrame.fromDf df XH 0
+			# 	include sf.lt.outer
+			# 	if [not para.isItalic] : include sf.lb.full

--- a/packages/font-glyphs/src/letter/armenian/lower-sha-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/lower-sha-group.ptl
@@ -8,12 +8,24 @@ glyph-module
 glyph-block Letter-Armenian-Lower-Sha-Group : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Armenian-Shared-Shapes : ArmHBar TwoNeck
+	glyph-block-import Letter-Armenian-Shared-Shapes : ArmHBar
 
 	# Common Params
 	define barPos : XH / 2
 	define highBarPos XH
 	define jut Jut
+
+	glyph-block-export TwoNeck
+	define [TwoNeck df top bot _left _right _adb _flatp] : begin
+		local adb : fallback _adb SmallArchDepthB
+		local flatp : fallback _flatp 0.75
+		local left : fallback _left df.leftSB
+		local right : fallback _right df.rightSB
+		local refY : top - adb * 1.5 - df.mvs / 2 * (1 - TanSlope)
+		return : list
+			g4.down.mid right (top - adb)
+			flat [mix left right flatp] [mix (bot + df.mvs) refY flatp]
+			curl left (bot + df.mvs) [widths.lhs df.mvs]
 
 	do "Sha"
 		create-glyph 'armn/sha' 0x577 : glyph-proc

--- a/packages/font-glyphs/src/letter/armenian/lower-u-group.ptl
+++ b/packages/font-glyphs/src/letter/armenian/lower-u-group.ptl
@@ -9,7 +9,7 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Shapes : nShoulder uBowl SerifFrame
-	glyph-block-import Letter-Armenian-Shared-Shapes : ArmHBar TwoNeck
+	glyph-block-import Letter-Armenian-Shared-Shapes : ArmHBar
 	glyph-block-import Letter-Latin-Lower-M : SmallMArches
 
 	# Common Params
@@ -24,11 +24,10 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			include : SmallMArches df XH 0 0 0
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH 0
-				include : if para.isItalic
-					composite-proc sf.lt.outer sf.rb.outer
-					if sf.enoughSpaceForFullSerifs
-						composite-proc sf.lt.outer sf.lb.full sf.mb.full sf.rb.full
-						composite-proc sf.lt.outer sf.lb.outer sf.rb.outer
+				include sf.lt.outer
+				include : if para.isItalic sf.rb.outer : if sf.enoughSpaceForFullSerifs
+					composite-proc sf.lb.full sf.mb.full sf.rb.full
+					composite-proc sf.lb.outer sf.rb.outer
 
 	do "Ayb"
 		create-glyph 'armn/ayb' 0x561 : glyph-proc
@@ -38,9 +37,9 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			include : FlipAround df.middle (XH / 2)
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH 0
-				include : if ([not para.isItalic] && sf.enoughSpaceForFullSerifs)
-					composite-proc sf.lt.outer sf.mt.left sf.rt.inner sf.rb.outer
-					composite-proc sf.lt.outer sf.rb.outer
+				include : composite-proc sf.lt.outer sf.rb.outer
+				if ([not para.isItalic] && sf.enoughSpaceForFullSerifs) : begin
+					include : composite-proc sf.mt.left sf.rt.inner
 
 	do "Ben"
 		create-glyph 'armn/ben' 0x562 : glyph-proc
@@ -58,7 +57,8 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			include : [ArmHBar.normal df].base
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH Descender
-				include : composite-proc sf.lt.outer sf.lb.fullSide
+				include sf.lt.outer
+				if [not para.isItalic] : include sf.lb.fullSide
 
 	do "Da"
 		create-glyph 'armn/da' 0x564 : glyph-proc
@@ -76,10 +76,9 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH 0
 				local sf2 : SerifFrame.fromDf df XH Descender
-				if para.isItalic
-					include sf.lt.outer
-					include : composite-proc sf.lt.outer sf.lb.full
-				include sf2.rb.fullSide
+				include sf.lt.outer
+				include : if para.isItalic sf2.rb.outer
+					composite-proc sf.lb.full sf2.rb.fullSide
 
 	do "Ech"
 		create-glyph 'armn/ech' 0x565 : glyph-proc
@@ -115,8 +114,8 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH Descender
 				local sf2 : SerifFrame.fromDf df XH 0
-				include sf.lt.outer
-				include : if para.isItalic sf2.rb.outer sf2.rb.full
+				include : composite-proc sf.lt.outer
+					if para.isItalic sf2.rb.outer sf2.rb.full
 
 	do "Ini"
 		create-glyph 'armn/ini' 0x56B : glyph-proc
@@ -133,8 +132,9 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df Ascender Descender
 				local sf2 : SerifFrame.fromDf df XH 0
-				include : composite-proc sf.lt.outer sf.lb.fullSide
-				include : if para.isItalic sf2.rb.outer sf2.rb.full
+				include sf.lt.outer
+				include : if para.isItalic sf2.rb.outer
+					composite-proc sf.lb.fullSide sf2.rb.full
 
 	do "Xeh"
 		create-glyph 'armn/xeh' 0x56D : glyph-proc
@@ -164,10 +164,9 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df Ascender Descender
 				local sf2 : SerifFrame.fromDf df XH 0
-				include : composite-proc sf.lt.outer sf.lb.fullSide
-				if para.isItalic
-					include sf2.rb.outer
-					include : composite-proc sf2.rt.inner sf2.rb.outer
+				include : composite-proc sf.lt.outer sf2.rb.outer
+				if [not para.isItalic] : begin
+					include : composite-proc sf.lb.fullSide sf2.rt.inner
 
 	do "Ken"
 		create-glyph 'armn/ken' 0x56F : glyph-proc
@@ -185,9 +184,8 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 				local sf : SerifFrame.fromDf df Ascender 0
 				local sf2 : SerifFrame.fromDf df XH Descender
 				include sf.lt.outer
-				if para.isItalic
-					include sf2.rb.fullSide
-					include : composite-proc sf2.rt.inner sf2.rb.fullSide
+				include : if para.isItalic sf2.rb.outer
+					composite-proc sf2.rt.inner sf2.rb.fullSide
 
 	do "Ho"
 		create-glyph 'armn/ho' 0x570 : glyph-proc
@@ -203,9 +201,9 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 				fine   -- df.shoulderFine
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df Ascender 0
-				include : if para.isItalic
-					composite-proc sf.lt.outer sf.rb.outer
-					composite-proc sf.lt.outer sf.lb.full sf.rb.full
+				include sf.lt.outer
+				include : if para.isItalic sf.rb.outer
+					composite-proc sf.lb.full sf.rb.full
 
 	do "Ghat"
 		create-glyph 'armn/ghat' 0x572 : glyph-proc
@@ -275,9 +273,9 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 				fine   -- df.shoulderFine
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH 0
-				include : if para.isItalic
-					composite-proc sf.lt.outer sf.rb.outer
-					composite-proc sf.lt.outer sf.lb.full sf.rb.full
+				include sf.lt.outer
+				include : if para.isItalic sf.rb.outer
+					composite-proc sf.lb.full sf.rb.full
 
 	do "Peh"
 		create-glyph 'armn/peh' 0x57A : glyph-proc
@@ -288,43 +286,10 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			include : VBar.r df.rightSB Descender XH df.mvs
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH Descender
-				include : if ([not para.isItalic] && sf.enoughSpaceForFullSerifs)
-					composite-proc sf.lt.outer sf.mt.left sf.rt.inner sf.rb.fullSide
-					composite-proc sf.lt.outer sf.rb.fullSide
-
-	do "Rra"
-		create-glyph 'armn/rra' 0x57C : glyph-proc
-			local df : include : DivFrame 1
-			include : df.markSet.e
-			include : VBar.l df.leftSB 0 XH df.mvs
-
-			# Combination of nShoulder and straight '2' shape
-			local left : Math.max df.middle : (df.rightSB - [HSwToV df.mvs]) - jut
-			include : dispiro
-				widths.rhs df.shoulderFine
-				flat (df.leftSB + [HSwToV : df.mvs - df.shoulderFine]) (XH - SmallArchDepthA - TINY)
-				curl (df.leftSB + [HSwToV : df.mvs - df.shoulderFine]) (XH - SmallArchDepthA)
-				arch.rhs XH (sw -- df.mvs) (swBefore -- df.shoulderFine)
-				TwoNeck df XH 0 left
-			include : HBar.b left ((left + [HSwToV df.mvs]) + jut) 0 df.mvs
-			if SLAB : begin
-				local sf : SerifFrame.fromDf df XH 0
-				include sf.lt.outer
-				if [not para.isItalic] : include sf.lb.outer
-
-			# Alternate straight 'n' form
-			# include : nShoulder.shape
-			# 	top    -- XH
-			# 	bottom -- 0
-			# 	left   -- (df.leftSB + [HSwToV df.mvs])
-			# 	right  -- df.rightSB
-			# 	stroke -- df.mvs
-			# 	fine   -- df.shoulderFine
-			# include : [ArmHBar.right df].base
-			# if SLAB : begin
-			# 	local sf : SerifFrame.fromDf df XH 0
-			# 	include sf.lt.outer
-			# 	if [not para.isItalic] : include sf.lb.full
+				include : composite-proc sf.lt.outer
+					if para.isItalic sf.rb.outer sf.rb.fullSide
+				if ([not para.isItalic] && sf.enoughSpaceForFullSerifs) : begin
+					include : composite-proc sf.mt.left sf.rt.inner
 
 	do "Seh"
 		create-glyph 'armn/seh' 0x57D : glyph-proc
@@ -340,9 +305,8 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			include : VBar.r df.rightSB 0 XH df.mvs
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH 0
-				include : if para.isItalic
-					composite-proc sf.lt.outer sf.rb.outer
-					composite-proc sf.lt.outer sf.rt.inner sf.rb.outer
+				include : composite-proc sf.lt.outer sf.rb.outer
+				if [not para.isItalic] : include sf.rt.inner
 
 	do "Vew"
 		create-glyph 'armn/vew' 0x57E : glyph-proc
@@ -388,9 +352,9 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 				adb    -- subDf.smallArchDepthB
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH 0
-				include : if ([not para.isItalic] && sf.enoughSpaceForFullSerifs)
-					composite-proc sf.lt.outer sf.mt.left sf.mb.right sf.rb.full
-					composite-proc sf.lt.outer sf.rb.outer
+				include sf.lt.outer
+				include : if (para.isItalic || [not sf.enoughSpaceForFullSerifs]) sf.rb.outer
+					composite-proc sf.mt.left sf.mb.right sf.rb.full
 
 	do "Reh"
 		create-glyph 'armn/reh' 0x580 : glyph-proc
@@ -407,8 +371,9 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH Descender
 				local sf2 : SerifFrame.fromDf df XH 0
-				include : composite-proc sf.lt.outer sf.lb.fullSide
-				include : if para.isItalic sf2.rb.outer sf2.rb.full
+				include sf.lt.outer
+				include : if para.isItalic sf2.rb.outer
+					composite-proc sf.lb.fullSide sf2.rb.full
 
 	do "P'iur"
 		create-glyph 'armn/piur' 0x583 : glyph-proc
@@ -437,10 +402,9 @@ glyph-block Letter-Armenian-Lower-U-Group : begin
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH 0
 				local sf2 : SerifFrame.fromDf df Ascender Descender
-				include : if ([not para.isItalic] && sf.enoughSpaceForFullSerifs)
-					composite-proc sf.lt.outer sf.rb.full
-					composite-proc sf.lt.outer sf.rb.outer
-				include : composite-proc sf2.mt.left sf2.mb.fullCenter
+				include : composite-proc sf.lt.outer sf2.mt.left
+					if (para.isItalic || [not sf.enoughSpaceForFullSerifs]) sf.rb.outer sf.rb.full
+				if [not para.isItalic] : include sf2.mb.fullCenter
 
 	do "Ew"
 		create-glyph 'armn/ew' 0x587 : glyph-proc

--- a/packages/font-glyphs/src/letter/armenian/shared.ptl
+++ b/packages/font-glyphs/src/letter/armenian/shared.ptl
@@ -47,15 +47,3 @@ glyph-block Letter-Armenian-Shared-Shapes : begin
 	set [ArmHBar.normal df] : ArmHBar JUT.NORMAL df
 	set [ArmHBar.right  df] : ArmHBar JUT.RIGHT  df
 	set [ArmHBar.left   df] : ArmHBar JUT.LEFT   df
-
-	glyph-block-export TwoNeck
-	define [TwoNeck df top bot _left _right _adb _flatp] : begin
-		local adb : fallback _adb SmallArchDepthB
-		local flatp : fallback _flatp 0.75
-		local left : fallback _left df.leftSB
-		local right : fallback _right df.rightSB
-		local refY : top - adb * 1.5 - df.mvs / 2 * (1 - TanSlope)
-		return : list
-			g4.down.mid right (top - adb)
-			flat [mix left right flatp] [mix (bot + df.mvs) refY flatp]
-			curl left (bot + df.mvs) [widths.lhs df.mvs]

--- a/packages/font-glyphs/src/letter/armenian/to.ptl
+++ b/packages/font-glyphs/src/letter/armenian/to.ptl
@@ -56,4 +56,5 @@ glyph-block Letter-Armenian-To : begin
 				curl (df.rightSB + jut * [if SLAB 1.5 1] - [HSwToV : 0.5 * df.mvs]) barPosT [heading Rightward]
 			if SLAB : begin
 				local sf : SerifFrame.fromDf df XH Descender
-				include : composite-proc sf.lt.outer sf.lb.fullSide
+				include sf.lt.outer
+				if [not para.isItalic] : include sf.lb.fullSide

--- a/packages/font-glyphs/src/letter/greek/psi.ptl
+++ b/packages/font-glyphs/src/letter/greek/psi.ptl
@@ -17,16 +17,17 @@ glyph-block Letter-Greek-Psi : begin
 		include : VBar.m df.middle y2 y4 df.mvs
 		include : VBar.m df.middle y1 (y2 + HalfStroke)
 
-		local doFullSerifs : doSerifLT && doSerifRT && doSerifMT # && doSerifMB
-		if doSerifLT : include : tagged 'serifLT' : if doFullSerifs
-			HSerif.mt (df.leftSB + [HSwToV : 0.5 * df.mvs]) y3 (Jut - [HSwToV : 0.5 * (Stroke - df.mvs)])
-			HSerif.lt df.leftSB y3 SideJut
-		if doSerifRT : include : tagged 'serifRT' : if doFullSerifs
-			HSerif.mt (df.rightSB - [HSwToV : 0.5 * df.mvs]) y3 (Jut - [HSwToV : 0.5 * (Stroke - df.mvs)])
-			HSerif.rt df.rightSB y3 SideJut
-		if doSerifMT : include : tagged 'serifMT' : if doFullSerifs
-			HSerif.mt df.middle y4 (Jut - [HSwToV : 0.5 * (Stroke - df.mvs)])
-			HSerif.lt (df.middle - [HSwToV : 0.5 * df.mvs]) y4 SideJut
+		local doFullSerifs : (df.width > para.refJut * 7) && doSerifLT && doSerifRT && doSerifMT && doSerifMB
+		if doSerifLT : include : tagged 'serifLT' : piecewise
+			doFullSerifs : HSerif.mt (df.leftSB + [HSwToV : 0.5 * df.mvs]) y3 (Jut - [HSwToV : 0.5 * (Stroke - df.mvs)])
+			true         : HSerif.lt df.leftSB y3 SideJut
+		if doSerifRT : include : tagged 'serifRT' : piecewise
+			doFullSerifs : HSerif.mt (df.rightSB - [HSwToV : 0.5 * df.mvs]) y3 (Jut - [HSwToV : 0.5 * (Stroke - df.mvs)])
+			true         : HSerif.rt df.rightSB y3 SideJut
+		if doSerifMT : include : tagged 'serifMT' : piecewise
+			(y4 > y3)    : HSerif.lt (df.middle - [HSwToV : 0.5 * df.mvs]) y4 SideJut
+			doFullSerifs : HSerif.mt df.middle y4 (Jut - [HSwToV : 0.5 * (Stroke - df.mvs)])
+			true         : no-shape
 		if doSerifMB : include : tagged 'serifMB' : HSerif.mb df.middle y1 MidJutCenter
 
 	create-glyph 'grek/Psi' 0x3A8 : glyph-proc
@@ -35,7 +36,7 @@ glyph-block Letter-Greek-Psi : begin
 		include : PsiShape df 0 [mix 0 CAP 0.3] CAP CAP df.archDepthA df.archDepthB
 			doSerifLT -- SLAB
 			doSerifRT -- SLAB
-			doSerifMT -- (SLAB && (df.width > para.refJut * 7))
+			doSerifMT -- SLAB
 			doSerifMB -- SLAB
 
 	create-glyph 'smcpPsi' 0x1D2A : glyph-proc
@@ -50,7 +51,7 @@ glyph-block Letter-Greek-Psi : begin
 	define [CyrPsiShape fBarStraight] : function [] : with-params [df y1 y2 y3 y4 ada adb doSerifLT doSerifRT doSerifMT doSerifMB] : glyph-proc
 		local fine : Math.min df.mvs : AdviceStroke 3.3 df.adws
 		local fine2 : clamp fine Stroke : VSwToH : 2 * VCornerHalfWidth * (fine / Stroke)
-		local doFullSerifs : doSerifLT && doSerifRT && doSerifMT # && doSerifMB
+		local doFullSerifs : (df.width > para.refJut * 7) && doSerifLT && doSerifMT && doSerifMB
 		include : with-transform [ApparentTranslate 0 (y2 - 0)] : union
 			VHookRightShape
 				df             -- df
@@ -67,9 +68,10 @@ glyph-block Letter-Greek-Psi : begin
 
 		include : VBar.m df.middle y2 y4 fine
 		include : VBar.m df.middle y1 (y2 + HalfStroke) fine2
-		if doSerifMT : include : tagged 'serifMT' : if doFullSerifs
-			HSerif.mt df.middle y4 (Jut - [HSwToV : 0.5 * (Stroke - fine)]) fine2
-			HSerif.lt (df.middle - [HSwToV : 0.5 * fine]) y4 SideJut fine2 fine
+		if doSerifMT : include : tagged 'serifMT' : piecewise
+			(y4 > y3)    : HSerif.lt (df.middle - [HSwToV : 0.5 * fine]) y4 SideJut fine2 fine
+			doFullSerifs : HSerif.mt df.middle y4 (Jut - [HSwToV : 0.5 * (Stroke - fine)]) fine2
+			true         : no-shape
 		if doSerifMB : include : tagged 'serifMB' : HSerif.mb df.middle y1 (MidJutCenter - [HSwToV : 0.5 * (Stroke - fine2)]) fine2
 
 	define VConfig : object
@@ -82,8 +84,8 @@ glyph-block Letter-Greek-Psi : begin
 			include : df.markSet.capital
 			include : [CyrPsiShape fBarStraight] df 0 [mix 0 CAP 0.3] CAP CAP df.archDepthA df.archDepthB
 				doSerifLT -- SLAB
-				doSerifRT -- SLAB
-				doSerifMT -- (SLAB && (df.width > para.refJut * 7))
+				doSerifRT -- false
+				doSerifMT -- SLAB
 				doSerifMB -- SLAB
 
 	select-variant 'cyrl/Psi' 0x470 (follow -- 'cyrl/Psi/Izhitsa')
@@ -117,8 +119,8 @@ glyph-block Letter-Greek-Psi : begin
 				include : [CyrPsiShape fBarStraight] df Descender 0 XH top df.smallArchDepthA df.smallArchDepthB
 					doSerifLT -- fSlab
 					doSerifRT -- false
-					doSerifMT -- (fSlab && SLAB && (top > XH))
-					doSerifMB -- (fSlab && SLAB)
+					doSerifMT -- (fSlab && SLAB && (!para.isItalic || (top > XH)))
+					doSerifMB -- (fSlab && SLAB &&  !para.isItalic)
 
 		select-variant "cyrl/psi.\(suffix)" (follow -- 'cyrl/psi/izhitsa')
 

--- a/packages/font-glyphs/src/letter/latin/k.ptl
+++ b/packages/font-glyphs/src/letter/latin/k.ptl
@@ -616,9 +616,11 @@ glyph-block Letter-Latin-K : begin
 			include : new-glyph : composite-proc
 				LegsImpl false SB RightSB Stroke XH slabLT slabLegs
 				FlipAround Middle (XH / 2)
-			if slabLT : include : tagged 'serifLT' : union
-				HSerif.rb (xBarRight - [HSwToV HalfStroke]) Descender Jut
-				HSerif.lb (xBarRight - [HSwToV HalfStroke]) Descender MidJutSide
+			if slabLT : include : tagged 'serifLT' : if para.isItalic
+				HSerif.rb xBarRight Descender SideJut
+				union
+					HSerif.rb (xBarRight - [HSwToV HalfStroke]) Descender Jut
+					HSerif.lb (xBarRight - [HSwToV HalfStroke]) Descender MidJutSide
 			if slabLB : include : tagged 'serifLB' : if [HasFullSerif slabLegs]
 				HSerif.mt (xBarRight - [HSwToV HalfStroke]) XH Jut
 				HSerif.rt xBarRight XH SideJut

--- a/packages/font-glyphs/src/letter/latin/lower-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-m.ptl
@@ -249,7 +249,7 @@ glyph-block Letter-Latin-Lower-M : begin
 			"bottomRightSerifed"           { RbSerifs   }
 			"topLeftAndBottomRightSerifed" { LtRbSerifs }
 
-	foreach { suffix { {Body earless} {shortLeg} {tailed} {Serifs} } } [pairs-of SmallMConfig] : do
+	foreach { suffix { { Body earless } { shortLeg } { tailed } { Serifs } } } [pairs-of SmallMConfig] : do
 		define [mShapeBody df top _sw _ada _adb] : begin
 			return : mShapeBodyImpl df top Body earless shortLeg tailed Serifs _sw _ada _adb
 
@@ -384,7 +384,7 @@ glyph-block Letter-Latin-Lower-M : begin
 				[Just 'toothed'] { LtRbSerifs }
 				__               { RbSerifs   } # The name-shaping mapping is swapped by design
 
-	foreach { suffix { {Body toothless tailed} {Serifs} } } [pairs-of TurnMConfig] : do
+	foreach { suffix { { Body toothless tailed } { Serifs } } } [pairs-of TurnMConfig] : do
 		define [turnMShapeBody df top _sw _ada _adb] : glyph-proc
 			include : turnMShapeBodyImpl df top Body toothless tailed Serifs _sw _ada _adb
 
@@ -400,18 +400,6 @@ glyph-block Letter-Latin-Lower-M : begin
 				SmallMSmoothA df ArchDepth
 				SmallMSmoothB df ArchDepth
 
-		if (!tailed) : begin
-			create-glyph "turnmLeg.\(suffix)" : glyph-proc
-				local df : include : dfM
-				include : df.markSet.p
-				include : turnMShapeBody df XH
-				eject-contour 'serifLT'
-				include : VBar.r df.rightSB Descender XH df.mvs
-				if (Serifs !== no-shape) : begin
-					local sf : SerifFrame.fromDf df XH Descender
-					include sf.rb.fullSide
-				include : LeaningAnchor.Below.VBar.r df.rightSB
-
 		create-glyph "turnmSideways.\(suffix)" : glyph-proc
 			local realHeight : XH * para.advanceScaleMM
 			local realTop : XH / 2 + realHeight / 2
@@ -422,19 +410,31 @@ glyph-block Letter-Latin-Lower-M : begin
 				include : turnMShapeBody df RightSB
 				include : Translate 0 (SB / 2)
 
-		if (Body === SmallMArches && !tailed) : begin
-			create-glyph "cyrl/shcha.italic.\(suffix)" : glyph-proc
-				local df : include : dfM
-				include : df.markSet.e
-				include : turnMShapeBody df XH
-				eject-contour 'serifLT'
-				include : CyrDescender.rSideJut df.rightSB 0 (refSw -- df.mvs)
-			create-glyph "cyrl/shwe.italic.\(suffix)" : glyph-proc
+		if (!tailed) : begin
+			create-glyph "turnmLeg.\(suffix)" : glyph-proc
 				local df : include : dfM
 				include : df.markSet.p
 				include : turnMShapeBody df XH
 				eject-contour 'serifLT'
-				include : CyrCurlDescender.rSideJut df.rightSB 0 (refSw -- df.mvs)
+				include : VBar.r df.rightSB Descender XH df.mvs
+				if (Serifs !== no-shape) : begin
+					local sf : SerifFrame.fromDf df XH Descender
+					include sf.rb.[if para.isItalic 'outer' 'fullSide']
+				include : LeaningAnchor.Below.VBar.r df.rightSB
+
+			if (Body === SmallMArches) : begin
+				create-glyph "cyrl/shcha.italic.\(suffix)" : glyph-proc
+					local df : include : dfM
+					include : df.markSet.e
+					include : turnMShapeBody df XH
+					eject-contour 'serifLT'
+					include : CyrDescender.rSideJut df.rightSB 0 (refSw -- df.mvs)
+				create-glyph "cyrl/shwe.italic.\(suffix)" : glyph-proc
+					local df : include : dfM
+					include : df.markSet.p
+					include : turnMShapeBody df XH
+					eject-contour 'serifLT'
+					include : CyrCurlDescender.rSideJut df.rightSB 0 (refSw -- df.mvs)
 
 	select-variant 'turnm' 0x26F (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'turnm/full' 'turnm/reduced'])
 	select-variant 'turnm/reduced' (shapeFrom -- 'turnm')

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -245,7 +245,7 @@ glyph-block Letter-Latin-U : begin
 			eject-contour 'serifRB'
 			if (Slabs !== no-shape) : begin
 				local sf : SerifFrame.fromDf df XH Descender
-				include sf.rb.fullSide
+				include sf.rb.[if para.isItalic 'outer' 'fullSide']
 			include : LeaningAnchor.Below.VBar.r df.rightSB
 
 		create-glyph "uShortLeg.\(suffix)" : glyph-proc
@@ -273,7 +273,7 @@ glyph-block Letter-Latin-U : begin
 			eject-contour 'serifRB'
 			if (Slabs !== no-shape) : begin
 				local sf : SerifFrame.fromDf df XH Descender
-				include sf.rb.fullSide
+				include sf.rb.[if para.isItalic 'outer' 'fullSide']
 			include : LeaningAnchor.Below.VBar.r df.rightSB
 
 		create-glyph "turnhHookLeftRTail.\(suffix)" : glyph-proc


### PR DESCRIPTION
Same rationale as in #3125 ; Down-right flowing serifs against the slope angle, meaning bottom-left serif disappears and bottom-right serif points outward.

Also apply this to a selection of homoglyphs and other similar/related characters.

```
ՠաբգդեզէըթժիլխծկ
հձղճմյնշոչպջռսվտ
րցւփքօֆևֈ
Ɥɥɰ Ʞ𝼐ʞ ꭒʮʯ Ψᴪψ Ѱѱ
```

Slab upright:
<img width="1986" height="1114" alt="image" src="https://github.com/user-attachments/assets/ed8d13f6-38f5-461d-9c05-43e4e444b771" />
Slab Italic:
<img width="2002" height="1106" alt="image" src="https://github.com/user-attachments/assets/21e9172b-f12d-4c93-b264-af9fd0da04a2" />
Etoile Upright:
<img width="2425" height="1105" alt="image" src="https://github.com/user-attachments/assets/2f2b856f-3afd-4174-87c7-7e6528a57205" />
Etoile Italic:
<img width="2443" height="1127" alt="image" src="https://github.com/user-attachments/assets/23f10740-aa3e-4b7a-81fc-8da7e05ffc3f" />
