### PR TITLE
Add `above-baseline` variants for Greek Lower Chi (`χ`), for `ss12` and `ss14`.

### DIFF
--- a/changes/34.4.0.md
+++ b/changes/34.4.0.md
@@ -1,0 +1,1 @@
+* Add `above-baseline` variants for Greek Lower Chi (`χ`).

--- a/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
@@ -238,7 +238,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 	do "Er subglyphs"
 		glyph-block-import Letter-Latin-Lower-P : PConfig
 
-		foreach { suffix { Body {Serifs doTS doBS} }} [Object.entries PConfig] : do
+		foreach { suffix { Body { Serifs doTS doBS } } } [Object.entries PConfig] : do
 			create-glyph "cyrl/rha/left.\(suffix)" : glyph-proc
 				local df : include : DivFrame para.advanceScaleM 3
 				include : df.markSet.p
@@ -258,7 +258,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 		glyph-block-import Letter-Shared-Shapes : SerifFrame WithSerifOverflowMask
 		glyph-block-import Letter-Latin-X : XConfig XLetterForm XSerifs
 
-		foreach { suffix {stroke1 stroke2 serifShape fMaskBase} } [Object.entries XConfig] : do
+		foreach { suffix { { stroke1 stroke2 } { desc } { serifShape fMaskBase } } } [Object.entries XConfig] : do
 			define [halfLetterShape df top bot turn tension] : glyph-proc
 				local lf : XLetterForm df top bot stroke1 stroke2 turn tension
 				include : WithSerifOverflowMask fMaskBase top bot df.leftSB df.rightSB : lf.rightHalf fMaskBase
@@ -286,29 +286,30 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 						[Just XSerifs.BilateralMotion] : composite-proc sf.rb.outer
 						__ : glyph-proc
 
-			create-glyph "cyrl/rha/right.\(suffix)" : glyph-proc
-				local df : DivFrame para.advanceScaleM 3
-				set-width 0
-				set-mark-anchor 'cvDecompose' 0 0
-				include : halfLetterShape df XH 0 0.1 0.20
+			if (!desc) : begin
+				create-glyph "cyrl/rha/right.\(suffix)" : glyph-proc
+					local df : DivFrame para.advanceScaleM 3
+					set-width 0
+					set-mark-anchor 'cvDecompose' 0 0
+					include : halfLetterShape df XH 0 0.1 0.20
 
-			create-glyph "cyrl/lha/right.\(suffix)" : glyph-proc
-				local df : DivFrame para.advanceScaleM 3.2
-				set-width 0
-				set-mark-anchor 'cvDecompose' 0 0
+				create-glyph "cyrl/lha/right.\(suffix)" : glyph-proc
+					local df : DivFrame para.advanceScaleM 3.2
+					set-width 0
+					set-mark-anchor 'cvDecompose' 0 0
 
-				local { subDf shift } : SubDfAndShiftEx 6 4 1 df
-				include : with-transform [ApparentTranslate shift 0]
-					LhaRightLetterShape subDf XH 0 0.1 0.20
+					local { subDf shift } : SubDfAndShiftEx 6 4 1 df
+					include : with-transform [ApparentTranslate shift 0]
+						LhaRightLetterShape subDf XH 0 0.1 0.20
 
-			create-glyph "cyrl/Lha/right.\(suffix)" : glyph-proc
-				local df : DivFrame para.advanceScaleM 3.2
-				set-width 0
-				set-mark-anchor 'cvDecompose' 0 0
+				create-glyph "cyrl/Lha/right.\(suffix)" : glyph-proc
+					local df : DivFrame para.advanceScaleM 3.2
+					set-width 0
+					set-mark-anchor 'cvDecompose' 0 0
 
-				local { subDf shift } : SubDfAndShiftEx 6 4 1 df
-				include : with-transform [ApparentTranslate shift 0]
-					LhaRightLetterShape subDf CAP 0 0.1 0.28
+					local { subDf shift } : SubDfAndShiftEx 6 4 1 df
+					include : with-transform [ApparentTranslate shift 0]
+						LhaRightLetterShape subDf CAP 0 0.1 0.28
 
 	do "Te (upright) subglyphs"
 		define [EsTeRightShape subDf doTopSerifs doBottomSerifs] : new-glyph : glyph-proc
@@ -340,7 +341,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 
 	do "Te (italic) subglyphs"
 		glyph-block-import Letter-Latin-Lower-M : mShapeBodyImpl SmallMConfig
-		foreach { suffix { {Body earless} {shortLeg} {tailed} {Serifs} } } [pairs-of SmallMConfig] : do
+		foreach { suffix { { Body earless } { shortLeg } { tailed } { Serifs } } } [pairs-of SmallMConfig] : do
 			create-glyph "cyrl/este.italic/right.\(suffix)" : glyph-proc
 				local df : DivFrame para.advanceScaleMM 4.75
 				local subDfLeft : df.slice 4.5 2

--- a/packages/font-glyphs/src/letter/latin-ext/upper-aa-ao.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/upper-aa-ao.ptl
@@ -113,7 +113,7 @@ glyph-block Letter-Latin-Upper-AA-AO : begin
 		define { subDf shift } : SubDfAndShift 1 df
 		define sg : UShapeGroup subDf.archDepthA subDf.archDepthB
 
-		foreach { suffix { Base {Slabs fLTSlab} } } [Object.entries : CapitalUConfigT sg] : do
+		foreach { suffix { Base { Slabs fLTSlab } } } [Object.entries : CapitalUConfigT sg] : do
 			create-glyph "AU/Right.\(suffix)" : glyph-proc
 				include : with-transform [ApparentTranslate shift 0]
 					union [Base subDf CAP df.mvs] [Slabs subDf CAP df.mvs]
@@ -154,7 +154,7 @@ glyph-block Letter-Latin-Upper-AA-AO : begin
 						PShape.OpenGap (df -- subDf) (top -- CAP) (bot -- [if fSlabBot df.mvs 0])
 						no-shape
 
-		foreach { suffix {stroke1 stroke2 serifShape fMaskBase} } [Object.entries XConfig] : do
+		foreach { suffix { { stroke1 stroke2 } { desc } { serifShape fMaskBase } } } [Object.entries XConfig] : do
 			define [letterShape df top bot turn tension] : glyph-proc
 				local lf : XLetterForm df top bot stroke1 stroke2 turn tension
 				include : WithSerifOverflowMask fMaskBase top bot df.leftSB df.rightSB : lf.rightHalf fMaskBase
@@ -165,11 +165,12 @@ glyph-block Letter-Latin-Upper-AA-AO : begin
 						[Just XSerifs.BilateralMotion] : composite-proc sf.rb.outer
 						__ : glyph-proc
 
-			create-glyph "cyrl/Rha/right.\(suffix)" : glyph-proc
-				local df : DivFrame para.advanceScaleM 3
-				set-width 0
-				set-mark-anchor 'cvDecompose' 0 0
-				include : letterShape df CAP 0 0.1 0.28
+			if (!desc) : begin
+				create-glyph "cyrl/Rha/right.\(suffix)" : glyph-proc
+					local df : DivFrame para.advanceScaleM 3
+					set-width 0
+					set-mark-anchor 'cvDecompose' 0 0
+					include : letterShape df CAP 0 0.1 0.28
 
 		select-variant "cyrl/Rha/left" (follow -- 'cyrl/Er')
 		select-variant "cyrl/Rha/right"

--- a/packages/font-glyphs/src/letter/latin/x.ptl
+++ b/packages/font-glyphs/src/letter/latin/x.ptl
@@ -1,6 +1,6 @@
 $$include '../../meta/macros.ptl'
 
-import [mix linreg clamp fallback] from "@iosevka/util"
+import [mix linreg clamp fallback SuffixCfg] from "@iosevka/util"
 import [MathSansSerif] from "@iosevka/glyph/relation"
 
 glyph-module
@@ -29,19 +29,19 @@ glyph-block Letter-Latin-X : begin
 		: else : begin
 			local height : Math.abs (yOuter - yCenter)
 			local slabClearance : if fSlab ((sw / Stroke) * [AdviceStroke2 2 3 height]) 0
-			local turnyOuter : mix yOuter yCenter [if fSlab [Math.max turn (slabClearance / height)] turn]
-			local cyOuter : mix turnyOuter yCenter tension
-			local straightXOuter : mix xOuter xCenter pStraight
+			local turnyOuter : mix yOuter     yCenter : if fSlab [Math.max turn (slabClearance / height)] turn
+			local cyOuter    : mix turnyOuter yCenter tension
+			local straightXOuter : mix xOuter  xCenter pStraight
 			local straightYOuter : mix cyOuter yCenter pStraight
-			local xCenterAdj : mix xCenter xOuter [fallback _pConn 0]
-			local yCenterAdj : mix yCenter cyOuter [fallback _pConn 0]
+			local xCenterAdj : mix xCenter xOuter  : fallback _pConn 0
+			local yCenterAdj : mix yCenter cyOuter : fallback _pConn 0
 			include : dispiro
 				widths.center sw
-				flat xOuter yOuter [heading [if (yOuter < yCenter) Upward Downward]]
+				flat xOuter yOuter     [heading [if (yOuter < yCenter) Upward Downward]]
 				curl xOuter turnyOuter [heading [if (yOuter < yCenter) Upward Downward]]
 				quadControls 0 ((cyOuter - turnyOuter) / (straightYOuter - turnyOuter)) 24
 				flat straightXOuter straightYOuter
-				curl xCenterAdj yCenterAdj
+				curl xCenterAdj     yCenterAdj
 
 	glyph-block-export XStrand
 	define [XStrand stb slab xLeft yLeft xRight yRight turn pStraight tension _sw] : glyph-proc
@@ -68,23 +68,27 @@ glyph-block Letter-Latin-X : begin
 				flat [mix leftX rightX 0.5] [mix leftY rightY 0.5] [widths.center fine]
 				list
 					flat (leftX - [if fSlab SideJut 0]) (leftY - sign * sw / 2) [widths.center.heading sw Rightward]
-					curl (leftX + TINY) (leftY - sign * sw / 2) [widths.center.heading sw Rightward]
+					curl (leftX + TINY)                 (leftY - sign * sw / 2) [widths.center.heading sw Rightward]
 					alsoThruThem {{blendK1X blendK1Y} {blendK2X blendK2Y}}
-					flat [mix leftX rightX pStraightX] [mix leftY rightY pStraightY] [widths.center : mix sw fine 0.5]
-					corner [mix leftX rightX 0.5] [mix leftY rightY 0.5] [widths.center fine]
+					flat   [mix leftX rightX pStraightX] [mix leftY rightY pStraightY] [widths.center : mix sw fine 0.5]
+					corner [mix leftX rightX 0.5]        [mix leftY rightY 0.5]        [widths.center fine]
 			curl [mix leftX rightX (1 - pStraightX)] [mix leftY rightY (1 - pStraightY)] [widths.center : mix sw fine 0.5]
 			alsoThruThem {{(1 - blendK2X) (1 - blendK2Y)} {(1 - blendK1X) (1 - blendK1Y)}}
-			flat (rightX - TINY) (rightY + sign * sw / 2) [widths.center.heading sw Rightward]
+			flat (rightX - TINY)                 (rightY + sign * sw / 2) [widths.center.heading sw Rightward]
 			curl (rightX + [if fSlab SideJut 0]) (rightY + sign * sw / 2) [widths.center.heading sw Rightward]
 
 	glyph-block-export XCursiveHalfShape
-	define [XCursiveHalfShape] : with-params [
-			top bottom left right
-			[swMid   [AdviceStroke 2.75]]
-			[swEnd   [AdviceStroke 3.00]]
-			[swCoEnd [AdviceStroke 2.00]]
-			[setMark false] [flatTail false]
-		] : glyph-proc
+	define flex-params [XCursiveHalfShape] : glyph-proc
+		local-parameter : top
+		local-parameter : bottom
+		local-parameter : left
+		local-parameter : right
+		local-parameter : swMid    -- [AdviceStroke 2.75]
+		local-parameter : swEnd    -- [AdviceStroke 3.00]
+		local-parameter : swCoEnd  -- [AdviceStroke 2.00]
+		local-parameter : setMark  -- false
+		local-parameter : flatTail -- false
+
 		local ada : ArchDepthAOf (ArchDepth * 0.8) (Width / 2)
 		local adb : ArchDepthBOf (ArchDepth * 0.8) (Width / 2)
 		local adws : (right - left) / (RightSB - Middle)
@@ -130,13 +134,19 @@ glyph-block Letter-Latin-X : begin
 	define STROKE-CURSIVE-FLAT 4
 
 	glyph-block-export XLetterForm
-	define [XLetterForm] : with-params [
-			df top bot stroke1 stroke2 turn tension [sw df.mvs]
-			[swCursiveMid   ([AdviceStroke 2.75] * (sw / Stroke))]
-			[swCursiveEnd   ([AdviceStroke 3.00] * (sw / Stroke))]
-			[swCursiveCoEnd ([AdviceStroke 2.00] * (sw / Stroke))]
-		] : namespace
-		local sw df.mvs
+	define flex-params [XLetterForm] : namespace
+		local-parameter : df
+		local-parameter : top
+		local-parameter : bot
+		local-parameter : stroke1
+		local-parameter : stroke2
+		local-parameter : turn
+		local-parameter : tension
+		local-parameter : sw             -- df.mvs
+		local-parameter : swCursiveMid   -- ([AdviceStroke 2.75] * (sw / Stroke))
+		local-parameter : swCursiveEnd   -- ([AdviceStroke 3.00] * (sw / Stroke))
+		local-parameter : swCursiveCoEnd -- ([AdviceStroke 2.00] * (sw / Stroke))
+
 		export : define [base fSlab] : glyph-proc
 			include : match stroke1
 				[Just STROKE-STRAIGHT] : XStrand true  fSlab df.leftSB bot df.rightSB top turn 0.4 tension sw
@@ -189,25 +199,38 @@ glyph-block Letter-Latin-X : begin
 		export : define [GrekLowerChi sf]     : composite-proc sf.lt.outer sf.rt.full sf.lb.full sf.rb.outer
 
 	glyph-block-export XConfig
-	define XConfig : object
-		straightSerifless               { STROKE-STRAIGHT STROKE-STRAIGHT null                     false }
-		curlySerifless                  { STROKE-CURLY    STROKE-CURLY    null                     false }
-		cursive                         { STROKE-CURSIVE  STROKE-CURSIVE  null                     false }
-		semiChanceryStraightSerifless   { STROKE-STRAIGHT STROKE-CHANCERY null                     false }
-		semiChanceryCurlySerifless      { STROKE-CURLY    STROKE-CHANCERY null                     false }
-		chancery                        { STROKE-CHANCERY STROKE-CHANCERY null                     false }
-		straightSerifed                 { STROKE-STRAIGHT STROKE-STRAIGHT XSerifs.Full             true  }
-		curlySerifed                    { STROKE-CURLY    STROKE-CURLY    XSerifs.Full             true  }
-		semiChanceryStraightSerifed     { STROKE-STRAIGHT STROKE-CHANCERY XSerifs.SemiChancery     true  }
-		semiChanceryCurlySerifed        { STROKE-CURLY    STROKE-CHANCERY XSerifs.SemiChancery     true  }
-		straightUnilateralMotionSerifed { STROKE-STRAIGHT STROKE-STRAIGHT XSerifs.UnilateralMotion false }
-		curlyUnilateralMotionSerifed    { STROKE-CURLY    STROKE-CURLY    XSerifs.UnilateralMotion false }
-		straightBilateralMotionSerifed  { STROKE-STRAIGHT STROKE-STRAIGHT XSerifs.BilateralMotion  false }
-		curlyBilateralMotionSerifed     { STROKE-CURLY    STROKE-CURLY    XSerifs.BilateralMotion  false }
-		straightGrekLowerChiSerifed     { STROKE-STRAIGHT STROKE-STRAIGHT XSerifs.GrekLowerChi     true  }
-		curlyGrekLowerChiSerifed        { STROKE-CURLY    STROKE-CURLY    XSerifs.GrekLowerChi     true  }
+	define XConfig : SuffixCfg.combine
+		SuffixCfg.weave # standard variants
+			object # body
+				straight                { STROKE-STRAIGHT STROKE-STRAIGHT }
+				curly                   { STROKE-CURLY    STROKE-CURLY    }
+			object # height
+				""                      { 0         'capital' 'e' }
+				descending              { Descender 'capDesc' 'p' }
+			object # serifs
+				serifless               { null                     false }
+				unilateralMotionSerifed { XSerifs.UnilateralMotion false }
+				bilateralMotionSerifed  { XSerifs.BilateralMotion  false }
+				serifed                 { XSerifs.Full             true  }
+				grekLowerChiSerifed     { XSerifs.GrekLowerChi     true  }
+		SuffixCfg.weave # semi-chancery variants
+			object # body
+				semiChanceryStraight    { STROKE-STRAIGHT STROKE-CHANCERY }
+				semiChanceryCurly       { STROKE-CURLY    STROKE-CHANCERY }
+			object # height
+				""                      { 0         'capital' 'e' }
+				descending              { Descender 'capDesc' 'p' }
+			object # serifs
+				serifless               { null                 false }
+				serifed                 { XSerifs.SemiChancery true  }
+		object # chancery variants
+			chancery              { { STROKE-CHANCERY STROKE-CHANCERY } { 0         'capital' 'e' } { null false } }
+			chanceryDescending    { { STROKE-CHANCERY STROKE-CHANCERY } { Descender 'capDesc' 'p' } { null false } }
+		object # cursive variants
+			cursive               { { STROKE-CURSIVE  STROKE-CURSIVE  } { 0         'capital' 'e' } { null false } }
+			cursiveDescending     { { STROKE-CURSIVE  STROKE-CURSIVE  } { Descender 'capDesc' 'p' } { null false } }
 
-	foreach { suffix {stroke1 stroke2 serifShape fMaskBase} } [Object.entries XConfig] : do
+	foreach { suffix { { stroke1 stroke2 } { bottom mkCap mkXH } { serifShape fMaskBase } } } [Object.entries XConfig] : do
 		define [letterShape top bot turn tension] : glyph-proc
 			local df : DivFrame 1 2
 			local lf : XLetterForm df top bot stroke1 stroke2 turn tension
@@ -217,40 +240,32 @@ glyph-block Letter-Latin-X : begin
 				include : serifShape sf
 
 		create-glyph "X.\(suffix)" : glyph-proc
-			include : MarkSet.capital
-			include : letterShape CAP 0 0.1 0.28
+			include : MarkSet.(mkCap)
+			include : letterShape CAP bottom 0.1 0.28
 
 		create-glyph "x.\(suffix)" : glyph-proc
-			include : MarkSet.e
-			include : letterShape XH 0 0.1 0.20
-
-		create-glyph "latn/chi.\(suffix)" : glyph-proc
-			include : MarkSet.p
-			include : letterShape XH Descender 0.1 0.20
-
-		create-glyph "latn/Chi.\(suffix)" : glyph-proc
-			include : MarkSet.capDesc
-			include : letterShape CAP Descender 0.1 0.20
+			include : MarkSet.(mkXH)
+			include : letterShape XH bottom 0.1 0.20
 
 	select-variant 'X' 'X'
 	link-reduced-variant 'X/sansSerif' 'X' MathSansSerif
-	alias 'grek/Chi' 0x3A7 'X'
-	alias-reduced-variant 'grek/Chi/sansSerif' 'grek/Chi' 'X/sansSerif' MathSansSerif
-	alias 'cyrl/Kha' 0x425 'X'
+	select-variant 'smcpX' (shapeFrom -- 'x') (follow -- 'X')
 
 	select-variant 'x' 'x'
 	link-reduced-variant 'x/sansSerif' 'x' MathSansSerif
-	alias 'cyrl/kha' 0x445 'x'
 
+	alias 'grek/Chi' 0x3A7 'X'
+	alias-reduced-variant 'grek/Chi/sansSerif' 'grek/Chi' 'X/sansSerif' MathSansSerif
+	select-variant 'latn/Chi' 0xA7B3 (shapeFrom -- 'X')
+
+	select-variant 'grek/chi' 0x3C7 (shapeFrom -- 'x')
+	link-reduced-variant 'grek/chi/sansSerif' 'grek/chi' MathSansSerif (shapeFrom -- 'x')
+	select-variant 'latn/chi' 0xAB53 (shapeFrom -- 'x')
+
+	alias 'cyrl/Kha' 0x425 'X'
+	alias 'cyrl/kha' 0x445 'x'
 	select-variant 'cyrl/Kha/descBase' (shapeFrom -- 'X') (follow -- 'X/descBase')
 	select-variant 'cyrl/kha/descBase' (shapeFrom -- 'x') (follow -- 'x/descBase')
-
-	select-variant 'grek/chi' 0x3C7 (shapeFrom -- 'latn/chi')
-	link-reduced-variant 'grek/chi/sansSerif' 'grek/chi' MathSansSerif (shapeFrom -- 'latn/chi')
-	select-variant 'latn/chi' 0xAB53 (follow -- 'x')
-	select-variant 'latn/Chi' 0xA7B3 (follow -- 'X')
-
-	select-variant 'smcpX' (shapeFrom -- 'x') (follow -- 'X')
 
 	define [AddDescender Ctor] : function [src sel] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
@@ -278,22 +293,18 @@ glyph-block Letter-Latin-X : begin
 
 	glyph-block-import Letter-Blackboard : BBS BBD
 	define [BBXShape l r top] : let [kDiag : DiagCorDs top (r - l) BBD] : union
-		intersection
-			Rect top 0 (-Width) (Width * 2)
-			union
-				ExtLineCenter  l                top (r - kDiag * BBD) 0 BBS 1
-				ExtLineCenter (l + kDiag * BBD) top  r                0 BBS 1
+		intersection [Rect top 0 [mix Width 0 2] [mix 0 Width 2]] : union
+			ExtLineCenter  l                top (r - kDiag * BBD) 0 BBS 1
+			ExtLineCenter (l + kDiag * BBD) top  r                0 BBS 1
 		HBar.t l (l + kDiag * BBD) top BBS
 		HBar.b r (r - kDiag * BBD) 0   BBS
-		intersection
-			Rect top 0 (-Width) (Width * 2)
-			difference
-				ExtLineCenter l 0 r top BBS 1
-				spiro-outline
-					corner  l                top
-					corner (l + kDiag * BBD) top
-					corner  r                0
-					corner (r - kDiag * BBD) 0
+		intersection [Rect top 0 [mix Width 0 2] [mix 0 Width 2]] : difference
+			ExtLineCenter l 0 r top BBS 1
+			spiro-outline
+				corner  l                top
+				corner (l + kDiag * BBD) top
+				corner  r                0
+				corner (r - kDiag * BBD) 0
 
 	create-glyph 'mathbb/X' 0x1D54F : composite-proc [MarkSet.capital] [BBXShape SB RightSB CAP]
 	create-glyph 'mathbb/x' 0x1D569 : composite-proc [MarkSet.e]       [BBXShape SB RightSB XH]

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1978,6 +1978,7 @@ descriptionAffix = "straight shape"
 selectorAffix.X = "straight"
 selectorAffix."X/sansSerif" = "straight"
 selectorAffix."X/descBase" = "straight"
+selectorAffix."latn/Chi" = "straightDescending"
 selectorAffix."cyrl/Rha/right" = "straight"
 
 [prime.capital-x.variants-buildup.stages.body.curly]
@@ -1986,6 +1987,7 @@ descriptionAffix = "curly shape"
 selectorAffix.X = "curly"
 selectorAffix."X/sansSerif" = "curly"
 selectorAffix."X/descBase" = "curly"
+selectorAffix."latn/Chi" = "curlyDescending"
 selectorAffix."cyrl/Rha/right" = "curly"
 
 [prime.capital-x.variants-buildup.stages.serifs.serifless]
@@ -1995,6 +1997,7 @@ descriptionJoiner = "without"
 selectorAffix.X = "serifless"
 selectorAffix."X/sansSerif" = "serifless"
 selectorAffix."X/descBase" = "serifless"
+selectorAffix."latn/Chi" = "serifless"
 selectorAffix."cyrl/Rha/right" = "serifless"
 
 [prime.capital-x.variants-buildup.stages.serifs.unilateral-motion-serifed]
@@ -2003,6 +2006,7 @@ descriptionAffix = "motion serifs at top-left"
 selectorAffix.X = "unilateralMotionSerifed"
 selectorAffix."X/sansSerif" = "serifless"
 selectorAffix."X/descBase" = "unilateralMotionSerifed"
+selectorAffix."latn/Chi" = "unilateralMotionSerifed"
 selectorAffix."cyrl/Rha/right" = "serifless"
 
 [prime.capital-x.variants-buildup.stages.serifs.bilateral-motion-serifed]
@@ -2011,6 +2015,7 @@ descriptionAffix = "motion serifs at top-left and bottom-right"
 selectorAffix.X = "bilateralMotionSerifed"
 selectorAffix."X/sansSerif" = "serifless"
 selectorAffix."X/descBase" = "unilateralMotionSerifed"
+selectorAffix."latn/Chi" = "bilateralMotionSerifed"
 selectorAffix."cyrl/Rha/right" = "bilateralMotionSerifed"
 
 [prime.capital-x.variants-buildup.stages.serifs.serifed]
@@ -2019,6 +2024,7 @@ descriptionAffix = "serifs"
 selectorAffix.X = "serifed"
 selectorAffix."X/sansSerif" = "serifless"
 selectorAffix."X/descBase" = "serifed"
+selectorAffix."latn/Chi" = "serifed"
 selectorAffix."cyrl/Rha/right" = "serifed"
 
 
@@ -5075,52 +5081,64 @@ next = "serifs"
 
 [prime.x.variants-buildup.stages.body.straight]
 rank = 1
+groupRank = 1
 descriptionAffix = "straight shape"
 selectorAffix.x = "straight"
 selectorAffix."x/sansSerif" = "straight"
 selectorAffix."x/descBase" = "straight"
+selectorAffix."latn/chi" = "straightDescending"
 selectorAffix."cyrl/rha/right" = "straight"
 
 [prime.x.variants-buildup.stages.body.curly]
 rank = 2
+groupRank = 2
 descriptionAffix = "curly shape"
 selectorAffix.x = "curly"
 selectorAffix."x/sansSerif" = "curly"
 selectorAffix."x/descBase" = "curly"
+selectorAffix."latn/chi" = "curlyDescending"
 selectorAffix."cyrl/rha/right" = "curly"
 
 [prime.x.variants-buildup.stages.body.semi-chancery-straight]
 rank = 3
+groupRank = 3
 descriptionAffix = "Semi-chancery shape with straight counter-leg"
 selectorAffix.x = "semiChanceryStraight"
 selectorAffix."x/sansSerif" = "semiChanceryStraight"
 selectorAffix."x/descBase" = "semiChanceryStraight"
+selectorAffix."latn/chi" = "semiChanceryStraightDescending"
 selectorAffix."cyrl/rha/right" = "semiChanceryStraight"
 
 [prime.x.variants-buildup.stages.body.semi-chancery-curly]
 rank = 4
+groupRank = 3
 descriptionAffix = "Semi-chancery shape with curly counter-leg"
 selectorAffix.x = "semiChanceryCurly"
 selectorAffix."x/sansSerif" = "semiChanceryCurly"
 selectorAffix."x/descBase" = "semiChanceryCurly"
+selectorAffix."latn/chi" = "semiChanceryCurlyDescending"
 selectorAffix."cyrl/rha/right" = "semiChanceryCurly"
 
 [prime.x.variants-buildup.stages.body.chancery]
 rank = 5
+groupRank = 4
 next = "END"
 descriptionAffix = "Chancery shape"
 selectorAffix.x = "chancery"
 selectorAffix."x/sansSerif" = "chancery"
 selectorAffix."x/descBase" = "chancery"
+selectorAffix."latn/chi" = "chanceryDescending"
 selectorAffix."cyrl/rha/right" = "chancery"
 
 [prime.x.variants-buildup.stages.body.cursive]
 rank = 6
+groupRank = 4
 next = "END"
 descriptionAffix = "cursive shape"
 selectorAffix.x = "cursive"
 selectorAffix."x/sansSerif" = "cursive"
 selectorAffix."x/descBase" = "cursive"
+selectorAffix."latn/chi" = "cursiveDescending"
 selectorAffix."cyrl/rha/right" = "cursive"
 
 [prime.x.variants-buildup.stages.serifs.serifless]
@@ -5130,6 +5148,7 @@ descriptionJoiner = "without"
 selectorAffix.x = "serifless"
 selectorAffix."x/sansSerif" = "serifless"
 selectorAffix."x/descBase" = "serifless"
+selectorAffix."latn/chi" = "serifless"
 selectorAffix."cyrl/rha/right" = "serifless"
 
 [prime.x.variants-buildup.stages.serifs.unilateral-motion-serifed]
@@ -5139,6 +5158,7 @@ descriptionAffix = "motion serifs at top-left"
 selectorAffix.x = "unilateralMotionSerifed"
 selectorAffix."x/sansSerif" = "serifless"
 selectorAffix."x/descBase" = "unilateralMotionSerifed"
+selectorAffix."latn/chi" = "unilateralMotionSerifed"
 selectorAffix."cyrl/rha/right" = "serifless"
 
 [prime.x.variants-buildup.stages.serifs.bilateral-motion-serifed]
@@ -5148,6 +5168,7 @@ descriptionAffix = "motion serifs at top-left and bottom-right"
 selectorAffix.x = "bilateralMotionSerifed"
 selectorAffix."x/sansSerif" = "serifless"
 selectorAffix."x/descBase" = "unilateralMotionSerifed"
+selectorAffix."latn/chi" = "bilateralMotionSerifed"
 selectorAffix."cyrl/rha/right" = "bilateralMotionSerifed"
 
 [prime.x.variants-buildup.stages.serifs.serifed]
@@ -5156,6 +5177,7 @@ descriptionAffix = "serifs"
 selectorAffix.x = "serifed"
 selectorAffix."x/sansSerif" = "serifless"
 selectorAffix."x/descBase" = "serifed"
+selectorAffix."latn/chi" = "serifed"
 selectorAffix."cyrl/rha/right" = "serifed"
 
 
@@ -5715,12 +5737,12 @@ tagKind = "letter"
 [prime.lower-eth.variants.straight-bar]
 rank = 1
 description = "Lowercase Eth (`ð`) with a straight bar"
-selector."eth" = "straight-bar"
+selector.eth = "straight-bar"
 
 [prime.lower-eth.variants.curly-bar]
 rank = 2
 description = "Lowercase Eth (`ð`) with a curly bar"
-selector."eth" = "curly-bar"
+selector.eth = "curly-bar"
 
 
 
@@ -6724,38 +6746,78 @@ entry = "body"
 descriptionLeader = "Greek lower Chi (`χ`)"
 
 [prime.lower-chi.variants-buildup.stages.body."*"]
-next = "serifs"
+next = "height"
 
 [prime.lower-chi.variants-buildup.stages.body.straight]
 rank = 1
+groupRank = 1
 descriptionAffix = "straight shape"
 selectorAffix."grek/chi" = "straight"
 selectorAffix."grek/chi/sansSerif" = "straight"
 
 [prime.lower-chi.variants-buildup.stages.body.curly]
 rank = 2
+groupRank = 2
 descriptionAffix = "curly shape"
 selectorAffix."grek/chi" = "curly"
 selectorAffix."grek/chi/sansSerif" = "curly"
 
 [prime.lower-chi.variants-buildup.stages.body.semi-chancery-straight]
 rank = 3
+groupRank = 3
 descriptionAffix = "Semi-chancery shape with straight counter-leg"
 selectorAffix."grek/chi" = "semiChanceryStraight"
 selectorAffix."grek/chi/sansSerif" = "semiChanceryStraight"
 
 [prime.lower-chi.variants-buildup.stages.body.semi-chancery-curly]
 rank = 4
+groupRank = 3
 descriptionAffix = "Semi-chancery shape with curly counter-leg"
 selectorAffix."grek/chi" = "semiChanceryCurly"
 selectorAffix."grek/chi/sansSerif" = "semiChanceryCurly"
 
 [prime.lower-chi.variants-buildup.stages.body.chancery]
 rank = 5
-next = "END"
+groupRank = 4
 descriptionAffix = "Chancery shape"
 selectorAffix."grek/chi" = "chancery"
 selectorAffix."grek/chi/sansSerif" = "chancery"
+
+[prime.lower-chi.variants-buildup.stages.height.descending__normal]
+rank = 1
+next = "serifs"
+disableIf = [{ body = "chancery" }]
+keyAffix = ""
+selectorAffix."grek/chi" = "descending"
+selectorAffix."grek/chi/sansSerif" = "descending"
+
+[prime.lower-chi.variants-buildup.stages.height.descending__chancery]
+rank = 1
+next = "END"
+disableIf = [{ body = "NOT chancery" }]
+keyAffix = ""
+selectorAffix."grek/chi" = "descending"
+selectorAffix."grek/chi/sansSerif" = "descending"
+
+[prime.lower-chi.variants-buildup.stages.height.above-baseline__normal]
+rank = 2
+nonBreakingVariantAdditionPriority = 100
+next = "serifs"
+disableIf = [{ body = "chancery" }]
+keyAffix = "above-baseline"
+descriptionAffix = "short height entirely above the baseline"
+selectorAffix."grek/chi" = ""
+selectorAffix."grek/chi/sansSerif" = ""
+
+[prime.lower-chi.variants-buildup.stages.height.above-baseline__chancery]
+rank = 2
+nonBreakingVariantAdditionPriority = 100
+next = "END"
+disableIf = [{ body = "NOT chancery" }]
+keyAffix = "above-baseline"
+descriptionAffix = "short height entirely above the baseline"
+selectorAffix."grek/chi" = ""
+selectorAffix."grek/chi/sansSerif" = ""
 
 [prime.lower-chi.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -11258,6 +11320,7 @@ lower-pi = "small-capital"
 lower-tau = "semi-tailed"
 lower-upsilon = "straight-serifless"
 lower-phi = "neo-hellenic"
+lower-chi = "straight-above-baseline-serifless"
 lower-psi = "flat-top-serifless"
 partial-derivative = "closed-contour"
 cyrl-a = "double-storey-tailed"
@@ -11338,6 +11401,7 @@ lower-kappa = "symmetric-touching-tri-serifed"
 lower-mu = "toothless-corner-serifed"
 lower-nu = "straight-serifed"
 lower-upsilon = "straight-serifed"
+lower-chi = "straight-above-baseline-bilateral-motion-serifed"
 lower-psi = "flat-top-serifed"
 cyrl-capital-ka = "symmetric-touching-serifed"
 cyrl-ka = "symmetric-touching-serifed"
@@ -11536,6 +11600,7 @@ lower-nu = "straight"
 lower-xi = "rounded"
 lower-tau = "flat-tailed"
 lower-upsilon = "straight-serifless"
+lower-chi = "straight-above-baseline-serifless"
 lower-psi = "flat-top-serifless"
 cyrl-a = "double-storey-serifless"
 cyrl-ve = "standard-serifless"
@@ -11609,6 +11674,7 @@ lower-kappa = "symmetric-connected-tri-serifed"
 lower-mu = "toothed-serifed"
 lower-nu = "straight-serifed"
 lower-upsilon = "straight-serifed"
+lower-chi = "straight-above-baseline-bilateral-motion-serifed"
 lower-psi = "flat-top-serifed"
 cyrl-a = "double-storey-serifed"
 cyrl-ve = "standard-bilateral-serifed"
@@ -11692,6 +11758,7 @@ lower-pi = "tailed"
 lower-tau = "flat-tailed"
 lower-upsilon = "straight-serifless"
 lower-chi = "semi-chancery-straight-serifless"
+lower-psi = "short-neck-serifless"
 cyrl-a = "double-storey-tailed"
 cyrl-capital-ka = "symmetric-connected-bottom-right-serifed"
 cyrl-ka = "symmetric-connected-bottom-right-serifed"
@@ -11767,10 +11834,11 @@ w = "straight-flat-top-serifed"
 x = "straight-serifed"
 y = "straight-turn-serifed"
 z = "straight-serifed"
-capital-eszet = "corner-bottom-serifed"
+capital-eszet = "corner-serifed"
 eszet = "traditional-flat-hook-bottom-serifed"
 lower-kappa = "straight-tri-serifed"
 lower-upsilon = "straight-serifed"
+lower-psi = "short-neck-serifed"
 cyrl-capital-ka = "symmetric-connected-serifed"
 cyrl-ka = "symmetric-connected-serifed"
 cyrl-em = "hanging-serifed"
@@ -12055,6 +12123,7 @@ z = "cursive"
 long-s = "bent-hook-descending"
 eszet = "longs-s-lig-descending-serifless"
 lower-kappa = "straight-bottom-right-serifed"
+lower-chi = "chancery"
 cyrl-a = "single-storey-tailed"
 cyrl-ze = "unilateral-bottom-inward-serifed"
 cyrl-ka = "symmetric-connected-bottom-right-serifed"


### PR DESCRIPTION
Ubuntu Mono and Jetbrains Mono use a form of Greek Lower Chi (`χ`) that resembles a Latin Lower X (`x`), or a Small‑Capital Greek Chi (`Χ`).

These variants are implemented in a way that _does not create any new glyphs_ (even when considering the internal `grekLowerChiSerifed` variants). This is accomplished by reworking Latin Chi (`Ꭓ`, `ꭓ`) to be built via `descending` variants of `X`⁠/⁠`x`.

```
ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ
abc.def.ghi.jkl.mno.pqrs.tuv.wxyz
!iIlL17|¦ ¢coO08BDQ $5SZ2zs ∂96µm
float il1[]={1-2/3.4,5+6=7/8%90};
1234567890 ,._-+= >< «¯-¬_» ~–÷+×
{*}[]()<>`+-=$/#_%^@\&|~?'" !,.;:
g9q¶ Þẞðþſß ΓΔΛαβγδηθικλμνξπτυφχψ
ЖЗКНРУЭЯавжзклмнруфчьыэя <= != ==
```

Sans `ss12` upright:
<img width="1692" height="1024" alt="image" src="https://github.com/user-attachments/assets/74d1c95c-7696-4833-b24c-4bc3a1900de5" />
Sans `ss12` italic:
<img width="1696" height="1030" alt="image" src="https://github.com/user-attachments/assets/5cfa3110-cb3b-4b3d-b87e-3e07efe70b8b" />
Slab `ss12` upright:
<img width="1683" height="1016" alt="image" src="https://github.com/user-attachments/assets/2e111170-b8be-4fa9-9f5b-8295fa537702" />
Slab `ss12` italic:
<img width="1692" height="1029" alt="image" src="https://github.com/user-attachments/assets/9ce0489a-bd88-4419-97ef-4eddf54632e0" />
Sans `ss14` upright:
<img width="1690" height="1014" alt="image" src="https://github.com/user-attachments/assets/9a60d0d0-a559-4294-a0c6-ba9ff4827ec2" />
Sans `ss14` italic:
<img width="1687" height="1031" alt="image" src="https://github.com/user-attachments/assets/50500d11-cab2-4066-934f-cc36f3ea71bd" />
Slab `ss14` upright:
<img width="1683" height="1009" alt="image" src="https://github.com/user-attachments/assets/d0d9da32-ee77-4d75-929f-742b5bdd9820" />
Slab `ss14` italic:
<img width="1698" height="1030" alt="image" src="https://github.com/user-attachments/assets/7758046a-9dd8-4033-94c0-2a8706174ed0" />
