### PR TITLE
Add `tall` (descending) variants for Cyrillic Lower Ze (`з`), like Cascadia Code Italic.

### DIFF
--- a/changes/34.4.0.md
+++ b/changes/34.4.0.md
@@ -1,1 +1,2 @@
 * Add `above-baseline` variants for Greek Lower Chi (`χ`).
+* Add `tall` variants for Cyrillic Capital/Lower Ze (`З`, `з`).

--- a/changes/34.4.0.md
+++ b/changes/34.4.0.md
@@ -1,2 +1,2 @@
 * Add `above-baseline` variants for Greek Lower Chi (`χ`).
-* Add `tall` variants for Cyrillic Capital/Lower Ze (`З`, `з`).
+* Add `tall` variants for Cyrillic Lower Ze (`з`).

--- a/packages/font-glyphs/src/letter/cyrillic/de.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/de.ptl
@@ -137,7 +137,7 @@ glyph-block Letter-Cyrillic-De : begin
 				adb    -- adb
 			return : union [ze.Shape] [ze.AutoEndSerifL]
 
-		if (!desc) : begin
+		if (!desc && !st) : begin
 			create-glyph "cyrl/Dzze.\(suffix)" : glyph-proc
 				include : MarkSet.capital
 				include : ExtendBelowBaseAnchors BottomExtension
@@ -194,7 +194,7 @@ glyph-block Letter-Cyrillic-De : begin
 		include : CyrDeItalicShapeT dispiro df
 
 	foreach { suffix { { desc } { st sb } } } [Object.entries ZeConfig] : do
-		if desc : begin
+		if (desc && !st) : begin
 			create-glyph "cyrl/dzze.italic.\(suffix)" : glyph-proc
 				local df : include : DivFrame para.advanceScaleMM 3
 				include : df.markSet.bp

--- a/packages/font-glyphs/src/letter/cyrillic/de.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/de.ptl
@@ -119,7 +119,7 @@ glyph-block Letter-Cyrillic-De : begin
 
 	select-variant 'cyrl/deSoft' 0xA663 (follow -- 'cyrl/enghe/ghePart')
 
-	foreach { suffix { st sb }} [Object.entries ZeConfig] : do
+	foreach { suffix { { desc } { st sb } } } [Object.entries ZeConfig] : do
 		define [DzzeDescendershape de ada adb] : begin
 			local sr : [mix RightSB Width 0.5] - O * 2
 			local sl : mix sr de.xTopRight 2
@@ -137,19 +137,20 @@ glyph-block Letter-Cyrillic-De : begin
 				adb    -- adb
 			return : union [ze.Shape] [ze.AutoEndSerifL]
 
-		create-glyph "cyrl/Dzze.\(suffix)" : glyph-proc
-			include : MarkSet.capital
-			include : ExtendBelowBaseAnchors BottomExtension
-			local de : include : CyrDeShape true CAP SB RightSB
-			eject-contour 'footR'
-			include : DzzeDescendershape de ArchDepthA ArchDepthB
+		if (!desc) : begin
+			create-glyph "cyrl/Dzze.\(suffix)" : glyph-proc
+				include : MarkSet.capital
+				include : ExtendBelowBaseAnchors BottomExtension
+				local de : include : CyrDeShape true CAP SB RightSB
+				eject-contour 'footR'
+				include : DzzeDescendershape de ArchDepthA ArchDepthB
 
-		create-glyph "cyrl/dzze.upright.\(suffix)" : glyph-proc
-			include : MarkSet.e
-			include : ExtendBelowBaseAnchors BottomExtension
-			local de : include : CyrDeShape false XH SB RightSB
-			eject-contour 'footR'
-			include : DzzeDescendershape de SmallArchDepthA SmallArchDepthB
+			create-glyph "cyrl/dzze.upright.\(suffix)" : glyph-proc
+				include : MarkSet.e
+				include : ExtendBelowBaseAnchors BottomExtension
+				local de : include : CyrDeShape false XH SB RightSB
+				eject-contour 'footR'
+				include : DzzeDescendershape de SmallArchDepthA SmallArchDepthB
 
 	create-glyph "cyrl/Dwe" 0xA680 : glyph-proc
 		include : MarkSet.capital
@@ -192,26 +193,27 @@ glyph-block Letter-Cyrillic-De : begin
 		include : df.markSet.b
 		include : CyrDeItalicShapeT dispiro df
 
-	foreach { suffix { st sb }} [Object.entries ZeConfig] : do
-		create-glyph "cyrl/dzze.italic.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.advanceScaleMM 3
-			include : df.markSet.bp
+	foreach { suffix { { desc } { st sb } } } [Object.entries ZeConfig] : do
+		if desc : begin
+			create-glyph "cyrl/dzze.italic.\(suffix)" : glyph-proc
+				local df : include : DivFrame para.advanceScaleMM 3
+				include : df.markSet.bp
 
-			local subDf : df.slice 3 2 OX
-			include : CyrDeItalicShapeT dispiro subDf df.mvs
+				local subDf : df.slice 3 2 OX
+				include : CyrDeItalicShapeT dispiro subDf df.mvs
 
-			local shift : df.width - subDf.width
-			local ze : CyrZe 1 sb XH Descender
-				left      -- ((subDf.leftSB  + OX) + shift)
-				right     -- ((subDf.rightSB - OX) + shift)
-				blend     -- 0.7
-				hook      -- SHook
-				xOverflow -- 0
-				stroke    -- df.mvs
-				ada       -- SmallArchDepthA
-				adb       -- SmallArchDepthB
-			include : union [ze.Shape] [ze.AutoEndSerifL]
+				local shift : df.width - subDf.width
+				local ze : CyrZe 1 sb XH Descender
+					left      -- ((subDf.leftSB  + OX) + shift)
+					right     -- ((subDf.rightSB - OX) + shift)
+					blend     -- 0.7
+					hook      -- SHook
+					xOverflow -- 0
+					stroke    -- df.mvs
+					ada       -- SmallArchDepthA
+					adb       -- SmallArchDepthB
+				include : union [ze.Shape] [ze.AutoEndSerifL]
 
-	select-variant 'cyrl/Dzze' 0xA688  (follow -- 'cyrl/Ze/bottomSerif')
-	select-variant 'cyrl/dzze.upright' (follow -- 'cyrl/ze/bottomSerif')
-	select-variant 'cyrl/dzze.italic'  (follow -- 'cyrl/ze/bottomSerif')
+	select-variant 'cyrl/Dzze' 0xA688  (follow -- 'cyrl/Dzze/Ze')
+	select-variant 'cyrl/dzze.upright' (follow -- 'cyrl/dzze.upright/ze')
+	select-variant 'cyrl/dzze.italic'  (follow -- 'cyrl/dzze.italic/ze')

--- a/packages/font-glyphs/src/letter/cyrillic/dzzhe-zhwe.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/dzzhe-zhwe.ptl
@@ -51,9 +51,9 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 			include : CyrDzzheDeItalicShape df
 
 	do "ze subglyph"
-		define [CyrZhweZeShape slabTop slabBot df top hook ada adb] : glyph-proc
+		define [CyrZhweZeShape slabTop slabBot df top bot hook ada adb] : glyph-proc
 			local [object subDf sw] : SubDfDimBy4 0 2 df OX
-			local ze : CyrZe slabTop slabBot top 0
+			local ze : CyrZe slabTop slabBot top bot
 				left   -- subDf.leftSB
 				right  -- subDf.rightSB
 				hook   -- hook
@@ -63,18 +63,19 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 				adb    -- adb
 			include : union [ze.Shape] [ze.AutoStartSerifL] [ze.AutoEndSerifL]
 
-		foreach { suffix { slabTop slabBot } } [Object.entries ZeConfig] : do
-			create-glyph "cyrl/Zhwe/left.\(suffix)" : glyph-proc
-				define df : include : DivFrame [mix 1 para.advanceScaleMM 2] 3.5
-				include : df.markSet.capital
-				set-base-anchor 'cvDecompose' 0 0
-				include : CyrZhweZeShape slabTop slabBot df CAP Hook ArchDepthA ArchDepthB
+		foreach { suffix { { desc } { slabTop slabBot } } } [Object.entries ZeConfig] : do
+			if (!desc) : begin
+				create-glyph "cyrl/Zhwe/left.\(suffix)" : glyph-proc
+					define df : include : DivFrame [mix 1 para.advanceScaleMM 2] 3.5
+					include : df.markSet.capital
+					set-base-anchor 'cvDecompose' 0 0
+					include : CyrZhweZeShape slabTop slabBot df CAP 0 Hook ArchDepthA ArchDepthB
 
-			create-glyph "cyrl/zhwe/left.\(suffix)" : glyph-proc
-				define df : include : DivFrame [mix 1 para.advanceScaleM 2] 3.5
-				include : df.markSet.e
-				set-base-anchor 'cvDecompose' 0 0
-				include : CyrZhweZeShape slabTop slabBot df XH SHook SmallArchDepthA SmallArchDepthB
+				create-glyph "cyrl/zhwe/left.\(suffix)" : glyph-proc
+					define df : include : DivFrame [mix 1 para.advanceScaleM 2] 3.5
+					include : df.markSet.e
+					set-base-anchor 'cvDecompose' 0 0
+					include : CyrZhweZeShape slabTop slabBot df XH 0 SHook SmallArchDepthA SmallArchDepthB
 
 	do "zhe subglyphs"
 		glyph-block-import Letter-Cyrillic-Zhe : Zhe
@@ -88,9 +89,9 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 			local swInner : [AdviceStroke 2.75] * (sw / Stroke)
 			return : [mix subDf.leftSB subDf.rightSB : StrokeWidthBlend 0.95 0.96] - [HSwToV : 0.5 * swInner]
 
-		define [ZhweZheShape legShape fSlab fMidSlab df top hook ada adb] : glyph-proc
+		define [ZhweZheShape legShape fSlab fMidSlab df top bot hook ada adb] : glyph-proc
 			local [object subDf sw] : SubDfDimBy4 0 2 df OX
-			local zeNoO : CyrZe 0 0 top 0
+			local zeNoO : CyrZe 0 0 top bot
 				left   -- subDf.leftSB
 				right  -- subDf.rightSB
 				hook   -- hook
@@ -135,21 +136,21 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 				define df : include : DivFrame [mix 1 para.advanceScaleMM 2] 3.5
 				include : df.markSet.capital
 				set-base-anchor 'cvDecompose' 0 0
-				include : ZhweZheShape legShape fSlab fMidSlab df CAP Hook ArchDepthA ArchDepthB
+				include : ZhweZheShape legShape fSlab fMidSlab df CAP 0 Hook ArchDepthA ArchDepthB
 
 			create-glyph "cyrl/zhwe/right.\(suffix)" : glyph-proc
 				define df : include : DivFrame [mix 1 para.advanceScaleM 2] 3.5
 				include : df.markSet.e
 				set-base-anchor 'cvDecompose' 0 0
-				include : ZhweZheShape legShape fSlab fMidSlab df XH SHook SmallArchDepthA SmallArchDepthB
+				include : ZhweZheShape legShape fSlab fMidSlab df XH 0 SHook SmallArchDepthA SmallArchDepthB
 
 	select-variant "cyrl/Dzzhe/right" (follow -- "cyrl/Zhe")
 	select-variant "cyrl/dzzhe.upright/right" (follow -- "cyrl/zhe")
 	select-variant "cyrl/dzzhe.italic/right"  (follow -- "cyrl/zhe")
 	select-variant "cyrl/Zhwe/right" (follow -- "cyrl/Zhe")
 	select-variant "cyrl/zhwe/right" (follow -- "cyrl/zhe")
-	select-variant "cyrl/Zhwe/left"  (follow -- "cyrl/Ze")
-	select-variant "cyrl/zhwe/left"  (follow -- "cyrl/ze")
+	select-variant "cyrl/Zhwe/left"  (follow -- "cyrl/Zhwe/Ze")
+	select-variant "cyrl/zhwe/left"  (follow -- "cyrl/zhwe/ze")
 
 	derive-composites 'cyrl/Dzzhe' 0x52A 'cyrl/Dzzhe/left' 'cyrl/Dzzhe/right'
 	derive-composites 'cyrl/dzzhe.upright' null 'cyrl/dzzhe.upright/left' 'cyrl/dzzhe.upright/right'

--- a/packages/font-glyphs/src/letter/cyrillic/iotified-a.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/iotified-a.ptl
@@ -166,8 +166,8 @@ glyph-block Letter-Cyrillic-Iotified-A : begin
 	do "Iotified e"
 		glyph-block-import Letter-Latin-C : CLetterForm CConfig
 
-		foreach { suffix { sty styBot fMidSerif } } [Object.entries CConfig] : do
-			define [IotifiedEShape fCapital df top ada adb] : glyph-proc
+		foreach { suffix { sty styBot } } [Object.entries CConfig] : do
+			define [IotifiedEShape fCapital fMidSerif df top ada adb] : glyph-proc
 				local sw : Math.min df.mvs : AdviceStroke2 2 3 top (0.75 * df.adws)
 				local gap : 0.375 * (df.rightSB - df.leftSB) - [HSwToV : 0.25 * sw] + sw / 16
 				local subDf : DivFrame [Math.min ((df.width - gap) / Width) (0.75 * df.adws)] 2
@@ -198,12 +198,20 @@ glyph-block Letter-Cyrillic-Iotified-A : begin
 			create-glyph "cyrl/EIotified.\(suffix)" : glyph-proc
 				local df : include : DivFrame para.advanceScaleM 3
 				include : df.markSet.capital
-				include : IotifiedEShape true df CAP ArchDepthA ArchDepthB
+				include : IotifiedEShape true false df CAP ArchDepthA ArchDepthB
+			create-glyph "cyrl/EIotified.\(suffix)Capped" : glyph-proc
+				local df : include : DivFrame para.advanceScaleM 3
+				include : df.markSet.capital
+				include : IotifiedEShape true true df CAP ArchDepthA ArchDepthB
 
 			create-glyph "cyrl/eIotified.\(suffix)" : glyph-proc
 				local df : include : DivFrame para.advanceScaleM 3
 				include : df.markSet.e
-				include : IotifiedEShape false df XH SmallArchDepthA SmallArchDepthB
+				include : IotifiedEShape false false df XH SmallArchDepthA SmallArchDepthB
+			create-glyph "cyrl/eIotified.\(suffix)Capped" : glyph-proc
+				local df : include : DivFrame para.advanceScaleM 3
+				include : df.markSet.e
+				include : IotifiedEShape false true df XH SmallArchDepthA SmallArchDepthB
 
 	do "Latin iotified e"
 		glyph-block-import Letter-Latin-Lower-E : SmallEConfig

--- a/packages/font-glyphs/src/letter/cyrillic/ze.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/ze.ptl
@@ -9,7 +9,7 @@ glyph-module
 glyph-block Letter-Cyrillic-Ze : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Mark-Shared-Metrics : markFine
+	glyph-block-import Mark-Shared-Metrics : markFine markMiddle
 	glyph-block-import Mark-Adjustment : ExtendBelowBaseAnchors
 	glyph-block-import Letter-Shared : CreateTurnedLetter
 	glyph-block-import Letter-Shared-Shapes : SerifedArcStart SerifedArcEnd SerifFrame
@@ -238,36 +238,32 @@ glyph-block Letter-Cyrillic-Ze : begin
 				__ : glyph-proc
 
 	glyph-block-export ZeConfig
-	define ZeConfig : object
-		serifless               { SLAB-NONE      SLAB-NONE      }
-		bottomSerifed           { SLAB-NONE      SLAB-CLASSICAL }
-		bottomInwardSerifed     { SLAB-NONE      SLAB-INWARD    }
-		unilateralSerifed       { SLAB-CLASSICAL SLAB-NONE      }
-		bilateralSerifed        { SLAB-CLASSICAL SLAB-CLASSICAL }
-		unilateralInwardSerifed { SLAB-INWARD    SLAB-NONE      }
-		bilateralInwardSerifed  { SLAB-INWARD    SLAB-INWARD    }
-		hybridSerifed1          { SLAB-INWARD    SLAB-CLASSICAL }
+	define ZeConfig : SuffixCfg.weave
+		object # height
+			""                      { 0         'capital' 'e' }
+			tall                    { Descender 'capDesc' 'p' }
+		object # serifs
+			serifless               { SLAB-NONE      SLAB-NONE      }
+			bottomSerifed           { SLAB-NONE      SLAB-CLASSICAL }
+			bottomInwardSerifed     { SLAB-NONE      SLAB-INWARD    }
+			unilateralSerifed       { SLAB-CLASSICAL SLAB-NONE      }
+			bilateralSerifed        { SLAB-CLASSICAL SLAB-CLASSICAL }
+			unilateralInwardSerifed { SLAB-INWARD    SLAB-NONE      }
+			bilateralInwardSerifed  { SLAB-INWARD    SLAB-INWARD    }
+			hybridSerifed1          { SLAB-INWARD    SLAB-CLASSICAL }
 
-	foreach { suffix { slabTop slabBot } } [Object.entries ZeConfig] : do
+	foreach { suffix { { bottom mkCap mkXH } { slabTop slabBot } } } [Object.entries ZeConfig] : do
 		create-glyph "cyrl/Ze.\(suffix)" : glyph-proc
-			include : MarkSet.capital
-			local ze : CyrZe slabTop slabBot CAP 0
+			include : MarkSet.(mkCap)
+			local ze : CyrZe slabTop slabBot CAP bottom
 				hook -- Hook
 				ada  -- ArchDepthA
 				adb  -- ArchDepthB
 			include : union [ze.Shape] [ze.AutoStartSerifL] [ze.AutoEndSerifL]
 
 		create-glyph "cyrl/ze.\(suffix)" : glyph-proc
-			include : MarkSet.e
-			local ze : CyrZe slabTop slabBot XH 0
-				hook -- SHook
-				ada  -- SmallArchDepthA
-				adb  -- SmallArchDepthB
-			include : union [ze.Shape] [ze.AutoStartSerifL] [ze.AutoEndSerifL]
-
-		create-glyph "cyrl/ze.BGR.\(suffix)" : glyph-proc
-			include : MarkSet.p
-			local ze : CyrZe slabTop slabBot XH Descender
+			include : MarkSet.(mkXH)
+			local ze : CyrZe slabTop slabBot XH bottom
 				hook -- SHook
 				ada  -- SmallArchDepthA
 				adb  -- SmallArchDepthB
@@ -275,43 +271,43 @@ glyph-block Letter-Cyrillic-Ze : begin
 
 		create-glyph "cyrl/Dhe.\(suffix)" : glyph-proc
 			include [refer-glyph "cyrl/Ze.\(suffix)"] AS_BASE ALSO_METRICS
-			local desc : (-LongVJut) + QuarterStroke
+			local desc : bottom - LongVJut + QuarterStroke
 			include : ExtendBelowBaseAnchors desc
-			local zeNoO : CyrZe slabTop slabBot CAP 0
+			local zeNoO : CyrZe slabTop slabBot CAP bottom
 				hook -- Hook
 				ada  -- ArchDepthA
 				adb  -- ArchDepthB
 				xo   -- 0
 				yo   -- 0
 			include : difference
-				VBar.m [Arch.adjust-x.bot Middle] desc (O + Stroke) VJutStroke
+				VBar.m [Arch.adjust-x.bot Middle] desc (bottom + O + Stroke) VJutStroke
 				zeNoO.ShapeMask
 
 		create-glyph "cyrl/dhe.\(suffix)" : glyph-proc
 			include [refer-glyph "cyrl/ze.\(suffix)"] AS_BASE ALSO_METRICS
-			local desc : (-LongVJut) + QuarterStroke
+			local desc : bottom - LongVJut + QuarterStroke
 			include : ExtendBelowBaseAnchors desc
-			local zeNoO : CyrZe slabTop slabBot XH 0
+			local zeNoO : CyrZe slabTop slabBot XH bottom
 				hook -- SHook
 				ada  -- SmallArchDepthA
 				adb  -- SmallArchDepthB
 				xo   -- 0
 				yo   -- 0
 			include : difference
-				VBar.m [Arch.adjust-x.bot Middle] desc (O + Stroke) VJutStroke
+				VBar.m [Arch.adjust-x.bot Middle] desc (bottom + O + Stroke) VJutStroke
 				zeNoO.ShapeMask
 
-		create-glyph "latn/Epsilon.\(suffix)" : glyph-proc
-			include : MarkSet.capital
-			local eps : SmallEpsilon slabTop slabBot CAP 0
+		create-glyph "cyrl/revZe.\(suffix)" : glyph-proc
+			include : MarkSet.(mkCap)
+			local eps : SmallEpsilon slabTop slabBot CAP bottom
 				hook -- Hook
 				ada  -- ArchDepthA
 				adb  -- ArchDepthB
 			include : union [eps.Shape] [eps.AutoStartSerifR] [eps.AutoEndSerifR]
 
-		create-glyph "latn/epsilon.\(suffix)" : glyph-proc
-			include : MarkSet.e
-			local eps : SmallEpsilon slabTop slabBot XH 0
+		create-glyph "cyrl/revze.\(suffix)" : glyph-proc
+			include : MarkSet.(mkXH)
+			local eps : SmallEpsilon slabTop slabBot XH bottom
 				hook -- SHook
 				ada  -- SmallArchDepthA
 				adb  -- SmallArchDepthB
@@ -319,124 +315,125 @@ glyph-block Letter-Cyrillic-Ze : begin
 
 		create-glyph "cyrl/zeRhoticHook.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleM 1
-			include : df.markSet.e
-			local dfSub : DivFrame (0.75 * para.advanceScaleM) 2
-			local stroke : dfSub.adviceStroke2 2 3 XH
-			local ze : CyrZe slabTop slabBot XH 0
-				left   -- dfSub.leftSB
-				right  -- dfSub.rightSB
+			include : df.markSet.(mkXH)
+			local subDf : DivFrame (0.75 * para.advanceScaleM) 2
+			local stroke : subDf.adviceStroke2 2 3 (XH - bottom)
+			local ze : CyrZe slabTop slabBot XH bottom
+				left   -- subDf.leftSB
+				right  -- subDf.rightSB
 				hook   -- SHook
-				ada    -- [dfSub.archDepthAOf SmallArchDepth stroke]
-				adb    -- [dfSub.archDepthBOf SmallArchDepth stroke]
+				ada    -- [subDf.archDepthAOf SmallArchDepth stroke]
+				adb    -- [subDf.archDepthBOf SmallArchDepth stroke]
 				stroke -- stroke
 			include : union [ze.Shape] [ze.AutoStartSerifL] [ze.AutoEndSerifL]
-			include : RhoticHookShape (dfSub.rightSB - [HSwToV : 1.25 * markFine]) df.width (XH * 0.825) (XH * 0.2)
+			include : RhoticHookShape (subDf.rightSB - [HSwToV : 1.25 * markFine]) df.width [mix bottom XH 0.825] [mix bottom XH 0.2]
 
-		create-glyph "cyrl/DzjeKomi.\(suffix)" : glyph-proc
-			include : MarkSet.capital
-			local ze : CyrZe slabTop OPEN-VERTICAL CAP 0
-				hook -- Hook
-				ada  -- ArchDepthA
-				adb  -- ArchDepthB
-			include : union [ze.Shape] [ze.AutoStartSerifL]
-			include : CyrDescender.rSideJut (RightSB - OX * 2) 0
+		if (!bottom) : begin
+			create-glyph "cyrl/DzjeKomi.\(suffix)" : glyph-proc
+				include : MarkSet.capital
+				local ze : CyrZe slabTop OPEN-VERTICAL CAP 0
+					hook -- Hook
+					ada  -- ArchDepthA
+					adb  -- ArchDepthB
+				include : union [ze.Shape] [ze.AutoStartSerifL]
+				include : CyrDescender.rSideJut (RightSB - OX * 2) 0
 
-		create-glyph "cyrl/dzjeKomi.\(suffix)" : glyph-proc
-			include : MarkSet.e
-			local ze : CyrZe slabTop OPEN-VERTICAL XH 0
-				hook -- SHook
-				ada  -- SmallArchDepthA
-				adb  -- SmallArchDepthB
-			include : union [ze.Shape] [ze.AutoStartSerifL]
-			include : CyrDescender.rSideJut (RightSB - OX * 2) 0
+			create-glyph "cyrl/dzjeKomi.\(suffix)" : glyph-proc
+				include : MarkSet.e
+				local ze : CyrZe slabTop OPEN-VERTICAL XH 0
+					hook -- SHook
+					ada  -- SmallArchDepthA
+					adb  -- SmallArchDepthB
+				include : union [ze.Shape] [ze.AutoStartSerifL]
+				include : CyrDescender.rSideJut (RightSB - OX * 2) 0
 
-		create-glyph "cyrl/ZjeKomi.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.advanceScaleMM 3
-			include : df.markSet.capital
+			create-glyph "cyrl/ZjeKomi.\(suffix)" : glyph-proc
+				local df : include : DivFrame para.advanceScaleMM 3
+				include : df.markSet.capital
 
-			local xm : df.middle + [HSwToV : 0.5 * df.mvs]
-			local ze : CyrZe slabTop OPEN-HALF CAP 0
-				left   -- df.leftSB
-				right  -- xm
-				hook   -- Hook
-				ada    -- ArchDepthA
-				adb    -- ArchDepthB
-				stroke -- df.mvs
-			define [object stroke midy] : ze.Dim
-			include : union [ze.Shape] [ze.AutoStartSerifL]
-			include : UpwardHookShape
-				left   -- (xm - OX * 2 - [HSwToV stroke])
-				right  -- df.rightSB
-				ybegin -- [YSmoothMidR (midy + stroke / 2) 0 ArchDepthA ArchDepthB]
-				yend   -- (CAP / 2 + HalfStroke)
-				ada    -- (ArchDepthA * (2 / df.hPack) * df.adws)
-				adb    -- (ArchDepthB * (2 / df.hPack) * df.adws)
-				sw     -- stroke
-			if SLAB : begin
-				local sf2 : [SerifFrame.fromDf df (CAP / 2 + HalfStroke) 0].slice 1 2
-				include sf2.rt.full
+				local xm : df.middle + [HSwToV : 0.5 * df.mvs]
+				local ze : CyrZe slabTop OPEN-HALF CAP 0
+					left   -- df.leftSB
+					right  -- xm
+					hook   -- Hook
+					ada    -- ArchDepthA
+					adb    -- ArchDepthB
+					stroke -- df.mvs
+				define [object stroke midy] : ze.Dim
+				include : union [ze.Shape] [ze.AutoStartSerifL]
+				include : UpwardHookShape
+					left   -- (xm - OX * 2 - [HSwToV stroke])
+					right  -- df.rightSB
+					ybegin -- [YSmoothMidR (midy + stroke / 2) 0 ArchDepthA ArchDepthB]
+					yend   -- (CAP / 2 + HalfStroke)
+					ada    -- (ArchDepthA * (2 / df.hPack) * df.adws)
+					adb    -- (ArchDepthB * (2 / df.hPack) * df.adws)
+					sw     -- stroke
+				if SLAB : begin
+					local sf2 : [SerifFrame.fromDf df (CAP / 2 + HalfStroke) 0].slice 1 2
+					include sf2.rt.full
 
-		create-glyph "cyrl/zjeKomi.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.advanceScaleMM 3
-			include : df.markSet.e
+			create-glyph "cyrl/zjeKomi.\(suffix)" : glyph-proc
+				local df : include : DivFrame para.advanceScaleMM 3
+				include : df.markSet.e
 
-			local xm : df.middle + [HSwToV : 0.5 * df.mvs]
-			local ze : CyrZe slabTop OPEN-HALF XH 0
-				left   -- df.leftSB
-				right  -- xm
-				hook   -- SHook
-				ada    -- SmallArchDepthA
-				adb    -- SmallArchDepthB
-				stroke -- df.mvs
-			define [object stroke midy] : ze.Dim
-			include : union [ze.Shape] [ze.AutoStartSerifL]
-			include : UpwardHookShape
-				left   -- (xm - OX * 2 - [HSwToV stroke])
-				right  -- df.rightSB
-				ybegin -- [YSmoothMidR (midy + stroke / 2) 0 SmallArchDepthA SmallArchDepthB]
-				yend   -- (XH / 2 + HalfStroke)
-				ada    -- (ArchDepthA * (2 / df.hPack) * df.adws)
-				adb    -- (ArchDepthB * (2 / df.hPack) * df.adws)
-				sw     -- stroke
-			if SLAB : begin
-				local sf2 : [SerifFrame.fromDf df (XH / 2 + HalfStroke) 0].slice 1 2
-				include sf2.rt.full
+				local xm : df.middle + [HSwToV : 0.5 * df.mvs]
+				local ze : CyrZe slabTop OPEN-HALF XH 0
+					left   -- df.leftSB
+					right  -- xm
+					hook   -- SHook
+					ada    -- SmallArchDepthA
+					adb    -- SmallArchDepthB
+					stroke -- df.mvs
+				define [object stroke midy] : ze.Dim
+				include : union [ze.Shape] [ze.AutoStartSerifL]
+				include : UpwardHookShape
+					left   -- (xm - OX * 2 - [HSwToV stroke])
+					right  -- df.rightSB
+					ybegin -- [YSmoothMidR (midy + stroke / 2) 0 SmallArchDepthA SmallArchDepthB]
+					yend   -- (XH / 2 + HalfStroke)
+					ada    -- (ArchDepthA * (2 / df.hPack) * df.adws)
+					adb    -- (ArchDepthB * (2 / df.hPack) * df.adws)
+					sw     -- stroke
+				if SLAB : begin
+					local sf2 : [SerifFrame.fromDf df (XH / 2 + HalfStroke) 0].slice 1 2
+					include sf2.rt.full
 
-		create-glyph "cyrl/Ksi/base.\(suffix)" : glyph-proc
-			include : MarkSet.capDesc
-			local ze : CyrZe slabTop SLAB-NONE CAP 0
-				hook -- Hook
-				ada  -- ArchDepthA
-				adb  -- ArchDepthB
-			include : union [ze.KsiBaseShape] [ze.AutoStartSerifL]
+			create-glyph "cyrl/Ksi/base.\(suffix)" : glyph-proc
+				include : MarkSet.capDesc
+				local ze : CyrZe slabTop SLAB-NONE CAP 0
+					hook -- Hook
+					ada  -- ArchDepthA
+					adb  -- ArchDepthB
+				include : union [ze.KsiBaseShape] [ze.AutoStartSerifL]
 
-		create-glyph "cyrl/ksi/base.\(suffix)" : glyph-proc
-			include : MarkSet.p
-			local ze : CyrZe slabTop SLAB-NONE XH 0
-				hook -- SHook
-				ada  -- SmallArchDepthA
-				adb  -- SmallArchDepthB
-			include : union [ze.KsiBaseShape] [ze.AutoStartSerifL]
+			create-glyph "cyrl/ksi/base.\(suffix)" : glyph-proc
+				include : MarkSet.p
+				local ze : CyrZe slabTop SLAB-NONE XH 0
+					hook -- SHook
+					ada  -- SmallArchDepthA
+					adb  -- SmallArchDepthB
+				include : union [ze.KsiBaseShape] [ze.AutoStartSerifL]
 
 	select-variant 'cyrl/Ze' 0x417
 	select-variant 'cyrl/ze' 0x437
-	select-variant 'cyrl/ze.BGR' (follow -- 'cyrl/ze')
+	select-variant 'cyrl/ze.BGR' (shapeFrom -- 'cyrl/ze')
 
 	select-variant 'cyrl/Dhe' 0x498 (follow -- 'cyrl/Ze')
 	select-variant 'cyrl/dhe' 0x499 (follow -- 'cyrl/ze')
 
-	select-variant 'latn/Epsilon' 0x190
-	select-variant 'latn/epsilon' 0x25B
-	alias 'grek/epsilon' 0x3B5 'latn/epsilon.serifless'
+	select-variant 'latn/Epsilon' 0x190 (shapeFrom -- 'cyrl/revZe')
+	select-variant 'latn/epsilon' 0x25B (shapeFrom -- 'cyrl/revze')
+	alias 'grek/epsilon' 0x3B5 'cyrl/revze.serifless'
 
 	CreateTurnedLetter 'turnepsilon' 0x1D08 'latn/epsilon' HalfAdvance (XH / 2)
 
-	alias 'cyrl/Epsilon' 0x510 'latn/Epsilon'
-	alias 'cyrl/epsilon' 0x511 'latn/epsilon'
+	select-variant 'cyrl/revZe' 0x510
+	select-variant 'cyrl/revze' 0x511
 
-	alias 'latn/revEpsilon' 0xA7AB 'cyrl/Ze'
-	alias 'latn/revepsilon' 0x25C  'cyrl/ze'
-	select-variant 'latn/revepsilonRhoticHook' 0x25D (shapeFrom -- 'cyrl/zeRhoticHook') (follow -- 'cyrl/ze')
+	select-variant 'latn/revEpsilon' 0xA7AB (shapeFrom -- 'cyrl/Ze')
+	select-variant 'latn/revepsilon' 0x25C  (shapeFrom -- 'cyrl/ze')
+	select-variant 'latn/revepsilonRhoticHook' 0x25D (shapeFrom -- 'cyrl/zeRhoticHook') (follow -- 'latn/revepsilon')
 
 	select-variant 'cyrl/ZjeKomi'  0x504 (follow -- 'cyrl/Ze/topSerif')
 	select-variant 'cyrl/zjeKomi'  0x505 (follow -- 'cyrl/ze/topSerif')
@@ -448,30 +445,40 @@ glyph-block Letter-Cyrillic-Ze : begin
 
 	derive-multi-part-glyphs 'cyrl/Dhe.BSH' null { 'cyrl/Ze' 'invCommaBelow' } : lambda [srcs gr] : glyph-proc
 		local { base mark } srcs
-		include : refer-glyph mark
-		include : Translate Width AccentClearance
+		define baseGlyph : query-glyph base
+		include : with-transform
+			ApparentTranslate
+				[Arch.adjust-x.bot Middle]    - markMiddle
+				baseGlyph.baseAnchors.below.y + AccentClearance
+			refer-glyph mark
 		include [refer-glyph base] AS_BASE ALSO_METRICS
-		include : ExtendBelowBaseAnchors (-AccentHeight)
+		include : ExtendBelowBaseAnchors (baseGlyph.baseAnchors.below.y - AccentHeight)
 
 	derive-multi-part-glyphs 'cyrl/dhe.BSH' null { 'cyrl/ze' 'invCommaBelow' } : lambda [srcs gr] : glyph-proc
 		local { base mark } srcs
-		include : refer-glyph mark
-		include : Translate Width AccentClearance
+		define baseGlyph : query-glyph base
+		include : with-transform
+			ApparentTranslate
+				[Arch.adjust-x.bot Middle]    - markMiddle
+				baseGlyph.baseAnchors.below.y + AccentClearance
+			refer-glyph mark
 		include [refer-glyph base] AS_BASE ALSO_METRICS
-		include : ExtendBelowBaseAnchors (-AccentHeight)
+		include : ExtendBelowBaseAnchors (baseGlyph.baseAnchors.below.y - AccentHeight)
 
-	select-variant 'latn/epsilon/descBase' (shapeFrom -- 'latn/epsilon')
+	select-variant 'latn/epsilon/descBase' (shapeFrom -- 'cyrl/revze')
 	derive-composites 'latn/epsilonRetroflexHook' 0x1D93 'latn/epsilon/descBase'
 		RetroflexHook.r RightSB 0 (refSw -- [AdviceStroke2 2 3 XH])
 
-	select-variant 'latn/revepsilon/descBase' (shapeFrom -- 'cyrl/ze') (follow -- 'cyrl/ze/descBase')
+	select-variant 'latn/revepsilon/descBase' (shapeFrom -- 'cyrl/ze')
 	derive-composites 'latn/revepsilonRetroflexHook' 0x1D94 'latn/revepsilon/descBase'
 		RetroflexHook.l SB 0 (refSw -- [AdviceStroke2 2 3 XH])
 
 	create-glyph 'voicedLaryngealSpirant' 0x1D24 : glyph-proc
 		include : MarkSet.b
 		local blend 0.505
-		local midGap : Math.max [AdviceStroke2 3 12 Ascender] (Ascender / 8 - [AdviceStroke2 3 6 XH])
+		local midGap : Math.max
+			[mix 0 Ascender 0.000] + [AdviceStroke2 3 12 (Ascender - 0)]
+			[mix 0 Ascender 0.125] - [AdviceStroke2 3  6 (XH       - 0)]
 		local strokeV : AdviceStroke 4
 		local ze : CyrZe SLAB-NONE SLAB-NONE Ascender midGap
 			blend -- blend

--- a/packages/font-glyphs/src/letter/cyrillic/ze.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/ze.ptl
@@ -156,21 +156,26 @@ glyph-block Letter-Cyrillic-Ze : begin
 				[Just SLAB-INWARD]    : ArcEndSerif.InwardL   left bot stroke hook
 				__ : glyph-proc
 
-	define flex-params [SmallEpsilon] : namespace
+	define flex-params [CyrRevZe] : namespace
 		local-parameter : slabTop
 		local-parameter : slabBot
 		local-parameter : top
 		local-parameter : bot
+		local-parameter : left      -- SB
+		local-parameter : right     -- RightSB
 		local-parameter : blend     -- StdBlend
 		local-parameter : hook      -- Hook
 		local-parameter : stroke    -- [AdviceStroke2 2 3 : top - bot]
 		local-parameter : xOverflow -- [HSwToV stroke]
+		local-parameter : xo        -- OX
+		local-parameter : yo        -- O
+		local-parameter : barPos    -- OverlayPos
 		local-parameter : ada       -- SmallArchDepthA
 		local-parameter : adb       -- SmallArchDepthB
 
 		export : define [Dim] : begin
-			local midx : mix (SB + ([HSwToV stroke] - xOverflow)) (RightSB - ([HSwToV stroke] - xOverflow)) blend
-			local midy : mix bot top OverlayPos
+			local midx : mix (left + ([HSwToV stroke] - xOverflow)) (right - ([HSwToV stroke] - xOverflow)) blend
+			local midy : mix bot top barPos
 			local fine : stroke * CThin
 			local shoulderFine : ShoulderFine * (stroke / Stroke)
 			return : object stroke midx midy fine shoulderFine
@@ -179,21 +184,21 @@ glyph-block Letter-Cyrillic-Ze : begin
 			define [object stroke midx midy fine shoulderFine] : Dim
 			return : dispiro
 				match slabTop
-					[Just SLAB-CLASSICAL] : SerifedArcStart.RtlLhs RightSB top stroke hook
-					[Just SLAB-INWARD] : InwardSlabArcStart.RtlLhs RightSB top stroke hook
-					[Just OPEN-VERTICAL] : flat SB top [widths.lhs.heading stroke Downward]
+					[Just SLAB-CLASSICAL] : SerifedArcStart.RtlLhs right top stroke hook (o -- yo)
+					[Just SLAB-INWARD] : InwardSlabArcStart.RtlLhs right top stroke hook (o -- yo)
+					[Just OPEN-VERTICAL] : flat left top [widths.lhs.heading stroke Downward]
 					([Just CLOSED-CIRCLE] || [Just CLOSED-ROUND]) : list
-						flat (RightSB - [if (slabTop === CLOSED-CIRCLE) OX 0]) midy [widths.lhs stroke]
-						curl (RightSB - [if (slabTop === CLOSED-CIRCLE) OX 0]) [Math.max (top - adb) (midy + TINY)]
-						Arch.lhs top (sw -- stroke)
+						flat (right - [if (slabTop === CLOSED-CIRCLE) xo 0]) midy [widths.lhs stroke]
+						curl (right - [if (slabTop === CLOSED-CIRCLE) xo 0]) [Math.max (top - adb) (midy + TINY)]
+						Arch.lhs top (sw -- stroke) (o -- yo)
 					[Just CLOSED-STEM] : list
-						flat (RightSB - [HSwToV : stroke - shoulderFine]) midy [widths.lhs shoulderFine]
-						curl (RightSB - [HSwToV : stroke - shoulderFine]) [Math.max (top - adb) (midy + TINY)]
-						Arch.lhs top (sw -- stroke) (swBefore -- shoulderFine)
+						flat (right - [HSwToV : stroke - shoulderFine]) midy [widths.lhs shoulderFine]
+						curl (right - [HSwToV : stroke - shoulderFine]) [Math.max (top - adb) (midy + TINY)]
+						Arch.lhs top (sw -- stroke) (swBefore -- shoulderFine) (o -- yo)
 					__ : list
-						g4   (RightSB + OX) (top - hook) [widths.lhs]
-						HookStart top (sw -- stroke)
-				[if (slabTop === OPEN-VERTICAL) curl g4] SB [YSmoothMidL top (midy - stroke / 2) ada adb]
+						g4   (right + xo) (top - hook) [widths.lhs]
+						HookStart top (sw -- stroke) (o -- yo)
+				[if (slabTop === OPEN-VERTICAL) curl g4] left [YSmoothMidL top (midy - stroke / 2) ada adb]
 				arcvh
 				flat Middle (midy + (stroke / 2 - fine)) [widths.heading fine 0 Rightward]
 				curl midx   (midy + (stroke / 2 - fine)) [heading Rightward]
@@ -204,37 +209,37 @@ glyph-block Letter-Cyrillic-Ze : begin
 				flat midx   (midy - (stroke / 2 - fine)) [widths.heading fine 0 Leftward]
 				curl Middle (midy - (stroke / 2 - fine)) [heading Leftward]
 				archv
-				[if (slabBot === OPEN-VERTICAL) flat g4] (SB + OX * 2) [YSmoothMidL (midy + stroke / 2) bot ada adb] [widths.lhs stroke]
+				[if (slabBot === OPEN-VERTICAL) flat g4] (left + xo * 2) [YSmoothMidL (midy + stroke / 2) bot ada adb] [widths.lhs stroke]
 				match slabBot
-					[Just SLAB-CLASSICAL] : SerifedArcEnd.LtrLhs RightSB bot stroke hook
-					[Just SLAB-INWARD] : InwardSlabArcEnd.LtrLhs RightSB bot stroke hook
-					[Just OPEN-VERTICAL] : curl (SB + OX * 2) bot [heading Downward]
+					[Just SLAB-CLASSICAL] : SerifedArcEnd.LtrLhs right bot stroke hook (o -- yo)
+					[Just SLAB-INWARD] : InwardSlabArcEnd.LtrLhs right bot stroke hook (o -- yo)
+					[Just OPEN-VERTICAL] : curl (left + xo * 2) bot [heading Downward]
 					([Just CLOSED-CIRCLE] || [Just CLOSED-ROUND]) : list
-						Arch.lhs bot (sw -- stroke)
-						flat (RightSB - [if (slabBot === CLOSED-CIRCLE) OX 0]) [Math.min (bot + ada) (midy - TINY)]
-						curl (RightSB - [if (slabBot === CLOSED-CIRCLE) OX 0]) midy
+						Arch.lhs bot (sw -- stroke) (o -- yo)
+						flat (right - [if (slabBot === CLOSED-CIRCLE) xo 0]) [Math.min (bot + ada) (midy - TINY)]
+						curl (right - [if (slabBot === CLOSED-CIRCLE) xo 0]) midy
 					[Just CLOSED-STEM] : list
-						Arch.lhs bot (sw -- stroke) (swAfter -- shoulderFine)
-						flat (RightSB - [HSwToV : stroke - shoulderFine]) [Math.min (bot + ada) (midy - TINY)] [widths.lhs shoulderFine]
-						curl (RightSB - [HSwToV : stroke - shoulderFine]) midy
+						Arch.lhs bot (sw -- stroke) (swAfter -- shoulderFine) (o -- yo)
+						flat (right - [HSwToV : stroke - shoulderFine]) [Math.min (bot + ada) (midy - TINY)] [widths.lhs shoulderFine]
+						curl (right - [HSwToV : stroke - shoulderFine]) midy
 					__ : list
-						HookEnd bot (sw -- stroke)
-						g4   (RightSB - OX) (bot + hook)
+						HookEnd bot (sw -- stroke) (o -- yo)
+						g4   (right - xo) (bot + hook)
 
 		export : define [Shape] : union [UpperShape] [LowerShape]
 
 		export : define [AutoStartSerifR] : begin
 			define [object stroke] : Dim
 			return : match slabTop
-				[Just SLAB-CLASSICAL] : ArcStartSerif.R       RightSB top stroke hook
-				[Just SLAB-INWARD]    : ArcStartSerif.InwardR RightSB top stroke hook
+				[Just SLAB-CLASSICAL] : ArcStartSerif.R       right top stroke hook
+				[Just SLAB-INWARD]    : ArcStartSerif.InwardR right top stroke hook
 				__ : glyph-proc
 
 		export : define [AutoEndSerifR] : begin
 			define [object stroke] : Dim
 			return : match slabBot
-				[Just SLAB-CLASSICAL] : ArcEndSerif.R         RightSB bot stroke hook
-				[Just SLAB-INWARD]    : ArcEndSerif.InwardR   RightSB bot stroke hook
+				[Just SLAB-CLASSICAL] : ArcEndSerif.R         right bot stroke hook
+				[Just SLAB-INWARD]    : ArcEndSerif.InwardR   right bot stroke hook
 				__ : glyph-proc
 
 	glyph-block-export ZeConfig
@@ -297,22 +302,6 @@ glyph-block Letter-Cyrillic-Ze : begin
 				VBar.m [Arch.adjust-x.bot Middle] desc (bottom + O + Stroke) VJutStroke
 				zeNoO.ShapeMask
 
-		create-glyph "cyrl/revZe.\(suffix)" : glyph-proc
-			include : MarkSet.(mkCap)
-			local eps : SmallEpsilon slabTop slabBot CAP bottom
-				hook -- Hook
-				ada  -- ArchDepthA
-				adb  -- ArchDepthB
-			include : union [eps.Shape] [eps.AutoStartSerifR] [eps.AutoEndSerifR]
-
-		create-glyph "cyrl/revze.\(suffix)" : glyph-proc
-			include : MarkSet.(mkXH)
-			local eps : SmallEpsilon slabTop slabBot XH bottom
-				hook -- SHook
-				ada  -- SmallArchDepthA
-				adb  -- SmallArchDepthB
-			include : union [eps.Shape] [eps.AutoStartSerifR] [eps.AutoEndSerifR]
-
 		create-glyph "cyrl/zeRhoticHook.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleM 1
 			include : df.markSet.(mkXH)
@@ -327,6 +316,22 @@ glyph-block Letter-Cyrillic-Ze : begin
 				stroke -- stroke
 			include : union [ze.Shape] [ze.AutoStartSerifL] [ze.AutoEndSerifL]
 			include : RhoticHookShape (subDf.rightSB - [HSwToV : 1.25 * markFine]) df.width [mix bottom XH 0.825] [mix bottom XH 0.2]
+
+		create-glyph "cyrl/revZe.\(suffix)" : glyph-proc
+			include : MarkSet.(mkCap)
+			local revZe : CyrRevZe slabTop slabBot CAP bottom
+				hook -- Hook
+				ada  -- ArchDepthA
+				adb  -- ArchDepthB
+			include : union [revZe.Shape] [revZe.AutoStartSerifR] [revZe.AutoEndSerifR]
+
+		create-glyph "cyrl/revze.\(suffix)" : glyph-proc
+			include : MarkSet.(mkXH)
+			local revZe : CyrRevZe slabTop slabBot XH bottom
+				hook -- SHook
+				ada  -- SmallArchDepthA
+				adb  -- SmallArchDepthB
+			include : union [revZe.Shape] [revZe.AutoStartSerifR] [revZe.AutoEndSerifR]
 
 		if (!bottom) : begin
 			create-glyph "cyrl/DzjeKomi.\(suffix)" : glyph-proc
@@ -487,13 +492,13 @@ glyph-block Letter-Cyrillic-Ze : begin
 			adb   -- ArchDepthB
 		local dimUpper : ze.Dim
 
-		local epsilon : SmallEpsilon SLAB-NONE SLAB-NONE (Ascender - midGap) 0
+		local revZe : CyrRevZe SLAB-NONE SLAB-NONE (Ascender - midGap) 0
 			blend -- blend
 			hook  -- Hook
 			ada   -- ArchDepthA
 			adb   -- ArchDepthB
-		local dimLower : epsilon.Dim
-		include : union [epsilon.LowerShape] [ze.UpperShape] : Rect
+		local dimLower : revZe.Dim
+		include : union [revZe.LowerShape] [ze.UpperShape] : Rect
 			dimUpper.midy + dimUpper.stroke / 2
 			dimLower.midy - dimLower.stroke / 2
 			Middle - [HSwToV : 0.5 * strokeV]
@@ -502,13 +507,13 @@ glyph-block Letter-Cyrillic-Ze : begin
 	do "Closed Epsilon Shapes"
 		create-glyph 'latn/epsilonClosed' 0x29A : glyph-proc
 			include : MarkSet.e
-			local eps : SmallEpsilon CLOSED-CIRCLE CLOSED-CIRCLE XH 0
+			local revZe : CyrRevZe CLOSED-CIRCLE CLOSED-CIRCLE XH 0
 				blend     -- 0.7
 				hook      -- SHook
 				xOverflow -- 0
 				ada       -- SmallArchDepthA
 				adb       -- SmallArchDepthB
-			include : eps.Shape
+			include : revZe.Shape
 
 		create-glyph 'latn/revepsilonClosed' 0x25E : glyph-proc
 			include : MarkSet.e
@@ -522,47 +527,47 @@ glyph-block Letter-Cyrillic-Ze : begin
 
 		create-glyph 'OeVolapuk' 0xA79C : glyph-proc
 			include : MarkSet.capital
-			local eps : SmallEpsilon CLOSED-CIRCLE CLOSED-CIRCLE CAP 0
+			local revZe : CyrRevZe CLOSED-CIRCLE CLOSED-CIRCLE CAP 0
 				blend     -- VolBlend
 				hook      -- Hook
 				xOverflow -- 0
 				ada       -- ArchDepthA
 				adb       -- ArchDepthB
-			include : eps.Shape
+			include : revZe.Shape
 
 		create-glyph 'oeVolapuk' 0xA79D : glyph-proc
 			include : MarkSet.e
-			local eps : SmallEpsilon CLOSED-CIRCLE CLOSED-CIRCLE XH 0
+			local revZe : CyrRevZe CLOSED-CIRCLE CLOSED-CIRCLE XH 0
 				blend     -- VolBlend
 				hook      -- SHook
 				xOverflow -- 0
 				ada       -- SmallArchDepthA
 				adb       -- SmallArchDepthB
-			include : eps.Shape
+			include : revZe.Shape
 
 	do "Volapuk AE"
 		glyph-block-import Letter-Latin-Lower-A : SingleStorey
 
 		define [FullBarBody df top bar hook ada adb] : glyph-proc
-			local eps : SmallEpsilon CLOSED-STEM CLOSED-STEM top 0
+			local revZe : CyrRevZe CLOSED-STEM CLOSED-STEM top 0
 				blend     -- VolBlend
 				hook      -- hook
 				xOverflow -- 0
 				ada       -- ada
 				adb       -- adb
-			define [object stroke] : eps.Dim
-			include : eps.Shape
+			define [object stroke] : revZe.Dim
+			include : revZe.Shape
 			include : bar df top stroke
 
 		define [TopCutBody df top bar hook ada adb] : glyph-proc
-			local eps : SmallEpsilon CLOSED-STEM CLOSED-STEM top 0
+			local revZe : CyrRevZe CLOSED-STEM CLOSED-STEM top 0
 				blend     -- VolBlend
 				hook      -- hook
 				xOverflow -- 0
 				ada       -- ada
 				adb       -- adb
-			define [object stroke] : eps.Dim
-			include : eps.Shape
+			define [object stroke] : revZe.Dim
+			include : revZe.Shape
 			include : bar df (top - HalfStroke) stroke
 			include : spiro-outline
 				corner  df.rightSB                     top
@@ -570,25 +575,25 @@ glyph-block Letter-Cyrillic-Ze : begin
 				corner (df.rightSB - [HSwToV stroke]) (top - HalfStroke)
 
 		define [EarlessCornerBody df top bar hook ada adb] : glyph-proc
-			local eps : SmallEpsilon SLAB-INWARD CLOSED-STEM top 0
+			local revZe : CyrRevZe SLAB-INWARD CLOSED-STEM top 0
 				blend     -- VolBlend
 				hook      -- hook
 				xOverflow -- 0
 				ada       -- ada
 				adb       -- adb
-			define [object stroke] : eps.Dim
-			include : eps.Shape
+			define [object stroke] : revZe.Dim
+			include : revZe.Shape
 			include : bar df (top - DToothlessRise) stroke
 
 		define [EarlessRoundedBody df top bar hook ada adb] : glyph-proc
-			local eps : SmallEpsilon CLOSED-ROUND CLOSED-STEM top 0
+			local revZe : CyrRevZe CLOSED-ROUND CLOSED-STEM top 0
 				blend     -- VolBlend
 				hook      -- hook
 				xOverflow -- 0
 				ada       -- ada
 				adb       -- adb
-			define [object stroke] : eps.Dim
-			include : eps.Shape
+			define [object stroke] : revZe.Dim
+			include : revZe.Shape
 			include : bar df (top - adb) stroke
 
 		define SingleStoreyConfig : object
@@ -630,51 +635,51 @@ glyph-block Letter-Cyrillic-Ze : begin
 
 		define [UToothed df top slab hook ada adb] : glyph-proc
 			set-base-anchor 'trailing' df.rightSB 0
-			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-STEM top 0
+			local revZe : CyrRevZe OPEN-VERTICAL CLOSED-STEM top 0
 				blend     -- VolBlend
 				hook      -- hook
 				xOverflow -- 0
 				ada       -- ada
 				adb       -- adb
-			define [object stroke] : eps.Dim
-			include : eps.Shape
+			define [object stroke] : revZe.Dim
+			include : revZe.Shape
 			include : VBar.r df.rightSB 0 top stroke
 			include : slab df top stroke
 
 		define [UTailed df top slab hook ada adb] : glyph-proc
 			set-base-anchor 'trailing' (df.rightSB + SideJut) 0
-			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-STEM top 0
+			local revZe : CyrRevZe OPEN-VERTICAL CLOSED-STEM top 0
 				blend     -- VolBlend
 				hook      -- hook
 				xOverflow -- 0
 				ada       -- ada
 				adb       -- adb
-			define [object stroke] : eps.Dim
-			include : eps.Shape
+			define [object stroke] : revZe.Dim
+			include : revZe.Shape
 			include : RightwardTailedBar df.rightSB 0 top stroke
 			include : slab df top stroke
 
 		define [UToothlessRounded df top slab hook ada adb] : glyph-proc
-			local eps : SmallEpsilon OPEN-VERTICAL CLOSED-ROUND top 0
+			local revZe : CyrRevZe OPEN-VERTICAL CLOSED-ROUND top 0
 				blend     -- VolBlend
 				hook      -- hook
 				xOverflow -- 0
 				ada       -- ada
 				adb       -- adb
-			define [object stroke] : eps.Dim
-			include : eps.Shape
+			define [object stroke] : revZe.Dim
+			include : revZe.Shape
 			include : VBar.r df.rightSB ada top stroke
 			include : slab df top stroke
 
 		define [UToothlessCorner df top slab hook ada adb] : glyph-proc
-			local eps : SmallEpsilon OPEN-VERTICAL SLAB-INWARD top 0
+			local revZe : CyrRevZe OPEN-VERTICAL SLAB-INWARD top 0
 				blend     -- VolBlend
 				hook      -- hook
 				xOverflow -- 0
 				ada       -- ada
 				adb       -- adb
-			define [object stroke] : eps.Dim
-			include : eps.Shape
+			define [object stroke] : revZe.Dim
+			include : revZe.Shape
 			include : VBar.r df.rightSB DToothlessRise top stroke
 			include : slab df top stroke
 

--- a/packages/font-glyphs/src/letter/cyrillic/ze.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/ze.ptl
@@ -333,7 +333,7 @@ glyph-block Letter-Cyrillic-Ze : begin
 				adb  -- SmallArchDepthB
 			include : union [revZe.Shape] [revZe.AutoStartSerifR] [revZe.AutoEndSerifR]
 
-		if (!bottom) : begin
+		if (!bottom && !slabBot) : begin
 			create-glyph "cyrl/DzjeKomi.\(suffix)" : glyph-proc
 				include : MarkSet.capital
 				local ze : CyrZe slabTop OPEN-VERTICAL CAP 0

--- a/packages/font-glyphs/src/letter/latin/c.ptl
+++ b/packages/font-glyphs/src/letter/latin/c.ptl
@@ -131,22 +131,16 @@ glyph-block Letter-Latin-C : begin
 
 	glyph-block-export CConfig
 	define CConfig : object
-		serifless                  { SLAB-NONE      SLAB-NONE      false }
-		bottomSerifed              { SLAB-NONE      SLAB-CLASSICAL false }
-		bottomInwardSerifed        { SLAB-NONE      SLAB-INWARD    false }
-		unilateralSerifed          { SLAB-CLASSICAL SLAB-NONE      false }
-		bilateralSerifed           { SLAB-CLASSICAL SLAB-CLASSICAL false }
-		unilateralInwardSerifed    { SLAB-INWARD    SLAB-NONE      false }
-		bilateralInwardSerifed     { SLAB-INWARD    SLAB-INWARD    false }
-		hybridSerifed1             { SLAB-INWARD    SLAB-CLASSICAL false }
-		bottomMidSerifed           { SLAB-NONE      SLAB-CLASSICAL true  }
-		bottomInwardMidSerifed     { SLAB-NONE      SLAB-INWARD    true  }
-		unilateralMidSerifed       { SLAB-CLASSICAL SLAB-NONE      true  }
-		bilateralMidSerifed        { SLAB-CLASSICAL SLAB-CLASSICAL true  }
-		unilateralInwardMidSerifed { SLAB-INWARD    SLAB-NONE      true  }
-		bilateralInwardMidSerifed  { SLAB-INWARD    SLAB-INWARD    true  }
+		serifless                  { SLAB-NONE      SLAB-NONE      }
+		bottomSerifed              { SLAB-NONE      SLAB-CLASSICAL }
+		bottomInwardSerifed        { SLAB-NONE      SLAB-INWARD    }
+		unilateralSerifed          { SLAB-CLASSICAL SLAB-NONE      }
+		bilateralSerifed           { SLAB-CLASSICAL SLAB-CLASSICAL }
+		unilateralInwardSerifed    { SLAB-INWARD    SLAB-NONE      }
+		bilateralInwardSerifed     { SLAB-INWARD    SLAB-INWARD    }
+		hybridSerifed1             { SLAB-INWARD    SLAB-CLASSICAL }
 
-	foreach { suffix { sty styBot fMidSerif } } [Object.entries CConfig] : do
+	foreach { suffix { sty styBot } } [Object.entries CConfig] : do
 		create-glyph "C.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			local lf : CLetterForm [DivFrame 1] sty styBot CAP 0
@@ -265,7 +259,7 @@ glyph-block Letter-Latin-C : begin
 				adb -- [df.archDepthBOf SmallArchDepth Stroke]
 			include : lf.full
 
-		define [CyrEShepe fCapital df top ada adb] : glyph-proc
+		define [CyrEShepe fCapital fMidSerif df top ada adb] : glyph-proc
 			local sw : Math.min df.mvs : AdviceStroke2 2 3 top df.adws
 			local lf : CLetterForm df sty styBot top 0
 				ada -- ada
@@ -284,7 +278,7 @@ glyph-block Letter-Latin-C : begin
 					VSwToH : [if fCapital 0.800 0.625] * ((df.rightSB - [HSwToV sw]) - [if fCapital xMidBarLeft : df.leftSB + [HSwToV sw]])
 				include : VSerif.ml (xMidBarLeft - [if fCapital 0 : HSwToV : 0.5 * swVJut]) (top / 2) jutMid swVJut
 
-		define [CyrYeShape fCapital df top ada adb] : glyph-proc
+		define [CyrYeShape fCapital fMidSerif df top ada adb] : glyph-proc
 			local sw : Math.min df.mvs : AdviceStroke2 2 3 top df.adws
 			local lf : CLetterForm df sty styBot top 0
 				ada -- ada
@@ -305,21 +299,35 @@ glyph-block Letter-Latin-C : begin
 
 		create-glyph "cyrl/E.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : CyrEShepe true [DivFrame 1] CAP ArchDepthA ArchDepthB
+			include : CyrEShepe true false [DivFrame 1] CAP ArchDepthA ArchDepthB
+		create-glyph "cyrl/E.\(suffix)Capped" : glyph-proc
+			include : MarkSet.capital
+			include : CyrEShepe true true [DivFrame 1] CAP ArchDepthA ArchDepthB
 
 		create-glyph "cyrl/e.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			set-base-anchor 'cvDecompose' 0 0
-			include : CyrEShepe false [DivFrame 1] XH SmallArchDepthA SmallArchDepthB
+			include : CyrEShepe false false [DivFrame 1] XH SmallArchDepthA SmallArchDepthB
+		create-glyph "cyrl/e.\(suffix)Capped" : glyph-proc
+			include : MarkSet.e
+			set-base-anchor 'cvDecompose' 0 0
+			include : CyrEShepe false true [DivFrame 1] XH SmallArchDepthA SmallArchDepthB
 
 		create-glyph "cyrl/YeUkrainian.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : CyrYeShape true [DivFrame 1] CAP ArchDepthA ArchDepthB
+			include : CyrYeShape true false [DivFrame 1] CAP ArchDepthA ArchDepthB
+		create-glyph "cyrl/YeUkrainian.\(suffix)Capped" : glyph-proc
+			include : MarkSet.capital
+			include : CyrYeShape true true [DivFrame 1] CAP ArchDepthA ArchDepthB
 
 		create-glyph "cyrl/yeUkrainian.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			set-base-anchor 'cvDecompose' 0 0
-			include : CyrYeShape false [DivFrame 1] XH SmallArchDepthA SmallArchDepthB
+			include : CyrYeShape false false [DivFrame 1] XH SmallArchDepthA SmallArchDepthB
+		create-glyph "cyrl/yeUkrainian.\(suffix)Capped" : glyph-proc
+			include : MarkSet.e
+			set-base-anchor 'cvDecompose' 0 0
+			include : CyrYeShape false true [DivFrame 1] XH SmallArchDepthA SmallArchDepthB
 
 		define [CyrKoppaShapeT base styTop styBot top] : union
 			VBar.r (Middle + [HSwToV Stroke]) Descender HalfStroke

--- a/packages/font-glyphs/src/letter/latin/c.ptl
+++ b/packages/font-glyphs/src/letter/latin/c.ptl
@@ -8,6 +8,7 @@ glyph-module
 glyph-block Letter-Latin-C : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
+	glyph-block-import Mark-Shared-Metrics : markMiddle
 	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors ExtendBelowBaseAnchors LeaningAnchor
 	glyph-block-import Letter-Shared : CreateAccentedComposition CreateDependentComposite
 	glyph-block-import Letter-Shared-Metrics : EFVJutLength
@@ -446,35 +447,41 @@ glyph-block Letter-Latin-C : begin
 
 	derive-glyphs 'cyrl/The' 0x4AA "cyrl/Es" : function [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
-		local desc : (-LongVJut) + QuarterStroke
+		local desc : 0 - LongVJut + QuarterStroke
 		include : ExtendBelowBaseAnchors desc
 		include : difference
-			VBar.m [Arch.adjust-x.bot Middle] desc (Stroke + O) VJutStroke
+			VBar.m [Arch.adjust-x.bot Middle] desc (O + Stroke) VJutStroke
 			OShapeOutline.NoOvershoot CAP 0 SB RightSB Stroke ArchDepthA ArchDepthB
 
 	derive-multi-part-glyphs 'cyrl/The.BSH' null { 'cyrl/Es' 'invCommaBelow' } : lambda [srcs gr] : glyph-proc
 		local { base mark } srcs
-		include : refer-glyph mark
-		include : Translate Width AccentClearance
+		include : with-transform
+			ApparentTranslate
+				[Arch.adjust-x.bot Middle] - markMiddle
+				0                          + AccentClearance
+			refer-glyph mark
 		include [refer-glyph base] AS_BASE ALSO_METRICS
-		include : ExtendBelowBaseAnchors (-AccentHeight)
+		include : ExtendBelowBaseAnchors (0 - AccentHeight)
 
 	alias 'cyrl/The.CHU' null 'CCedilla'
 
 	derive-glyphs 'cyrl/the' 0x4AB "cyrl/es" : function [src gr] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
-		local desc : (-LongVJut) + QuarterStroke
+		local desc : 0 - LongVJut + QuarterStroke
 		include : ExtendBelowBaseAnchors desc
 		include : difference
-			VBar.m [Arch.adjust-x.bot Middle] desc (Stroke + O) VJutStroke
+			VBar.m [Arch.adjust-x.bot Middle] desc (O + Stroke) VJutStroke
 			OShapeOutline.NoOvershoot XH 0 SB RightSB Stroke SmallArchDepthA SmallArchDepthB
 
 	derive-multi-part-glyphs 'cyrl/the.BSH' null { 'cyrl/es' 'invCommaBelow' } : lambda [srcs gr] : glyph-proc
 		local { base mark } srcs
-		include : refer-glyph mark
-		include : Translate Width AccentClearance
+		include : with-transform
+			ApparentTranslate
+				[Arch.adjust-x.bot Middle] - markMiddle
+				0                          + AccentClearance
+			refer-glyph mark
 		include [refer-glyph base] AS_BASE ALSO_METRICS
-		include : ExtendBelowBaseAnchors (-AccentHeight)
+		include : ExtendBelowBaseAnchors (0 - AccentHeight)
 
 	alias 'cyrl/the.CHU' null 'cCedilla'
 
@@ -515,7 +522,7 @@ glyph-block Letter-Latin-C : begin
 		define [xTop df] : mix df.leftSB df.rightSB (0.5 + sl)
 
 		define swBarThick : AdviceStroke 3
-		define swBarFine : AdviceStroke [StrokeWidthBlend 3 5.5]
+		define swBarFine  : AdviceStroke [StrokeWidthBlend 3.0 5.5]
 
 		define [FullBar df sw] : dispiro
 			flat [xBot df] bot [widths.center.heading sw Downward]
@@ -525,10 +532,10 @@ glyph-block Letter-Latin-C : begin
 			local cofine : AdviceStroke 4
 			return : union
 				dispiro
-					flat [xTop df] top [widths.center.heading cofine Downward]
+					flat [xTop df]      top          [widths.center.heading cofine    Downward]
 					curl df.middle [mix top bot 0.5] [widths.center.heading swBarFine Downward]
 				dispiro
-					flat [xBot df] bot [widths.center.heading cofine Upward]
+					flat [xBot df]      bot          [widths.center.heading cofine    Upward]
 					curl df.middle [mix bot top 0.5] [widths.center.heading swBarFine Upward]
 
 		define [OutlineMask df] : lift-@ : spiro-outline
@@ -549,9 +556,10 @@ glyph-block Letter-Latin-C : begin
 			DependentSelector.set currentGlyph selector
 
 			include : difference [FullBar df swBarThick] [OutlineMask df]
-			if (fillType === 1) : include : intersection [FullBar df swBarFine] [OutlineMask df]
-			if (fillType === 2) : include : intersection [InterruptBar df]
-				difference [OutlineMask df] [InterruptMask df]
+			include : match fillType
+				[Just 1] : intersection [FullBar df swBarFine] [OutlineMask df]
+				[Just 2] : intersection [InterruptBar df] [difference [OutlineMask df] [InterruptMask df]]
+				__       : no-shape
 
 	select-variant 'cent/bar' (follow -- 'cent')
 

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -349,28 +349,28 @@ glyph-block Letter-Latin-Lower-E : begin
 			create-glyph "schwaRhoticHook.\(suffix).\(suffixSerif)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
-				local dfSub : DivFrame (0.75 * para.advanceScaleM) 2
-				local stroke : dfSub.adviceStroke2 2 3 XH
-				include : Body dfSub XH
+				local subDf : DivFrame (0.75 * para.advanceScaleM) 2
+				local stroke : subDf.adviceStroke2 2 3 XH
+				include : Body subDf XH
 					stroke -- stroke
 					hook   -- AHook
-					ada    -- [dfSub.archDepthAOf SmallArchDepth stroke]
-					adb    -- [dfSub.archDepthBOf SmallArchDepth stroke]
+					ada    -- [subDf.archDepthAOf SmallArchDepth stroke]
+					adb    -- [subDf.archDepthBOf SmallArchDepth stroke]
 					turned -- true
 					styTop -- styTop
 					styBot -- styBot
-				include : RhoticHookShape (dfSub.rightSB - [HSwToV : 1.25 * markFine]) rhoticDf.width [mix 0 XH DesignParameters.eBarPos] [mix 0 XH 0.2]
+				include : RhoticHookShape (subDf.rightSB - [HSwToV : 1.25 * markFine]) rhoticDf.width [mix 0 XH DesignParameters.eBarPos] [mix 0 XH 0.2]
 
 			create-glyph "schwaRetroflexHook.\(suffix).\(suffixSerif)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
-				local dfSub : DivFrame (0.75 * para.advanceScaleM) 2
-				local stroke : dfSub.adviceStroke2 2 3 XH
-				include : Body dfSub XH
+				local subDf : DivFrame (0.75 * para.advanceScaleM) 2
+				local stroke : subDf.adviceStroke2 2 3 XH
+				include : Body subDf XH
 					stroke -- stroke
 					hook   -- AHook
-					ada    -- [dfSub.archDepthAOf SmallArchDepth stroke]
-					adb    -- [dfSub.archDepthBOf SmallArchDepth stroke]
+					ada    -- [subDf.archDepthAOf SmallArchDepth stroke]
+					adb    -- [subDf.archDepthBOf SmallArchDepth stroke]
 					turned -- true
 					styTop -- styTop
 					styBot -- styBot
@@ -378,7 +378,7 @@ glyph-block Letter-Latin-Lower-E : begin
 					x       -- [mix RightSB rhoticDf.width 0.5]
 					y       -- 0
 					yAttach -- ([mix 0 XH DesignParameters.eBarPos] - HalfStroke)
-					xLink   -- (dfSub.rightSB - [HSwToV : 0.5 * stroke])
+					xLink   -- (subDf.rightSB - [HSwToV : 0.5 * stroke])
 					refSw   -- [AdviceStroke 4]
 
 			create-glyph "cyrl/abk/Che.\(suffix).\(suffixSerif)" : glyph-proc

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -6746,7 +6746,7 @@ entry = "body"
 descriptionLeader = "Greek lower Chi (`χ`)"
 
 [prime.lower-chi.variants-buildup.stages.body."*"]
-next = "height"
+next = "bottom"
 
 [prime.lower-chi.variants-buildup.stages.body.straight]
 rank = 1
@@ -6783,7 +6783,7 @@ descriptionAffix = "Chancery shape"
 selectorAffix."grek/chi" = "chancery"
 selectorAffix."grek/chi/sansSerif" = "chancery"
 
-[prime.lower-chi.variants-buildup.stages.height.descending__normal]
+[prime.lower-chi.variants-buildup.stages.bottom.descending__normal]
 rank = 1
 next = "serifs"
 disableIf = [{ body = "chancery" }]
@@ -6791,7 +6791,7 @@ keyAffix = ""
 selectorAffix."grek/chi" = "descending"
 selectorAffix."grek/chi/sansSerif" = "descending"
 
-[prime.lower-chi.variants-buildup.stages.height.descending__chancery]
+[prime.lower-chi.variants-buildup.stages.bottom.descending__chancery]
 rank = 1
 next = "END"
 disableIf = [{ body = "NOT chancery" }]
@@ -6799,23 +6799,23 @@ keyAffix = ""
 selectorAffix."grek/chi" = "descending"
 selectorAffix."grek/chi/sansSerif" = "descending"
 
-[prime.lower-chi.variants-buildup.stages.height.above-baseline__normal]
+[prime.lower-chi.variants-buildup.stages.bottom.above-baseline__normal]
 rank = 2
 nonBreakingVariantAdditionPriority = 100
 next = "serifs"
 disableIf = [{ body = "chancery" }]
 keyAffix = "above-baseline"
-descriptionAffix = "short height entirely above the baseline"
+descriptionAffix = "short body that sits entirely above the baseline"
 selectorAffix."grek/chi" = ""
 selectorAffix."grek/chi/sansSerif" = ""
 
-[prime.lower-chi.variants-buildup.stages.height.above-baseline__chancery]
+[prime.lower-chi.variants-buildup.stages.bottom.above-baseline__chancery]
 rank = 2
 nonBreakingVariantAdditionPriority = 100
 next = "END"
 disableIf = [{ body = "NOT chancery" }]
 keyAffix = "above-baseline"
-descriptionAffix = "short height entirely above the baseline"
+descriptionAffix = "short body that sits entirely above the baseline"
 selectorAffix."grek/chi" = ""
 selectorAffix."grek/chi/sansSerif" = ""
 
@@ -7189,61 +7189,112 @@ sampler = "З"
 samplerExplain = "Cyrillic Capital Ze"
 tagKind = "letter"
 
-[prime.cyrl-capital-ze.variants.serifless]
+[prime.cyrl-capital-ze.variants-buildup]
+entry = "height"
+descriptionLeader = "Cyrillic Capital Ze (`З`)"
+
+[prime.cyrl-capital-ze.variants-buildup.stages.height."*"]
+next = "serifs"
+
+[prime.cyrl-capital-ze.variants-buildup.stages.height.non-descending]
 rank = 1
-description = "Serifless Cyrillic Capital Ze (`З`)"
-selector."latn/Epsilon" = "serifless"
-selector."cyrl/Ze" = "serifless"
-selector."cyrl/Ze/topSerif" = "serifless"
-selector."cyrl/Ze/bottomSerif" = "serifless"
+keyAffix = ""
+selectorAffix."cyrl/Ze" = ""
+selectorAffix."cyrl/Ze/topSerif" = ""
+selectorAffix."cyrl/revZe" = ""
+selectorAffix."cyrl/Zhwe/Ze" = ""
+selectorAffix."cyrl/Dzze/Ze" = ""
+selectorAffix."latn/Epsilon" = ""
+selectorAffix."latn/revEpsilon" = ""
 
-[prime.cyrl-capital-ze.variants.unilateral-serifed]
+[prime.cyrl-capital-ze.variants-buildup.stages.height.tall]
 rank = 2
-description = "Cyrillic Capital Ze (`З`) with serif at top"
-selector."latn/Epsilon" = "unilateralSerifed"
-selector."cyrl/Ze" = "unilateralSerifed"
-selector."cyrl/Ze/topSerif" = "unilateralSerifed"
-selector."cyrl/Ze/bottomSerif" = "serifless"
+descriptionAffix = "tall body that descends below the baseline"
+selectorAffix."cyrl/Ze" = "tall"
+selectorAffix."cyrl/Ze/topSerif" = ""
+selectorAffix."cyrl/revZe" = "tall"
+selectorAffix."cyrl/Zhwe/Ze" = ""
+selectorAffix."cyrl/Dzze/Ze" = ""
+selectorAffix."latn/Epsilon" = ""
+selectorAffix."latn/revEpsilon" = ""
 
-[prime.cyrl-capital-ze.variants.unilateral-bottom-serifed]
+[prime.cyrl-capital-ze.variants-buildup.stages.serifs.serifless]
+rank = 1
+descriptionAffix = "serifs"
+descriptionJoiner = "without"
+selectorAffix."cyrl/Ze" = "serifless"
+selectorAffix."cyrl/Ze/topSerif" = "serifless"
+selectorAffix."cyrl/revZe" = "serifless"
+selectorAffix."cyrl/Zhwe/Ze" = "serifless"
+selectorAffix."cyrl/Dzze/Ze" = "serifless"
+selectorAffix."latn/Epsilon" = "serifless"
+selectorAffix."latn/revEpsilon" = "serifless"
+
+[prime.cyrl-capital-ze.variants-buildup.stages.serifs.unilateral-serifed]
+rank = 2
+descriptionAffix = "serif at top"
+selectorAffix."cyrl/Ze" = "unilateralSerifed"
+selectorAffix."cyrl/Ze/topSerif" = "unilateralSerifed"
+selectorAffix."cyrl/revZe" = "unilateralSerifed"
+selectorAffix."cyrl/Zhwe/Ze" = "unilateralSerifed"
+selectorAffix."cyrl/Dzze/Ze" = "serifless"
+selectorAffix."latn/Epsilon" = "unilateralSerifed"
+selectorAffix."latn/revEpsilon" = "unilateralSerifed"
+
+[prime.cyrl-capital-ze.variants-buildup.stages.serifs.unilateral-bottom-serifed]
 rank = 3
-description = "Cyrillic Capital Ze (`З`) with serif at bottom"
-selector."latn/Epsilon" = "unilateralSerifed"
-selector."cyrl/Ze" = "bottomSerifed"
-selector."cyrl/Ze/topSerif" = "serifless"
-selector."cyrl/Ze/bottomSerif" = "bottomSerifed"
+descriptionAffix = "serif at bottom"
+selectorAffix."cyrl/Ze" = "bottomSerifed"
+selectorAffix."cyrl/Ze/topSerif" = "serifless"
+selectorAffix."cyrl/revZe" = "unilateralSerifed"
+selectorAffix."cyrl/Zhwe/Ze" = "bottomSerifed"
+selectorAffix."cyrl/Dzze/Ze" = "bottomSerifed"
+selectorAffix."latn/Epsilon" = "unilateralSerifed"
+selectorAffix."latn/revEpsilon" = "bottomSerifed"
 
-[prime.cyrl-capital-ze.variants.bilateral-serifed]
+[prime.cyrl-capital-ze.variants-buildup.stages.serifs.bilateral-serifed]
 rank = 4
-description = "Cyrillic Capital Ze (`З`) with serif at both top and bottom"
-selector."latn/Epsilon" = "bilateralSerifed"
-selector."cyrl/Ze" = "bilateralSerifed"
-selector."cyrl/Ze/topSerif" = "unilateralSerifed"
-selector."cyrl/Ze/bottomSerif" = "bottomSerifed"
+descriptionAffix = "serif at both top and bottom"
+selectorAffix."cyrl/Ze" = "bilateralSerifed"
+selectorAffix."cyrl/Ze/topSerif" = "unilateralSerifed"
+selectorAffix."cyrl/revZe" = "bilateralSerifed"
+selectorAffix."cyrl/Zhwe/Ze" = "bilateralSerifed"
+selectorAffix."cyrl/Dzze/Ze" = "bottomSerifed"
+selectorAffix."latn/Epsilon" = "bilateralSerifed"
+selectorAffix."latn/revEpsilon" = "bilateralSerifed"
 
-[prime.cyrl-capital-ze.variants.unilateral-inward-serifed]
+[prime.cyrl-capital-ze.variants-buildup.stages.serifs.unilateral-inward-serifed]
 rank = 5
-description = "Cyrillic Capital Ze (`З`) with inward serif at top"
-selector."latn/Epsilon" = "unilateralInwardSerifed"
-selector."cyrl/Ze" = "unilateralInwardSerifed"
-selector."cyrl/Ze/topSerif" = "unilateralInwardSerifed"
-selector."cyrl/Ze/bottomSerif" = "serifless"
+descriptionAffix = "inward serif at top"
+selectorAffix."cyrl/Ze" = "unilateralInwardSerifed"
+selectorAffix."cyrl/Ze/topSerif" = "unilateralInwardSerifed"
+selectorAffix."cyrl/revZe" = "unilateralInwardSerifed"
+selectorAffix."cyrl/Zhwe/Ze" = "unilateralInwardSerifed"
+selectorAffix."cyrl/Dzze/Ze" = "serifless"
+selectorAffix."latn/Epsilon" = "unilateralInwardSerifed"
+selectorAffix."latn/revEpsilon" = "unilateralInwardSerifed"
 
-[prime.cyrl-capital-ze.variants.unilateral-bottom-inward-serifed]
+[prime.cyrl-capital-ze.variants-buildup.stages.serifs.unilateral-bottom-inward-serifed]
 rank = 6
-description = "Cyrillic Capital Ze (`З`) with inward serif at bottom"
-selector."latn/Epsilon" = "unilateralInwardSerifed"
-selector."cyrl/Ze" = "bottomInwardSerifed"
-selector."cyrl/Ze/topSerif" = "serifless"
-selector."cyrl/Ze/bottomSerif" = "bottomInwardSerifed"
+descriptionAffix = "inward serif at bottom"
+selectorAffix."cyrl/Ze" = "bottomInwardSerifed"
+selectorAffix."cyrl/Ze/topSerif" = "serifless"
+selectorAffix."cyrl/revZe" = "unilateralInwardSerifed"
+selectorAffix."cyrl/Zhwe/Ze" = "bottomInwardSerifed"
+selectorAffix."cyrl/Dzze/Ze" = "bottomInwardSerifed"
+selectorAffix."latn/Epsilon" = "unilateralInwardSerifed"
+selectorAffix."latn/revEpsilon" = "bottomInwardSerifed"
 
-[prime.cyrl-capital-ze.variants.bilateral-inward-serifed]
+[prime.cyrl-capital-ze.variants-buildup.stages.serifs.bilateral-inward-serifed]
 rank = 7
-description = "Cyrillic Capital Ze (`З`) with inward serif at both top and bottom"
-selector."latn/Epsilon" = "bilateralInwardSerifed"
-selector."cyrl/Ze" = "bilateralInwardSerifed"
-selector."cyrl/Ze/topSerif" = "unilateralInwardSerifed"
-selector."cyrl/Ze/bottomSerif" = "bottomInwardSerifed"
+descriptionAffix = "inward serif at both top and bottom"
+selectorAffix."cyrl/Ze" = "bilateralInwardSerifed"
+selectorAffix."cyrl/Ze/topSerif" = "unilateralInwardSerifed"
+selectorAffix."cyrl/revZe" = "bilateralInwardSerifed"
+selectorAffix."cyrl/Zhwe/Ze" = "bilateralInwardSerifed"
+selectorAffix."cyrl/Dzze/Ze" = "bottomInwardSerifed"
+selectorAffix."latn/Epsilon" = "bilateralInwardSerifed"
+selectorAffix."latn/revEpsilon" = "bilateralInwardSerifed"
 
 
 
@@ -7252,75 +7303,148 @@ sampler = "з"
 samplerExplain = "Cyrillic Lower Ze"
 tagKind = "letter"
 
-[prime.cyrl-ze.variants.serifless]
+[prime.cyrl-ze.variants-buildup]
+entry = "height"
+descriptionLeader = "Cyrillic Lower Ze (`з`)"
+
+[prime.cyrl-ze.variants-buildup.stages.height."*"]
+next = "serifs"
+
+[prime.cyrl-ze.variants-buildup.stages.height.non-descending]
 rank = 1
-description = "Serifless Cyrillic Lower Ze (`з`)"
-selector."latn/epsilon" = "serifless"
-selector."latn/epsilon/descBase" = "bottomSerifed"
-selector."cyrl/ze" = "serifless"
-selector."cyrl/ze/descBase" = "bottomSerifed"
-selector."cyrl/ze/topSerif" = "serifless"
-selector."cyrl/ze/bottomSerif" = "serifless"
+keyAffix = ""
+selectorAffix."cyrl/ze" = ""
+selectorAffix."cyrl/ze/topSerif" = ""
+selectorAffix."cyrl/ze.BGR" = "tall"
+selectorAffix."cyrl/revze" = ""
+selectorAffix."cyrl/zhwe/ze" = ""
+selectorAffix."cyrl/dzze.upright/ze" = ""
+selectorAffix."cyrl/dzze.italic/ze" = "tall"
+selectorAffix."latn/epsilon" = ""
+selectorAffix."latn/epsilon/descBase" = ""
+selectorAffix."latn/revepsilon" = ""
+selectorAffix."latn/revepsilon/descBase" = ""
 
-[prime.cyrl-ze.variants.unilateral-serifed]
+[prime.cyrl-ze.variants-buildup.stages.height.tall]
 rank = 2
-description = "Cyrillic Lower Ze (`з`) with serif at top"
-selector."latn/epsilon" = "unilateralSerifed"
-selector."latn/epsilon/descBase" = "bilateralSerifed"
-selector."cyrl/ze" = "unilateralSerifed"
-selector."cyrl/ze/descBase" = "bilateralSerifed"
-selector."cyrl/ze/topSerif" = "unilateralSerifed"
-selector."cyrl/ze/bottomSerif" = "serifless"
+descriptionAffix = "tall body that descends below the baseline"
+selectorAffix."cyrl/ze" = "tall"
+selectorAffix."cyrl/ze/topSerif" = ""
+selectorAffix."cyrl/ze.BGR" = "tall"
+selectorAffix."cyrl/revze" = "tall"
+selectorAffix."cyrl/zhwe/ze" = ""
+selectorAffix."cyrl/dzze.upright/ze" = ""
+selectorAffix."cyrl/dzze.italic/ze" = "tall"
+selectorAffix."latn/epsilon" = ""
+selectorAffix."latn/epsilon/descBase" = ""
+selectorAffix."latn/revepsilon" = ""
+selectorAffix."latn/revepsilon/descBase" = ""
 
-[prime.cyrl-ze.variants.unilateral-bottom-serifed]
+[prime.cyrl-ze.variants-buildup.stages.serifs.serifless]
+rank = 1
+descriptionAffix = "serifs"
+descriptionJoiner = "without"
+selectorAffix."cyrl/ze" = "serifless"
+selectorAffix."cyrl/ze/topSerif" = "serifless"
+selectorAffix."cyrl/ze.BGR" = "serifless"
+selectorAffix."cyrl/revze" = "serifless"
+selectorAffix."cyrl/zhwe/ze" = "serifless"
+selectorAffix."cyrl/dzze.upright/ze" = "serifless"
+selectorAffix."cyrl/dzze.italic/ze" = "serifless"
+selectorAffix."latn/epsilon" = "serifless"
+selectorAffix."latn/epsilon/descBase" = "bottomSerifed"
+selectorAffix."latn/revepsilon" = "serifless"
+selectorAffix."latn/revepsilon/descBase" = "bottomSerifed"
+
+[prime.cyrl-ze.variants-buildup.stages.serifs.unilateral-serifed]
+rank = 2
+descriptionAffix = "serif at top"
+selectorAffix."cyrl/ze" = "unilateralSerifed"
+selectorAffix."cyrl/ze/topSerif" = "unilateralSerifed"
+selectorAffix."cyrl/ze.BGR" = "unilateralSerifed"
+selectorAffix."cyrl/revze" = "unilateralSerifed"
+selectorAffix."cyrl/zhwe/ze" = "unilateralSerifed"
+selectorAffix."cyrl/dzze.upright/ze" = "serifless"
+selectorAffix."cyrl/dzze.italic/ze" = "serifless"
+selectorAffix."latn/epsilon" = "unilateralSerifed"
+selectorAffix."latn/epsilon/descBase" = "bilateralSerifed"
+selectorAffix."latn/revepsilon" = "unilateralSerifed"
+selectorAffix."latn/revepsilon/descBase" = "bilateralSerifed"
+
+[prime.cyrl-ze.variants-buildup.stages.serifs.unilateral-bottom-serifed]
 rank = 3
-description = "Cyrillic Lower Ze (`з`) with serif at bottom"
-selector."latn/epsilon" = "unilateralSerifed"
-selector."latn/epsilon/descBase" = "bilateralSerifed"
-selector."cyrl/ze" = "bottomSerifed"
-selector."cyrl/ze/descBase" = "bottomSerifed"
-selector."cyrl/ze/topSerif" = "serifless"
-selector."cyrl/ze/bottomSerif" = "bottomSerifed"
+descriptionAffix = "serif at bottom"
+selectorAffix."cyrl/ze" = "bottomSerifed"
+selectorAffix."cyrl/ze/topSerif" = "serifless"
+selectorAffix."cyrl/ze.BGR" = "bottomSerifed"
+selectorAffix."cyrl/revze" = "unilateralSerifed"
+selectorAffix."cyrl/zhwe/ze" = "bottomSerifed"
+selectorAffix."cyrl/dzze.upright/ze" = "bottomSerifed"
+selectorAffix."cyrl/dzze.italic/ze" = "bottomSerifed"
+selectorAffix."latn/epsilon" = "unilateralSerifed"
+selectorAffix."latn/epsilon/descBase" = "bilateralSerifed"
+selectorAffix."latn/revepsilon" = "bottomSerifed"
+selectorAffix."latn/revepsilon/descBase" = "bottomSerifed"
 
-[prime.cyrl-ze.variants.bilateral-serifed]
+[prime.cyrl-ze.variants-buildup.stages.serifs.bilateral-serifed]
 rank = 4
-description = "Cyrillic Lower Ze (`з`) with serif at both top and bottom"
-selector."latn/epsilon" = "bilateralSerifed"
-selector."latn/epsilon/descBase" = "bilateralSerifed"
-selector."cyrl/ze" = "bilateralSerifed"
-selector."cyrl/ze/descBase" = "bilateralSerifed"
-selector."cyrl/ze/topSerif" = "unilateralSerifed"
-selector."cyrl/ze/bottomSerif" = "bottomSerifed"
+descriptionAffix = "serif at both top and bottom"
+selectorAffix."cyrl/ze" = "bilateralSerifed"
+selectorAffix."cyrl/ze/topSerif" = "unilateralSerifed"
+selectorAffix."cyrl/ze.BGR" = "bilateralSerifed"
+selectorAffix."cyrl/revze" = "bilateralSerifed"
+selectorAffix."cyrl/zhwe/ze" = "bilateralSerifed"
+selectorAffix."cyrl/dzze.upright/ze" = "bottomSerifed"
+selectorAffix."cyrl/dzze.italic/ze" = "bottomSerifed"
+selectorAffix."latn/epsilon" = "bilateralSerifed"
+selectorAffix."latn/epsilon/descBase" = "bilateralSerifed"
+selectorAffix."latn/revepsilon" = "bilateralSerifed"
+selectorAffix."latn/revepsilon/descBase" = "bilateralSerifed"
 
-[prime.cyrl-ze.variants.unilateral-inward-serifed]
+[prime.cyrl-ze.variants-buildup.stages.serifs.unilateral-inward-serifed]
 rank = 5
-description = "Cyrillic Lower Ze (`з`) with inward serif at top"
-selector."latn/epsilon" = "unilateralInwardSerifed"
-selector."latn/epsilon/descBase" = "hybridSerifed1"
-selector."cyrl/ze" = "unilateralInwardSerifed"
-selector."cyrl/ze/descBase" = "hybridSerifed1"
-selector."cyrl/ze/topSerif" = "unilateralInwardSerifed"
-selector."cyrl/ze/bottomSerif" = "serifless"
+descriptionAffix = "inward serif at top"
+selectorAffix."cyrl/ze" = "unilateralInwardSerifed"
+selectorAffix."cyrl/ze/topSerif" = "unilateralInwardSerifed"
+selectorAffix."cyrl/ze.BGR" = "unilateralInwardSerifed"
+selectorAffix."cyrl/revze" = "unilateralInwardSerifed"
+selectorAffix."cyrl/zhwe/ze" = "unilateralInwardSerifed"
+selectorAffix."cyrl/dzze.upright/ze" = "serifless"
+selectorAffix."cyrl/dzze.italic/ze" = "serifless"
+selectorAffix."latn/epsilon" = "unilateralInwardSerifed"
+selectorAffix."latn/epsilon/descBase" = "hybridSerifed1"
+selectorAffix."latn/revepsilon" = "unilateralInwardSerifed"
+selectorAffix."latn/revepsilon/descBase" = "hybridSerifed1"
 
-[prime.cyrl-ze.variants.unilateral-bottom-inward-serifed]
+[prime.cyrl-ze.variants-buildup.stages.serifs.unilateral-bottom-inward-serifed]
 rank = 6
-description = "Cyrillic Lower Ze (`з`) with inward serif at bottom"
-selector."latn/epsilon" = "unilateralInwardSerifed"
-selector."latn/epsilon/descBase" = "hybridSerifed1"
-selector."cyrl/ze" = "bottomInwardSerifed"
-selector."cyrl/ze/descBase" = "bottomSerifed"
-selector."cyrl/ze/topSerif" = "serifless"
-selector."cyrl/ze/bottomSerif" = "bottomInwardSerifed"
+descriptionAffix = "inward serif at bottom"
+selectorAffix."cyrl/ze" = "bottomInwardSerifed"
+selectorAffix."cyrl/ze/topSerif" = "serifless"
+selectorAffix."cyrl/ze.BGR" = "bottomInwardSerifed"
+selectorAffix."cyrl/revze" = "unilateralInwardSerifed"
+selectorAffix."cyrl/zhwe/ze" = "bottomInwardSerifed"
+selectorAffix."cyrl/dzze.upright/ze" = "bottomInwardSerifed"
+selectorAffix."cyrl/dzze.italic/ze" = "bottomInwardSerifed"
+selectorAffix."latn/epsilon" = "unilateralInwardSerifed"
+selectorAffix."latn/epsilon/descBase" = "hybridSerifed1"
+selectorAffix."latn/revepsilon" = "bottomInwardSerifed"
+selectorAffix."latn/revepsilon/descBase" = "bottomSerifed"
 
-[prime.cyrl-ze.variants.bilateral-inward-serifed]
+[prime.cyrl-ze.variants-buildup.stages.serifs.bilateral-inward-serifed]
 rank = 7
-description = "Cyrillic Lower Ze (`з`) with inward serif at both top and bottom"
-selector."latn/epsilon" = "bilateralInwardSerifed"
-selector."latn/epsilon/descBase" = "hybridSerifed1"
-selector."cyrl/ze" = "bilateralInwardSerifed"
-selector."cyrl/ze/descBase" = "hybridSerifed1"
-selector."cyrl/ze/topSerif" = "unilateralInwardSerifed"
-selector."cyrl/ze/bottomSerif" = "bottomInwardSerifed"
+descriptionAffix = "inward serif at both top and bottom"
+selectorAffix."cyrl/ze" = "bilateralInwardSerifed"
+selectorAffix."cyrl/ze/topSerif" = "unilateralInwardSerifed"
+selectorAffix."cyrl/ze.BGR" = "bilateralInwardSerifed"
+selectorAffix."cyrl/revze" = "bilateralInwardSerifed"
+selectorAffix."cyrl/zhwe/ze" = "bilateralInwardSerifed"
+selectorAffix."cyrl/dzze.upright/ze" = "bottomInwardSerifed"
+selectorAffix."cyrl/dzze.italic/ze" = "bottomInwardSerifed"
+selectorAffix."latn/epsilon" = "bilateralInwardSerifed"
+selectorAffix."latn/epsilon/descBase" = "hybridSerifed1"
+selectorAffix."latn/revepsilon" = "bilateralInwardSerifed"
+selectorAffix."latn/revepsilon/descBase" = "hybridSerifed1"
 
 
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -7189,113 +7189,82 @@ sampler = "З"
 samplerExplain = "Cyrillic Capital Ze"
 tagKind = "letter"
 
-[prime.cyrl-capital-ze.variants-buildup]
-entry = "height"
-descriptionLeader = "Cyrillic Capital Ze (`З`)"
-
-[prime.cyrl-capital-ze.variants-buildup.stages.height."*"]
-next = "serifs"
-
-[prime.cyrl-capital-ze.variants-buildup.stages.height.non-descending]
+[prime.cyrl-capital-ze.variants.serifless]
 rank = 1
-keyAffix = ""
-selectorAffix."cyrl/Ze" = ""
-selectorAffix."cyrl/Ze/topSerif" = ""
-selectorAffix."cyrl/revZe" = ""
-selectorAffix."cyrl/Zhwe/Ze" = ""
-selectorAffix."cyrl/Dzze/Ze" = ""
-selectorAffix."latn/Epsilon" = ""
-selectorAffix."latn/revEpsilon" = ""
+description = "Cyrillic Capital Ze (`З`) without serifs"
+selector."cyrl/Ze" = "serifless"
+selector."cyrl/Ze/topSerif" = "serifless"
+selector."cyrl/revZe" = "serifless"
+selector."cyrl/Zhwe/Ze" = "serifless"
+selector."cyrl/Dzze/Ze" = "serifless"
+selector."latn/Epsilon" = "serifless"
+selector."latn/revEpsilon" = "serifless"
 
-[prime.cyrl-capital-ze.variants-buildup.stages.height.tall]
+[prime.cyrl-capital-ze.variants.unilateral-serifed]
 rank = 2
-nonBreakingVariantAdditionPriority = 100
-descriptionAffix = "tall body that descends below the baseline"
-selectorAffix."cyrl/Ze" = "tall"
-selectorAffix."cyrl/Ze/topSerif" = ""
-selectorAffix."cyrl/revZe" = "tall"
-selectorAffix."cyrl/Zhwe/Ze" = ""
-selectorAffix."cyrl/Dzze/Ze" = ""
-selectorAffix."latn/Epsilon" = ""
-selectorAffix."latn/revEpsilon" = ""
+description = "Cyrillic Capital Ze (`З`) with serif at top"
+selector."cyrl/Ze" = "unilateralSerifed"
+selector."cyrl/Ze/topSerif" = "unilateralSerifed"
+selector."cyrl/revZe" = "unilateralSerifed"
+selector."cyrl/Zhwe/Ze" = "unilateralSerifed"
+selector."cyrl/Dzze/Ze" = "serifless"
+selector."latn/Epsilon" = "unilateralSerifed"
+selector."latn/revEpsilon" = "unilateralSerifed"
 
-[prime.cyrl-capital-ze.variants-buildup.stages.serifs.serifless]
-rank = 1
-descriptionAffix = "serifs"
-descriptionJoiner = "without"
-selectorAffix."cyrl/Ze" = "serifless"
-selectorAffix."cyrl/Ze/topSerif" = "serifless"
-selectorAffix."cyrl/revZe" = "serifless"
-selectorAffix."cyrl/Zhwe/Ze" = "serifless"
-selectorAffix."cyrl/Dzze/Ze" = "serifless"
-selectorAffix."latn/Epsilon" = "serifless"
-selectorAffix."latn/revEpsilon" = "serifless"
-
-[prime.cyrl-capital-ze.variants-buildup.stages.serifs.unilateral-serifed]
-rank = 2
-descriptionAffix = "serif at top"
-selectorAffix."cyrl/Ze" = "unilateralSerifed"
-selectorAffix."cyrl/Ze/topSerif" = "unilateralSerifed"
-selectorAffix."cyrl/revZe" = "unilateralSerifed"
-selectorAffix."cyrl/Zhwe/Ze" = "unilateralSerifed"
-selectorAffix."cyrl/Dzze/Ze" = "serifless"
-selectorAffix."latn/Epsilon" = "unilateralSerifed"
-selectorAffix."latn/revEpsilon" = "unilateralSerifed"
-
-[prime.cyrl-capital-ze.variants-buildup.stages.serifs.unilateral-bottom-serifed]
+[prime.cyrl-capital-ze.variants.unilateral-bottom-serifed]
 rank = 3
-descriptionAffix = "serif at bottom"
-selectorAffix."cyrl/Ze" = "bottomSerifed"
-selectorAffix."cyrl/Ze/topSerif" = "serifless"
-selectorAffix."cyrl/revZe" = "unilateralSerifed"
-selectorAffix."cyrl/Zhwe/Ze" = "bottomSerifed"
-selectorAffix."cyrl/Dzze/Ze" = "bottomSerifed"
-selectorAffix."latn/Epsilon" = "unilateralSerifed"
-selectorAffix."latn/revEpsilon" = "bottomSerifed"
+description = "Cyrillic Capital Ze (`З`) with serif at bottom"
+selector."cyrl/Ze" = "bottomSerifed"
+selector."cyrl/Ze/topSerif" = "serifless"
+selector."cyrl/revZe" = "unilateralSerifed"
+selector."cyrl/Zhwe/Ze" = "bottomSerifed"
+selector."cyrl/Dzze/Ze" = "bottomSerifed"
+selector."latn/Epsilon" = "unilateralSerifed"
+selector."latn/revEpsilon" = "bottomSerifed"
 
-[prime.cyrl-capital-ze.variants-buildup.stages.serifs.bilateral-serifed]
+[prime.cyrl-capital-ze.variants.bilateral-serifed]
 rank = 4
-descriptionAffix = "serif at both top and bottom"
-selectorAffix."cyrl/Ze" = "bilateralSerifed"
-selectorAffix."cyrl/Ze/topSerif" = "unilateralSerifed"
-selectorAffix."cyrl/revZe" = "bilateralSerifed"
-selectorAffix."cyrl/Zhwe/Ze" = "bilateralSerifed"
-selectorAffix."cyrl/Dzze/Ze" = "bottomSerifed"
-selectorAffix."latn/Epsilon" = "bilateralSerifed"
-selectorAffix."latn/revEpsilon" = "bilateralSerifed"
+description = "Cyrillic Capital Ze (`З`) with serif at both top and bottom"
+selector."cyrl/Ze" = "bilateralSerifed"
+selector."cyrl/Ze/topSerif" = "unilateralSerifed"
+selector."cyrl/revZe" = "bilateralSerifed"
+selector."cyrl/Zhwe/Ze" = "bilateralSerifed"
+selector."cyrl/Dzze/Ze" = "bottomSerifed"
+selector."latn/Epsilon" = "bilateralSerifed"
+selector."latn/revEpsilon" = "bilateralSerifed"
 
-[prime.cyrl-capital-ze.variants-buildup.stages.serifs.unilateral-inward-serifed]
+[prime.cyrl-capital-ze.variants.unilateral-inward-serifed]
 rank = 5
-descriptionAffix = "inward serif at top"
-selectorAffix."cyrl/Ze" = "unilateralInwardSerifed"
-selectorAffix."cyrl/Ze/topSerif" = "unilateralInwardSerifed"
-selectorAffix."cyrl/revZe" = "unilateralInwardSerifed"
-selectorAffix."cyrl/Zhwe/Ze" = "unilateralInwardSerifed"
-selectorAffix."cyrl/Dzze/Ze" = "serifless"
-selectorAffix."latn/Epsilon" = "unilateralInwardSerifed"
-selectorAffix."latn/revEpsilon" = "unilateralInwardSerifed"
+description = "Cyrillic Capital Ze (`З`) with inward serif at top"
+selector."cyrl/Ze" = "unilateralInwardSerifed"
+selector."cyrl/Ze/topSerif" = "unilateralInwardSerifed"
+selector."cyrl/revZe" = "unilateralInwardSerifed"
+selector."cyrl/Zhwe/Ze" = "unilateralInwardSerifed"
+selector."cyrl/Dzze/Ze" = "serifless"
+selector."latn/Epsilon" = "unilateralInwardSerifed"
+selector."latn/revEpsilon" = "unilateralInwardSerifed"
 
-[prime.cyrl-capital-ze.variants-buildup.stages.serifs.unilateral-bottom-inward-serifed]
+[prime.cyrl-capital-ze.variants.unilateral-bottom-inward-serifed]
 rank = 6
-descriptionAffix = "inward serif at bottom"
-selectorAffix."cyrl/Ze" = "bottomInwardSerifed"
-selectorAffix."cyrl/Ze/topSerif" = "serifless"
-selectorAffix."cyrl/revZe" = "unilateralInwardSerifed"
-selectorAffix."cyrl/Zhwe/Ze" = "bottomInwardSerifed"
-selectorAffix."cyrl/Dzze/Ze" = "bottomInwardSerifed"
-selectorAffix."latn/Epsilon" = "unilateralInwardSerifed"
-selectorAffix."latn/revEpsilon" = "bottomInwardSerifed"
+description = "Cyrillic Capital Ze (`З`) with inward serif at bottom"
+selector."cyrl/Ze" = "bottomInwardSerifed"
+selector."cyrl/Ze/topSerif" = "serifless"
+selector."cyrl/revZe" = "unilateralInwardSerifed"
+selector."cyrl/Zhwe/Ze" = "bottomInwardSerifed"
+selector."cyrl/Dzze/Ze" = "bottomInwardSerifed"
+selector."latn/Epsilon" = "unilateralInwardSerifed"
+selector."latn/revEpsilon" = "bottomInwardSerifed"
 
-[prime.cyrl-capital-ze.variants-buildup.stages.serifs.bilateral-inward-serifed]
+[prime.cyrl-capital-ze.variants.bilateral-inward-serifed]
 rank = 7
-descriptionAffix = "inward serif at both top and bottom"
-selectorAffix."cyrl/Ze" = "bilateralInwardSerifed"
-selectorAffix."cyrl/Ze/topSerif" = "unilateralInwardSerifed"
-selectorAffix."cyrl/revZe" = "bilateralInwardSerifed"
-selectorAffix."cyrl/Zhwe/Ze" = "bilateralInwardSerifed"
-selectorAffix."cyrl/Dzze/Ze" = "bottomInwardSerifed"
-selectorAffix."latn/Epsilon" = "bilateralInwardSerifed"
-selectorAffix."latn/revEpsilon" = "bilateralInwardSerifed"
+description = "Cyrillic Capital Ze (`З`) with inward serif at both top and bottom"
+selector."cyrl/Ze" = "bilateralInwardSerifed"
+selector."cyrl/Ze/topSerif" = "unilateralInwardSerifed"
+selector."cyrl/revZe" = "bilateralInwardSerifed"
+selector."cyrl/Zhwe/Ze" = "bilateralInwardSerifed"
+selector."cyrl/Dzze/Ze" = "bottomInwardSerifed"
+selector."latn/Epsilon" = "bilateralInwardSerifed"
+selector."latn/revEpsilon" = "bilateralInwardSerifed"
 
 
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -7209,6 +7209,7 @@ selectorAffix."latn/revEpsilon" = ""
 
 [prime.cyrl-capital-ze.variants-buildup.stages.height.tall]
 rank = 2
+nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "tall body that descends below the baseline"
 selectorAffix."cyrl/Ze" = "tall"
 selectorAffix."cyrl/Ze/topSerif" = ""
@@ -7327,6 +7328,7 @@ selectorAffix."latn/revepsilon/descBase" = ""
 
 [prime.cyrl-ze.variants-buildup.stages.height.tall]
 rank = 2
+nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "tall body that descends below the baseline"
 selectorAffix."cyrl/ze" = "tall"
 selectorAffix."cyrl/ze/topSerif" = ""

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -8472,54 +8472,54 @@ selector."currency/euroSign" = "bilateralInwardSerifed"
 [prime.cyrl-capital-e.variants.unilateral-mid-serifed]
 rank = 8
 description = "Cyrillic Capital E (`Э`) with serif at top and center"
-selector."cyrl/E" = "unilateralMidSerifed"
+selector."cyrl/E" = "unilateralSerifedCapped"
 selector."cyrl/E/topSerif" = "unilateralSerifed"
-selector."cyrl/YeUkrainian" = "unilateralMidSerifed"
+selector."cyrl/YeUkrainian" = "unilateralSerifedCapped"
 selector."cyrl/YeUkrainian/topSerif" = "unilateralSerifed"
 selector."currency/euroSign" = "unilateralSerifed"
 
 [prime.cyrl-capital-e.variants.unilateral-bottom-mid-serifed]
 rank = 9
 description = "Cyrillic Capital E (`Э`) with serif at bottom and center"
-selector."cyrl/E" = "bottomMidSerifed"
+selector."cyrl/E" = "bottomSerifedCapped"
 selector."cyrl/E/topSerif" = "serifless"
-selector."cyrl/YeUkrainian" = "unilateralMidSerifed"
+selector."cyrl/YeUkrainian" = "unilateralSerifedCapped"
 selector."cyrl/YeUkrainian/topSerif" = "unilateralSerifed"
 selector."currency/euroSign" = "unilateralSerifed"
 
 [prime.cyrl-capital-e.variants.bilateral-mid-serifed]
 rank = 10
 description = "Cyrillic Capital E (`Э`) with serifs at both top, bottom and center"
-selector."cyrl/E" = "bilateralMidSerifed"
+selector."cyrl/E" = "bilateralSerifedCapped"
 selector."cyrl/E/topSerif" = "unilateralSerifed"
-selector."cyrl/YeUkrainian" = "bilateralMidSerifed"
+selector."cyrl/YeUkrainian" = "bilateralSerifedCapped"
 selector."cyrl/YeUkrainian/topSerif" = "unilateralSerifed"
 selector."currency/euroSign" = "bilateralSerifed"
 
 [prime.cyrl-capital-e.variants.unilateral-inward-mid-serifed]
 rank = 11
 description = "Cyrillic Capital E (`Э`) with inward serif at top and center"
-selector."cyrl/E" = "unilateralInwardMidSerifed"
+selector."cyrl/E" = "unilateralInwardSerifedCapped"
 selector."cyrl/E/topSerif" = "unilateralInwardSerifed"
-selector."cyrl/YeUkrainian" = "unilateralInwardMidSerifed"
+selector."cyrl/YeUkrainian" = "unilateralInwardSerifedCapped"
 selector."cyrl/YeUkrainian/topSerif" = "unilateralInwardSerifed"
 selector."currency/euroSign" = "unilateralInwardSerifed"
 
 [prime.cyrl-capital-e.variants.unilateral-bottom-inward-mid-serifed]
 rank = 12
 description = "Cyrillic Capital E (`Э`) with inward serif at bottom and center"
-selector."cyrl/E" = "bottomInwardMidSerifed"
+selector."cyrl/E" = "bottomInwardSerifedCapped"
 selector."cyrl/E/topSerif" = "serifless"
-selector."cyrl/YeUkrainian" = "unilateralInwardMidSerifed"
+selector."cyrl/YeUkrainian" = "unilateralInwardSerifedCapped"
 selector."cyrl/YeUkrainian/topSerif" = "unilateralInwardSerifed"
 selector."currency/euroSign" = "unilateralInwardSerifed"
 
 [prime.cyrl-capital-e.variants.bilateral-inward-mid-serifed]
 rank = 13
 description = "Cyrillic Capital E (`Э`) with inward serif at both top, bottom and center"
-selector."cyrl/E" = "bilateralInwardMidSerifed"
+selector."cyrl/E" = "bilateralInwardSerifedCapped"
 selector."cyrl/E/topSerif" = "unilateralInwardSerifed"
-selector."cyrl/YeUkrainian" = "bilateralInwardMidSerifed"
+selector."cyrl/YeUkrainian" = "bilateralInwardSerifedCapped"
 selector."cyrl/YeUkrainian/topSerif" = "unilateralInwardSerifed"
 selector."currency/euroSign" = "bilateralInwardSerifed"
 
@@ -8589,49 +8589,49 @@ selector."cyrl/yeUkrainian/topSerif" = "unilateralInwardSerifed"
 [prime.cyrl-e.variants.unilateral-mid-serifed]
 rank = 8
 description = "Cyrillic Lower E (`э`) with serif at top and center"
-selector."cyrl/e" = "unilateralMidSerifed"
+selector."cyrl/e" = "unilateralSerifedCapped"
 selector."cyrl/e/topSerif" = "unilateralSerifed"
-selector."cyrl/yeUkrainian" = "unilateralMidSerifed"
+selector."cyrl/yeUkrainian" = "unilateralSerifedCapped"
 selector."cyrl/yeUkrainian/topSerif" = "unilateralSerifed"
 
 [prime.cyrl-e.variants.unilateral-bottom-mid-serifed]
 rank = 9
 description = "Cyrillic Lower E (`э`) with serif at bottom and center"
-selector."cyrl/e" = "bottomMidSerifed"
+selector."cyrl/e" = "bottomSerifedCapped"
 selector."cyrl/e/topSerif" = "serifless"
-selector."cyrl/yeUkrainian" = "unilateralMidSerifed"
+selector."cyrl/yeUkrainian" = "unilateralSerifedCapped"
 selector."cyrl/yeUkrainian/topSerif" = "unilateralSerifed"
 
 [prime.cyrl-e.variants.bilateral-mid-serifed]
 rank = 10
 description = "Cyrillic Lower E (`э`) with serifs at both top, bottom and center"
-selector."cyrl/e" = "bilateralMidSerifed"
+selector."cyrl/e" = "bilateralSerifedCapped"
 selector."cyrl/e/topSerif" = "unilateralSerifed"
-selector."cyrl/yeUkrainian" = "bilateralMidSerifed"
+selector."cyrl/yeUkrainian" = "bilateralSerifedCapped"
 selector."cyrl/yeUkrainian/topSerif" = "unilateralSerifed"
 
 [prime.cyrl-e.variants.unilateral-inward-mid-serifed]
 rank = 11
 description = "Cyrillic Lower E (`э`) with inward serif at top and center"
-selector."cyrl/e" = "unilateralInwardMidSerifed"
+selector."cyrl/e" = "unilateralInwardSerifedCapped"
 selector."cyrl/e/topSerif" = "unilateralInwardSerifed"
-selector."cyrl/yeUkrainian" = "unilateralInwardMidSerifed"
+selector."cyrl/yeUkrainian" = "unilateralInwardSerifedCapped"
 selector."cyrl/yeUkrainian/topSerif" = "unilateralInwardSerifed"
 
 [prime.cyrl-e.variants.unilateral-bottom-inward-mid-serifed]
 rank = 12
 description = "Cyrillic Lower E (`э`) with inward serif at bottom and center"
-selector."cyrl/e" = "bottomInwardMidSerifed"
+selector."cyrl/e" = "bottomInwardSerifedCapped"
 selector."cyrl/e/topSerif" = "serifless"
-selector."cyrl/yeUkrainian" = "unilateralInwardMidSerifed"
+selector."cyrl/yeUkrainian" = "unilateralInwardSerifedCapped"
 selector."cyrl/yeUkrainian/topSerif" = "unilateralInwardSerifed"
 
 [prime.cyrl-e.variants.bilateral-inward-mid-serifed]
 rank = 13
 description = "Cyrillic Lower E (`э`) with inward serif at both top, bottom and center"
-selector."cyrl/e" = "bilateralInwardMidSerifed"
+selector."cyrl/e" = "bilateralInwardSerifedCapped"
 selector."cyrl/e/topSerif" = "unilateralInwardSerifed"
-selector."cyrl/yeUkrainian" = "bilateralInwardMidSerifed"
+selector."cyrl/yeUkrainian" = "bilateralInwardSerifedCapped"
 selector."cyrl/yeUkrainian/topSerif" = "unilateralInwardSerifed"
 
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -8408,6 +8408,7 @@ tagKind = "letter"
 
 [prime.cyrl-capital-e.variants.serifless]
 rank = 1
+groupRank = 1
 description = "Serifless Cyrillic Capital E (`Э`)"
 selector."cyrl/E" = "serifless"
 selector."cyrl/E/topSerif" = "serifless"
@@ -8417,6 +8418,7 @@ selector."currency/euroSign" = "serifless"
 
 [prime.cyrl-capital-e.variants.unilateral-serifed]
 rank = 2
+groupRank = 1
 description = "Cyrillic Capital E (`Э`) with serif at top"
 selector."cyrl/E" = "unilateralSerifed"
 selector."cyrl/E/topSerif" = "unilateralSerifed"
@@ -8426,6 +8428,7 @@ selector."currency/euroSign" = "unilateralSerifed"
 
 [prime.cyrl-capital-e.variants.unilateral-bottom-serifed]
 rank = 3
+groupRank = 1
 description = "Cyrillic Capital E (`Э`) with serif at bottom"
 selector."cyrl/E" = "bottomSerifed"
 selector."cyrl/E/topSerif" = "serifless"
@@ -8435,6 +8438,7 @@ selector."currency/euroSign" = "unilateralSerifed"
 
 [prime.cyrl-capital-e.variants.bilateral-serifed]
 rank = 4
+groupRank = 1
 description = "Cyrillic Capital E (`Э`) with serifs at both top and bottom"
 selector."cyrl/E" = "bilateralSerifed"
 selector."cyrl/E/topSerif" = "unilateralSerifed"
@@ -8444,6 +8448,7 @@ selector."currency/euroSign" = "bilateralSerifed"
 
 [prime.cyrl-capital-e.variants.unilateral-inward-serifed]
 rank = 5
+groupRank = 1
 description = "Cyrillic Capital E (`Э`) with inward serif at top"
 selector."cyrl/E" = "unilateralInwardSerifed"
 selector."cyrl/E/topSerif" = "unilateralInwardSerifed"
@@ -8453,6 +8458,7 @@ selector."currency/euroSign" = "unilateralInwardSerifed"
 
 [prime.cyrl-capital-e.variants.unilateral-bottom-inward-serifed]
 rank = 6
+groupRank = 1
 description = "Cyrillic Capital E (`Э`) with inward serif at bottom"
 selector."cyrl/E" = "bottomInwardSerifed"
 selector."cyrl/E/topSerif" = "serifless"
@@ -8462,6 +8468,7 @@ selector."currency/euroSign" = "unilateralInwardSerifed"
 
 [prime.cyrl-capital-e.variants.bilateral-inward-serifed]
 rank = 7
+groupRank = 1
 description = "Cyrillic Capital E (`Э`) with inward serif at both top and bottom"
 selector."cyrl/E" = "bilateralInwardSerifed"
 selector."cyrl/E/topSerif" = "unilateralInwardSerifed"
@@ -8471,6 +8478,7 @@ selector."currency/euroSign" = "bilateralInwardSerifed"
 
 [prime.cyrl-capital-e.variants.unilateral-mid-serifed]
 rank = 8
+groupRank = 2
 description = "Cyrillic Capital E (`Э`) with serif at top and center"
 selector."cyrl/E" = "unilateralSerifedCapped"
 selector."cyrl/E/topSerif" = "unilateralSerifed"
@@ -8480,6 +8488,7 @@ selector."currency/euroSign" = "unilateralSerifed"
 
 [prime.cyrl-capital-e.variants.unilateral-bottom-mid-serifed]
 rank = 9
+groupRank = 2
 description = "Cyrillic Capital E (`Э`) with serif at bottom and center"
 selector."cyrl/E" = "bottomSerifedCapped"
 selector."cyrl/E/topSerif" = "serifless"
@@ -8489,6 +8498,7 @@ selector."currency/euroSign" = "unilateralSerifed"
 
 [prime.cyrl-capital-e.variants.bilateral-mid-serifed]
 rank = 10
+groupRank = 2
 description = "Cyrillic Capital E (`Э`) with serifs at both top, bottom and center"
 selector."cyrl/E" = "bilateralSerifedCapped"
 selector."cyrl/E/topSerif" = "unilateralSerifed"
@@ -8498,6 +8508,7 @@ selector."currency/euroSign" = "bilateralSerifed"
 
 [prime.cyrl-capital-e.variants.unilateral-inward-mid-serifed]
 rank = 11
+groupRank = 2
 description = "Cyrillic Capital E (`Э`) with inward serif at top and center"
 selector."cyrl/E" = "unilateralInwardSerifedCapped"
 selector."cyrl/E/topSerif" = "unilateralInwardSerifed"
@@ -8507,6 +8518,7 @@ selector."currency/euroSign" = "unilateralInwardSerifed"
 
 [prime.cyrl-capital-e.variants.unilateral-bottom-inward-mid-serifed]
 rank = 12
+groupRank = 2
 description = "Cyrillic Capital E (`Э`) with inward serif at bottom and center"
 selector."cyrl/E" = "bottomInwardSerifedCapped"
 selector."cyrl/E/topSerif" = "serifless"
@@ -8516,6 +8528,7 @@ selector."currency/euroSign" = "unilateralInwardSerifed"
 
 [prime.cyrl-capital-e.variants.bilateral-inward-mid-serifed]
 rank = 13
+groupRank = 2
 description = "Cyrillic Capital E (`Э`) with inward serif at both top, bottom and center"
 selector."cyrl/E" = "bilateralInwardSerifedCapped"
 selector."cyrl/E/topSerif" = "unilateralInwardSerifed"
@@ -8532,6 +8545,7 @@ tagKind = "letter"
 
 [prime.cyrl-e.variants.serifless]
 rank = 1
+groupRank = 1
 description = "Serifless Cyrillic Lower E (`э`)"
 selector."cyrl/e" = "serifless"
 selector."cyrl/e/topSerif" = "serifless"
@@ -8540,6 +8554,7 @@ selector."cyrl/yeUkrainian/topSerif" = "serifless"
 
 [prime.cyrl-e.variants.unilateral-serifed]
 rank = 2
+groupRank = 1
 description = "Cyrillic Lower E (`э`) with serif at top"
 selector."cyrl/e" = "unilateralSerifed"
 selector."cyrl/e/topSerif" = "unilateralSerifed"
@@ -8548,6 +8563,7 @@ selector."cyrl/yeUkrainian/topSerif" = "unilateralSerifed"
 
 [prime.cyrl-e.variants.unilateral-bottom-serifed]
 rank = 3
+groupRank = 1
 description = "Cyrillic Lower E (`э`) with serif at bottom"
 selector."cyrl/e" = "bottomSerifed"
 selector."cyrl/e/topSerif" = "serifless"
@@ -8556,6 +8572,7 @@ selector."cyrl/yeUkrainian/topSerif" = "unilateralSerifed"
 
 [prime.cyrl-e.variants.bilateral-serifed]
 rank = 4
+groupRank = 1
 description = "Cyrillic Lower E (`э`) with serifs at both top and bottom"
 selector."cyrl/e" = "bilateralSerifed"
 selector."cyrl/e/topSerif" = "unilateralSerifed"
@@ -8564,6 +8581,7 @@ selector."cyrl/yeUkrainian/topSerif" = "unilateralSerifed"
 
 [prime.cyrl-e.variants.unilateral-inward-serifed]
 rank = 5
+groupRank = 1
 description = "Cyrillic Lower E (`э`) with inward serif at top"
 selector."cyrl/e" = "unilateralInwardSerifed"
 selector."cyrl/e/topSerif" = "unilateralInwardSerifed"
@@ -8572,6 +8590,7 @@ selector."cyrl/yeUkrainian/topSerif" = "unilateralInwardSerifed"
 
 [prime.cyrl-e.variants.unilateral-bottom-inward-serifed]
 rank = 6
+groupRank = 1
 description = "Cyrillic Lower E (`э`) with inward serif at bottom"
 selector."cyrl/e" = "bottomInwardSerifed"
 selector."cyrl/e/topSerif" = "serifless"
@@ -8580,6 +8599,7 @@ selector."cyrl/yeUkrainian/topSerif" = "unilateralInwardSerifed"
 
 [prime.cyrl-e.variants.bilateral-inward-serifed]
 rank = 7
+groupRank = 1
 description = "Cyrillic Lower E (`э`) with inward serif at both top and bottom"
 selector."cyrl/e" = "bilateralInwardSerifed"
 selector."cyrl/e/topSerif" = "unilateralInwardSerifed"
@@ -8588,6 +8608,7 @@ selector."cyrl/yeUkrainian/topSerif" = "unilateralInwardSerifed"
 
 [prime.cyrl-e.variants.unilateral-mid-serifed]
 rank = 8
+groupRank = 2
 description = "Cyrillic Lower E (`э`) with serif at top and center"
 selector."cyrl/e" = "unilateralSerifedCapped"
 selector."cyrl/e/topSerif" = "unilateralSerifed"
@@ -8596,6 +8617,7 @@ selector."cyrl/yeUkrainian/topSerif" = "unilateralSerifed"
 
 [prime.cyrl-e.variants.unilateral-bottom-mid-serifed]
 rank = 9
+groupRank = 2
 description = "Cyrillic Lower E (`э`) with serif at bottom and center"
 selector."cyrl/e" = "bottomSerifedCapped"
 selector."cyrl/e/topSerif" = "serifless"
@@ -8604,6 +8626,7 @@ selector."cyrl/yeUkrainian/topSerif" = "unilateralSerifed"
 
 [prime.cyrl-e.variants.bilateral-mid-serifed]
 rank = 10
+groupRank = 2
 description = "Cyrillic Lower E (`э`) with serifs at both top, bottom and center"
 selector."cyrl/e" = "bilateralSerifedCapped"
 selector."cyrl/e/topSerif" = "unilateralSerifed"
@@ -8612,6 +8635,7 @@ selector."cyrl/yeUkrainian/topSerif" = "unilateralSerifed"
 
 [prime.cyrl-e.variants.unilateral-inward-mid-serifed]
 rank = 11
+groupRank = 2
 description = "Cyrillic Lower E (`э`) with inward serif at top and center"
 selector."cyrl/e" = "unilateralInwardSerifedCapped"
 selector."cyrl/e/topSerif" = "unilateralInwardSerifed"
@@ -8620,6 +8644,7 @@ selector."cyrl/yeUkrainian/topSerif" = "unilateralInwardSerifed"
 
 [prime.cyrl-e.variants.unilateral-bottom-inward-mid-serifed]
 rank = 12
+groupRank = 2
 description = "Cyrillic Lower E (`э`) with inward serif at bottom and center"
 selector."cyrl/e" = "bottomInwardSerifedCapped"
 selector."cyrl/e/topSerif" = "serifless"
@@ -8628,6 +8653,7 @@ selector."cyrl/yeUkrainian/topSerif" = "unilateralInwardSerifed"
 
 [prime.cyrl-e.variants.bilateral-inward-mid-serifed]
 rank = 13
+groupRank = 2
 description = "Cyrillic Lower E (`э`) with inward serif at both top, bottom and center"
 selector."cyrl/e" = "bilateralInwardSerifedCapped"
 selector."cyrl/e/topSerif" = "unilateralInwardSerifed"


### PR DESCRIPTION
Microsoft's [Cascadia Code](https://github.com/microsoft/cascadia-code) (the primary terminal font in Windows 11) expands upon the older Consolas' "tall" (Bulgarian-like) Italic Cyrillic Lower Ve (`в`) by also using a tall Italic Cyrillic Lower Ze (`з`).

The new variants are added at the end of the stack by virtue of being at the beginning of the `variants-buildup` tree, so `nonBreakingVariantAdditionPriority = …` is not required here.

Latin Epsilon (`Ɛ`, `ɛ`, `Ɜ`, `ɜ`) and its `serifless` Greek alias (`ε`) only follow the `non-descending` variants (`keyAffix = ""`), but Cyrillic Reversed Ze (`Ԑ`, `ԑ`) follows _both_ height variants, even though it is likely, in origin, a [Cyrillic Epsilon](https://en.wikipedia.org/wiki/Epsilon_(Cyrillic)), or a Script Ye (`Е`, `е`).

-----

Cascadia Code for comparison:

```
ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ
abc.def.ghi.jkl.mno.pqrs.tuv.wxyz
!iIlL17|¦ ¢coO08BDQ $5SZ2zs ∂96µm
float il1[]={1-2/3.4,5+6=7/8%90};
1234567890 ,._-+= >< «¯-¬_» ~–÷+×
{*}[]()<>`+-=$/#_%^@\&|~?'" !,.;:
g9q¶ Þẞðþſß ΓΔΛαβγδηθικλμνξπτυφχψ
ЖЗКНРУЭЯавжзклмнруфчьыэя <= != ==
```

Regular:
<img width="1131" height="548" alt="image" src="https://github.com/user-attachments/assets/848a9ae6-c202-4d34-8be9-03b2e2df8ffe" />

Italic:
<img width="1140" height="553" alt="image" src="https://github.com/user-attachments/assets/c179ec7e-ed1e-4137-ae6b-5a7677548fcd" />

-----

All Cyrillic Ze variants:

`ԐЗҘꚄꚈԑзҙꚅꚉ ƐꞫɛεϵɜɝ϶`

<img width="2519" height="1189" alt="image" src="https://github.com/user-attachments/assets/f2748411-3690-49b1-a973-760c96dd21ab" />
