### PR TITLE
Optimize `cursive` glyphs for Cyrillic Lower Ve (`в`).

### DIFF
--- a/changes/34.4.0.md
+++ b/changes/34.4.0.md
@@ -1,2 +1,3 @@
 * Add `above-baseline` variants for Greek Lower Chi (`χ`).
 * Add `tall` variants for Cyrillic Lower Ze (`з`).
+* Optimize glyphs for `cursive` and `cursive-tall` variants for Cyrillic Lower Ve (`в`).

--- a/packages/font-glyphs/src/common/shapes.ptl
+++ b/packages/font-glyphs/src/common/shapes.ptl
@@ -547,13 +547,17 @@ glyph-block CommonShapes : begin
 			local-parameter : ada -- ArchDepthA
 			local-parameter : adb -- ArchDepthB
 			local-parameter : ox  -- OX
-			local-parameter : af  -- nothing # Additional function for the control knots
+			# Additional function(s) for the control knots
+			local-parameter : af      -- nothing
+			local-parameter : startAf -- af
+			local-parameter : endAf   -- af
 
 			return : if (u - d > ada + adb)
 				list
-					flat (x + ox) (u - ada) af
-					curl (x + ox) (d + adb)
-				g4 (x + ox) [YSmoothMidL u d ada adb] af
+					flat (x + ox) (u - ada) startAf
+					curl (x + ox) (d + adb) endAf
+				list
+					g4   (x + ox) [YSmoothMidL u d ada adb] af
 
 		export : define flex-params [lu]: begin
 			local-parameter : x              # X-position of the stroke, without overshoot
@@ -562,13 +566,17 @@ glyph-block CommonShapes : begin
 			local-parameter : ada -- ArchDepthA
 			local-parameter : adb -- ArchDepthB
 			local-parameter : ox  -- OX
-			local-parameter : af  -- nothing # Additional function for the control knots
+			# Additional function(s) for the control knots
+			local-parameter : af      -- nothing
+			local-parameter : startAf -- af
+			local-parameter : endAf   -- af
 
 			return : if (u - d > ada + adb)
 				list
-					flat (x + ox) (d + adb) af
-					curl (x + ox) (u - ada)
-				g4 (x + ox) [YSmoothMidL u d ada adb] af
+					flat (x + ox) (d + adb) startAf
+					curl (x + ox) (u - ada) endAf
+				list
+					g4   (x + ox) [YSmoothMidL u d ada adb] af
 
 		export : define flex-params [rd]: begin
 			local-parameter : x              # X-position of the stroke, without overshoot
@@ -577,13 +585,17 @@ glyph-block CommonShapes : begin
 			local-parameter : ada -- ArchDepthA
 			local-parameter : adb -- ArchDepthB
 			local-parameter : ox  -- OX
-			local-parameter : af  -- nothing # Additional function for the control knots
+			# Additional function(s) for the control knots
+			local-parameter : af      -- nothing
+			local-parameter : startAf -- af
+			local-parameter : endAf   -- af
 
 			return : if (u - d > ada + adb)
 				list
-					flat (x - ox) (u - adb) af
-					curl (x - ox) (d + ada)
-				g4 (x - ox) [YSmoothMidR u d ada adb] af
+					flat (x - ox) (u - adb) startAf
+					curl (x - ox) (d + ada) endAf
+				list
+					g4   (x - ox) [YSmoothMidR u d ada adb] af
 
 		export : define flex-params [ru]: begin
 			local-parameter : x              # X-position of the stroke, without overshoot
@@ -592,13 +604,17 @@ glyph-block CommonShapes : begin
 			local-parameter : ada -- ArchDepthA
 			local-parameter : adb -- ArchDepthB
 			local-parameter : ox  -- OX
-			local-parameter : af  -- nothing # Additional function for the control knots
+			# Additional function(s) for the control knots
+			local-parameter : af      -- nothing
+			local-parameter : startAf -- af
+			local-parameter : endAf   -- af
 
 			return : if (u - d > ada + adb)
 				list
-					flat (x - ox) (d + ada) af
-					curl (x - ox) (u - adb)
-				g4 (x - ox) [YSmoothMidR u d ada adb] af
+					flat (x - ox) (d + ada) startAf
+					curl (x - ox) (u - adb) endAf
+				list
+					g4   (x - ox) [YSmoothMidR u d ada adb] af
 
 	glyph-block-export Arch
 	define Arch : namespace

--- a/packages/font-glyphs/src/letter/latin/upper-b.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-b.ptl
@@ -150,7 +150,7 @@ glyph-block Letter-Latin-Upper-B : begin
 			archv
 			g4   xTopArcRight [YSmoothMidR top (bowl - stroke) adaTop adbTop] [widths.lhs stroke]
 			Arch.lhs top (sw -- stroke)
-			flatside.ld SB 0 top SmallArchDepthA SmallArchDepthB 0 [widths.lhs.heading stroke Downward]
+			flatside.ld SB 0 top adaTop adbBot 0 [widths.lhs.heading stroke Downward]
 			Arch.lhs 0   (sw -- stroke)
 			g4   xBotArcRight [YSmoothMidR bowl 0 adaBot adbBot] [widths.lhs stroke]
 			arcvh
@@ -184,6 +184,7 @@ glyph-block Letter-Latin-Upper-B : begin
 		include : MarkSet.b
 		include : CursiveCyrVeShape Ascender
 			barPos           -- AsymmetricBBarPos
+			stroke           -- [AdviceStroke2 2 4 Ascender]
 			topArcShift      -- AsymmetricBTopArcShift
 			topArcInnerShift -- AsymmetricBTopArcInnerShift
 
@@ -217,9 +218,9 @@ glyph-block Letter-Latin-Upper-B : begin
 			moreAsymmetric            { AsymmetricShape            AsymmetricMask AsymmetricBBarPos false }
 			moreAsymmetricInterrupted { AsymmetricShapeInterrupted AsymmetricMask AsymmetricBBarPos true  }
 		object # serifs
-			serifless         { false false }
-			unilateralSerifed { true  false }
-			bilateralSerifed  { true  true  }
+			serifless                 { false false }
+			unilateralSerifed         { true  false }
+			bilateralSerifed          { true  true  }
 
 	foreach { suffix { { body mask bp fGap } { ts bs } } } [Object.entries BConfig] : do
 		local fMotion : ts && !bs
@@ -325,10 +326,10 @@ glyph-block Letter-Latin-Upper-B : begin
 					archv
 					g4   xTopArcRight [YSmoothMidR Ascender (bowl - Stroke) adaTop adbTop] [widths.lhs]
 					Arch.lhs Ascender
-					flat SB (Ascender - SmallArchDepthA) [heading Downward]
-					curl SB Descender                    [heading Downward]
+					flat SB (Ascender - adaTop) [heading Downward]
+					curl SB Descender           [heading Downward]
 				dispiro
-					g4.down.start (SB + [HSwToV : Stroke - ShoulderFine]) SmallArchDepthB [widths.lhs.heading ShoulderFine Downward]
+					g4.down.start (SB + [HSwToV : Stroke - ShoulderFine]) adbBot [widths.lhs.heading ShoulderFine Downward]
 					Arch.lhs 0 (swBefore -- ShoulderFine)
 					g4   xBotArcRight [YSmoothMidR bowl 0 adaBot adbBot] [widths.lhs]
 					arcvh

--- a/packages/font-glyphs/src/letter/latin/upper-b.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-b.ptl
@@ -145,8 +145,9 @@ glyph-block Letter-Latin-Upper-B : begin
 		local adbTop : ArchDepthBOf : ArchDepth * 0.9 - (curveLeftBot - curveLeftTop)
 
 		include : sink
-			flat (SB - O)     (bowl - fine + offset) [widths.lhs.heading fine Rightward]
-			curl curveLeftTop (bowl - fine + offset) [widths.lhs.heading fine Rightward]
+			widths.lhs fine
+			flat (SB - O) (bowl - fine + offset) [heading Rightward]
+			curl [Arch.adjust-x.bot curveLeftTop (sw -- stroke)] (bowl - fine + offset)
 			archv
 			g4   (xTopArcRight - offset) [YSmoothMidR top (bowl - stroke) adaTop adbTop] [widths.lhs stroke]
 			Arch.lhs (top - offset) (sw -- stroke)
@@ -154,8 +155,8 @@ glyph-block Letter-Latin-Upper-B : begin
 			Arch.lhs (0   + offset) (sw -- stroke)
 			g4   (xBotArcRight - offset) [YSmoothMidR bowl 0 adaBot adbBot] [widths.lhs stroke]
 			arcvh
-			flat curveLeftBot (bowl - stroke + fine - offset) [widths.lhs.heading fine Leftward]
-			curl (SB - O)     (bowl - stroke + fine - offset) [widths.lhs.heading fine Leftward]
+			flat [Arch.adjust-x.top curveLeftBot (sw -- stroke)] (bowl - stroke + fine - offset) [widths.lhs fine]
+			curl (SB - O) (bowl - stroke + fine - offset) [heading Leftward]
 
 		return : object bowl
 
@@ -329,20 +330,22 @@ glyph-block Letter-Latin-Upper-B : begin
 		include : difference
 			union
 				dispiro
-					flat (SB - O)     (bowl - fine) [widths.lhs.heading fine Rightward]
-					curl curveLeftTop (bowl - fine) [widths.lhs.heading fine Rightward]
+					widths.lhs fine
+					flat (SB - O) (bowl - fine) [heading Rightward]
+					curl [Arch.adjust-x.bot curveLeftTop] (bowl - fine)
 					archv
 					g4   xTopArcRight [YSmoothMidR Ascender (bowl - Stroke) adaTop adbTop] [widths.lhs]
 					Arch.lhs Ascender
 					flat SB (Ascender - adaTop) [heading Downward]
 					curl SB Descender           [heading Downward]
 				dispiro
-					g4.down.start (SB + [HSwToV : Stroke - ShoulderFine]) adbBot [widths.lhs.heading ShoulderFine Downward]
+					widths.lhs ShoulderFine
+					g4.down.start (SB + [HSwToV : Stroke - ShoulderFine]) adbBot [heading Downward]
 					Arch.lhs 0 (swBefore -- ShoulderFine)
 					g4   xBotArcRight [YSmoothMidR bowl 0 adaBot adbBot] [widths.lhs]
 					arcvh
-					flat curveLeftBot (bowl - Stroke + fine) [widths.lhs.heading fine Leftward]
-					curl (SB - O)     (bowl - Stroke + fine) [widths.lhs.heading fine Leftward]
+					flat [Arch.adjust-x.top curveLeftBot] (bowl - Stroke + fine) [widths.lhs fine]
+					curl (SB - O) (bowl - Stroke + fine) [heading Leftward]
 			[InterruptShape BBarPos] Ascender Stroke
 
 	create-glyph 'grek/beta.cursive' : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/upper-b.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-b.ptl
@@ -11,55 +11,65 @@ glyph-block Letter-Latin-Upper-B : begin
 	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared-Metrics : BowlXDepth
 	glyph-block-import Letter-Shared-Shapes : LetterBarOverlay SerifFrame LeftHook
-	glyph-block-import Letter-Blackboard : BBS BBD
 
 	define BArcMix           0.93
 	define BBarPos           0.52
 	define AsymmetricBBarPos 0.60
-	define [BShapeArcsT] : with-params [sink top stroke offset barPos topArcShift topArcInnerShift] : glyph-proc
-		local bowl : top * barPos + stroke * (1 - barPos)
-		local barleft SB
-		local mockBowlDepth : BowlXDepth top (bowl - stroke) barleft RightSB stroke
-		local curvleft : (RightSB - (SB * 0.5)) - mockBowlDepth + topArcInnerShift
-		local curvleftTop : Math.min curvleft : (RightSB - (SB * 0.5)) - OX - stroke * 1.375 + topArcInnerShift
+
+	define AsymmetricBTopArcShift      : (-0.05) * (RightSB - SB)
+	define AsymmetricBTopArcInnerShift : (-0.10) * (RightSB - SB)
+
+	define [BShapeArcsT sink] : function [] : with-params [top stroke offset barPos topArcShift topArcInnerShift] : glyph-proc
+		local bowl : mix stroke top barPos
+		local mockBowlDepth : BowlXDepth top (bowl - stroke) SB RightSB stroke
+		local curveLeftBot : [mix Width RightSB 1.5] - mockBowlDepth + topArcInnerShift
+		local curveLeftTop : Math.min curveLeftBot : [mix Width RightSB 1.5] - OX - stroke * 1.375 + topArcInnerShift
 		local xTopArcRight : [mix SB RightSB BArcMix] - OX * 2 + topArcShift
+		local xBotArcRight : RightSB - OX * 2
 		local fine : stroke * CThin
 
-		local ada    : ArchDepthAOf : ArchDepth * 0.9
-		local adb    : ArchDepthBOf : ArchDepth * 0.9
-		local adaTop : ArchDepthAOf : ArchDepth * 0.9 - (curvleft - curvleftTop)
-		local adbTop : ArchDepthBOf : ArchDepth * 0.9 - (curvleft - curvleftTop)
+		local adaBot : ArchDepthAOf : ArchDepth * 0.9
+		local adbBot : ArchDepthBOf : ArchDepth * 0.9
+		local adaTop : ArchDepthAOf : ArchDepth * 0.9 - (curveLeftBot - curveLeftTop)
+		local adbTop : ArchDepthBOf : ArchDepth * 0.9 - (curveLeftBot - curveLeftTop)
 
 		include : sink
 			widths.rhs stroke
-			flat (barleft - O) (top - offset) [heading Rightward]
-			curl [Arch.adjust-x.top curvleftTop (sw -- stroke)] (top - offset)
+			flat (SB - O) (top - offset) [heading Rightward]
+			curl [Arch.adjust-x.top curveLeftTop (sw -- stroke)] (top - offset)
 			archv
-			g4 (xTopArcRight - offset) [YSmoothMidR top (bowl - stroke) adaTop adbTop]
+			g4   (xTopArcRight - offset) [YSmoothMidR top (bowl - stroke) adaTop adbTop]
 			arcvh
-			flat [Arch.adjust-x.bot curvleftTop (sw -- stroke)] (bowl - fine + offset) [widths.rhs fine]
-			curl (barleft - O) (bowl - fine + offset) [heading Leftward]
+			flat [Arch.adjust-x.bot curveLeftTop (sw -- stroke)] (bowl - fine + offset) [widths.rhs fine]
+			curl (SB - O) (bowl - fine + offset) [heading Leftward]
 
 		include : sink
 			widths.rhs fine
-			flat (barleft - O) (bowl - stroke + fine - offset) [heading Rightward]
-			curl [Arch.adjust-x.top curvleft (sw -- stroke)] (bowl - stroke + fine - offset)
+			flat (SB - O) (bowl - stroke + fine - offset) [heading Rightward]
+			curl [Arch.adjust-x.top curveLeftBot (sw -- stroke)] (bowl - stroke + fine - offset)
 			archv
-			g4 (RightSB - OX * 2 - offset) [YSmoothMidR bowl 0 ada adb] [widths.rhs stroke]
+			g4   (xBotArcRight - offset) [YSmoothMidR bowl 0 adaBot adbBot] [widths.rhs stroke]
 			arcvh
-			flat [Arch.adjust-x.bot curvleft (sw -- stroke)] offset
-			curl (barleft - O) offset [heading Leftward]
+			flat [Arch.adjust-x.bot curveLeftBot (sw -- stroke)] offset
+			curl (SB - O) offset [heading Leftward]
 
 		return : object bowl
 
+	define flex-params [BShape] : glyph-proc
+		local-parameter : top
+		local-parameter : stroke           -- [AdviceStroke2 2 3 top]
+		local-parameter : barPos           -- BBarPos
+		local-parameter : topArcShift      -- 0
+		local-parameter : topArcInnerShift -- 0
+		local-parameter : serifTop         -- false
+		local-parameter : serifBot         -- false
 
-	define [BShape] : with-params [top [stroke : AdviceStroke2 2 3 top] [barPos BBarPos] [topArcShift 0] [topArcInnerShift 0] [serifTop false] [serifBot false]] : glyph-proc
 		include : VBar.l SB 0 top stroke
-		local dims : include : BShapeArcsT dispiro top
-			offset -- 0
-			stroke -- stroke
-			barPos -- barPos
-			topArcShift -- topArcShift
+		local dims : include : [BShapeArcsT dispiro] top
+			offset           -- 0
+			stroke           -- stroke
+			barPos           -- barPos
+			topArcShift      -- topArcShift
 			topArcInnerShift -- topArcInnerShift
 
 		set-base-anchor 'strike' Middle (dims.bowl - 0.5 * stroke)
@@ -68,66 +78,150 @@ glyph-block Letter-Latin-Upper-B : begin
 		if serifTop : include sf.lt.outer
 		if serifBot : include sf.lb.outer
 
-	define [BShapeMask] : with-params [top [stroke : AdviceStroke2 2 3 top] [barPos BBarPos] [topArcShift 0] [topArcInnerShift 0]] : glyph-proc
-		include : BShapeArcsT spiro-outline top
-			offset -- 1
-			stroke -- stroke
-			barPos -- barPos
-			topArcShift -- topArcShift
+	define flex-params [BShapeMask] : glyph-proc
+		local-parameter : top
+		local-parameter : stroke           -- [AdviceStroke2 2 3 top]
+		local-parameter : barPos           -- BBarPos
+		local-parameter : topArcShift      -- 0
+		local-parameter : topArcInnerShift -- 0
+
+		include : [BShapeArcsT spiro-outline] top
+			offset           -- 1
+			stroke           -- stroke
+			barPos           -- barPos
+			topArcShift      -- topArcShift
 			topArcInnerShift -- topArcInnerShift
 
-	define [InterruptShape bp top sw st sb] : begin
-		local bowl : top * bp + sw * (1 - bp)
-		local gap : Math.max (((RightSB - SB) - [HSwToV : 2 * sw]) * 0.15) : AdviceStroke 10
-		return : VBar.l (SB + [HSwToV sw]) (bowl - 1 * sw + O) (bowl + 0 * sw - O) gap
+	define [InterruptShape bp] : function [top sw _st _sb] : begin
+		local bowl : mix sw top bp
+		return : VBar.l
+			SB + [HSwToV sw]
+			bowl - sw + O
+			bowl      - O
+			VSwToH : 0.20 * (RightSB - SB) * ([AdviceStroke 5] / Stroke)
 
-	define [StdShape top sw st sb] : BShape top (stroke -- sw) (serifTop -- st) (serifBot -- sb)
-	define [StdShapeInterrupted top sw st sb] : difference [StdShape top sw st sb] [InterruptShape BBarPos top sw st sb]
-	define [StdMask top sw] : BShapeMask top (stroke -- sw)
-
-	define [AsymmetricShape top sw st sb] : BShape top
-		stroke -- [fallback sw : AdviceStroke2 2 3 top]
-		barPos -- AsymmetricBBarPos
-		topArcShift -- ((-0.05) * (RightSB - SB))
-		topArcInnerShift -- ((-0.1) * (RightSB - SB))
+	define [StdShape top sw st sb] : BShape top
+		stroke   -- sw
+		barPos   -- BBarPos
 		serifTop -- st
 		serifBot -- sb
-	define [AsymmetricShapeInterrupted top sw st sb] : difference [AsymmetricShape top sw st sb] [InterruptShape 0.6 top sw st sb]
+	define [StdShapeInterrupted top sw st sb] : difference
+		StdShape                 top sw st sb
+		[InterruptShape BBarPos] top sw st sb
+	define [StdMask top sw] : BShapeMask top
+		stroke   -- sw
+		barPos   -- BBarPos
+
+	define [AsymmetricShape top sw st sb] : BShape top
+		stroke           -- [fallback sw : AdviceStroke2 2 3 top]
+		barPos           -- AsymmetricBBarPos
+		topArcShift      -- AsymmetricBTopArcShift
+		topArcInnerShift -- AsymmetricBTopArcInnerShift
+		serifTop         -- st
+		serifBot         -- sb
+	define [AsymmetricShapeInterrupted top sw st sb] : difference
+		AsymmetricShape                    top sw st sb
+		[InterruptShape AsymmetricBBarPos] top sw st sb
 	define [AsymmetricMask top sw] : BShapeMask top
-		stroke -- [fallback sw : AdviceStroke2 2 3 top]
-		barPos -- AsymmetricBBarPos
-		topArcShift -- ((-0.05) * (RightSB - SB))
-		topArcInnerShift -- ((-0.1) * (RightSB - SB))
+		stroke           -- [fallback sw : AdviceStroke2 2 3 top]
+		barPos           -- AsymmetricBBarPos
+		topArcShift      -- AsymmetricBTopArcShift
+		topArcInnerShift -- AsymmetricBTopArcInnerShift
+
+	### Cyrillic Lower Ve
+
+	define [CursiveCyrVeArcsT sink] : function [] : with-params [top stroke offset barPos topArcShift topArcInnerShift] : glyph-proc
+		local bowl : mix stroke top barPos
+		local mockBowlDepth : BowlXDepth top (bowl - stroke) SB RightSB stroke
+		local curveLeftBot : [mix Width RightSB 1.5] - mockBowlDepth + topArcInnerShift
+		local curveLeftTop : Math.min curveLeftBot : [mix Width RightSB 1.5] - OX - stroke * 1.375 + topArcInnerShift
+		local xTopArcRight : [mix SB RightSB BArcMix] - OX * 2 + topArcShift
+		local xBotArcRight : RightSB - OX * 2
+		local fine : stroke * CThin
+
+		local adaBot : ArchDepthAOf : ArchDepth * 0.9
+		local adbBot : ArchDepthBOf : ArchDepth * 0.9
+		local adaTop : ArchDepthAOf : ArchDepth * 0.9 - (curveLeftBot - curveLeftTop)
+		local adbTop : ArchDepthBOf : ArchDepth * 0.9 - (curveLeftBot - curveLeftTop)
+
+		include : sink
+			flat (SB - O)     (bowl - fine) [widths.lhs.heading fine Rightward]
+			curl curveLeftTop (bowl - fine) [widths.lhs.heading fine Rightward]
+			archv
+			g4   xTopArcRight [YSmoothMidR top (bowl - stroke) adaTop adbTop] [widths.lhs stroke]
+			Arch.lhs top (sw -- stroke)
+			flatside.ld SB 0 top SmallArchDepthA SmallArchDepthB 0 [widths.lhs.heading stroke Downward]
+			Arch.lhs 0   (sw -- stroke)
+			g4   xBotArcRight [YSmoothMidR bowl 0 adaBot adbBot] [widths.lhs stroke]
+			arcvh
+			flat curveLeftBot (bowl - stroke + fine) [widths.lhs.heading fine Leftward]
+			curl (SB - O)     (bowl - stroke + fine) [widths.lhs.heading fine Leftward]
+
+		return : object bowl
+
+	define flex-params [CursiveCyrVeShape] : glyph-proc
+		local-parameter : top
+		local-parameter : stroke           -- [AdviceStroke2 2 3 top]
+		local-parameter : barPos           -- BBarPos
+		local-parameter : topArcShift      -- 0
+		local-parameter : topArcInnerShift -- 0
+		local-parameter : serifTop         -- false
+		local-parameter : serifBot         -- false
+
+		local dims : include : [CursiveCyrVeArcsT dispiro] top
+			offset           -- 0
+			stroke           -- stroke
+			barPos           -- barPos
+			topArcShift      -- topArcShift
+			topArcInnerShift -- topArcInnerShift
+
+		set-base-anchor 'strike' Middle (dims.bowl - 0.5 * stroke)
+
+	create-glyph "smcpB.cursive" : glyph-proc
+		include : MarkSet.e
+		include : CursiveCyrVeShape XH
+	create-glyph "smcpB.cursiveTall" : glyph-proc
+		include : MarkSet.b
+		include : CursiveCyrVeShape Ascender
+			barPos           -- AsymmetricBBarPos
+			topArcShift      -- AsymmetricBTopArcShift
+			topArcInnerShift -- AsymmetricBTopArcInnerShift
 
 	define [BOverlayStroke top bp] : begin
 		local stroke : AdviceStroke2 2 3 top
-		return : LetterBarOverlay.l.in SB stroke (top * bp - 0.5 * stroke)
+		return : LetterBarOverlay.l.in SB stroke ([mix stroke top bp] - stroke)
 			space -- { 0 (RightSB - [HSwToV Stroke]) }
 
 	define [BOverlayBar top bp] : begin
 		local stroke : AdviceStroke2 2 3 top
-		return : HBar.m [mix 0 SB 0.3] [mix Width RightSB 0.3] (top * bp)
+		return : HBar.t [mix 0 SB 0.3] [mix Width RightSB 0.3] [mix stroke top bp] stroke
 
-	define [BahtBar sw] : VBar.m [mix SB RightSB 0.48] (CAP - Descender / 2) (Descender / 2) sw
-	define [BitcoinBar sw] : begin
+	define [BahtBar sw] : begin
+		local asc  : CAP + ([mix XH Ascender 0.5] - XH)
+		local desc : mix 0 Descender 0.5
 		local xMid : mix SB RightSB 0.48
-		local gap : Math.max ((RightSB - SB) / 6) : AdviceStroke 4
+		return : VBar.m xMid asc desc sw
+	define [BitcoinBar sw] : begin
+		local asc  : CAP + ([mix XH Ascender 0.5] - XH)
+		local desc : mix 0 Descender 0.5
+		local xMid : mix SB RightSB 0.48
+		local gap  : Math.max ((RightSB - SB) / 6) : AdviceStroke 4
 		return : union
-			VBar.m (xMid - (gap + [HSwToV sw]) / 2) (CAP - Descender / 2) (Descender / 2) sw
-			VBar.m (xMid + (gap + [HSwToV sw]) / 2) (CAP - Descender / 2) (Descender / 2) sw
+			VBar.m (xMid - gap / 2 - [HSwToV : 0.5 * sw]) asc desc sw
+			VBar.m (xMid + gap / 2 + [HSwToV : 0.5 * sw]) asc desc sw
 
 	define BConfig : SuffixCfg.weave
 		object # body
 			standard                  { StdShape                   StdMask        BBarPos           false }
-			moreAsymmetric            { AsymmetricShape            AsymmetricMask AsymmetricBBarPos false }
 			standardInterrupted       { StdShapeInterrupted        StdMask        BBarPos           true  }
+			moreAsymmetric            { AsymmetricShape            AsymmetricMask AsymmetricBBarPos false }
 			moreAsymmetricInterrupted { AsymmetricShapeInterrupted AsymmetricMask AsymmetricBBarPos true  }
 		object # serifs
 			serifless         { false false }
 			unilateralSerifed { true  false }
 			bilateralSerifed  { true  true  }
 
-	foreach { suffix { {body mask bp fGap} {ts bs} } } [Object.entries BConfig] : do
+	foreach { suffix { { body mask bp fGap } { ts bs } } } [Object.entries BConfig] : do
 		local fMotion : ts && !bs
 		local fAsymmetric : mask === AsymmetricMask
 		local currencySw : AdviceStroke2 3.5 3 CAP
@@ -149,18 +243,18 @@ glyph-block Letter-Latin-Upper-B : begin
 			include [refer-glyph "B.\(suffix)"] AS_BASE ALSO_METRICS
 			include : BOverlayBar CAP bp
 
-		if (!fAsymmetric) : create-glyph "cyrl/ve.\(suffix)" : glyph-proc
+		if (!fAsymmetric) : create-glyph "smcpB.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			include : body XH [AdviceStroke2 2 3 XH] ts bs
 
 		if (!fGap && !fAsymmetric) : create-glyph "smcpBBar.\(suffix)" : glyph-proc
-			include [refer-glyph "cyrl/ve.\(suffix)"] AS_BASE ALSO_METRICS
+			include [refer-glyph "smcpB.\(suffix)"] AS_BASE ALSO_METRICS
 			include : BOverlayBar XH bp
 
 		create-glyph "currency/baht.\(suffix)" : union
 			body CAP currencySw ts bs
 			intersection [BahtBar : AdviceStroke 5] [mask CAP : AdviceStroke2 2 3 CAP]
-			difference   [BahtBar   Stroke]         [mask CAP : AdviceStroke2 2 3 CAP]
+			difference   [BahtBar : AdviceStroke 2] [mask CAP : AdviceStroke2 2 3 CAP]
 
 		create-glyph "currency/bitcoin.\(suffix)" : union
 			body CAP currencySw ts bs
@@ -177,100 +271,81 @@ glyph-block Letter-Latin-Upper-B : begin
 
 	select-variant 'B' 'B'
 	link-reduced-variant 'B/sansSerif' 'B' MathSansSerif
-	select-variant 'currency/baht' 0xE3F (follow -- 'B')
+	select-variant 'Bhookleft' 0x181
+	select-variant 'BStroke'   0x243 (follow -- 'B')
+	select-variant 'BBar'
+	select-variant 'smcpB'     0x299
+	select-variant 'smcpBBar'  0x1D03
+
+	select-variant 'currency/baht'    0xE3F  (follow -- 'B')
 	select-variant 'currency/bitcoin' 0x20BF (follow -- 'B')
-	select-variant 'BStroke' 0x243 (follow -- 'B')
-	select-variant 'latn/Beta' 0xA7B4
+
 	alias 'grek/Beta' 0x392 'B'
 	alias-reduced-variant 'grek/Beta/sansSerif' 'grek/Beta' 'B/sansSerif' MathSansSerif
+	select-variant 'latn/Beta' 0xA7B4
+
 	alias 'cyrl/Ve' 0x412 'B'
+	select-variant 'cyrl/ve' 0x432 (shapeFrom -- 'smcpB')
+	alias 'cyrl/ve.BGR' null 'smcpB.cursiveTall'
 
-	select-variant 'BBar'
-	select-variant 'Bhookleft' 0x181
-
-	define [CursiveCyrveShape top] : glyph-proc
-		local stroke : AdviceStroke2 2 3 top
-		local fine : stroke * CThin
-		local yMiddle : top * HBarPos
-		local xMidLeft : mix (RightSB - [HSwToV stroke]) (SB + [HSwToV stroke]) 0.7
-		local xMidArc  : Math.max Middle : mix xMidLeft RightSB 0.1
-		include : dispiro
-			widths.lhs fine
-			flat xMidLeft (yMiddle + (stroke / 2 - fine)) [heading Rightward]
-			curl xMidArc  (yMiddle + (stroke / 2 - fine)) [heading Rightward]
-			archv
-			g4   ((RightSB + O) - OX) ([mix (yMiddle + stroke / 2) (top - O - stroke) (ArchDepthA / (ArchDepthA + ArchDepthB))] - [HSwToV : TanSlope * stroke]) [widths.lhs stroke]
-			Arch.lhs top
-			flatside.ld SB 0 top SmallArchDepthA SmallArchDepthB O
-			Arch.lhs 0
-			g4   ((RightSB - O) - OX) ([mix (O + stroke) (yMiddle - stroke / 2) (ArchDepthA / (ArchDepthA + ArchDepthB))] - [HSwToV : TanSlope * stroke])
-			arcvh
-			flat xMidArc  (yMiddle - (stroke / 2 - fine)) [widths.lhs.heading fine Leftward]
-			curl xMidLeft (yMiddle - (stroke / 2 - fine)) [heading Leftward]
-
-	create-glyph 'cyrl/ve.cursive' : glyph-proc
-		include : MarkSet.e
-		include : CursiveCyrveShape XH
-
-	create-glyph 'cyrl/ve.cursiveTall' : glyph-proc
-		include : MarkSet.b
-		include : CursiveCyrveShape Ascender
-
-	select-variant 'cyrl/ve'  0x432
-	select-variant 'smcpB'    0x299  (shapeFrom -- 'cyrl/ve')
-	select-variant 'smcpBBar' 0x1D03
-
+	glyph-block-import Letter-Blackboard : BBS BBD
 	create-glyph 'mathbb/B' 0x1D539 : glyph-proc
 		include : MarkSet.capital
 		include : difference
-			union
-				BShape CAP (stroke -- BBS) (serifs -- false)
-				intersection
-					BShapeMask CAP (stroke -- BBS)
-					union
-						VBar.r ((RightSB - OX * 2) - BBD) 0 (CAP * BBarPos) BBS
-						VBar.r (([mix SB RightSB BArcMix] - OX * 2) - BBD) (CAP * BBarPos) CAP BBS
-						VBar.l (SB + BBD) 0 CAP BBS
+			union [BShape CAP (stroke -- BBS)] : intersection [BShapeMask CAP (stroke -- BBS)] : union
+				VBar.r         ((RightSB          - OX * 2) - BBD)      0              [mix 0 CAP BBarPos] BBS
+				VBar.r (([mix SB RightSB BArcMix] - OX * 2) - BBD) [mix 0 CAP BBarPos]        CAP          BBS
+				VBar.l       (SB                            + BBD)      0                     CAP          BBS
 			Rect (CAP - BBS) (0 + BBS) (SB + [HSwToV BBS]) (SB + BBD)
 
-	### Greek Beta
+	### Greek Lower Beta
 
 	create-glyph 'grek/beta.standard' : glyph-proc
 		include : MarkSet.bp
 		include : LeaningAnchor.Below.VBar.l SB
-		define pBar 0.55
-		define fine : Stroke * CThin
-		define yMiddle : Ascender * pBar - Stroke * 0.2
-		define ada : ArchDepthAOf (ArchDepth * 0.75) (Width * 0.5)
-		define adb : ArchDepthBOf (ArchDepth * 0.75) (Width * 0.5)
-		define xMidLeft : mix (RightSB - [HSwToV Stroke]) (SB + [HSwToV Stroke]) 0.7
-		define xMidArc  : Math.max Middle : mix xMidLeft RightSB 0.1
-		include : dispiro
-			widths.lhs fine
-			flat xMidLeft (yMiddle + (Stroke / 2 - fine)) [heading Rightward]
-			curl xMidArc  (yMiddle + (Stroke / 2 - fine)) [heading Rightward]
-			archv
-			g4   ((RightSB + O * 3) - OX) [YSmoothMidR Ascender (yMiddle - Stroke / 2) ada adb] [widths.lhs]
-			Arch.lhs Ascender
-			flat SB (Ascender - SmallArchDepthA)
-			curl SB Descender [heading Downward]
-		include : dispiro
-			widths.lhs ShoulderFine
-			g4.down.start (SB + [HSwToV : Stroke - ShoulderFine]) adb
-			Arch.lhs 0 (swBefore -- ShoulderFine)
-			g4   (RightSB - OX) [YSmoothMidR (yMiddle + Stroke / 2) 0 ada adb] [widths.lhs]
-			arcvh
-			flat xMidArc  (yMiddle - (Stroke / 2 - fine)) [widths.lhs.heading fine Leftward]
-			curl xMidLeft (yMiddle - (Stroke / 2 - fine)) [heading Leftward]
 
-	alias 'grek/beta.cursive'  null  'cyrl/ve.cursiveTall'
+		local bowl : mix Stroke Ascender BBarPos
+		local mockBowlDepth : BowlXDepth Ascender (bowl - Stroke) SB RightSB Stroke
+		local curveLeftBot : [mix Width RightSB 1.5] - mockBowlDepth
+		local curveLeftTop : Math.min curveLeftBot : [mix Width RightSB 1.5] - OX - Stroke * 1.375
+		local xTopArcRight : [mix SB RightSB BArcMix] - OX * 2
+		local xBotArcRight : RightSB - OX * 2
+		local fine : Stroke * CThin
+
+		local adaBot : ArchDepthAOf : ArchDepth * 0.9
+		local adbBot : ArchDepthBOf : ArchDepth * 0.9
+		local adaTop : ArchDepthAOf : ArchDepth * 0.9 - (curveLeftBot - curveLeftTop)
+		local adbTop : ArchDepthBOf : ArchDepth * 0.9 - (curveLeftBot - curveLeftTop)
+
+		include : difference
+			union
+				dispiro
+					flat (SB - O)     (bowl - fine) [widths.lhs.heading fine Rightward]
+					curl curveLeftTop (bowl - fine) [widths.lhs.heading fine Rightward]
+					archv
+					g4   xTopArcRight [YSmoothMidR Ascender (bowl - Stroke) adaTop adbTop] [widths.lhs]
+					Arch.lhs Ascender
+					flat SB (Ascender - SmallArchDepthA) [heading Downward]
+					curl SB Descender                    [heading Downward]
+				dispiro
+					g4.down.start (SB + [HSwToV : Stroke - ShoulderFine]) SmallArchDepthB [widths.lhs.heading ShoulderFine Downward]
+					Arch.lhs 0 (swBefore -- ShoulderFine)
+					g4   xBotArcRight [YSmoothMidR bowl 0 adaBot adbBot] [widths.lhs]
+					arcvh
+					flat curveLeftBot (bowl - Stroke + fine) [widths.lhs.heading fine Leftward]
+					curl (SB - O)     (bowl - Stroke + fine) [widths.lhs.heading fine Leftward]
+			[InterruptShape BBarPos] Ascender Stroke
+
+	create-glyph 'grek/beta.cursive' : glyph-proc
+		include : MarkSet.b
+		include : difference
+			CursiveCyrVeShape        Ascender Stroke
+			[InterruptShape BBarPos] Ascender Stroke
+
 	select-variant 'grek/beta' 0x3B2
-
-	alias 'grek/betaSymbol' 0x3D0 'cyrl/ve.cursiveTall'
-	alias 'cyrl/ve.BGR'     null  'cyrl/ve.cursiveTall'
-
+	alias 'grek/betaSymbol' 0x3D0 'grek/beta.cursive'
 	derive-composites 'latn/beta' 0xA7B5 'grek/beta.standard'
-		if SLAB [SerifFrame.fromDf [DivFrame 1] XH Descender].lb.fullSide [no-shape]
+		NeedSlab SLAB [SerifFrame.fromDf [DivFrame 1] XH Descender].lb.fullSide
 
 	create-glyph 'cyrl/veRounded' 0x1C80 : glyph-proc
 		include : MarkSet.e

--- a/packages/font-glyphs/src/letter/latin/upper-b.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-b.ptl
@@ -184,9 +184,6 @@ glyph-block Letter-Latin-Upper-B : begin
 	create-glyph "smcpB.cursiveTall" : glyph-proc
 		include : MarkSet.b
 		include : CursiveCyrVeShape Ascender
-			barPos           -- (AsymmetricBBarPos - QuarterStroke / (Ascender - 0))
-			topArcShift      -- AsymmetricBTopArcShift
-			topArcInnerShift -- AsymmetricBTopArcInnerShift
 
 	define [BOverlayStroke top bp] : begin
 		local stroke : AdviceStroke2 2 3 (top - 0)

--- a/packages/font-glyphs/src/letter/latin/upper-b.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-b.ptl
@@ -145,17 +145,17 @@ glyph-block Letter-Latin-Upper-B : begin
 		local adbTop : ArchDepthBOf : ArchDepth * 0.9 - (curveLeftBot - curveLeftTop)
 
 		include : sink
-			flat (SB - O)     (bowl - fine) [widths.lhs.heading fine Rightward]
-			curl curveLeftTop (bowl - fine) [widths.lhs.heading fine Rightward]
+			flat (SB - O)     (bowl - fine + offset) [widths.lhs.heading fine Rightward]
+			curl curveLeftTop (bowl - fine + offset) [widths.lhs.heading fine Rightward]
 			archv
-			g4   xTopArcRight [YSmoothMidR top (bowl - stroke) adaTop adbTop] [widths.lhs stroke]
-			Arch.lhs top (sw -- stroke)
-			flatside.ld SB 0 top adaTop adbBot 0 [widths.lhs.heading stroke Downward]
-			Arch.lhs 0   (sw -- stroke)
-			g4   xBotArcRight [YSmoothMidR bowl 0 adaBot adbBot] [widths.lhs stroke]
+			g4   (xTopArcRight - offset) [YSmoothMidR top (bowl - stroke) adaTop adbTop] [widths.lhs stroke]
+			Arch.lhs (top - offset) (sw -- stroke)
+			flatside.ld (SB + offset) (0 + offset) (top - offset) adaTop adbBot 0 [widths.lhs.heading stroke Downward]
+			Arch.lhs (0   + offset) (sw -- stroke)
+			g4   (xBotArcRight - offset) [YSmoothMidR bowl 0 adaBot adbBot] [widths.lhs stroke]
 			arcvh
-			flat curveLeftBot (bowl - stroke + fine) [widths.lhs.heading fine Leftward]
-			curl (SB - O)     (bowl - stroke + fine) [widths.lhs.heading fine Leftward]
+			flat curveLeftBot (bowl - stroke + fine - offset) [widths.lhs.heading fine Leftward]
+			curl (SB - O)     (bowl - stroke + fine - offset) [widths.lhs.heading fine Leftward]
 
 		return : object bowl
 
@@ -182,9 +182,10 @@ glyph-block Letter-Latin-Upper-B : begin
 		include : CursiveCyrVeShape XH
 	create-glyph "smcpB.cursiveTall" : glyph-proc
 		include : MarkSet.b
+		local stroke : AdviceStroke2 2 4 Ascender
 		include : CursiveCyrVeShape Ascender
-			barPos           -- AsymmetricBBarPos
-			stroke           -- [AdviceStroke2 2 4 Ascender]
+			stroke           -- stroke
+			barPos           -- (AsymmetricBBarPos - (0.25 * stroke) / (Ascender - 0))
 			topArcShift      -- AsymmetricBTopArcShift
 			topArcInnerShift -- AsymmetricBTopArcInnerShift
 

--- a/packages/font-glyphs/src/letter/latin/upper-b.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-b.ptl
@@ -50,14 +50,14 @@ glyph-block Letter-Latin-Upper-B : begin
 			archv
 			g4   (xBotArcRight - offset) [YSmoothMidR bowl 0 adaBot adbBot] [widths.rhs stroke]
 			arcvh
-			flat [Arch.adjust-x.bot curveLeftBot (sw -- stroke)] offset
-			curl (SB - O) offset [heading Leftward]
+			flat [Arch.adjust-x.bot curveLeftBot (sw -- stroke)] (0 + offset)
+			curl (SB - O) (0 + offset) [heading Leftward]
 
 		return : object bowl
 
 	define flex-params [BShape] : glyph-proc
 		local-parameter : top
-		local-parameter : stroke           -- [AdviceStroke2 2 3 top]
+		local-parameter : stroke           -- [AdviceStroke2 2 3 (top - 0)]
 		local-parameter : barPos           -- BBarPos
 		local-parameter : topArcShift      -- 0
 		local-parameter : topArcInnerShift -- 0
@@ -80,7 +80,7 @@ glyph-block Letter-Latin-Upper-B : begin
 
 	define flex-params [BShapeMask] : glyph-proc
 		local-parameter : top
-		local-parameter : stroke           -- [AdviceStroke2 2 3 top]
+		local-parameter : stroke           -- [AdviceStroke2 2 3 (top - 0)]
 		local-parameter : barPos           -- BBarPos
 		local-parameter : topArcShift      -- 0
 		local-parameter : topArcInnerShift -- 0
@@ -113,7 +113,7 @@ glyph-block Letter-Latin-Upper-B : begin
 		barPos   -- BBarPos
 
 	define [AsymmetricShape top sw st sb] : BShape top
-		stroke           -- [fallback sw : AdviceStroke2 2 3 top]
+		stroke           -- [fallback sw : AdviceStroke2 2 3 (top - 0)]
 		barPos           -- AsymmetricBBarPos
 		topArcShift      -- AsymmetricBTopArcShift
 		topArcInnerShift -- AsymmetricBTopArcInnerShift
@@ -123,7 +123,7 @@ glyph-block Letter-Latin-Upper-B : begin
 		AsymmetricShape                    top sw st sb
 		[InterruptShape AsymmetricBBarPos] top sw st sb
 	define [AsymmetricMask top sw] : BShapeMask top
-		stroke           -- [fallback sw : AdviceStroke2 2 3 top]
+		stroke           -- [fallback sw : AdviceStroke2 2 3 (top - 0)]
 		barPos           -- AsymmetricBBarPos
 		topArcShift      -- AsymmetricBTopArcShift
 		topArcInnerShift -- AsymmetricBTopArcInnerShift
@@ -150,7 +150,7 @@ glyph-block Letter-Latin-Upper-B : begin
 			archv
 			g4   (xTopArcRight - offset) [YSmoothMidR top (bowl - stroke) adaTop adbTop] [widths.lhs stroke]
 			Arch.lhs (top - offset) (sw -- stroke)
-			flatside.ld (SB + offset) (0 + offset) (top - offset) adaTop adbBot 0 [widths.lhs.heading stroke Downward]
+			flatside.ld (SB + offset) 0 top adaTop adbBot 0 [widths.lhs.heading stroke Downward]
 			Arch.lhs (0   + offset) (sw -- stroke)
 			g4   (xBotArcRight - offset) [YSmoothMidR bowl 0 adaBot adbBot] [widths.lhs stroke]
 			arcvh
@@ -161,7 +161,7 @@ glyph-block Letter-Latin-Upper-B : begin
 
 	define flex-params [CursiveCyrVeShape] : glyph-proc
 		local-parameter : top
-		local-parameter : stroke           -- [AdviceStroke2 2 3 top]
+		local-parameter : stroke           -- [AdviceStroke2 2 3 (top - 0)]
 		local-parameter : barPos           -- BBarPos
 		local-parameter : topArcShift      -- 0
 		local-parameter : topArcInnerShift -- 0
@@ -182,20 +182,18 @@ glyph-block Letter-Latin-Upper-B : begin
 		include : CursiveCyrVeShape XH
 	create-glyph "smcpB.cursiveTall" : glyph-proc
 		include : MarkSet.b
-		local stroke : AdviceStroke2 2 4 Ascender
 		include : CursiveCyrVeShape Ascender
-			stroke           -- stroke
-			barPos           -- (AsymmetricBBarPos - (0.25 * stroke) / (Ascender - 0))
+			barPos           -- (AsymmetricBBarPos - QuarterStroke / (Ascender - 0))
 			topArcShift      -- AsymmetricBTopArcShift
 			topArcInnerShift -- AsymmetricBTopArcInnerShift
 
 	define [BOverlayStroke top bp] : begin
-		local stroke : AdviceStroke2 2 3 top
+		local stroke : AdviceStroke2 2 3 (top - 0)
 		return : LetterBarOverlay.l.in SB stroke ([mix stroke top bp] - stroke)
 			space -- { 0 (RightSB - [HSwToV Stroke]) }
 
 	define [BOverlayBar top bp] : begin
-		local stroke : AdviceStroke2 2 3 top
+		local stroke : AdviceStroke2 2 3 (top - 0)
 		return : HBar.t [mix 0 SB 0.3] [mix Width RightSB 0.3] [mix stroke top bp] stroke
 
 	define [BahtBar sw] : begin
@@ -207,7 +205,9 @@ glyph-block Letter-Latin-Upper-B : begin
 		local asc  : CAP + ([mix XH Ascender 0.5] - XH)
 		local desc : mix 0 Descender 0.5
 		local xMid : mix SB RightSB 0.48
-		local gap  : Math.max ((RightSB - SB) / 6) : AdviceStroke 4
+		local gap  : Math.max
+			AdviceStroke 4
+			(RightSB - SB) / 6
 		return : union
 			VBar.m (xMid - gap / 2 - [HSwToV : 0.5 * sw]) asc desc sw
 			VBar.m (xMid + gap / 2 + [HSwToV : 0.5 * sw]) asc desc sw
@@ -226,11 +226,11 @@ glyph-block Letter-Latin-Upper-B : begin
 	foreach { suffix { { body mask bp fGap } { ts bs } } } [Object.entries BConfig] : do
 		local fMotion : ts && !bs
 		local fAsymmetric : mask === AsymmetricMask
-		local currencySw : AdviceStroke2 3.5 3 CAP
+		local currencySw : AdviceStroke2 3.5 3 (CAP - 0)
 
 		create-glyph "B.\(suffix)" : glyph-proc
 			include : MarkSet.capital
-			include : body CAP [AdviceStroke2 2 3 CAP] ts bs
+			include : body CAP [AdviceStroke2 2 3 (CAP - 0)] ts bs
 
 		create-glyph "BStroke.\(suffix)" : glyph-proc
 			include [refer-glyph "B.\(suffix)"] AS_BASE ALSO_METRICS
@@ -247,7 +247,7 @@ glyph-block Letter-Latin-Upper-B : begin
 
 		if (!fAsymmetric) : create-glyph "smcpB.\(suffix)" : glyph-proc
 			include : MarkSet.e
-			include : body XH [AdviceStroke2 2 3 XH] ts bs
+			include : body XH [AdviceStroke2 2 3 (XH - 0)] ts bs
 
 		if (!fGap && !fAsymmetric) : create-glyph "smcpBBar.\(suffix)" : glyph-proc
 			include [refer-glyph "smcpB.\(suffix)"] AS_BASE ALSO_METRICS
@@ -255,17 +255,24 @@ glyph-block Letter-Latin-Upper-B : begin
 
 		create-glyph "currency/baht.\(suffix)" : union
 			body CAP currencySw ts bs
-			intersection [BahtBar : AdviceStroke 5] [mask CAP : AdviceStroke2 2 3 CAP]
-			difference   [BahtBar : AdviceStroke 2] [mask CAP : AdviceStroke2 2 3 CAP]
+			intersection
+				BahtBar  : AdviceStroke  5
+				mask CAP : AdviceStroke2 2 3 (CAP - 0)
+			difference
+				BahtBar  : AdviceStroke  2
+				mask CAP : AdviceStroke2 2 3 (CAP - 0)
 
 		create-glyph "currency/bitcoin.\(suffix)" : union
 			body CAP currencySw ts bs
-			difference [BitcoinBar : AdviceStroke 5] [mask CAP : AdviceStroke2 2 3 CAP]
+			difference
+				BitcoinBar : AdviceStroke  5
+				mask CAP   : AdviceStroke2 2 3 (CAP - 0)
 
 		if (!bs) : create-glyph "latn/Beta.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
 			include : LeaningAnchor.Below.VBar.l SB
-			include : body CAP [AdviceStroke2 2 3 CAP] ts false
+			include [refer-glyph "B.\(suffix)"]
+			eject-contour "serifLB"
 			include : VBar.l SB Descender 0
 			if SLAB : begin
 				local sf : SerifFrame.fromDf [DivFrame 1] CAP Descender

--- a/packages/font-glyphs/src/letter/latin/upper-p.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-p.ptl
@@ -169,13 +169,13 @@ glyph-block Letter-Latin-Upper-P : begin
 		[mix 0 df.leftSB mul] + [HSwToV sw]
 		Math.min ([PBarPosY top sw bp] - 0.5 * sw - TINY) bot
 		Math.max ([PBarPosY top sw bp] + 0.5 * sw + TINY) [mix top [PBarPosY top sw bp] 0.5]
-		0.2 * (df.rightSB - df.leftSB) * ([AdviceStroke 5] / Stroke)
+		VSwToH : 0.2 * (df.rightSB - df.leftSB) * ([AdviceStroke 5] / Stroke)
 
 	set RevPShape.OpenGap : function [] : with-params [top [df [DivFrame 1]] [bot 0] [mul PShape.defaultMul] [bp PShape.BarPos] [sw df.mvs]] : VBar.r
 		[mix df.width df.rightSB mul] - [HSwToV sw]
 		Math.min ([PBarPosY top sw bp] - 0.5 * sw - TINY) bot
 		Math.max ([PBarPosY top sw bp] + 0.5 * sw + TINY) [mix top [PBarPosY top sw bp] 0.5]
-		0.2 * (df.rightSB - df.leftSB) * ([AdviceStroke 5] / Stroke)
+		VSwToH : 0.2 * (df.rightSB - df.leftSB) * ([AdviceStroke 5] / Stroke)
 
 	glyph-block-export PConfig
 	define PConfig : SuffixCfg.weave


### PR DESCRIPTION
Also code cleanup surrounding `letter/latin/upper-b.ptl`.

### Motivation and Context

Basically, the default cursive Cyrillic Lower Ve glyphs resembled the `open` variants for `B`, so this changes the glyph to be `closed`, like real handwriting, as well as most contemporary italic fonts I checked.

Additionally, the bar position of `cyrl/ve.cursiveTall` is moved to the height of `AsymmetricBBarPos` because this variant is based on a handwritten form that looks identical to (cursive) Latin Lower `b`, with an enlarged lower bowl. This also makes it match `б`/_`д`_ more.

Greek Lower Beta is _very slightly_ changed, but only superficially, since I tried to preserve the original look feel of it as much as I could. Therefore, this disunifies `cyrl/ve.cursiveTall` from `grek/beta.cursive`, which technically adds two glyphs.

This also adds `startAf` and `endAf` arguments to `flatside` because there was previously no way to add a `heading` argument to the `curl` knot. I checked every instance of `flatside` in the code that uses the `af` argument, and the only uses were `[widths.`{`lhs`|`rhs`}` …]`, so I made both `startAf` and `endAf` default to the contents of the normal `af` argument since it appears to not disrupt anything if that usage gets copied over to the `curl` knot.

### Influenced Characters

  - U+03B2: GREEK SMALL LETTER BETA
  - U+03D0: GREEK BETA SYMBOL
  - U+0432: CYRILLIC SMALL LETTER VE

### Glyph Quantity

2

### Samples


`АаБбВвГгДд ΑαΒβϐΓγΔδ∂`

Default:
<img width="2362" height="1100" alt="image" src="https://github.com/user-attachments/assets/4612e6ea-8fb9-4d72-8981-0323cd407a7b" />
`ss03`:
<img width="2371" height="1094" alt="image" src="https://github.com/user-attachments/assets/196805c9-036c-40be-b905-d1fe9e98bdea" />
Compared to Consolas:
<img width="2299" height="365" alt="image" src="https://github.com/user-attachments/assets/eb6a7a84-b31c-4119-a8f1-83c2a283b6c7" />