### PR TITLE
chore: improve performance of dev-daily-build workflow via caching

### DIFF
--- a/.github/workflows/dev-daily-build.yml
+++ b/.github/workflows/dev-daily-build.yml
@@ -1,0 +1,52 @@
+name: "Dev Daily Build"
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Reason for running manually"
+        required: false
+        default: "Manual check"
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  build:
+    name: Build ${{ matrix.fontName }} font
+    if: github.repository == 'be5invis/Iosevka'
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        fontName: ["Iosevka", "IosevkaSlab", "IosevkaAile", "IosevkaEtoile"]
+
+    steps:
+      # Checkout repository into `iosevka` sub directory
+      - uses: actions/checkout@v6
+        with:
+          path: iosevka
+          ref: dev
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install ttfautohint
+        uses:  awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: ttfautohint
+
+      - name: Build Font ${{ matrix.fontName }}
+        shell: bash
+        working-directory: iosevka
+        run: |
+          npm install
+          npm run build -- ttc::${{ matrix.fontName }}
+
+      - name: Upload Font Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ttc-${{ matrix.fontName }}
+          path: iosevka/dist/.ttc/${{ matrix.fontName }}/


### PR DESCRIPTION
### Motivation and Context

Upon seeing dc156e65c0d9c06dbe93cb46afcc79a9567b9a78, I noticed that it could be a couple seconds faster, so I took what I have had at https://github.com/jaschiu/ljs-iosevka/blob/master/.github/workflows/build.yml to add efficient dependency caching. And `fail-fast: false` makes a job for one font that fails early not cancel other in-progress ones