### PR TITLE
Add `rounded-top` variants for Cyrillic Lower Ve (`в`) for `ss12` (italic).

### DIFF
--- a/changes/34.4.0.md
+++ b/changes/34.4.0.md
@@ -2,3 +2,4 @@
 * Add `tall` variants for Cyrillic Lower Ze (`з`).
 * Add `cursive-interrupted` and `cursive-interrupted-tall` variants for Cyrillic Lower Ve (`в`).
   - Optimize glyphs for original `cursive` and `cursive-tall` variants.
+* Add `rounded-top` variants for Cyrillic Lower Ve (`в`).

--- a/packages/font-glyphs/src/letter/latin/upper-b.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-b.ptl
@@ -130,6 +130,97 @@ glyph-block Letter-Latin-Upper-B : begin
 
 	### Cyrillic Lower Ve
 
+	define [RoundedCyrVeArcsT sink] : function [] : with-params [top stroke offset barPos topArcShift topArcInnerShift] : glyph-proc
+		local bowl : mix stroke top barPos
+		local mockBowlDepth : BowlXDepth top (bowl - stroke) SB RightSB stroke
+		local curveLeftBot : [mix Width RightSB 1.5] - mockBowlDepth + topArcInnerShift
+		local curveLeftTop : Math.min curveLeftBot : [mix Width RightSB 1.5] - OX - stroke * 1.375 + topArcInnerShift
+		local xTopArcRight : [mix SB RightSB BArcMix] - OX * 2 + topArcShift
+		local xBotArcRight : RightSB - OX * 2
+		local fine : stroke * CThin
+
+		local adaBot : ArchDepthAOf : ArchDepth * 0.9
+		local adbBot : ArchDepthBOf : ArchDepth * 0.9
+		local adaTop : ArchDepthAOf : ArchDepth * 0.9 - (curveLeftBot - curveLeftTop)
+		local adbTop : ArchDepthBOf : ArchDepth * 0.9 - (curveLeftBot - curveLeftTop)
+
+		include : sink
+			widths.lhs fine
+			flat (SB - O) (bowl - fine + offset) [heading Rightward]
+			curl [Arch.adjust-x.bot curveLeftTop (sw -- stroke)] (bowl - fine + offset)
+			archv
+			g4   (xTopArcRight - offset) [YSmoothMidR top (bowl - stroke) adaTop adbTop] [widths.lhs stroke]
+			Arch.lhs (top - offset) (sw -- stroke)
+			flat (SB + offset) [Math.max (0 + TINY) (top - adaTop)] [widths.lhs.heading stroke Downward]
+			curl (SB + offset) 0 [heading Downward]
+
+		include : sink
+			widths.rhs fine
+			flat (SB - O) (bowl - stroke + fine - offset) [heading Rightward]
+			curl [Arch.adjust-x.top curveLeftBot (sw -- stroke)] (bowl - stroke + fine - offset)
+			archv
+			g4   (xBotArcRight - offset) [YSmoothMidR bowl 0 adaBot adbBot] [widths.rhs stroke]
+			arcvh
+			flat [Arch.adjust-x.bot curveLeftBot (sw -- stroke)] (0 + offset)
+			curl (SB - O) (0 + offset) [heading Leftward]
+
+		return : object bowl
+
+	define flex-params [RoundedCyrVeShape] : glyph-proc
+		local-parameter : top
+		local-parameter : stroke           -- [AdviceStroke2 2 3 (top - 0)]
+		local-parameter : barPos           -- BBarPos
+		local-parameter : topArcShift      -- 0
+		local-parameter : topArcInnerShift -- 0
+		local-parameter : serifTop         -- false
+		local-parameter : serifBot         -- false
+
+		local dims : include : [RoundedCyrVeArcsT dispiro] top
+			offset           -- 0
+			stroke           -- stroke
+			barPos           -- barPos
+			topArcShift      -- topArcShift
+			topArcInnerShift -- topArcInnerShift
+
+		set-base-anchor 'strike' Middle (dims.bowl - 0.5 * stroke)
+
+		local sf : SerifFrame.fromDf [DivFrame 1] top 0
+		if serifBot : include sf.lb.outer
+
+	define flex-params [RoundedCyrVeShapeMask] : glyph-proc
+		local-parameter : top
+		local-parameter : stroke           -- [AdviceStroke2 2 3 (top - 0)]
+		local-parameter : barPos           -- BBarPos
+		local-parameter : topArcShift      -- 0
+		local-parameter : topArcInnerShift -- 0
+
+		include : [RoundedCyrVeArcsT spiro-outline] top
+			offset           -- 1
+			stroke           -- stroke
+			barPos           -- barPos
+			topArcShift      -- topArcShift
+			topArcInnerShift -- topArcInnerShift
+
+	define [RoundedShape top sw st sb] : RoundedCyrVeShape top
+		stroke   -- sw
+		barPos   -- BBarPos
+		serifTop -- st
+		serifBot -- sb
+	define [RoundedShapeInterrupted top sw st sb] : difference
+		RoundedShape             top sw st sb
+		[InterruptShape BBarPos] top sw st sb
+	define [RoundedMask top sw] : RoundedCyrVeShapeMask top
+		stroke   -- sw
+		barPos   -- BBarPos
+
+	create-glyph : glyph-proc
+		include : MarkSet.e
+		local stroke : AdviceStroke2 2 3 (XH - 0)
+		create-forked-glyph "smcpB.roundedTopSerifless"                          : RoundedShape            XH stroke false false
+		create-forked-glyph "smcpB.roundedTopUnilateralBottomSerifed"            : RoundedShape            XH stroke false true
+		create-forked-glyph "smcpB.roundedTopInterruptedSerifless"               : RoundedShapeInterrupted XH stroke false false
+		create-forked-glyph "smcpB.roundedTopInterruptedUnilateralBottomSerifed" : RoundedShapeInterrupted XH stroke false true
+
 	define [CursiveCyrVeArcsT sink] : function [] : with-params [top stroke offset barPos topArcShift topArcInnerShift] : glyph-proc
 		local bowl : mix stroke top barPos
 		local mockBowlDepth : BowlXDepth top (bowl - stroke) SB RightSB stroke
@@ -339,7 +430,7 @@ glyph-block Letter-Latin-Upper-B : begin
 
 	create-glyph 'grek/beta.standard' : glyph-proc
 		include : MarkSet.bp
-		local stroke : AdviceStroke2 2 3 Ascender
+		local stroke : AdviceStroke2 2 3 (Ascender - 0)
 		include : LeaningAnchor.Below.VBar.l SB stroke
 
 		local bowl : mix stroke Ascender BBarPos
@@ -365,8 +456,8 @@ glyph-block Letter-Latin-Upper-B : begin
 					archv
 					g4   xTopArcRight [YSmoothMidR Ascender (bowl - stroke) adaTop adbTop] [widths.lhs stroke]
 					Arch.lhs Ascender (sw -- stroke)
-					flat SB (Ascender - adaTop) [heading Downward]
-					curl SB Descender           [heading Downward]
+					flat SB (Ascender - adaTop) [widths.lhs.heading stroke Downward]
+					curl SB Descender [heading Downward]
 				dispiro
 					widths.lhs shoulderFine
 					g4.down.start (SB + [HSwToV : stroke - shoulderFine]) adbBot [heading Downward]

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -7073,16 +7073,23 @@ descriptionAffix = "standard body"
 selectorAffix."cyrl/ve" = "standard"
 selectorAffix."cyrl/ve.BGR" = "cursive"
 
-[prime.cyrl-ve.variants-buildup.stages.body.cursive]
+[prime.cyrl-ve.variants-buildup.stages.body.rounded-top]
 rank = 2
+nonBreakingVariantAdditionPriority = 200
+descriptionAffix = "rounded top"
+selectorAffix."cyrl/ve" = "roundedTop"
+selectorAffix."cyrl/ve.BGR" = "cursive"
+
+[prime.cyrl-ve.variants-buildup.stages.body.cursive]
+rank = 3
 descriptionAffix = "cursive body"
 selectorAffix."cyrl/ve" = "cursive"
 selectorAffix."cyrl/ve.BGR" = "cursive"
 
-[prime.cyrl-ve.variants-buildup.stages.openness.closed__standard]
+[prime.cyrl-ve.variants-buildup.stages.openness.closed__non-cursive]
 rank = 1
 next = "serifs"
-enableIf = [{ body = "standard" }]
+enableIf = [{ body = "NOT cursive" }]
 keyAffix = ""
 selectorAffix."cyrl/ve" = ""
 selectorAffix."cyrl/ve.BGR" = "tall"
@@ -7095,10 +7102,10 @@ keyAffix = ""
 selectorAffix."cyrl/ve" = ""
 selectorAffix."cyrl/ve.BGR" = ""
 
-[prime.cyrl-ve.variants-buildup.stages.openness.interrupted__standard]
+[prime.cyrl-ve.variants-buildup.stages.openness.interrupted__non-cursive]
 rank = 2
 next = "serifs"
-enableIf = [{ body = "standard" }]
+enableIf = [{ body = "NOT cursive" }]
 keyAffix = "interrupted"
 descriptionAffix = "interrupted middle bar"
 selectorAffix."cyrl/ve" = "interrupted"
@@ -7126,14 +7133,25 @@ selectorAffix."cyrl/ve.BGR" = ""
 
 [prime.cyrl-ve.variants-buildup.stages.serifs.unilateral-serifed]
 rank = 2
+enableIf = [{ body = "NOT rounded-top" }]
 descriptionAffix = "serifs at top"
 selectorAffix."cyrl/ve" = "unilateralSerifed"
 selectorAffix."cyrl/ve.BGR" = ""
 
-[prime.cyrl-ve.variants-buildup.stages.serifs.bilateral-serifed]
+[prime.cyrl-ve.variants-buildup.stages.serifs.bilateral-serifed__standard]
 rank = 3
+enableIf = [{ body = "standard" }]
+keyAffix = "bilateral-serifed"
 descriptionAffix = "serifs at both top and bottom"
 selectorAffix."cyrl/ve" = "bilateralSerifed"
+selectorAffix."cyrl/ve.BGR" = ""
+
+[prime.cyrl-ve.variants-buildup.stages.serifs.bilateral-serifed__rounded-top]
+rank = 3
+enableIf = [{ body = "rounded-top" }]
+keyAffix = "unilateral-bottom-serifed"
+descriptionAffix = "serifs at bottom"
+selectorAffix."cyrl/ve" = "unilateralBottomSerifed"
 selectorAffix."cyrl/ve.BGR" = ""
 
 [prime.cyrl-ve.variants-buildup.stages.height."*"]
@@ -11588,7 +11606,7 @@ lower-iota = "tailed-serifed"
 lower-mu = "tailed-serifless"
 lower-tau = "tailed"
 cyrl-a = "single-storey-earless-corner-tailed"
-cyrl-ve = "cursive"
+cyrl-ve = "rounded-top-serifless"
 cyrl-zhe = "cursive"
 micro-sign = "tailed-serifless"
 
@@ -11657,7 +11675,7 @@ long-s = "bent-hook-tailed"
 eszet = "longs-s-lig-tailed-serifless"
 lower-kappa = "symmetric-touching-top-left-and-bottom-right-serifed"
 lower-mu = "tailed-motion-serifed"
-cyrl-ve = "cursive"
+cyrl-ve = "rounded-top-serifless"
 cyrl-ka = "symmetric-touching-top-left-and-bottom-right-serifed"
 cyrl-u = "straight-turn-motion-serifed"
 cyrl-ef = "top-serifed"


### PR DESCRIPTION
### Motivation and Context

Ubuntu Mono uses a form of Italic Cyrillic Lower Ve that rounds the top bowl but not the bottom bowl.
This also matches its usage of `cyrl-`{`yeri`|`yery`}` = "corner"` under italics.

There is no need for `tall` versions of these variants at the moment.

`АаБбВвГгДд`
Ubuntu Mono:
<img width="1168" height="389" alt="image" src="https://github.com/user-attachments/assets/76430947-87b4-433b-bdd7-c619652136ae" />
Liberation Sans does this too:
<img width="1424" height="391" alt="image" src="https://github.com/user-attachments/assets/12191d4a-06f7-4a3b-85e4-6ef5e0fe9cb8" />

### Influenced Characters

  - U+0432: CYRILLIC SMALL LETTER VE

### Glyph Quantity

4:
  - `smcpB.roundTopSerifless`
  - `smcpB.roundTopInterruptedSerifless`
  - `smcpB.roundTopUnilateralBottomSerifed`
  - `smcpB.roundTopInterruptedUnilateralBottomSerifed`

### Samples

`АаБбВвГгДд`

Sans `ss12`:
<img width="1165" height="423" alt="image" src="https://github.com/user-attachments/assets/842db268-9fdb-469e-bed1-16328e0102d3" />
Slab `ss12`:
<img width="1162" height="414" alt="image" src="https://github.com/user-attachments/assets/fca489d0-df21-4ce6-80fa-7973896d55a9" />

