### PR TITLE
Optimize glyphs for Bulgarian Cyrillic Lower Ve⁠/⁠Yer⁠/⁠Yeri (`в`, `ъ`, `ь`).

### DIFF
--- a/packages/font-glyphs/src/letter/cyrillic/yer.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/yer.ptl
@@ -153,7 +153,7 @@ glyph-block Letter-Cyrillic-Yer : begin
 
 	select-variant 'cyrl/Yer' 0x42A
 	select-variant 'cyrl/yer' 0x44A
-	select-variant 'cyrl/yer.BGR'
+	select-variant 'cyrl/yer.BGR' (follow -- 'cyrl/yer')
 	select-variant 'cyrl/yerTall' 0x1C86 (follow -- 'cyrl/yer')
 
 	select-variant 'cyrl/YerNeutral' 0xA64E (follow -- 'cyrl/Yer')

--- a/packages/font-glyphs/src/letter/cyrillic/yeri.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/yeri.ptl
@@ -37,11 +37,16 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			local yTurnBottomL : YSmoothMidL bowlTop 0 ada adb
 			local yTurnBottomR : YSmoothMidR bowlTop 0 ada adb
 
-			include : union [VBar.l left 0 yStart stroke] : dispiro
+			include : union [VBar.l left [if fBGR (0 + DToothlessRise) 0] yStart stroke] : dispiro
 				widths.lhs stroke
-				flat (left - O) 0 [heading Rightward]
-				curl [Arch.adjust-x.bot [Math.max (right - turnRadius) : mix left right 0.5] (sw -- stroke)] 0
-				archv 8
+				if fBGR
+					list
+						g4 left (0 + DToothlessRise)
+						Arch.lhs 0 (sw -- stroke) (blendPre -- {})
+					list
+						flat (left - O) 0 [heading Rightward]
+						curl [Arch.adjust-x.bot [Math.max (right - turnRadius) : mix left right 0.5] (sw -- stroke)] 0
+						archv 8
 				g4   (right - OX) yTurnBottomR
 				arcvh 8
 				flat [Arch.adjust-x.top [Math.max (right - turnRadius) : mix left right 0.5] (sw -- stroke)] bowlTop
@@ -232,7 +237,7 @@ glyph-block Letter-Cyrillic-Yeri : begin
 
 	select-variant 'cyrl/Yeri' 0x42C
 	select-variant 'cyrl/yeri' 0x44C
-	select-variant 'cyrl/yeri.BGR'
+	select-variant 'cyrl/yeri.BGR' (follow -- 'cyrl/yeri')
 
 	select-variant 'cyrl/YeriBar' 0x48C (follow -- 'cyrl/Yeri')
 	select-variant 'cyrl/yeriBar' 0x48D (follow -- 'cyrl/yeri')

--- a/packages/font-glyphs/src/letter/latin/upper-b.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-b.ptl
@@ -130,7 +130,7 @@ glyph-block Letter-Latin-Upper-B : begin
 
 	### Cyrillic Lower Ve
 
-	define [RoundedCyrVeArcsT sink] : function [] : with-params [top stroke offset barPos topArcShift topArcInnerShift] : glyph-proc
+	define [RoundedTopCyrVeArcsT sink] : function [] : with-params [top stroke offset barPos topArcShift topArcInnerShift rise] : glyph-proc
 		local bowl : mix stroke top barPos
 		local mockBowlDepth : BowlXDepth top (bowl - stroke) SB RightSB stroke
 		local curveLeftBot : [mix Width RightSB 1.5] - mockBowlDepth + topArcInnerShift
@@ -151,8 +151,8 @@ glyph-block Letter-Latin-Upper-B : begin
 			archv
 			g4   (xTopArcRight - offset) [YSmoothMidR top (bowl - stroke) adaTop adbTop] [widths.lhs stroke]
 			Arch.lhs (top - offset) (sw -- stroke)
-			flat (SB + offset) [Math.max (0 + TINY) (top - adaTop)] [widths.lhs.heading stroke Downward]
-			curl (SB + offset) 0 [heading Downward]
+			flat (SB + offset) [Math.max (0 + rise + offset + TINY) (top - adaTop)] [widths.lhs.heading stroke Downward]
+			curl (SB + offset) (0 + rise + offset) [heading Downward]
 
 		include : sink
 			widths.rhs fine
@@ -160,66 +160,94 @@ glyph-block Letter-Latin-Upper-B : begin
 			curl [Arch.adjust-x.top curveLeftBot (sw -- stroke)] (bowl - stroke + fine - offset)
 			archv
 			g4   (xBotArcRight - offset) [YSmoothMidR bowl 0 adaBot adbBot] [widths.rhs stroke]
-			arcvh
-			flat [Arch.adjust-x.bot curveLeftBot (sw -- stroke)] (0 + offset)
-			curl (SB - O) (0 + offset) [heading Leftward]
+			if rise
+				list
+					Arch.rhs (0 + offset) (sw -- stroke) (blendPost -- {})
+					g4   (SB + offset) (0 + rise + offset) [widths.rhs stroke]
+				list
+					arcvh
+					flat [Arch.adjust-x.bot curveLeftBot (sw -- stroke)] (0 + offset)
+					curl (SB - O) (0 + offset) [heading Leftward]
 
 		return : object bowl
 
-	define flex-params [RoundedCyrVeShape] : glyph-proc
+	define flex-params [RoundedTopCyrVeShape] : glyph-proc
 		local-parameter : top
 		local-parameter : stroke           -- [AdviceStroke2 2 3 (top - 0)]
 		local-parameter : barPos           -- BBarPos
 		local-parameter : topArcShift      -- 0
 		local-parameter : topArcInnerShift -- 0
+		local-parameter : rise             -- 0
 		local-parameter : serifTop         -- false
 		local-parameter : serifBot         -- false
 
-		local dims : include : [RoundedCyrVeArcsT dispiro] top
+		local dims : include : [RoundedTopCyrVeArcsT dispiro] top
 			offset           -- 0
 			stroke           -- stroke
 			barPos           -- barPos
 			topArcShift      -- topArcShift
 			topArcInnerShift -- topArcInnerShift
+			rise             -- rise
 
 		set-base-anchor 'strike' Middle (dims.bowl - 0.5 * stroke)
 
 		local sf : SerifFrame.fromDf [DivFrame 1] top 0
 		if serifBot : include sf.lb.outer
 
-	define flex-params [RoundedCyrVeShapeMask] : glyph-proc
+	define flex-params [RoundedTopCyrVeShapeMask] : glyph-proc
 		local-parameter : top
 		local-parameter : stroke           -- [AdviceStroke2 2 3 (top - 0)]
 		local-parameter : barPos           -- BBarPos
 		local-parameter : topArcShift      -- 0
 		local-parameter : topArcInnerShift -- 0
+		local-parameter : rise             -- 0
 
-		include : [RoundedCyrVeArcsT spiro-outline] top
+		include : [RoundedTopCyrVeArcsT spiro-outline] top
 			offset           -- 1
 			stroke           -- stroke
 			barPos           -- barPos
 			topArcShift      -- topArcShift
 			topArcInnerShift -- topArcInnerShift
+			rise             -- rise
 
-	define [RoundedShape top sw st sb] : RoundedCyrVeShape top
+	define [RoundedTopShape top sw st sb] : RoundedTopCyrVeShape top
 		stroke   -- sw
 		barPos   -- BBarPos
 		serifTop -- st
 		serifBot -- sb
-	define [RoundedShapeInterrupted top sw st sb] : difference
-		RoundedShape             top sw st sb
+	define [RoundedTopShapeInterrupted top sw st sb] : difference
+		RoundedTopShape          top sw st sb
 		[InterruptShape BBarPos] top sw st sb
-	define [RoundedMask top sw] : RoundedCyrVeShapeMask top
+	define [RoundedTopMask top sw] : RoundedTopCyrVeShapeMask top
 		stroke   -- sw
 		barPos   -- BBarPos
+
+	define [RoundedTopShapeBGR top sw st sb] : RoundedTopCyrVeShape top
+		stroke   -- sw
+		barPos   -- BBarPos
+		rise     -- DToothlessRise
+		serifTop -- st
+		serifBot -- sb
+	define [RoundedTopShapeBGRInterrupted top sw st sb] : difference
+		RoundedTopShapeBGR       top sw st sb
+		[InterruptShape BBarPos] top sw st sb
+	define [RoundedTopBGRMask top sw] : RoundedTopCyrVeShapeMask top
+		stroke   -- sw
+		barPos   -- BBarPos
+		rise     -- DToothlessRise
 
 	create-glyph : glyph-proc
 		include : MarkSet.e
 		local stroke : AdviceStroke2 2 3 (XH - 0)
-		create-forked-glyph "smcpB.roundedTopSerifless"                          : RoundedShape            XH stroke false false
-		create-forked-glyph "smcpB.roundedTopUnilateralBottomSerifed"            : RoundedShape            XH stroke false true
-		create-forked-glyph "smcpB.roundedTopInterruptedSerifless"               : RoundedShapeInterrupted XH stroke false false
-		create-forked-glyph "smcpB.roundedTopInterruptedUnilateralBottomSerifed" : RoundedShapeInterrupted XH stroke false true
+		create-forked-glyph "smcpB.roundedTopSerifless"                          : RoundedTopShape            XH stroke false false
+		create-forked-glyph "smcpB.roundedTopUnilateralBottomSerifed"            : RoundedTopShape            XH stroke false true
+		create-forked-glyph "smcpB.roundedTopInterruptedSerifless"               : RoundedTopShapeInterrupted XH stroke false false
+		create-forked-glyph "smcpB.roundedTopInterruptedUnilateralBottomSerifed" : RoundedTopShapeInterrupted XH stroke false true
+	create-glyph : glyph-proc
+		include : MarkSet.b
+		local stroke : AdviceStroke2 2 3 (Ascender - 0)
+		create-forked-glyph "smcpB.roundedTopTall"            : RoundedTopShapeBGR            Ascender stroke false false
+		create-forked-glyph "smcpB.roundedTopInterruptedTall" : RoundedTopShapeBGRInterrupted Ascender stroke false false
 
 	define [CursiveCyrVeArcsT sink] : function [] : with-params [top stroke offset barPos topArcShift topArcInnerShift] : glyph-proc
 		local bowl : mix stroke top barPos

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -7071,14 +7071,14 @@ next = "openness"
 rank = 1
 descriptionAffix = "standard body"
 selectorAffix."cyrl/ve" = "standard"
-selectorAffix."cyrl/ve.BGR" = "cursive"
+selectorAffix."cyrl/ve.BGR" = "roundedTop"
 
 [prime.cyrl-ve.variants-buildup.stages.body.rounded-top]
 rank = 2
 nonBreakingVariantAdditionPriority = 200
 descriptionAffix = "rounded top"
 selectorAffix."cyrl/ve" = "roundedTop"
-selectorAffix."cyrl/ve.BGR" = "cursive"
+selectorAffix."cyrl/ve.BGR" = "roundedTop"
 
 [prime.cyrl-ve.variants-buildup.stages.body.cursive]
 rank = 3
@@ -8318,9 +8318,7 @@ tagKind = "letter"
 rank = 1
 description = "Cyrillic Lower Yeri (`ь`) with corner at bottom left"
 selector."cyrl/yer"  = "corner"
-selector."cyrl/yer.BGR"  = "round" # Bulgarian
 selector."cyrl/yeri" = "corner"
-selector."cyrl/yeri.BGR" = "round" # Bulgarian
 selector."cyrl/nje/rightHalf"  = "corner"
 selector."cyrl/lje"  = "corner"
 selector."cyrl/tje/rightHalf" = "corner"
@@ -8329,9 +8327,7 @@ selector."cyrl/tje/rightHalf" = "corner"
 rank = 2
 description = "Cyrillic Lower Yeri (`ь`) with rounded shape"
 selector."cyrl/yer"  = "round"
-selector."cyrl/yer.BGR"  = "round"
 selector."cyrl/yeri" = "round"
-selector."cyrl/yeri.BGR" = "round"
 selector."cyrl/nje/rightHalf"  = "round"
 selector."cyrl/lje"  = "round"
 selector."cyrl/tje/rightHalf" = "round"
@@ -8340,9 +8336,7 @@ selector."cyrl/tje/rightHalf" = "round"
 rank = 3
 description = "Cyrillic Lower Yeri (`ь`) with cursive shape"
 selector."cyrl/yer"  = "cursive"
-selector."cyrl/yer.BGR"  = "cursive"
 selector."cyrl/yeri" = "cursive"
-selector."cyrl/yeri.BGR" = "cursive"
 selector."cyrl/nje/rightHalf"  = "cursive"
 selector."cyrl/lje"  = "cursive"
 selector."cyrl/tje/rightHalf" = "cursive"


### PR DESCRIPTION
### Motivation and Context

This basically makes Bulgarian overrides for bowled-bottom letters have a distinctive **upright** form using a `b`-like toothless corner shape for the bottom, as opposed to the normal flat-bottom/`corner` shape used under `'DFLT'`, or the previous minimum of `ve.cursiveTall`/`yer`{`i`}`.rounded` variants of version 34.3.0 and prior.

### Influenced Characters

- U+0432: CYRILLIC SMALL LETTER VE (Bulgarian override)
- U+044A: CYRILLIC SMALL LETTER HARD SIGN (Bulgarian override)
- U+044C: CYRILLIC SMALL LETTER SOFT SIGN (Bulgarian override)

### Glyph Quantity

2:
  - `smcpB.roundTopTall` (Bulgarian-only)
  - `smcpB.roundTopInterruptedTall` (Bulgarian-only)

Two other glyphs are reworked but not actually new additions, as they have already existed internally but previously unused:
  - `cyrl/yer.BGR.corner`
  - `cyrl/yeri.BGR.corner`

### Samples

`пазачът Вальо (…) хапва`

Sans Monospace:
<img width="1744" height="1129" alt="image" src="https://github.com/user-attachments/assets/d24b9e02-5720-4ac8-9c3e-22fe8199751b" />
Slab Monospace:
<img width="1751" height="1150" alt="image" src="https://github.com/user-attachments/assets/90b849f5-036e-4e6f-a7b0-54d94a529fd4" />
Aile:
<img width="1834" height="1135" alt="image" src="https://github.com/user-attachments/assets/ff4fa295-d3f3-4463-8108-a7c45d47c5f2" />
Etoile:
<img width="1835" height="1140" alt="image" src="https://github.com/user-attachments/assets/2ca15cb1-502c-47f7-90a8-667d0bb5ce9e" />
