### PR TITLE
Make certain "conjoined-bowled" letters use `CThin` or `CThinB` for their center stroke.

### DIFF
--- a/changes/34.5.0.md
+++ b/changes/34.5.0.md
@@ -1,1 +1,7 @@
 * Add `bilateral-motion-serifed` variants for Cyrillic Capital/Lower Ya (`Я`, `я`).
+* Refine shape of the following characters:
+  - LATIN SMALL LETTER DB DIGRAPH (`U+0238`).
+  - LATIN SMALL LETTER QP DIGRAPH (`U+0239`).
+  - CYRILLIC CAPITAL LETTER KOMI DJE (`U+0502`).
+  - CYRILLIC SMALL LETTER KOMI DJE (`U+0503`).
+  - COMBINING LATIN SMALL LETTER FLATTENED OPEN A ABOVE (`U+1DD3`).

--- a/packages/font-glyphs/src/letter/cyrillic.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic.ptl
@@ -15,6 +15,7 @@ export : define [apply] : begin
 	run-glyph-module "./cyrillic/el.mjs"
 	run-glyph-module "./cyrillic/fita.mjs"
 	run-glyph-module "./cyrillic/iotified-a.mjs"
+	run-glyph-module "./cyrillic/komi-de-dje.mjs"
 	run-glyph-module "./cyrillic/lje.mjs"
 	run-glyph-module "./cyrillic/multiocular-o.mjs"
 	run-glyph-module "./cyrillic/nje.mjs"

--- a/packages/font-glyphs/src/letter/cyrillic/be.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/be.ptl
@@ -7,84 +7,43 @@ glyph-module
 glyph-block Letter-Cyrillic-Be : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared-Metrics : EFVJutLength
-	glyph-block-import Letter-Shared-Shapes : UpwardHookShape SerifFrame
 	glyph-block-import Letter-Cyrillic-Yeri : YeriBarPos YeriUpper RevYeriUpper
 
 	define BeConfig : object
-		standardSerifless         { false false }
-		standardUnilateralSerifed { true  false }
-		standardBilateralSerifed  { true  true  }
+		standardSerifless         { false false false }
+		standardUnilateralSerifed { true  false false }
+		standardBilateralSerifed  { true  true  true  }
 
-	foreach { suffix { doST doSB } } [Object.entries BeConfig] : do
-		define fMotion : doST && !doSB
-
+	foreach { suffix { doSerifLT doSerifRT doSerifLB } } [Object.entries BeConfig] : do
 		create-glyph "cyrl/Be.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			local stroke : AdviceStroke2 2 3 CAP
 			include : YeriUpper.Shape CAP SB RightSB stroke (fSlab -- false)
 			include : HBar.t (SB - O) [mix SB RightSB 0.9] CAP
-			if doST : begin
-				include : tagged 'serifLT' : HSerif.lt SB CAP SideJut stroke
+			if doSerifLT : include : tagged 'serifLT' : HSerif.lt SB CAP SideJut stroke
+			if doSerifRT : begin
 				local { jutTop jutBot jutMid } : EFVJutLength CAP 0 YeriBarPos stroke
 				local swVJut : VJutStroke * (stroke / Stroke)
 				include : tagged 'serifRT' : VSerif.dr [mix SB RightSB 0.9] CAP jutTop swVJut
-			if doSB : include : tagged 'serifLB' : HSerif.lb SB 0 SideJut stroke
+			if doSerifLB : include : tagged 'serifLB' : HSerif.lb SB 0 SideJut stroke
 
 		create-glyph "cyrl/revBe.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			local stroke : AdviceStroke2 2 3 CAP
 			include : RevYeriUpper.Shape CAP SB RightSB stroke (fSlab -- false)
 			include : HBar.t [mix SB RightSB 0.1] (RightSB + O) CAP
-			if doST : begin
-				include : tagged 'serifRT' : HSerif.rt RightSB CAP SideJut stroke
+			if doSerifLT : include : tagged 'serifRT' : HSerif.rt RightSB CAP SideJut stroke
+			if doSerifRT : begin
 				local { jutTop jutBot jutMid } : EFVJutLength CAP 0 YeriBarPos stroke
 				local swVJut : VJutStroke * (stroke / Stroke)
 				include : tagged 'serifLT' : VSerif.dl [mix SB RightSB 0.1] CAP jutTop swVJut
-			if doSB : include : tagged 'serifRB' : HSerif.rb RightSB 0 SideJut stroke
-
-		create-glyph "cyrl/DeKomi.\(suffix)" : glyph-proc
-			include : MarkSet.capital
-			local stroke : AdviceStroke2 2 3 CAP
-			include : LeaningAnchor.Above.VBar.r RightSB stroke
-			include : RevYeriUpper.Shape CAP SB RightSB stroke (fSlab -- false)
-			if doST : include : tagged 'serifRT' : if fMotion
-				HSerif.lt (RightSB - [HSwToV stroke]) CAP SideJut stroke
-				HSerif.mt (RightSB - [HSwToV : 0.5 * stroke]) CAP (Jut - [HSwToV : 0.5 * (Stroke - stroke)]) stroke
-			if doSB : include : tagged 'serifRB' : HSerif.rb RightSB 0 SideJut stroke
-
-		create-glyph "cyrl/DjeKomi.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.advanceScaleMM 3
-			include : df.markSet.capital
-
-			include : RevYeriUpper.RoundShape CAP
-				left   -- df.leftSB
-				right  -- (df.middle + [HSwToV : 0.5 * df.mvs])
-				stroke -- df.mvs
-				fSlab  -- false
-			if doST : include : tagged 'serifRT' : if fMotion
-				HSerif.lt (df.middle - [HSwToV : 0.5 * df.mvs]) CAP SideJut df.mvs
-				HSerif.mt df.middle CAP (Jut - [HSwToV : 0.5 * (Stroke - df.mvs)]) df.mvs
-			include : UpwardHookShape
-				left   -- (df.middle - [HSwToV : 0.5 * df.mvs])
-				right  -- df.rightSB
-				ybegin -- CAP
-				yend   -- (CAP / 2 + HalfStroke)
-				ada    -- (ArchDepthA * (2 / df.hPack) * df.adws)
-				adb    -- (ArchDepthB * (2 / df.hPack) * df.adws)
-				sw     -- df.mvs
-			if SLAB : begin
-				local sf2 : [SerifFrame.fromDf df (CAP / 2 + HalfStroke) 0].slice 1 2
-				include sf2.rt.full
+			if doSerifLB : include : tagged 'serifRB' : HSerif.rb RightSB 0 SideJut stroke
 
 	select-variant 'cyrl/Be' 0x411
 
 	select-variant 'latn/Be' 0x182 (shapeFrom -- 'cyrl/Be')    (follow -- 'bCap')
 	select-variant 'latn/De' 0x18B (shapeFrom -- 'cyrl/revBe') (follow -- 'dCap')
-
-	select-variant 'cyrl/DeKomi'  0x500 (follow -- 'dCap')
-	select-variant 'cyrl/DjeKomi' 0x502 (follow -- 'dCap')
 
 	create-glyph 'cyrl/be' 0x431 : glyph-proc
 		include : MarkSet.b

--- a/packages/font-glyphs/src/letter/cyrillic/komi-de-dje.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/komi-de-dje.ptl
@@ -1,0 +1,55 @@
+$$include '../../meta/macros.ptl'
+
+import [mix linreg clamp fallback] from "@iosevka/util"
+
+glyph-module
+
+glyph-block Letter-Cyrillic-Komi-De-Dje : begin
+	glyph-block-import CommonShapes
+	glyph-block-import Common-Derivatives
+	glyph-block-import Letter-Shared-Shapes : UpwardHookShape SerifFrame
+	glyph-block-import Letter-Cyrillic-Yeri : RevYeriUpper
+
+	define DeConfig : object
+		standardSerifless         { false false }
+		standardUnilateralSerifed { true  false }
+		standardBilateralSerifed  { true  true  }
+
+	foreach { suffix { doST doSB } } [Object.entries DeConfig] : do
+		define fMotion : doST && !doSB
+
+		create-glyph "cyrl/DeKomi.\(suffix)" : glyph-proc
+			include : MarkSet.capital
+			include : RevYeriUpper.Shape CAP (fSlab -- false)
+			if doST : include : tagged 'serifRT' : if fMotion
+				HSerif.lt (RightSB - [HSwToV Stroke]) CAP SideJut
+				HSerif.mt (RightSB - [HSwToV HalfStroke]) CAP Jut
+			if doSB : include : tagged 'serifRB' : HSerif.rb RightSB 0 SideJut
+
+		create-glyph "cyrl/DjeKomi.\(suffix)" : glyph-proc
+			local df : include : DivFrame para.advanceScaleMM 3
+			include : df.markSet.capital
+
+			include : RevYeriUpper.RoundShape CAP
+				left   -- df.leftSB
+				right  -- (df.middle - [HSwToV : (0.5 - CThinB) * df.mvs])
+				stroke -- df.mvs
+				swVBar -- (df.mvs * CThinB)
+				fSlab  -- false
+			if doST : include : tagged 'serifRT' : if fMotion
+				HSerif.lt (df.middle - [HSwToV : 0.5 * df.mvs]) CAP SideJut df.mvs
+				HSerif.mt df.middle CAP (Jut - [HSwToV : 0.5 * (Stroke - df.mvs)]) df.mvs
+			include : UpwardHookShape
+				left   -- (df.middle - [HSwToV : 0.5 * df.mvs])
+				right  -- df.rightSB
+				ybegin -- CAP
+				yend   -- (CAP / 2 + HalfStroke)
+				ada    -- (ArchDepthA * (2 / df.hPack) * df.adws)
+				adb    -- (ArchDepthB * (2 / df.hPack) * df.adws)
+				sw     -- df.mvs
+			if SLAB : begin
+				local sf2 : [SerifFrame.fromDf df (CAP / 2 + HalfStroke) 0].slice 1 2
+				include sf2.rt.full
+
+	select-variant 'cyrl/DeKomi'  0x500 (follow -- 'dCap')
+	select-variant 'cyrl/DjeKomi' 0x502 (follow -- 'dCap')

--- a/packages/font-glyphs/src/letter/cyrillic/yeri.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/yeri.ptl
@@ -21,44 +21,58 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			local-parameter : left   -- SB
 			local-parameter : right  -- RightSB
 			local-parameter : stroke -- Stroke
-			local-parameter : jut    -- (Jut - [HSwToV : 0.5 * (Stroke - stroke)])
+			local-parameter : fine   -- (ShoulderFine * (stroke / Stroke))
+			local-parameter : swVBar -- stroke
+			local-parameter : jut    -- (Jut - [HSwToV : 0.5 * (Stroke - swVBar)])
 			local-parameter : pBar   -- YeriBarPos
 			local-parameter : yStart -- top
 			local-parameter : fSlab  -- SLAB
 
 			local bowlTop : [mix 0 top pBar] + stroke / 2
-			local turnRadius : BowlXDepth bowlTop 0 left right stroke
-			local fine : ShoulderFine * (stroke / Stroke)
+			local mockLeft : left - [HSwToV : stroke - swVBar]
+			local turnRadius : BowlXDepth bowlTop 0 mockLeft right stroke
+			local xTurnRightT : clamp
+				Math.max
+					(left - O) + TINY + [Math.abs : TanSlope * stroke]
+					left + [HSwToV swVBar]
+				right - [HSwToV : 1.125 * stroke]
+				Arch.adjust-x.top (right - turnRadius) (sw -- stroke)
+			local xTurnRightB : clamp
+				Math.max
+					(left - O) + TINY + [Math.abs : TanSlope * stroke]
+					left + [HSwToV swVBar]
+				right - [HSwToV : 1.125 * stroke]
+				Arch.adjust-x.bot (right - turnRadius) (sw -- stroke)
 
-			local mockWidth : (right - left) + SB * 2
+			local mockWidth : (right - mockLeft) + SB * 2
 			local archDepth : Math.max (ArchDepth * (mockWidth / Width)) (stroke * 1.125)
 			local ada : ArchDepthAOf archDepth mockWidth
 			local adb : ArchDepthBOf archDepth mockWidth
 			local yTurnBottomL : YSmoothMidL bowlTop 0 ada adb
 			local yTurnBottomR : YSmoothMidR bowlTop 0 ada adb
 
-			include : union [VBar.l left [if fBGR (0 + DToothlessRise) 0] yStart stroke] : dispiro
+			include : union [VBar.l left (0 + [if fBGR DToothlessRise 0]) yStart swVBar] : dispiro
 				widths.lhs stroke
 				if fBGR
 					list
-						g4 left (0 + DToothlessRise)
+						g4   left (0 + DToothlessRise)
 						Arch.lhs 0 (sw -- stroke) (blendPre -- {})
 					list
-						flat (left - O) 0 [heading Rightward]
-						curl [Arch.adjust-x.bot [Math.max (right - turnRadius) : mix left right 0.5] (sw -- stroke)] 0
+						flat (left - O)  0 [heading Rightward]
+						curl xTurnRightB 0 [if (xTurnRightB - [Math.abs : TanSlope * stroke] <= left + [HSwToV swVBar]) [heading Rightward] nothing]
 						archv 8
 				g4   (right - OX) yTurnBottomR
 				arcvh 8
-				flat [Arch.adjust-x.top [Math.max (right - turnRadius) : mix left right 0.5] (sw -- stroke)] bowlTop
-				curl (left - O) bowlTop [heading Leftward]
+				flat xTurnRightT bowlTop [if (xTurnRightT - [Math.abs : TanSlope * stroke] <= left + [HSwToV swVBar]) [heading Leftward] nothing]
+				curl (left - O)  bowlTop [heading Leftward]
 
 			if fSlab : include : composite-proc
 				tagged 'serifYeriLB' : if useFullSerifs
-					HSerif.lb left 0 (jut - [HSwToV : 0.5 * stroke]) stroke
+					HSerif.lb left 0 (jut - [HSwToV : 0.5 * swVBar]) stroke swVBar
 					no-shape
 				tagged 'serifYeriLT' : if useFullSerifs
-					HSerif.mt (left + [HSwToV : 0.5 * stroke]) top jut stroke
-					HSerif.lt left top (jut - [HSwToV : 0.5 * stroke]) stroke
+					HSerif.mt (left + [HSwToV : 0.5 * swVBar]) top jut stroke
+					HSerif.lt left top (jut - [HSwToV : 0.5 * swVBar]) stroke swVBar
 		set Shape.useFullSerifs useFullSerifs
 
 		export : define flex-params [RoundShape] : glyph-proc
@@ -66,16 +80,30 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			local-parameter : left   -- SB
 			local-parameter : right  -- RightSB
 			local-parameter : stroke -- Stroke
-			local-parameter : jut    -- (Jut - [HSwToV : 0.5 * (Stroke - stroke)])
+			local-parameter : fine   -- (ShoulderFine * (stroke / Stroke))
+			local-parameter : swVBar -- stroke
+			local-parameter : jut    -- (Jut - [HSwToV : 0.5 * (Stroke - swVBar)])
 			local-parameter : pBar   -- YeriBarPos
 			local-parameter : yStart -- top
 			local-parameter : fSlab  -- SLAB
 
 			local bowlTop : [mix 0 top pBar] + stroke / 2
-			local turnRadius : BowlXDepth bowlTop 0 left right stroke
-			local fine : ShoulderFine * (stroke / Stroke)
+			local mockLeft : left - [HSwToV : stroke - swVBar]
+			local turnRadius : BowlXDepth bowlTop 0 mockLeft right stroke
+			local xTurnRightT : clamp
+				Math.max
+					(left - O) + TINY + [Math.abs : TanSlope * stroke]
+					left + [HSwToV swVBar]
+				right - [HSwToV : 1.125 * stroke]
+				Arch.adjust-x.top (right - turnRadius) (sw -- stroke)
+			local xTurnRightB : clamp
+				Math.max
+					(left - O) + TINY + [Math.abs : TanSlope * stroke]
+					left + [HSwToV swVBar]
+				right - [HSwToV : 1.125 * stroke]
+				Arch.adjust-x.bot (right - turnRadius) (sw -- stroke)
 
-			local mockWidth : (right - left) + SB * 2
+			local mockWidth : (right - mockLeft) + SB * 2
 			local archDepth : Math.max (ArchDepth * (mockWidth / Width)) (stroke * 1.125)
 			local ada : ArchDepthAOf archDepth mockWidth
 			local adb : ArchDepthBOf archDepth mockWidth
@@ -83,18 +111,18 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			local yTurnBottomR : YSmoothMidR bowlTop 0 ada adb
 
 			include : dispiro
-				widths.lhs stroke
+				widths.lhs swVBar
 				flat left yStart [heading Downward]
-				curl left [Math.min (yStart - TINY) (0 + adb) yTurnBottomL]
-				Arch.lhs 0 (sw -- stroke)
+				curl left [Math.min (yStart - TINY - [HSwToV : Math.abs : TanSlope * swVBar]) (0 + adb) yTurnBottomL]
+				Arch.lhs 0 (sw -- stroke) (swBefore -- swVBar)
 				g4   (right - OX) yTurnBottomR
 				arcvh 8
-				flat [Arch.adjust-x.top [Math.max (right - turnRadius) : mix left right 0.5] (sw -- stroke)] bowlTop
-				curl (left - O) bowlTop [heading Leftward]
+				flat xTurnRightT bowlTop [if (xTurnRightT - [Math.abs : TanSlope * stroke] <= left + [HSwToV swVBar]) [heading Leftward] nothing]
+				curl (left - O)  bowlTop [heading Leftward]
 
 			if fSlab : include : tagged 'serifYeriLT' : if useFullSerifs
-				HSerif.mt (left + [HSwToV : 0.5 * stroke]) top jut stroke
-				HSerif.lt left top (jut - [HSwToV : 0.5 * stroke]) stroke
+				HSerif.mt (left + [HSwToV : 0.5 * swVBar]) top jut stroke
+				HSerif.lt left top (jut - [HSwToV : 0.5 * swVBar]) stroke swVBar
 		set RoundShape.useFullSerifs useFullSerifs
 
 		export : define flex-params [CursiveShape] : glyph-proc
@@ -102,16 +130,30 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			local-parameter : left   -- SB
 			local-parameter : right  -- RightSB
 			local-parameter : stroke -- Stroke
-			local-parameter : jut    -- (Jut - [HSwToV : 0.5 * (Stroke - stroke)])
+			local-parameter : fine   -- (ShoulderFine * (stroke / Stroke))
+			local-parameter : swVBar -- stroke
+			local-parameter : jut    -- (Jut - [HSwToV : 0.5 * (Stroke - swVBar)])
 			local-parameter : pBar   -- YeriBarPos
 			local-parameter : yStart -- top
 			local-parameter : fSlab  -- SLAB
 
 			local bowlTop : [mix 0 top pBar] + stroke / 2
-			local turnRadius : BowlXDepth bowlTop 0 left right stroke
-			local fine : ShoulderFine * (stroke / Stroke)
+			local mockLeft : left - [HSwToV : stroke - swVBar]
+			local turnRadius : BowlXDepth bowlTop 0 mockLeft right stroke
+			local xTurnRightT : clamp
+				Math.max
+					(left - O) + TINY + [Math.abs : TanSlope * stroke]
+					left + [HSwToV swVBar]
+				right - [HSwToV : 1.125 * stroke]
+				Arch.adjust-x.top (right - turnRadius) (sw -- stroke)
+			local xTurnRightB : clamp
+				Math.max
+					(left - O) + TINY + [Math.abs : TanSlope * stroke]
+					left + [HSwToV swVBar]
+				right - [HSwToV : 1.125 * stroke]
+				Arch.adjust-x.bot (right - turnRadius) (sw -- stroke)
 
-			local mockWidth : (right - left) + SB * 2
+			local mockWidth : (right - mockLeft) + SB * 2
 			local archDepth : Math.max (ArchDepth * (mockWidth / Width)) (stroke * 1.125)
 			local ada : ArchDepthAOf archDepth mockWidth
 			local adb : ArchDepthBOf archDepth mockWidth
@@ -119,17 +161,17 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			local yTurnBottomR : YSmoothMidR bowlTop 0 ada adb
 
 			include : dispiro
-				widths.lhs stroke
+				widths.lhs swVBar
 				flat left yStart [heading Downward]
-				curl left [Math.min (yStart - TINY) (0 + adb) yTurnBottomL]
-				Arch.lhs 0 (sw -- stroke)
+				curl left [Math.min (yStart - TINY - [HSwToV : Math.abs : TanSlope * swVBar]) (0 + adb) yTurnBottomL]
+				Arch.lhs 0 (sw -- stroke) (swBefore -- swVBar)
 				g4   (right - OX) yTurnBottomR
 				Arch.lhs bowlTop (sw -- stroke) (swAfter -- fine)
-				g4.down.end (left + [HSwToV : stroke - fine]) [Math.max (bowlTop - ada) yTurnBottomL] [widths.lhs.heading fine Downward]
+				g4.down.end (left + [HSwToV : swVBar - fine]) [Math.max (bowlTop - ada) yTurnBottomL] [widths.lhs.heading fine Downward]
 
 			if fSlab : include : tagged 'serifYeriLT' : if useFullSerifs
-				HSerif.mt (left + [HSwToV : 0.5 * stroke]) top jut stroke
-				HSerif.lt left top (jut - [HSwToV : 0.5 * stroke]) stroke
+				HSerif.mt (left + [HSwToV : 0.5 * swVBar]) top jut stroke
+				HSerif.lt left top (jut - [HSwToV : 0.5 * swVBar]) stroke swVBar
 		set CursiveShape.useFullSerifs useFullSerifs
 
 	glyph-block-export YeriUpper YeriLower
@@ -144,51 +186,79 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			local-parameter : left   -- SB
 			local-parameter : right  -- RightSB
 			local-parameter : stroke -- Stroke
-			local-parameter : jut    -- (Jut - [HSwToV : 0.5 * (Stroke - stroke)])
+			local-parameter : fine   -- (ShoulderFine * (stroke / Stroke))
+			local-parameter : swVBar -- stroke
+			local-parameter : jut    -- (Jut - [HSwToV : 0.5 * (Stroke - swVBar)])
 			local-parameter : pBar   -- YeriBarPos
 			local-parameter : yStart -- top
 			local-parameter : fSlab  -- SLAB
 
 			local bowlTop : [mix 0 top pBar] + stroke / 2
-			local turnRadius : BowlXDepth bowlTop 0 left right stroke
-			local fine : ShoulderFine * (stroke / Stroke)
+			local mockRight : right + [HSwToV : stroke - swVBar]
+			local turnRadius : BowlXDepth bowlTop 0 left mockRight stroke
+			local xTurnLeftT : clamp
+				left + [HSwToV : 1.125 * stroke]
+				Math.min
+					(right + O) - TINY - [Math.abs : TanSlope * stroke]
+					right - [HSwToV swVBar]
+				Arch.adjust-x.top (left + turnRadius) (sw -- stroke)
+			local xTurnLeftB : clamp
+				left + [HSwToV : 1.125 * stroke]
+				Math.min
+					(right + O) - TINY - [Math.abs : TanSlope * stroke]
+					right - [HSwToV swVBar]
+				Arch.adjust-x.bot (left + turnRadius) (sw -- stroke)
 
-			local mockWidth : (right - left) + SB * 2
+			local mockWidth : (mockRight - left) + SB * 2
 			local archDepth : Math.max (ArchDepth * (mockWidth / Width)) (stroke * 1.125)
 			local ada : ArchDepthAOf archDepth mockWidth
 			local adb : ArchDepthBOf archDepth mockWidth
 			local yTurnBottomL : YSmoothMidL bowlTop 0 ada adb
 			local yTurnBottomR : YSmoothMidR bowlTop 0 ada adb
 
-			include : union [VBar.r right 0 yStart stroke] : dispiro
+			include : union [VBar.r right 0 yStart swVBar] : dispiro
 				widths.rhs stroke
 				flat (right + O) 0 [heading Leftward]
-				curl [Arch.adjust-x.bot [Math.min (left + turnRadius) : mix left right 0.5] (sw -- stroke)] 0
+				curl xTurnLeftB  0 [if (xTurnLeftB + [Math.abs : TanSlope * stroke] >= right - [HSwToV swVBar]) [heading Leftward] nothing]
 				archv 8
 				g4   (left + OX) yTurnBottomL
 				arcvh 8
-				flat [Arch.adjust-x.top [Math.min (left + turnRadius) : mix left right 0.5] (sw -- stroke)] bowlTop
+				flat xTurnLeftT  bowlTop [if (xTurnLeftT + [Math.abs : TanSlope * stroke] >= right - [HSwToV swVBar]) [heading Rightward] nothing]
 				curl (right + O) bowlTop [heading Rightward]
 
 			if fSlab : include : composite-proc
-				tagged 'serifYeriRB' : HSerif.rb right 0 (jut - [HSwToV : 0.5 * stroke]) stroke
-				tagged 'serifYeriRT' : HSerif.mt (right - [HSwToV : 0.5 * stroke]) top jut stroke
+				tagged 'serifYeriRB' : HSerif.rb right 0 (jut - [HSwToV : 0.5 * swVBar]) stroke swVBar
+				tagged 'serifYeriRT' : HSerif.mt (right - [HSwToV : 0.5 * swVBar]) top jut stroke
 
 		export : define flex-params [RoundShape] : glyph-proc
 			local-parameter : top
 			local-parameter : left   -- SB
 			local-parameter : right  -- RightSB
 			local-parameter : stroke -- Stroke
-			local-parameter : jut    -- (Jut - [HSwToV : 0.5 * (Stroke - stroke)])
+			local-parameter : fine   -- (ShoulderFine * (stroke / Stroke))
+			local-parameter : swVBar -- stroke
+			local-parameter : jut    -- (Jut - [HSwToV : 0.5 * (Stroke - swVBar)])
 			local-parameter : pBar   -- YeriBarPos
 			local-parameter : yStart -- top
 			local-parameter : fSlab  -- SLAB
 
 			local bowlTop : [mix 0 top pBar] + stroke / 2
-			local turnRadius : BowlXDepth bowlTop 0 left right stroke
-			local fine : ShoulderFine * (stroke / Stroke)
+			local mockRight : right + [HSwToV : stroke - swVBar]
+			local turnRadius : BowlXDepth bowlTop 0 left mockRight stroke
+			local xTurnLeftT : clamp
+				left + [HSwToV : 1.125 * stroke]
+				Math.min
+					(right + O) - TINY - [Math.abs : TanSlope * stroke]
+					right - [HSwToV swVBar]
+				Arch.adjust-x.top (left + turnRadius) (sw -- stroke)
+			local xTurnLeftB : clamp
+				left + [HSwToV : 1.125 * stroke]
+				Math.min
+					(right + O) - TINY - [Math.abs : TanSlope * stroke]
+					right - [HSwToV swVBar]
+				Arch.adjust-x.bot (left + turnRadius) (sw -- stroke)
 
-			local mockWidth : (right - left) + SB * 2
+			local mockWidth : (mockRight - left) + SB * 2
 			local archDepth : Math.max (ArchDepth * (mockWidth / Width)) (stroke * 1.125)
 			local ada : ArchDepthAOf archDepth mockWidth
 			local adb : ArchDepthBOf archDepth mockWidth
@@ -196,16 +266,16 @@ glyph-block Letter-Cyrillic-Yeri : begin
 			local yTurnBottomR : YSmoothMidR bowlTop 0 ada adb
 
 			include : dispiro
-				widths.rhs stroke
+				widths.rhs swVBar
 				flat right yStart [heading Downward]
-				curl right [Math.min (yStart - TINY) (0 + ada) yTurnBottomR]
-				Arch.rhs 0 (sw -- stroke)
+				curl right [Math.min (yStart - TINY - [HSwToV : Math.abs : TanSlope * swVBar]) (0 + ada) yTurnBottomR]
+				Arch.rhs 0 (sw -- stroke) (swBefore -- swVBar)
 				g4   (left + OX) yTurnBottomL
 				arcvh 8
-				flat [Arch.adjust-x.top [Math.min (left + turnRadius) : mix left right 0.5] (sw -- stroke)] bowlTop
+				flat xTurnLeftT  bowlTop [if (xTurnLeftT + [Math.abs : TanSlope * stroke] >= right - [HSwToV swVBar]) [heading Rightward] nothing]
 				curl (right + O) bowlTop [heading Rightward]
 
-			if fSlab : include : tagged 'serifYeriRT' : HSerif.mt (right - [HSwToV : 0.5 * stroke]) top jut stroke
+			if fSlab : include : tagged 'serifYeriRT' : HSerif.mt (right - [HSwToV : 0.5 * swVBar]) top jut stroke
 
 	glyph-block-export YeriConfig
 	define YeriConfig : object

--- a/packages/font-glyphs/src/letter/latin-ext/flattened-open-a.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/flattened-open-a.ptl
@@ -13,27 +13,25 @@ glyph-block Letter-Latin-Flattened-Open-A : begin
 		local df : include : DivFrame para.advanceScaleMM 3
 		include : df.markSet.e
 
-		local top : 0.5 * XH
+		local top : mix 0 XH 0.5
 
 		local subDf : df.slice 3 2 OX
-		local ada : Math.min subDf.smallArchDepthA : top - TINY
-		local adb : Math.min subDf.smallArchDepthB : top - TINY
+		local ada : Math.min subDf.smallArchDepthA : top - TINY - [HSwToV : Math.abs : TanSlope * df.mvs]
+		local adb : Math.min subDf.smallArchDepthB : top - TINY - [HSwToV : Math.abs : TanSlope * df.mvs]
+
+		local fine : df.mvs * CThin
 
 		include : dispiro
 			widths.lhs df.mvs
 			flat (df.leftSB + OX) top [heading Downward]
-			curl (df.leftSB + OX) adb [heading Downward]
-			arcvh
-			g4   [mix (df.leftSB + OX) (df.middle + [HSwToV : 0.5 * df.mvs]) 0.5] O [heading Rightward]
-			archv
-			flat (df.middle + [HSwToV : 0.5 * df.mvs]) ada [heading Upward]
-			curl (df.middle + [HSwToV : 0.5 * df.mvs]) top [heading Upward]
+			curl (df.leftSB + OX) adb
+			Arch.lhs 0 (sw -- df.mvs) (swAfter -- fine)
+			flat (df.middle - [HSwToV : 0.5 * df.mvs - fine]) ada [widths.lhs fine]
+			curl (df.middle - [HSwToV : 0.5 * df.mvs - fine]) top [heading Upward]
 		include : dispiro
-			widths.lhs df.mvs
-			flat (df.middle - [HSwToV : 0.5 * df.mvs]) top [heading Downward]
-			curl (df.middle - [HSwToV : 0.5 * df.mvs]) adb [heading Downward]
-			arcvh
-			g4   [mix (df.middle - [HSwToV : 0.5 * df.mvs]) (df.rightSB - OX) 0.5] O [heading Rightward]
-			archv
-			flat (df.rightSB - OX) ada [heading Upward]
+			widths.lhs fine
+			flat (df.middle + [HSwToV : 0.5 * df.mvs - fine]) top [heading Downward]
+			curl (df.middle + [HSwToV : 0.5 * df.mvs - fine]) adb
+			Arch.lhs 0 (sw -- df.mvs) (swBefore -- fine)
+			flat (df.rightSB - OX) ada [widths.lhs df.mvs]
 			curl (df.rightSB - OX) top [heading Upward]

--- a/packages/font-glyphs/src/letter/latin-ext/lower-db-qp.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/lower-db-qp.ptl
@@ -10,30 +10,53 @@ glyph-block Letter-Latin-Lower-DB-QP : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Shapes : OBarLeft OBarRight
 
-	define [DbCenterShape df] : glyph-proc
+	define [DbCenterShape df] : begin
 		local subDf : df.slice 3 2 OX
-		include : OBarRight.toothlessRounded
-			left      -- df.leftSB
-			right     -- (df.middle + [HSwToV : 0.5 * df.mvs])
-			yTerminal -- XH
-			sw        -- df.mvs
-			fine      -- df.shoulderFine
-			ada       -- subDf.smallArchDepthA
-			adb       -- subDf.smallArchDepthB
-		include : OBarLeft.toothlessRounded
-			left      -- (df.middle - [HSwToV : 0.5 * df.mvs])
-			right     -- df.rightSB
-			yTerminal -- (XH / 2)
-			sw        -- df.mvs
-			fine      -- df.shoulderFine
-			ada       -- subDf.smallArchDepthA
-			adb       -- subDf.smallArchDepthB
+		return : union
+			dispiro
+				OBarRight.arcStart
+					top       -- XH
+					left      -- df.leftSB
+					right     -- (df.middle + [HSwToV : 0.5 * df.mvs])
+					sw        -- df.mvs
+					fine      -- df.shoulderFine
+					ada       -- subDf.smallArchDepthA
+					adb       -- subDf.smallArchDepthB
+				flatside.ld df.leftSB 0 XH subDf.smallArchDepthA subDf.smallArchDepthB
+				OBarRight.arcEnd
+					bot       -- 0
+					left      -- df.leftSB
+					right     -- (df.middle + [HSwToV : 0.5 * df.mvs])
+					sw        -- df.mvs
+					fine      -- (df.mvs * CThin)
+					ada       -- subDf.smallArchDepthA
+					adb       -- subDf.smallArchDepthB
+					yend      -- XH
+			dispiro
+				OBarLeft.arcStart
+					top       -- XH
+					left      -- (df.middle - [HSwToV : 0.5 * df.mvs])
+					right     -- df.rightSB
+					sw        -- df.mvs
+					fine      -- df.shoulderFine
+					ada       -- subDf.smallArchDepthA
+					adb       -- subDf.smallArchDepthB
+				flatside.rd df.rightSB 0 XH subDf.smallArchDepthA subDf.smallArchDepthB
+				OBarLeft.arcEnd
+					bot       -- 0
+					left      -- (df.middle - [HSwToV : 0.5 * df.mvs])
+					right     -- df.rightSB
+					sw        -- df.mvs
+					fine      -- (df.mvs * CThin)
+					ada       -- subDf.smallArchDepthA
+					adb       -- subDf.smallArchDepthB
+					yend      -- XH
 
 	create-glyph 'db' 0x238 : glyph-proc
 		local df : include : DivFrame para.advanceScaleMM 3
 		include : df.markSet.b
 		include : DbCenterShape df
-		include : VBar.m df.middle XH Ascender df.mvs
+		include : VBar.m df.middle (XH / 2) Ascender df.mvs
 		if SLAB : include : HSerif.lt (df.middle - [HSwToV : 0.5 * df.mvs]) Ascender SideJut df.mvs
 
 	create-glyph 'qp' 0x239 : glyph-proc
@@ -41,5 +64,5 @@ glyph-block Letter-Latin-Lower-DB-QP : begin
 		include : df.markSet.p
 		include : DbCenterShape df
 		include : FlipAround df.middle (XH / 2)
-		include : VBar.m df.middle Descender 0 df.mvs
+		include : VBar.m df.middle Descender (XH / 2) df.mvs
 		if SLAB : include : HSerif.mb df.middle Descender (MidJutCenter - [HSwToV : 0.5 * (Stroke - df.mvs)]) df.mvs

--- a/packages/font-glyphs/src/letter/latin/lower-d.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-d.ptl
@@ -82,7 +82,7 @@ glyph-block Letter-Latin-Lower-D : begin
 			bottomSerifed            { null     BaseSerif }
 			serifed                  { TopSerif BaseSerif }
 
-	foreach { suffix { Body {topSerif bottomSerif} } } [Object.entries DConfig] : do
+	foreach { suffix { Body { topSerif bottomSerif } } } [Object.entries DConfig] : do
 		local yOverlay : mix XH (Ascender - [if topSerif Stroke 0]) 0.5
 
 		do
@@ -124,28 +124,6 @@ glyph-block Letter-Latin-Lower-D : begin
 			if bottomSerif : include : bottomSerif df Ascender
 			include : LeaningAnchor.Above.VBar.r df.rightSB
 
-		if [not bottomSerif] : create-glyph "cyrl/djeKomi.\(suffix)" : glyph-proc
-			local df : include : DivFrame para.advanceScaleMM 3
-			include : df.markSet.b
-
-			local dfHalf : df.slice 3 2
-			include : Body dfHalf Ascender
-			eject-contour 'rightBar'
-
-			include : with-transform [ApparentTranslate (df.width - dfHalf.width) 0] : UpwardHookShape
-				left   -- dfHalf.leftSB
-				right  -- dfHalf.rightSB
-				ybegin -- Ascender
-				yend   -- (XH / 2 + HalfStroke)
-				ada    -- (ArchDepthA * (2 / df.hPack) * df.adws)
-				adb    -- (ArchDepthB * (2 / df.hPack) * df.adws)
-				sw     -- df.mvs
-
-			if topSerif : include : topSerif dfHalf Ascender
-			if SLAB : begin
-				local sf2 : [SerifFrame.fromDf df (XH / 2 + HalfStroke) 0].slice 1 2
-				include sf2.rt.full
-
 	select-variant 'd' 'd'
 	link-reduced-variant 'd/sansSerif' 'd' MathSansSerif
 	link-reduced-variant 'd/phoneticLeft' 'd'
@@ -156,9 +134,6 @@ glyph-block Letter-Latin-Lower-D : begin
 
 	select-variant 'latn/de' 0x18C (follow -- 'd')
 	select-variant 'dHookTop' 0x257
-
-	alias 'cyrl/deKomi' 0x501 'd'
-	select-variant 'cyrl/djeKomi' 0x503
 
 	link-reduced-variant 'd/descBase' 'd'
 	derive-composites 'dPalatalHook' 0x1D81 'd/descBase' : PalatalHook.r
@@ -190,33 +165,72 @@ glyph-block Letter-Latin-Lower-D : begin
 
 	derive-composites 'tauGallicum' 0xA7C8 'd' : HBar.m (SB - OX) (RightSB + OX) (XH * 0.5) OverlayStroke
 
-	define DCurlyTailConfig : object
-		toothedSerifless  { false }
-		toothedTopSerifed { true  }
+	create-glyph "dCurlyTail.toothedSerifless" : glyph-proc
+		include : MarkSet.b
 
-	foreach { suffix { fSerif } } [Object.entries DCurlyTailConfig] : do
-		create-glyph "dCurlyTail.\(suffix)" : glyph-proc
-			include : MarkSet.b
+		local fine : AdviceStroke 4
+		local rinner : clamp (Width * 0.065) (XH * 0.05) (fine * 0.35)
+		local sw : AdviceStroke 2.75
+		local m : Math.min RightSB (Width - rinner * 2 - fine - OX)
 
-			local fine : AdviceStroke 4
-			local rinner : clamp (Width * 0.065) (XH * 0.05) (fine * 0.35)
-			local sw : AdviceStroke 2.75
-			local m : Math.min RightSB (Width - rinner * 2 - fine - OX)
-
-			include : LeaningAnchor.Above.VBar.r m
-			include : OBarRight.shape (left -- SB) (right -- m) (sw -- sw)
-			include : dispiro
-				widths.lhs sw
-				flat (m - [HSwToV sw]) Ascender [heading Downward]
-				curl (m - [HSwToV sw]) (rinner * 2 + fine)
-				CurlyTail.n fine 0 (m + rinner * 2 + fine)
-					x2 -- ([mix SB m 0.5] - [HSwToV : 0.75 * fine])
-					y2 -- (0.37 * Descender)
-					swBefore -- sw
-					terminalSlopeAdj -- 0.25
-			if fSerif : include : HSerif.lt (m - [HSwToV sw]) Ascender SideJut sw
+		include : LeaningAnchor.Above.VBar.r m
+		include : OBarRight.shape
+			left  -- SB
+			right -- m
+			sw    -- sw
+		include : dispiro
+			widths.lhs sw
+			flat (m - [HSwToV sw]) Ascender [heading Downward]
+			curl (m - [HSwToV sw]) (rinner * 2 + fine)
+			CurlyTail.n fine 0 (m + rinner * 2 + fine)
+				x2 -- ([mix SB m 0.5] - [HSwToV : 0.75 * fine])
+				y2 -- (0.37 * Descender)
+				swBefore -- sw
+				terminalSlopeAdj -- 0.25
+		create-forked-glyph "dCurlyTail.toothedTopSerifed" : HSerif.lt (m - [HSwToV sw]) Ascender SideJut sw
 
 	select-variant 'dCurlyTail' 0x221
+
+	create-glyph "cyrl/djeKomi.toothlessRoundedSerifless" : glyph-proc
+		local df : include : DivFrame para.advanceScaleMM 3
+		include : df.markSet.b
+
+		local subDf : df.slice 3 2
+		include : dispiro
+			OBarRight.arcStart
+				top       -- XH
+				left      -- df.leftSB
+				right     -- (df.middle + [HSwToV : 0.5 * df.mvs])
+				sw        -- df.mvs
+				fine      -- df.shoulderFine
+				ada       -- subDf.smallArchDepthA
+				adb       -- subDf.smallArchDepthB
+			flatside.ld df.leftSB 0 XH subDf.smallArchDepthA subDf.smallArchDepthB
+			OBarRight.arcEnd
+				bot       -- 0
+				left      -- df.leftSB
+				right     -- (df.middle + [HSwToV : 0.5 * df.mvs])
+				sw        -- df.mvs
+				fine      -- (df.mvs * CThinB)
+				ada       -- subDf.smallArchDepthA
+				adb       -- subDf.smallArchDepthB
+				yend      -- XH
+		include : UpwardHookShape
+			left   -- (df.middle - [HSwToV : 0.5 * df.mvs])
+			right  -- df.rightSB
+			ybegin -- Ascender
+			yend   -- (XH / 2 + HalfStroke)
+			ada    -- (ArchDepthA * (2 / df.hPack) * df.adws)
+			adb    -- (ArchDepthB * (2 / df.hPack) * df.adws)
+			sw     -- df.mvs
+		if SLAB : begin
+			local sf2 : [SerifFrame.fromDf df (XH / 2 + HalfStroke) 0].slice 1 2
+			include sf2.rt.full
+
+		create-forked-glyph "cyrl/djeKomi.toothlessRoundedTopSerifed" : HSerif.lt (df.middle - [HSwToV : 0.5 * df.mvs]) Ascender SideJut df.mvs
+
+	alias 'cyrl/deKomi' 0x501 'd'
+	select-variant 'cyrl/djeKomi' 0x503
 
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarRight
 	create-glyph 'mathbb/d' 0x1D555 : glyph-proc

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2632,7 +2632,7 @@ selectorAffix."d/rTailBase" = "toothed"
 selectorAffix.dCurlyTail = "toothed"
 selectorAffix.dHookTop = "toothed"
 selectorAffix."dHookTop/rTailBase" = "toothed"
-selectorAffix."cyrl/djeKomi" = "toothed"
+selectorAffix."cyrl/djeKomi" = "toothlessRounded"
 
 [prime.d.variants-buildup.stages.body.tailed]
 rank = 2
@@ -2645,7 +2645,7 @@ selectorAffix."d/rTailBase" = "toothed"
 selectorAffix.dCurlyTail = "toothed"
 selectorAffix.dHookTop = "tailed"
 selectorAffix."dHookTop/rTailBase" = "toothed"
-selectorAffix."cyrl/djeKomi" = "toothed"
+selectorAffix."cyrl/djeKomi" = "toothlessRounded"
 
 [prime.d.variants-buildup.stages.body.toothless-corner]
 rank = 3
@@ -2671,7 +2671,7 @@ selectorAffix."d/rTailBase" = "toothed"
 selectorAffix.dCurlyTail = "toothed"
 selectorAffix.dHookTop = "toothlessRounded"
 selectorAffix."dHookTop/rTailBase" = "toothed"
-selectorAffix."cyrl/djeKomi" = "toothed"
+selectorAffix."cyrl/djeKomi" = "toothlessRounded"
 
 [prime.d.variants-buildup.stages.serifs.serifless]
 rank = 1


### PR DESCRIPTION
Also optimize `turnRadius` and `[heading …]` control knots for Cyrillic Yeri (`Ь`, `ь`). Basically this just activates a `heading` direction for stability when the `turnRadius` touches the left bar under simultaneous extreme-narrow widths and extreme-heavy weights.

### Motivation and Context

Basically, the center stroke for these letters was too crowded under heavy. This is just a cosmetic improvement.

The characters `ȸ`/`ȹ`/`◌ᷓ` use `CThin` (bottom, both left and right), while the characters `Ԃ`/`ԃ` use `CThinB` (bottom, left only).

The top intersection (or bottom for `ȹ`) remains `[DivFrame].shoulderFine` for all characters (not applicable for capital `Ԃ`).

### Influenced Characters

  - LATIN SMALL LETTER DB DIGRAPH (`U+0238`).
  - LATIN SMALL LETTER QP DIGRAPH (`U+0239`).
  - CYRILLIC CAPITAL LETTER KOMI DJE (`U+0502`).
  - CYRILLIC SMALL LETTER KOMI DJE (`U+0503`).
  - COMBINING LATIN SMALL LETTER FLATTENED OPEN A ABOVE (`U+1DD3`).

### Glyph Quantity

usually N/A, but Lower Komi Dje (`ԃ`) is reduced to only define two total variant glyphs (`toothlessRoundedSerifless` and `toothlessRoundedTopSerifed`) so the total number of glyphs actually decreases based on that one character.

### Samples

`EƂЬbƃƌԁԀƋƎ Ԃԃȸȹ◌ᷓ`

Sans Monospace:
<img width="1816" height="1079" alt="image" src="https://github.com/user-attachments/assets/aa6ae4fe-9f1b-44b6-905c-d849368a6160" />
Slab Monospace:
<img width="1814" height="1081" alt="image" src="https://github.com/user-attachments/assets/b429dd07-d229-4a4d-8b70-d41a1953e71a" />
Aile:
<img width="2346" height="1091" alt="image" src="https://github.com/user-attachments/assets/273755c2-0a01-42ba-b09b-00584ecac803" />
Etoile:
<img width="2350" height="1089" alt="image" src="https://github.com/user-attachments/assets/a87ce3cc-0a62-4789-92ff-b0d0ca0cc5b7" />

