### PR TITLE
Upgrade typo-geom to leverage WASM Clipper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1330,12 +1330,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/clipper-lib": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/clipper-lib/-/clipper-lib-6.4.2.tgz",
-      "integrity": "sha512-knglhjQX5ihNj/XCIs6zCHrTemdvHY3LPZP9XB2nq2/3igyYMFueFXtfp84baJvEE+f8pO1ZS4UVeEgmLnAprQ==",
-      "license": "BSL"
-    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -2222,6 +2216,12 @@
         "node": ">=20"
       }
     },
+    "node_modules/js-angusj-clipper": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/js-angusj-clipper/-/js-angusj-clipper-1.3.1.tgz",
+      "integrity": "sha512-/qru4QXxN/gBbQjL4WaFl296YSM8kh5XKpNuNqfZhJ4t4Hw3KeLc5ERj3XHAeLi6pBrqeh6o9PFZUpS3QThEEQ==",
+      "license": "MIT"
+    },
     "node_modules/jsonfile": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
@@ -2877,13 +2877,13 @@
       }
     },
     "node_modules/typo-geom": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/typo-geom/-/typo-geom-0.16.1.tgz",
-      "integrity": "sha512-sLVzRyasp1VQDdhBaH7cmhCRVs2+HTVuiTKJgO7u7fDR7kWSca4wVz/zAVifYYIgbbzF88cS+PUAtQjtnGOntQ==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/typo-geom/-/typo-geom-0.20.1.tgz",
+      "integrity": "sha512-6n0wl2RVwT5b2UvDD2cyQgGDMCFsnknuIb+/9KY+Z6bY0kKto6n0fqwgsGafiUdZzMIhVzlglaohR78fi4/3Eg==",
       "license": "MIT",
       "dependencies": {
-        "clipper-lib": "^6.4.2",
-        "tslib": "^2.6.2"
+        "js-angusj-clipper": "^1.3.1",
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">= 8.9.0"
@@ -3140,7 +3140,7 @@
         "@iosevka/geometry-cache": "34.4.0",
         "@iosevka/glyph": "34.4.0",
         "@iosevka/util": "34.4.0",
-        "typo-geom": "^0.16.1"
+        "typo-geom": "^0.20.1"
       }
     },
     "packages/font-kits": {
@@ -3150,7 +3150,7 @@
         "@iosevka/geometry": "34.4.0",
         "@iosevka/glyph": "34.4.0",
         "@iosevka/util": "34.4.0",
-        "typo-geom": "^0.16.1"
+        "typo-geom": "^0.20.1"
       }
     },
     "packages/font-otl": {
@@ -3168,7 +3168,7 @@
       "dependencies": {
         "@iosevka/util": "34.4.0",
         "spiro": "^3.0.1",
-        "typo-geom": "^0.16.1"
+        "typo-geom": "^0.20.1"
       }
     },
     "packages/geometry-cache": {

--- a/packages/font-glyphs/package.json
+++ b/packages/font-glyphs/package.json
@@ -13,6 +13,6 @@
     "@iosevka/geometry-cache": "34.4.0",
     "@iosevka/glyph": "34.4.0",
     "@iosevka/util": "34.4.0",
-    "typo-geom": "^0.16.1"
+    "typo-geom": "^0.20.1"
   }
 }

--- a/packages/font-kits/package.json
+++ b/packages/font-kits/package.json
@@ -11,6 +11,6 @@
     "@iosevka/geometry": "34.4.0",
     "@iosevka/glyph": "34.4.0",
     "@iosevka/util": "34.4.0",
-    "typo-geom": "^0.16.1"
+    "typo-geom": "^0.20.1"
   }
 }

--- a/packages/font-kits/src/boole-kit.mjs
+++ b/packages/font-kits/src/boole-kit.mjs
@@ -29,11 +29,11 @@ class BooleImpl {
 }
 export function SetupBuilders(bindings) {
 	const union = (...operands) =>
-		new BooleImpl(bindings, TypoGeom.Boolean.ClipType.ctUnion, operands);
+		new BooleImpl(bindings, TypoGeom.Boolean.ClipType.Union, operands);
 	const intersection = (...operands) =>
-		new BooleImpl(bindings, TypoGeom.Boolean.ClipType.ctIntersection, operands);
+		new BooleImpl(bindings, TypoGeom.Boolean.ClipType.Intersection, operands);
 	const difference = (...operands) =>
-		new BooleImpl(bindings, TypoGeom.Boolean.ClipType.ctDifference, operands);
+		new BooleImpl(bindings, TypoGeom.Boolean.ClipType.Difference, operands);
 	const withKnockout = (mask, ...operands) => difference(union(...operands), mask);
 	return {
 		union: union,

--- a/packages/font/src/build-font/index.mjs
+++ b/packages/font/src/build-font/index.mjs
@@ -1,6 +1,7 @@
 import { buildGlyphs } from "@iosevka/font-glyphs";
 import { copyFontMetrics } from "@iosevka/font-glyphs/aesthetics";
 import { buildOtl } from "@iosevka/font-otl";
+import * as Geom from "@iosevka/geometry";
 import { createGrDisplaySheet } from "@iosevka/glyph/relation";
 import { createSubsetFilter } from "@iosevka/param";
 import { TaskYield } from "@iosevka/util";
@@ -15,6 +16,8 @@ import { generateTtfaControls } from "../ttfa-controls/index.mjs";
 import { validateFontConfigMono } from "../validate/metrics.mjs";
 
 export async function buildFont(para, cache) {
+	await Geom.Init();
+
 	const baseFont = CreateEmptyFont(para);
 	assignFontNames(baseFont, para.naming, para.isQuasiProportional);
 	await TaskYield();

--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -18,6 +18,6 @@
   "dependencies": {
     "@iosevka/util": "34.4.0",
     "spiro": "^3.0.1",
-    "typo-geom": "^0.16.1"
+    "typo-geom": "^0.20.1"
   }
 }

--- a/packages/geometry/src/curve-util.mjs
+++ b/packages/geometry/src/curve-util.mjs
@@ -155,22 +155,6 @@ export class BezToContoursSink {
 	}
 }
 
-export function InPlaceTransformBez3Shape(tf, shape) {
-	if (!tf || Transform.isIdentity(tf)) return shape;
-	for (const c of shape) {
-		for (let i = 0; i < c.length; i++) c[i] = Bez3WithTransform(c[i], tf);
-	}
-}
-export function Bez3WithTransform(arc, tf) {
-	if (!tf || Transform.isIdentity(tf)) return arc;
-	return new TypoGeom.Arcs.Bez3(
-		Point.transformedXY(tf, Point.Type.Corner, arc.a.x, arc.a.y),
-		Point.transformedXY(tf, Point.Type.CubicStart, arc.b.x, arc.b.y),
-		Point.transformedXY(tf, Point.Type.CubicEnd, arc.c.x, arc.c.y),
-		Point.transformedXY(tf, Point.Type.Corner, arc.d.x, arc.d.y),
-	);
-}
-
 export function Bez3FromHermite(zStart, dStart, zEnd, dEnd) {
 	const a = zStart,
 		d = zEnd;
@@ -228,4 +212,37 @@ export class RoundCapCurve {
 
 		return new Vec2(dx, dy);
 	}
+}
+
+export function InPlaceTransformBez3Shape(tf, shape) {
+	if (!tf || Transform.isIdentity(tf)) return shape;
+	for (const c of shape) {
+		for (let i = 0; i < c.length; i++) c[i] = Bez3WithTransform(c[i], tf);
+	}
+}
+export function Bez3WithTransform(arc, tf) {
+	if (!tf || Transform.isIdentity(tf)) return arc;
+	return new TypoGeom.Arcs.Bez3(
+		Point.transformedXY(tf, Point.Type.Corner, arc.a.x, arc.a.y),
+		Point.transformedXY(tf, Point.Type.CubicStart, arc.b.x, arc.b.y),
+		Point.transformedXY(tf, Point.Type.CubicEnd, arc.c.x, arc.c.y),
+		Point.transformedXY(tf, Point.Type.Corner, arc.d.x, arc.d.y),
+	);
+}
+
+export function rorateShapeToCanonicalStartingPoint(shape) {
+	for (const contour of shape) {
+		rotateContourToCanonicalStartingPoint(contour);
+	}
+}
+function rotateContourToCanonicalStartingPoint(arcContour) {
+	let minIndex = 0;
+	for (let i = 1; i < arcContour.length; i++) {
+		const aMin = arcContour[minIndex].a;
+		const aCurr = arcContour[i].a;
+		if (aCurr.y < aMin.y || (aCurr.y === aMin.y && aCurr.x < aMin.x)) {
+			minIndex = i;
+		}
+	}
+	if (minIndex > 0) arcContour.push(...arcContour.splice(0, minIndex));
 }

--- a/packages/geometry/src/index.mjs
+++ b/packages/geometry/src/index.mjs
@@ -9,6 +9,10 @@ import { spiroToBezArcsWithSimplification } from "./spiro-to-outline.mjs";
 import { strokeArcs } from "./stroke.mjs";
 import { Transform } from "./transform.mjs";
 
+export async function Init() {
+	await TypoGeom.Init();
+}
+
 export const CPLX_NON_EMPTY = 0x01; // A geometry tree that is not empty
 export const CPLX_NON_SIMPLE = 0x02; // A geometry tree that contains non-simple contours
 export const CPLX_BROKEN = 0x04; // A geometry tree that contains broken contours
@@ -154,11 +158,11 @@ export class SpiroPenGeometry extends SimpleGeometry {
 		for (const [i, c] of contours.entries()) {
 			stack.push({
 				type: "operand",
-				fillType: TypoGeom.Boolean.PolyFillType.pftNonZero,
+				fillType: TypoGeom.Boolean.PolyFillType.NonZero,
 				shape: CurveUtil.convertShapeToArcs([c]),
 			});
 			if (i > 0) {
-				stack.push({ type: "operator", operator: TypoGeom.Boolean.ClipType.ctUnion });
+				stack.push({ type: "operator", operator: TypoGeom.Boolean.ClipType.Union });
 			}
 		}
 
@@ -504,7 +508,7 @@ export class BooleanGeometry extends GeometryBase {
 		if (this.m_operands.length === 0) {
 			stack.push({
 				type: "operand",
-				fillType: TypoGeom.Boolean.PolyFillType.pftNonZero,
+				fillType: TypoGeom.Boolean.PolyFillType.NonZero,
 				shape: [],
 			});
 			return;
@@ -517,7 +521,7 @@ export class BooleanGeometry extends GeometryBase {
 			} else {
 				stack.push({
 					type: "operand",
-					fillType: TypoGeom.Boolean.PolyFillType.pftNonZero,
+					fillType: TypoGeom.Boolean.PolyFillType.NonZero,
 					shape: operand.toBezArcs(),
 				});
 			}
@@ -579,7 +583,7 @@ export class StrokeGeometry extends GeometryBase {
 		);
 		const arcs = TypoGeom.Boolean.removeOverlap(
 			nonTransformedGeometry.toBezArcs(),
-			TypoGeom.Boolean.PolyFillType.pftNonZero,
+			TypoGeom.Boolean.PolyFillType.NonZero,
 			CurveUtil.BOOLE_RESOLUTION,
 		);
 
@@ -634,7 +638,7 @@ export class RemoveHolesGeometry extends GeometryBase {
 		);
 		let arcs = TypoGeom.Boolean.removeOverlap(
 			nonTransformedGeometry.toBezArcs(),
-			TypoGeom.Boolean.PolyFillType.pftNonZero,
+			TypoGeom.Boolean.PolyFillType.NonZero,
 			CurveUtil.BOOLE_RESOLUTION,
 		);
 
@@ -642,17 +646,17 @@ export class RemoveHolesGeometry extends GeometryBase {
 			const stack = [];
 			stack.push({
 				type: "operand",
-				fillType: TypoGeom.Boolean.PolyFillType.pftNonZero,
+				fillType: TypoGeom.Boolean.PolyFillType.NonZero,
 				shape: [arcs[0]],
 			});
 
 			for (let i = 1; i < arcs.length; i++) {
 				stack.push({
 					type: "operand",
-					fillType: TypoGeom.Boolean.PolyFillType.pftNonZero,
+					fillType: TypoGeom.Boolean.PolyFillType.NonZero,
 					shape: [arcs[i]],
 				});
-				stack.push({ type: "operator", operator: TypoGeom.Boolean.ClipType.ctUnion });
+				stack.push({ type: "operator", operator: TypoGeom.Boolean.ClipType.Union });
 			}
 
 			arcs = TypoGeom.Boolean.combineStack(stack, CurveUtil.BOOLE_RESOLUTION);
@@ -702,6 +706,7 @@ export class SimplifyGeometry extends GeometryBase {
 	// Produce simplified arcs
 	toBezArcs() {
 		let arcs = this.m_geom.toBezArcs();
+		CurveUtil.rorateShapeToCanonicalStartingPoint(arcs);
 
 		const needsTransform = !Transform.isTranslate(this.m_gizmo);
 		if (needsTransform) CurveUtil.InPlaceTransformBez3Shape(this.m_gizmo.inverse(), arcs);
@@ -709,7 +714,7 @@ export class SimplifyGeometry extends GeometryBase {
 		if (this.m_geom.measureComplexity() & CPLX_NON_SIMPLE) {
 			arcs = TypoGeom.Boolean.removeOverlap(
 				arcs,
-				TypoGeom.Boolean.PolyFillType.pftNonZero,
+				TypoGeom.Boolean.PolyFillType.NonZero,
 				CurveUtil.BOOLE_RESOLUTION,
 			);
 		}

--- a/packages/geometry/src/stroke.mjs
+++ b/packages/geometry/src/stroke.mjs
@@ -22,11 +22,11 @@ export function strokeArcs(arcs, radius, contrast, fInside) {
 			currentArcs = bezs;
 		} else {
 			currentArcs = TypoGeom.Boolean.combine(
-				TypoGeom.Boolean.ClipType.ctUnion,
+				TypoGeom.Boolean.ClipType.Union,
 				currentArcs,
 				bezs,
-				TypoGeom.Boolean.PolyFillType.pftNonZero,
-				TypoGeom.Boolean.PolyFillType.pftNonZero,
+				TypoGeom.Boolean.PolyFillType.NonZero,
+				TypoGeom.Boolean.PolyFillType.NonZero,
 				BOOLE_RESOLUTION,
 			);
 		}
@@ -35,11 +35,11 @@ export function strokeArcs(arcs, radius, contrast, fInside) {
 	if (currentArcs) {
 		if (fInside) {
 			return TypoGeom.Boolean.combine(
-				TypoGeom.Boolean.ClipType.ctIntersection,
+				TypoGeom.Boolean.ClipType.Intersection,
 				TypoGeom.ShapeConv.convertShapeToBez3(arcs, GEOMETRY_PRECISION),
 				currentArcs,
-				TypoGeom.Boolean.PolyFillType.pftNonZero,
-				TypoGeom.Boolean.PolyFillType.pftNonZero,
+				TypoGeom.Boolean.PolyFillType.NonZero,
+				TypoGeom.Boolean.PolyFillType.NonZero,
 				BOOLE_RESOLUTION,
 			);
 		} else {

--- a/verdafile.mjs
+++ b/verdafile.mjs
@@ -511,7 +511,7 @@ const DistUnhintedTTF = file.make(
 			await target.need(de(charMapPath.dir), de(ttfaControlsPath.dir), de(SHARED_CACHE));
 
 			echo.action(echo.hl.command(`Create TTF`), out.full);
-			const { cacheUpdated } = await silently.node("packages/font/src/index.mjs", {
+			const { cacheUpdated } = await silently.node.worker("packages/font/src/index.mjs", {
 				// INPUT: font info
 				...fi,
 				// INPUT: path to parameters


### PR DESCRIPTION
A lot of build time was used in the clipperjs lib. This change utilizes typo-geom 0.20 which uses WASM Clipper