### PR TITLE
Add `double-storey-flat-bottom` variants for Latin⁠/⁠Cyrillic Lower A (`a`, `а`), for `ss10` and `ss12`.

### DIFF
--- a/changes/34.5.0.md
+++ b/changes/34.5.0.md
@@ -1,3 +1,4 @@
+* Add `double-storey-flat-bottom` variants for Latin/Cyrillic Lower A (`a`, `а`).
 * Add `bilateral-motion-serifed` variants for Cyrillic Capital/Lower Ya (`Я`, `я`).
 * Refine shape of the following characters:
   - LATIN SMALL LETTER DB DIGRAPH (`U+0238`).

--- a/packages/font-glyphs/src/letter/latin/lower-a.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-a.ptl
@@ -46,7 +46,7 @@ glyph-block Letter-Latin-Lower-A : begin
 			local sw : fallback _stroke : ADoubleStoreyStroke df
 			return : ADoubleStoreyHookAndBarT spiro-outline df hookStyle y0 sw
 
-		define [ADoubleStoreyArcT df sink kind rise stroke exd] : glyph-proc
+		define [ADoubleStoreyArcT df sink kind rise stroke bbd] : glyph-proc
 			local isMask : sink == spiro-outline
 			local barTop : XH * DesignParameters.aBarPos + stroke * 0.425
 			local ada2 : ArchDepthAOf : SmallArchDepth * DesignParameters.aBarPos
@@ -62,23 +62,28 @@ glyph-block Letter-Latin-Lower-A : begin
 				match kind
 					0 : list
 						Arch.lhs 0 (sw -- stroke) (swAfter -- df.shoulderFine)
-						[if isMask flat straight.up.end] (df.rightSB - exd - [HSwToV : stroke - df.shoulderFine]) [Math.min (barTop - [if isMask TINY 0]) : df.archDepthAOf (SmallArchDepth * 0.9) stroke] [widths.lhs df.shoulderFine]
-						if isMask { [corner (df.rightSB - exd - [HSwToV : stroke - df.shoulderFine]) barTop] } {}
-					1 : list
-						Arch.lhs 0 (sw -- stroke) (blendPost -- {})
-						g4   df.rightSB rise
+						[if isMask flat straight.up.end] (df.rightSB - bbd - [HSwToV : stroke - df.shoulderFine]) [Math.min (barTop - [if isMask TINY 0]) : df.archDepthAOf (SmallArchDepth * 0.9) stroke] [widths.lhs df.shoulderFine]
+						if isMask { [corner (df.rightSB - bbd - [HSwToV : stroke - df.shoulderFine]) barTop] } {}
+					1 : if rise
+						list
+							Arch.lhs 0 (sw -- stroke) (blendPost -- {})
+							g4   df.rightSB rise
+						list
+							arcvh
+							flat [Arch.adjust-x.bot df.middle (sw -- stroke)] 0
+							curl (df.rightSB + O) 0 [heading Rightward]
 					2 : list
 						Arch.lhs 0 (sw -- stroke)
 						flat df.rightSB [Math.min rise : YSmoothMidR barTop 0 ada2 adb2]
-						curl df.rightSB (rise + [HSwToV : Math.abs : stroke * TanSlope] + TINY) [heading Upward]
+						curl df.rightSB (rise + TINY + [HSwToV : Math.abs : stroke * TanSlope]) [heading Upward]
 
-		export : define [Arc df kind rise _sw _exd] : ADoubleStoreyArcT df dispiro kind rise
+		export : define [Arc df kind rise _sw _bbd] : ADoubleStoreyArcT df dispiro kind rise
 			fallback _sw : ADoubleStoreyStroke df
-			fallback _exd 0
+			fallback _bbd 0
 
-		export : define [ArcMask df kind rise _sw _exd] : ADoubleStoreyArcT df spiro-outline kind rise
+		export : define [ArcMask df kind rise _sw _bbd] : ADoubleStoreyArcT df spiro-outline kind rise
 			fallback _sw : ADoubleStoreyStroke df
-			fallback _exd 0
+			fallback _bbd 0
 
 		export : define [Serifless df hookStyle sw] : union
 			HookAndBar df hookStyle 0 sw
@@ -93,6 +98,14 @@ glyph-block Letter-Latin-Lower-A : begin
 			Arc        df 0         0                                    sw
 			RightwardTailedBar df.rightSB 0 (XH - [ADoubleStoreySmoothB df]) [fallback sw : ADoubleStoreyStroke df]
 
+		export : define [FlatBottomSerifless df hookStyle sw] : union
+			HookAndBar df hookStyle 0 sw
+			Arc        df 1         0 sw
+
+		export : define [FlatBottomSerifed df hookStyle sw] : union
+			FlatBottomSerifless df hookStyle sw
+			begin [SerifFrame.fromDf df XH 0 (swRef -- [fallback sw : ADoubleStoreyStroke df]) (swSerif -- df.mvs)].rb.outer
+
 		export : define [ToothlessCorner df hookStyle sw] : union
 			HookAndBar df hookStyle DToothlessRise sw
 			Arc        df 1         DToothlessRise sw
@@ -102,22 +115,28 @@ glyph-block Letter-Latin-Lower-A : begin
 			Arc        df 2         [ADoubleStoreySmoothA df] sw
 
 		export : define [GetMask shapeFn df sw] : match shapeFn
-			[Just ToothlessCorner]  : ArcMask df 1 DToothlessRise            sw
-			[Just ToothlessRounded] : ArcMask df 2 [ADoubleStoreySmoothA df] sw
-			__                      : ArcMask df 0 0                         sw
+			[Just FlatBottomSerifless] : ArcMask df 1 0                         sw
+			[Just FlatBottomSerifed]   : ArcMask df 1 0                         sw
+			[Just ToothlessCorner]     : ArcMask df 1 DToothlessRise            sw
+			[Just ToothlessRounded]    : ArcMask df 2 [ADoubleStoreySmoothA df] sw
+			__                         : ArcMask df 0 0                         sw
 
 	glyph-block-export DoubleStoreyConfig
 	define DoubleStoreyConfig : object
-		doubleStoreySerifless                         { DoubleStorey.Serifless         RightSB            1 }
-		doubleStoreySerifed                           { DoubleStorey.Serifed          (RightSB + SideJut) 1 }
-		doubleStoreyTailed                            { DoubleStorey.Tailed           (RightSB + SideJut) 1 }
-		doubleStoreyToothlessCorner                   { DoubleStorey.ToothlessCorner   nothing            1 }
-		doubleStoreyToothlessRounded                  { DoubleStorey.ToothlessRounded  nothing            1 }
-		doubleStoreyHookInwardSerifedSerifless        { DoubleStorey.Serifless         RightSB            2 }
-		doubleStoreyHookInwardSerifedSerifed          { DoubleStorey.Serifed          (RightSB + SideJut) 2 }
-		doubleStoreyHookInwardSerifedTailed           { DoubleStorey.Tailed           (RightSB + SideJut) 2 }
-		doubleStoreyHookInwardSerifedToothlessCorner  { DoubleStorey.ToothlessCorner   nothing            2 }
-		doubleStoreyHookInwardSerifedToothlessRounded { DoubleStorey.ToothlessRounded  nothing            2 }
+		doubleStoreySerifless                            { DoubleStorey.Serifless           RightSB            1 }
+		doubleStoreySerifed                              { DoubleStorey.Serifed            (RightSB + SideJut) 1 }
+		doubleStoreyTailed                               { DoubleStorey.Tailed             (RightSB + SideJut) 1 }
+		doubleStoreyFlatBottomSerifless                  { DoubleStorey.FlatBottomSerifless RightSB            1 }
+		doubleStoreyFlatBottomSerifed                    { DoubleStorey.FlatBottomSerifed  (RightSB + SideJut) 1 }
+		doubleStoreyToothlessCorner                      { DoubleStorey.ToothlessCorner     nothing            1 }
+		doubleStoreyToothlessRounded                     { DoubleStorey.ToothlessRounded    nothing            1 }
+		doubleStoreyHookInwardSerifedSerifless           { DoubleStorey.Serifless           RightSB            2 }
+		doubleStoreyHookInwardSerifedSerifed             { DoubleStorey.Serifed            (RightSB + SideJut) 2 }
+		doubleStoreyHookInwardSerifedTailed              { DoubleStorey.Tailed             (RightSB + SideJut) 2 }
+		doubleStoreyHookInwardSerifedFlatBottomSerifless { DoubleStorey.FlatBottomSerifless RightSB            2 }
+		doubleStoreyHookInwardSerifedFlatBottomSerifed   { DoubleStorey.FlatBottomSerifed  (RightSB + SideJut) 2 }
+		doubleStoreyHookInwardSerifedToothlessCorner     { DoubleStorey.ToothlessCorner     nothing            2 }
+		doubleStoreyHookInwardSerifedToothlessRounded    { DoubleStorey.ToothlessRounded    nothing            2 }
 
 	foreach { suffix { body xTrailing hookStyle } } [Object.entries DoubleStoreyConfig] : do
 		create-glyph "a.\(suffix)" : glyph-proc
@@ -125,9 +144,10 @@ glyph-block Letter-Latin-Lower-A : begin
 			include : df.markSet.e
 			if xTrailing : set-base-anchor 'trailing' xTrailing 0
 			include : body df hookStyle
-		create-glyph "aRetroflexHook.\(suffix)" : glyph-proc
-			include [refer-glyph "a.\(suffix)"] AS_BASE ALSO_METRICS
-			include : RetroflexHook.rSideJut RightSB 0 (yOverflow -- Stroke)
+		if (body === DoubleStorey.Serifless) : begin
+			create-glyph "aRetroflexHook.\(suffix)" : glyph-proc
+				include [refer-glyph "a.\(suffix)"] AS_BASE ALSO_METRICS
+				include : RetroflexHook.rSideJut RightSB 0 (yOverflow -- Stroke)
 
 	glyph-block-import Letter-Blackboard : BBS BBD
 	create-glyph 'mathbb/a' 0x1D552 : glyph-proc

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2432,8 +2432,40 @@ selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "topSerifed"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "topSerifed"
 selectorAffix."ae/a" = "toothlessRounded"
 
-[prime.a.variants-buildup.stages.bar.toothless-corner]
+[prime.a.variants-buildup.stages.bar.flat-bottom-serifless]
 rank = 6
+nonBreakingVariantAdditionPriority = 100
+disableIf = [{ storey = "single-storey" }]
+descriptionAffix = "flat bottom; without serif at terminal"
+selectorAffix.a = "flatBottomSerifless"
+selectorAffix."a/sansSerif" = "flatBottomSerifless"
+selectorAffix."aRetroflexHook" = "serifless"
+selectorAffix."a/doubleStorey" = "flatBottomSerifless"
+selectorAffix."aRetroflexHook/doubleStorey" = "serifless"
+selectorAffix."a/singleStorey/autoSerifed/slab" = "serifless"
+selectorAffix."a/singleStorey/autoSerifed/sans" = "serifless"
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "serifless"
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "serifless"
+selectorAffix."ae/a" = "toothlessRounded"
+
+[prime.a.variants-buildup.stages.bar.flat-bottom-serifed]
+rank = 7
+nonBreakingVariantAdditionPriority = 100
+disableIf = [{ storey = "single-storey" }]
+descriptionAffix = "flat bottom; with serif at terminal"
+selectorAffix.a = "flatBottomSerifed"
+selectorAffix."a/sansSerif" = "flatBottomSerifless"
+selectorAffix."aRetroflexHook" = "serifless"
+selectorAffix."a/doubleStorey" = "flatBottomSerifed"
+selectorAffix."aRetroflexHook/doubleStorey" = "serifless"
+selectorAffix."a/singleStorey/autoSerifed/slab" = "doubleSerifed"
+selectorAffix."a/singleStorey/autoSerifed/sans" = "serifed"
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "topSerifed"
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "serifless"
+selectorAffix."ae/a" = "toothlessRounded"
+
+[prime.a.variants-buildup.stages.bar.toothless-corner]
+rank = 8
 disableIf = [{ storey = "single-storey" }]
 descriptionAffix = "toothless (cornered bottom-right)"
 selectorAffix.a = "toothlessCorner"
@@ -2448,7 +2480,7 @@ selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "serifless"
 selectorAffix."ae/a" = "toothlessRounded"
 
 [prime.a.variants-buildup.stages.bar.toothless-rounded]
-rank = 7
+rank = 9
 disableIf = [{ storey = "single-storey" }]
 descriptionAffix = "toothless (rounded bottom-right)"
 selectorAffix.a = "toothlessRounded"
@@ -7049,15 +7081,31 @@ descriptionAffix = "curly tail; with serifs at top and bottom"
 selectorAffix."cyrl/a" = "tailedSerifed"
 selectorAffix."cyrl/aye/a" = "toothlessRounded"
 
-[prime.cyrl-a.variants-buildup.stages.bar.toothless-corner]
+[prime.cyrl-a.variants-buildup.stages.bar.flat-bottom-serifless]
 rank = 6
+nonBreakingVariantAdditionPriority = 100
+disableIf = [{ storey = "single-storey" }]
+descriptionAffix = "flat bottom; without serif at terminal"
+selectorAffix."cyrl/a" = "flatBottomSerifless"
+selectorAffix."cyrl/aye/a" = "toothlessRounded"
+
+[prime.cyrl-a.variants-buildup.stages.bar.flat-bottom-serifed]
+rank = 7
+nonBreakingVariantAdditionPriority = 100
+disableIf = [{ storey = "single-storey" }]
+descriptionAffix = "flat bottom; with serif at terminal"
+selectorAffix."cyrl/a" = "flatBottomSerifed"
+selectorAffix."cyrl/aye/a" = "toothlessRounded"
+
+[prime.cyrl-a.variants-buildup.stages.bar.toothless-corner]
+rank = 8
 disableIf = [{ storey = "single-storey" }]
 descriptionAffix = "toothless (cornered bottom-right)"
 selectorAffix."cyrl/a" = "toothlessCorner"
 selectorAffix."cyrl/aye/a" = "toothlessRounded"
 
 [prime.cyrl-a.variants-buildup.stages.bar.toothless-rounded]
-rank = 7
+rank = 9
 disableIf = [{ storey = "single-storey" }]
 descriptionAffix = "toothless (rounded bottom-right)"
 selectorAffix."cyrl/a" = "toothlessRounded"
@@ -11437,7 +11485,7 @@ capital-w = "straight-vertical-sides-serifless"
 capital-x = "straight-serifless"
 capital-y = "straight-serifless"
 capital-z = "straight-serifless"
-a = "double-storey-toothless-corner"
+a = "double-storey-flat-bottom-serifless"
 b = "toothed-serifless"
 d = "toothed-serifless"
 e = "flat-crossbar"
@@ -11464,7 +11512,7 @@ lower-kappa = "symmetric-connected-serifless"
 lower-lambda = "straight"
 lower-tau = "flat-tailed"
 lower-chi = "straight-serifless"
-cyrl-a = "double-storey-toothless-corner"
+cyrl-a = "double-storey-flat-bottom-serifless"
 cyrl-capital-zhe = "symmetric-connected"
 cyrl-zhe = "symmetric-connected"
 cyrl-capital-ka = "symmetric-connected-serifless"
@@ -11517,6 +11565,7 @@ capital-w = "straight-vertical-sides-serifed"
 capital-x = "straight-serifed"
 capital-y = "straight-serifed"
 capital-z = "straight-serifed"
+a = "double-storey-flat-bottom-serifed"
 b = "toothed-serifed"
 d = "toothed-serifed"
 f = "flat-hook-serifed"
@@ -11536,6 +11585,7 @@ long-s = "flat-hook-double-serifed"
 eszet = "sulzbacher-bottom-serifed"
 lower-kappa = "symmetric-connected-tri-serifed"
 lower-chi = "straight-bilateral-motion-serifed"
+cyrl-a = "double-storey-flat-bottom-serifed"
 cyrl-capital-ka = "symmetric-connected-serifed"
 cyrl-ka = "symmetric-connected-serifed"
 cyrl-capital-u = "straight-serifed"
@@ -11549,6 +11599,7 @@ micro-sign = "toothless-rounded-serifed"
 
 [composite.ss10.slab-override.italic]
 capital-a = "straight-base-serifed"
+a = "single-storey-top-cut-tailed"
 b = "bottom-cut-serifed"
 d = "tailed-serifed"
 f = "flat-hook-serifless"
@@ -11566,6 +11617,7 @@ y = "cursive-flat-hook-motion-serifed"
 long-s = "flat-hook-middle-serifed"
 eszet = "sulzbacher-serifless"
 lower-kappa = "symmetric-connected-top-left-and-bottom-right-serifed"
+cyrl-a = "single-storey-top-cut-tailed"
 cyrl-ka = "symmetric-connected-top-left-and-bottom-right-serifed"
 cyrl-u = "cursive-flat-hook-motion-serifed"
 cyrl-ya = "straight-bilateral-motion-serifed"
@@ -11672,7 +11724,7 @@ lower-phi = "neo-hellenic"
 lower-chi = "straight-above-baseline-serifless"
 lower-psi = "flat-top-serifless"
 partial-derivative = "closed-contour"
-cyrl-a = "double-storey-tailed"
+cyrl-a = "double-storey-flat-bottom-serifless"
 cyrl-ve = "standard-serifless"
 cyrl-capital-zhe = "symmetric-touching"
 cyrl-zhe = "symmetric-touching"
@@ -11759,6 +11811,7 @@ lower-nu = "straight-serifed"
 lower-upsilon = "straight-serifed"
 lower-chi = "straight-above-baseline-bilateral-motion-serifed"
 lower-psi = "flat-top-serifed"
+cyrl-a = "double-storey-flat-bottom-serifed"
 cyrl-ve = "standard-bilateral-serifed"
 cyrl-capital-ka = "symmetric-touching-serifed"
 cyrl-ka = "symmetric-touching-serifed"
@@ -11791,6 +11844,7 @@ long-s = "bent-hook-tailed"
 eszet = "longs-s-lig-tailed-serifless"
 lower-kappa = "symmetric-touching-top-left-and-bottom-right-serifed"
 lower-mu = "tailed-motion-serifed"
+cyrl-a = "single-storey-earless-corner-tailed"
 cyrl-ve = "rounded-top-serifless"
 cyrl-ka = "symmetric-touching-top-left-and-bottom-right-serifed"
 cyrl-u = "straight-turn-motion-serifed"


### PR DESCRIPTION
### Motivation and Context

This is a special "toothless-like" variant for double-storey `a` that resembles a reversed Cyrillic Yeri (`ь`).

Envy Code R uses it, while Ubuntu Mono appears somewhere between `toothless-corner` and `flat-bottom`, looking more like the former when shown next to Latin `b` and more like latter when shown next to Cyrillic `в`.

The construction of this terminal shape is based on implementing an alternate "mode" of the `DoubleStorey.ToothlessCorner` code, which is accessed when the `rise` argument is `0`.

### Influenced Characters

  Please list the characters that are added or modified by this change. You can use the following format:
  - U+0061: LATIN SMALL LETTER A
  - U+0250: LATIN SMALL LETTER TURNED A
  - U+0430: CYRILLIC SMALL LETTER A
  - U+A657: CYRILLIC SMALL LETTER IOTIFIED A
  - U+A733: LATIN SMALL LETTER AA

### Glyph Quantity

+4 (when accounting for hook/terminal serifs) for each of `a`, `ɐ`, `a`, `ꙗ`, and `ꜳ`; However, the glyph count is actually reduced for `ᶏ` in particular (`a` with retroflex hook).

Composites such as `æ` etc. with the `a`-part on the left do not generate new glyphs, because the additional work of #3167 has reduced them to only define `toothlessRounded` glyphs.

### Samples

```
ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ
abc.def.ghi.jkl.mno.pqrs.tuv.wxyz
!iIlL17|¦ ¢coO08BDQ $5SZ2zs ∂96µm
float il1[]={1-2/3.4,5+6=7/8%90};
1234567890 ,._-+= >< «¯-¬_» ~–÷+×
{*}[]()<>`+-=$/#_%^@\&|~?'" !,.;:
g9q¶ Þẞðþſß ΓΔΛαβγδηθικλμνξπτυφχψ
ЖЗКНРУЭЯавжзклмнруфчьыэя <= != ==
```

Sans Upright under `ss10`:
<img width="1806" height="1096" alt="image" src="https://github.com/user-attachments/assets/2a6a591f-f68c-491c-8b15-2966723f7591" />
Sans Italic under `ss10` (unchanged):
<img width="1823" height="1100" alt="image" src="https://github.com/user-attachments/assets/edec365f-a6ad-48f9-814b-7b9710a343ee" />

Compared to Envy Code R (using GNU Unifont as a fallback):

Upright:
<img width="1929" height="1008" alt="image" src="https://github.com/user-attachments/assets/6f47b28e-0ae0-4b82-9847-7c5678a4fc0a" />
Italic:
<img width="1930" height="1006" alt="image" src="https://github.com/user-attachments/assets/607bc374-5c55-4e4e-9d6a-25c023aca277" />

-----

```
ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ
abc.def.ghi.jkl.mno.pqrs.tuv.wxyz
!iIlL17|¦ ¢coO08BDQ $5SZ2zs ∂96µm
float il1[]={1-2/3.4,5+6=7/8%90};
1234567890 ,._-+= >< «¯-¬_» ~–÷+×
{*}[]()<>`+-=$/#_%^@\&|~?'" !,.;:
g9q¶ Þẞðþſß ΓΔΛαβγδηθικλμνξπτυφχψ
ЖЗКНРУЭЯавжзклмнруфчьыэя <= != ==
```

Sans Upright under `ss12` (for Cyrillic `а` in particular):
<img width="1821" height="1094" alt="image" src="https://github.com/user-attachments/assets/2ea71ad7-6d70-428e-9b0b-8e59832cf5bc" />
Sans Italic under `ss12` (unchanged):
<img width="1814" height="1097" alt="image" src="https://github.com/user-attachments/assets/b7077f7e-87b3-45da-bca9-2eb60d865494" />

Compared to Ubuntu Mono (using _proportional_ Ubuntu as a fallback):

Upright:
<img width="1816" height="1032" alt="image" src="https://github.com/user-attachments/assets/51e60503-d9fb-4b3c-a179-48811a0392d7" />
Italic:
<img width="1829" height="1041" alt="image" src="https://github.com/user-attachments/assets/ba8dabfe-8261-46ef-ad7d-c9b777b5cd5d" />

