### PR TITLE
Add `ꭃ`⁠/⁠`ꭄ`.

### DIFF
--- a/changes/34.5.0.md
+++ b/changes/34.5.0.md
@@ -1,6 +1,8 @@
 * Add Characters:
   - WHITE HEAVY CHECK MARK (`U+2705`) (#3171).
   - NEGATIVE SQUARED CROSS MARK (`U+274E`) (#3171).
+  - LATIN SMALL LETTER TURNED O OPEN-O (`U+AB43`).
+  - LATIN SMALL LETTER TURNED O OPEN-O WITH STROKE (`U+AB44`).
 * Add `double-storey-flat-bottom` variants for Latin/Cyrillic Lower A (`a`, `а`).
 * Add `bilateral-motion-serifed` variants for Cyrillic Capital/Lower Ya (`Я`, `я`).
 * Refine shape of the following characters:

--- a/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/lower-ae-oe.ptl
@@ -115,7 +115,7 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 				set-mark-anchor 'cvDecompose' 0 0
 				include : EShape 1 df body
 
-			create-glyph "ae/eInv.\(suffix)" : glyph-proc
+			create-glyph "ae/inve.\(suffix)" : glyph-proc
 				local df : DivFrame para.advanceScaleMM 3
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
@@ -153,9 +153,9 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 	do "c subglyphs"
 		glyph-block-import Letter-Latin-C : CLetterForm CConfig
 
-		define [openOShape df sty styBot] : new-glyph : glyph-proc
+		define [openOShape df styTop styBot] : new-glyph : glyph-proc
 			local subDf : df.slice 3 2 OX
-			local lf : CLetterForm subDf sty styBot XH 0
+			local lf : CLetterForm subDf styTop styBot XH 0
 				ada -- subDf.smallArchDepthA
 				adb -- subDf.smallArchDepthB
 				sw  -- df.mvs
@@ -169,26 +169,27 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 				sw  -- subDf.mvs
 			include : lf.full
 
-		foreach { suffix { sty styBot } } [Object.entries CConfig] : do
+		foreach { suffix { styTop styBot } } [Object.entries CConfig] : do
 			create-glyph "oe/oOpen.\(suffix)" : glyph-proc
 				local df : include : DivFrame para.advanceScaleMM 3
 				include : df.markSet.e
 				set-base-anchor 'cvDecompose' 0 0
-				include : openOShape df sty styBot
+				include : openOShape df styTop styBot
 
-			create-glyph "cyrl/este.upright/left.\(suffix)" : glyph-proc
-				local df : include : DivFrame para.advanceScaleMM 3.5
-				local subDfLeft : df.slice 3.25 1.875
-				include : df.markSet.e
-				set-base-anchor 'cvDecompose' 0 0
-				include : EsTeLeftShape subDfLeft styBot
+			if (!styTop) : begin
+				create-glyph "cyrl/este.upright/left.\(suffix)" : glyph-proc
+					local df : include : DivFrame para.advanceScaleMM 3.5
+					local subDfLeft : df.slice 3.25 1.875
+					include : df.markSet.e
+					set-base-anchor 'cvDecompose' 0 0
+					include : EsTeLeftShape subDfLeft styBot
 
-			create-glyph "cyrl/este.italic/left.\(suffix)" : glyph-proc
-				local df : include : DivFrame para.advanceScaleMM 4.75
-				local subDfLeft : df.slice 4.5 2
-				include : df.markSet.e
-				set-base-anchor 'cvDecompose' 0 0
-				include : EsTeLeftShape subDfLeft styBot
+				create-glyph "cyrl/este.italic/left.\(suffix)" : glyph-proc
+					local df : include : DivFrame para.advanceScaleMM 4.75
+					local subDfLeft : df.slice 4.5 2
+					include : df.markSet.e
+					set-base-anchor 'cvDecompose' 0 0
+					include : EsTeLeftShape subDfLeft styBot
 
 	do "Ya subglyphs"
 		glyph-block-import Letter-Latin-Upper-P : PShape PBarPosY
@@ -309,29 +310,31 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 
 		foreach { suffix { doST doSB } } [Object.entries TConfig] : do
 			create-glyph "cyrl/este.upright/right.\(suffix)" : glyph-proc
-				local df : include : DivFrame para.advanceScaleMM 3.5
+				local df : DivFrame para.advanceScaleMM 3.5
 				local subDfLeft : df.slice 3.25 1.875
-				local subdfRight : df.restCompact 1 subDfLeft 2
+				local subDfRight : df.restCompact 1 subDfLeft 2
 
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
-				include : EsTeRightShape subdfRight doST doSB
-				include : ApparentTranslate (df.width - subdfRight.width) 0
+				include : EsTeRightShape subDfRight doST doSB
+				include : ApparentTranslate (df.width - subDfRight.width) 0
 
 	do "Te (italic) subglyphs"
 		glyph-block-import Letter-Latin-Lower-M : mShapeBodyImpl SmallMConfig
+
 		foreach { suffix { { Body earless } { shortLeg } { tailed } { Serifs } } } [pairs-of SmallMConfig] : do
 			create-glyph "cyrl/este.italic/right.\(suffix)" : glyph-proc
 				local df : DivFrame para.advanceScaleMM 4.75
 				local subDfLeft : df.slice 4.5 2
-				local subdfRight : df.restCompact 0.5 subDfLeft 3
+				local subDfRight : df.restCompact 0.5 subDfLeft 3
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
-				include : mShapeBodyImpl subdfRight XH Body earless shortLeg tailed Serifs
-				include : ApparentTranslate (df.width - subdfRight.width) 0
+				include : mShapeBodyImpl subDfRight XH Body earless shortLeg tailed Serifs
+				include : ApparentTranslate (df.width - subDfRight.width) 0
 
 	do "El subglyphs"
 		glyph-block-import Letter-Cyrillic-El : CyrElShape
+
 		create-glyph 'cyrl/Lha/left' : glyph-proc
 			local df : include : DivFrame para.advanceScaleM 3.2
 			include : df.markSet.capital
@@ -364,10 +367,8 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 	select-variant "aa" 0xA733 (follow -- 'a/doubleStorey')
 
 	select-variant "ae/a"
-	select-variant "ae/e"     (follow -- 'e')
-	select-variant "ae/eInv"  (follow -- 'e')
+	select-variant "ae/e" (follow -- 'e')
 	select-variant "au/u"
-	select-variant "oe/oOpen" (follow -- 'oOpen')
 	select-variant "ue/u"
 
 	select-variant "cyrl/aye/a" (shapeFrom -- 'ae/a')
@@ -385,21 +386,24 @@ glyph-block Letter-Latin-Lower-AE-OE : begin
 	derive-composites 'au' 0xA737 'ae/a' 'au/u'
 	derive-composites 'uo' 0xAB63 'ue/u' 'ao/o'
 
-	derive-composites 'aeInv'  0xAB31 'ae/a' 'ae/eInv'
-	derive-composites 'oeInv'  0xAB40 'oe/o' 'ae/eInv'
-	derive-composites 'oOpene' 0xAB62 'oe/oOpen' 'ae/e'
+	CreateTurnedLetter 'turnae' 0x1D02 'ae' HalfAdvance (XH / 2) [DivFrame para.advanceScaleMM 3]
+	CreateTurnedLetter 'turnoe' 0x1D14 'oe' HalfAdvance (XH / 2) [DivFrame para.advanceScaleMM 3]
+
+	select-variant "ae/inve" (follow -- 'e')
+	derive-composites 'aInve' 0xAB31 'ae/a' 'ae/inve'
+	derive-composites 'oInve' 0xAB40 'oe/o' 'ae/inve'
+
+	derive-composites 'turnoeSlash' 0xAB41 'turnoe' 'rightHalfSlashOverlay'
+	derive-composites 'turnoeBar'   0xAB42 'turnoe' 'rightHalfBarOverlay'
+
+	select-variant "oe/oOpen" (follow -- 'oOpen')
+	derive-composites 'oeOpen' 0xAB62 'oe/oOpen' 'ae/e'
 
 	derive-composites 'cyrl/aye'  0x4D5 'cyrl/aye/a'   'ae/e'
 	derive-composites 'cyrl/yaye' 0x519 'cyrl/yaye/ya' 'ae/e'
 
 	derive-composites 'cyrl/Lha' 0x514 'cyrl/Lha/left' 'cyrl/Lha/right'
 	derive-composites 'cyrl/lha' 0x515 'cyrl/lha/left' 'cyrl/lha/right'
-
-	CreateTurnedLetter 'turnae' 0x1D02 'ae' HalfAdvance (XH / 2) [DivFrame para.advanceScaleMM 3]
-	CreateTurnedLetter 'turnoe' 0x1D14 'oe' HalfAdvance (XH / 2) [DivFrame para.advanceScaleMM 3]
-
-	derive-composites 'turnoSlashe' 0xAB41 'turnoe' 'rightHalfSlashOverlay'
-	derive-composites 'turnoBare'   0xAB42 'turnoe' 'rightHalfBarOverlay'
 
 	select-variant 'cyrl/este.upright/left'  (follow -- 'c/bottomSerif')
 	select-variant 'cyrl/este.upright/right' (follow -- 'T')

--- a/packages/font-glyphs/src/letter/latin-ext/oo.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/oo.ptl
@@ -45,28 +45,50 @@ glyph-block Letter-Latin-OO : begin
 	alias 'cyrl/OO' 0xA698 'OO'
 	alias 'cyrl/oo' 0xA699 'oo'
 
-	define [OODots df kHeight fRound kdr] : glyph-proc
+	create-glyph 'turnooOpen' 0xAB43 : glyph-proc
+		local df : include : DivFrame para.advanceScaleMM 3
+		include : df.markSet.e
 		local subDf : df.slice 3 2 OX
-		local space : InnerDot.spaceOfDf subDf
-		local kHeight2 : [Math.sqrt : [InnerDot.spaceOfDf : DivFrame 1] / space] * kHeight
-		local offset : 0.5 * (space + [HSwToV df.mvs])
+		include : dispiro
+			widths.lhs df.mvs
+			g4 [Math.min (df.leftSB + HookX + [HSwToV : 0.5 * df.mvs]) : Arch.adjust-x.top subDf.middle (sw -- df.mvs)] (XH - O)
+			archv
+			flatside.ld df.leftSB 0 XH subDf.smallArchDepthA subDf.smallArchDepthB
+			OBarRight.arcEnd
+				bot       -- 0
+				left      -- df.leftSB
+				right     -- (df.middle + [HSwToV : 0.5 * df.mvs])
+				sw        -- df.mvs
+				fine      -- (df.mvs * CThinB)
+				ada       -- subDf.smallArchDepthA
+				adb       -- subDf.smallArchDepthB
+				yend      -- (XH / 2)
+		include : OShape XH 0 (df.middle - [HSwToV : 0.5 * df.mvs] - OX) df.rightSB df.mvs subDf.smallArchDepthA subDf.smallArchDepthB
+
+	derive-composites 'turnooOpenSlash' 0xAB44 'turnooOpen' 'rightHalfSlashOverlay'
+
+	define [CyrOODots df kHeight fRound kdr] : glyph-proc
+		local space  : InnerDot.spaceOfDf [df.slice 3 2 OX]
+		local spaceN : InnerDot.spaceOfDf [DivFrame 1]
+		local kHeight2 : kHeight * [Math.sqrt : spaceN / space]
+		local offset : 0.5 * (space - 0) + [HSwToV : 0.5 * df.mvs]
 		include : InnerDot (-offset) 0 kHeight2 fRound kdr space 3
 		include : InnerDot (+offset) 0 kHeight2 fRound kdr space 3
 
 	foreach { suffix { DrawAt kdr } } [Object.entries DotVariants] : do
-		create-glyph "cyrl/OO/dots.\(suffix)" : glyph-proc
+		create-glyph "cyrl/OOBinocular/dots.\(suffix)" : glyph-proc
 			set-width 0
 			set-mark-anchor 'slash' 0 0 0 0
 			local df : DivFrame para.advanceScaleMM 3
-			include : OODots df 2 (DrawAt === DotAt) kdr
-		create-glyph "cyrl/oo/dots.\(suffix)" : glyph-proc
+			include : CyrOODots df 2 (DrawAt === DotAt) kdr
+		create-glyph "cyrl/ooBinocular/dots.\(suffix)" : glyph-proc
 			set-width 0
 			set-mark-anchor 'slash' 0 0 0 0
 			local df : DivFrame para.advanceScaleMM 3
-			include : OODots df 1.5 (DrawAt === DotAt) kdr
+			include : CyrOODots df 1.5 (DrawAt === DotAt) kdr
 
-	select-variant 'cyrl/OO/dots' (follow -- 'diacriticDot')
-	select-variant 'cyrl/oo/dots' (follow -- 'diacriticDot')
+	select-variant 'cyrl/OOBinocular/dots' (follow -- 'diacriticDot')
+	select-variant 'cyrl/ooBinocular/dots' (follow -- 'diacriticDot')
 
-	derive-composites 'cyrl/OOBinocular' 0xA66C 'cyrl/OO' 'cyrl/OO/dots'
-	derive-composites 'cyrl/ooBinocular' 0xA66D 'cyrl/oo' 'cyrl/oo/dots'
+	derive-composites 'cyrl/OOBinocular' 0xA66C 'cyrl/OO' 'cyrl/OOBinocular/dots'
+	derive-composites 'cyrl/ooBinocular' 0xA66D 'cyrl/oo' 'cyrl/ooBinocular/dots'

--- a/packages/font-glyphs/src/letter/latin-ext/oo.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/oo.ptl
@@ -48,10 +48,11 @@ glyph-block Letter-Latin-OO : begin
 	create-glyph 'turnooOpen' 0xAB43 : glyph-proc
 		local df : include : DivFrame para.advanceScaleMM 3
 		include : df.markSet.e
+		set-base-anchor 'cvDecompose' 0 0
 		local subDf : df.slice 3 2 OX
 		include : dispiro
 			widths.lhs df.mvs
-			g4 [Math.min (df.leftSB + HookX + [HSwToV : 0.5 * df.mvs]) : Arch.adjust-x.top subDf.middle (sw -- df.mvs)] (XH - O)
+			g4.left.start [Math.min (df.leftSB + HookX + [HSwToV : 0.5 * df.mvs]) : Arch.adjust-x.top subDf.middle (sw -- df.mvs)] (XH - O)
 			archv
 			flatside.ld df.leftSB 0 XH subDf.smallArchDepthA subDf.smallArchDepthB
 			OBarRight.arcEnd

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -12,7 +12,6 @@ glyph-block Letter-Latin-Lower-E : begin
 	glyph-block-import Letter-Shared-Shapes : FlatHookDepth RetroflexHook RhoticHookShape
 	glyph-block-import Letter-Shared-Shapes : SerifedArcEnd InwardSlabArcEnd ArcEndSerif
 	glyph-block-import Mark-Shared-Metrics : markExtend markStroke markStress markFine
-	glyph-block-import Mark-Above : aboveMarkTop aboveMarkBot aboveMarkMid aboveMarkStack
 	glyph-block-import Mark-Adjustment : ExtendBelowBaseAnchors
 	glyph-block-import Letter-Latin-C : CConfig
 
@@ -325,98 +324,100 @@ glyph-block Letter-Latin-Lower-E : begin
 		DefineSelectorGlyph "cyrl/abk/cheDescender" suffix abkCheDf 'p'
 
 		foreach { suffixSerif { styTop styBot } } [Object.entries CConfig] : do
-			create-glyph "Schwa.\(suffix).\(suffixSerif)" : glyph-proc
-				set-width 0
-				set-mark-anchor 'cvDecompose' 0 0
-				include : Body [DivFrame 1] CAP
-					hook   -- Hook
-					ada    -- ArchDepthA
-					adb    -- ArchDepthB
-					turned -- true
-					styTop -- styTop
-					styBot -- styBot
-			create-glyph "schwa.\(suffix).\(suffixSerif)" : glyph-proc
-				set-width 0
-				set-mark-anchor 'cvDecompose' 0 0
-				include : Body [DivFrame 1] XH
-					hook   -- AHook
-					ada    -- SmallArchDepthA
-					adb    -- SmallArchDepthB
-					turned -- true
-					styTop -- styTop
-					styBot -- styBot
+			if (!styBot) : begin
+				create-glyph "Schwa.\(suffix).\(suffixSerif)" : glyph-proc
+					set-width 0
+					set-mark-anchor 'cvDecompose' 0 0
+					include : Body [DivFrame 1] CAP
+						hook   -- Hook
+						ada    -- ArchDepthA
+						adb    -- ArchDepthB
+						turned -- true
+						styTop -- styTop
+						styBot -- styBot
+				create-glyph "schwa.\(suffix).\(suffixSerif)" : glyph-proc
+					set-width 0
+					set-mark-anchor 'cvDecompose' 0 0
+					include : Body [DivFrame 1] XH
+						hook   -- AHook
+						ada    -- SmallArchDepthA
+						adb    -- SmallArchDepthB
+						turned -- true
+						styTop -- styTop
+						styBot -- styBot
 
-			create-glyph "schwaRhoticHook.\(suffix).\(suffixSerif)" : glyph-proc
-				set-width 0
-				set-mark-anchor 'cvDecompose' 0 0
-				local subDf : DivFrame (0.75 * para.advanceScaleM) 2
-				local stroke : subDf.adviceStroke2 2 3 XH
-				include : Body subDf XH
-					stroke -- stroke
-					hook   -- AHook
-					ada    -- [subDf.archDepthAOf SmallArchDepth stroke]
-					adb    -- [subDf.archDepthBOf SmallArchDepth stroke]
-					turned -- true
-					styTop -- styTop
-					styBot -- styBot
-				include : RhoticHookShape (subDf.rightSB - [HSwToV : 1.25 * markFine]) rhoticDf.width [mix 0 XH DesignParameters.eBarPos] [mix 0 XH 0.2]
+				create-glyph "schwaRhoticHook.\(suffix).\(suffixSerif)" : glyph-proc
+					set-width 0
+					set-mark-anchor 'cvDecompose' 0 0
+					local subDf : DivFrame (0.75 * para.advanceScaleM) 2
+					local stroke : subDf.adviceStroke2 2 3 XH
+					include : Body subDf XH
+						stroke -- stroke
+						hook   -- AHook
+						ada    -- [subDf.archDepthAOf SmallArchDepth stroke]
+						adb    -- [subDf.archDepthBOf SmallArchDepth stroke]
+						turned -- true
+						styTop -- styTop
+						styBot -- styBot
+					include : RhoticHookShape (subDf.rightSB - [HSwToV : 1.25 * markFine]) rhoticDf.width [mix 0 XH DesignParameters.eBarPos] [mix 0 XH 0.2]
 
-			create-glyph "schwaRetroflexHook.\(suffix).\(suffixSerif)" : glyph-proc
-				set-width 0
-				set-mark-anchor 'cvDecompose' 0 0
-				local subDf : DivFrame (0.75 * para.advanceScaleM) 2
-				local stroke : subDf.adviceStroke2 2 3 XH
-				include : Body subDf XH
-					stroke -- stroke
-					hook   -- AHook
-					ada    -- [subDf.archDepthAOf SmallArchDepth stroke]
-					adb    -- [subDf.archDepthBOf SmallArchDepth stroke]
-					turned -- true
-					styTop -- styTop
-					styBot -- styBot
-				include : RetroflexHook.r
-					x       -- [mix RightSB rhoticDf.width 0.5]
-					y       -- 0
-					yAttach -- ([mix 0 XH DesignParameters.eBarPos] - HalfStroke)
-					xLink   -- (subDf.rightSB - [HSwToV : 0.5 * stroke])
-					refSw   -- [AdviceStroke 4]
+				create-glyph "schwaRetroflexHook.\(suffix).\(suffixSerif)" : glyph-proc
+					set-width 0
+					set-mark-anchor 'cvDecompose' 0 0
+					local subDf : DivFrame (0.75 * para.advanceScaleM) 2
+					local stroke : subDf.adviceStroke2 2 3 XH
+					include : Body subDf XH
+						stroke -- stroke
+						hook   -- AHook
+						ada    -- [subDf.archDepthAOf SmallArchDepth stroke]
+						adb    -- [subDf.archDepthBOf SmallArchDepth stroke]
+						turned -- true
+						styTop -- styTop
+						styBot -- styBot
+					include : RetroflexHook.r
+						x       -- [mix RightSB rhoticDf.width 0.5]
+						y       -- 0
+						yAttach -- ([mix 0 XH DesignParameters.eBarPos] - HalfStroke)
+						xLink   -- (subDf.rightSB - [HSwToV : 0.5 * stroke])
+						refSw   -- [AdviceStroke 4]
 
-			create-glyph "cyrl/abk/Che.\(suffix).\(suffixSerif)" : glyph-proc
-				set-width 0
-				set-mark-anchor 'cvDecompose' 0 0
-				include : AbkCheShape false Body abkCheDf CAP
-					hook   -- Hook
-					ada    -- ArchDepthA
-					adb    -- ArchDepthB
-					styTop -- styTop
-					styBot -- styBot
-			create-glyph "cyrl/abk/che.\(suffix).\(suffixSerif)" : glyph-proc
-				set-width 0
-				set-mark-anchor 'cvDecompose' 0 0
-				include : AbkCheShape false Body abkCheDf XH
-					hook   -- AHook
-					ada    -- SmallArchDepthA
-					adb    -- SmallArchDepthB
-					styTop -- styTop
-					styBot -- styBot
-			create-glyph "cyrl/abk/CheDescender.\(suffix).\(suffixSerif)" : glyph-proc
-				set-width 0
-				set-mark-anchor 'cvDecompose' 0 0
-				include : AbkCheShape true Body abkCheDf CAP
-					hook   -- Hook
-					ada    -- ArchDepthA
-					adb    -- ArchDepthB
-					styTop -- styTop
-					styBot -- styBot
-			create-glyph "cyrl/abk/cheDescender.\(suffix).\(suffixSerif)" : glyph-proc
-				set-width 0
-				set-mark-anchor 'cvDecompose' 0 0
-				include : AbkCheShape true Body abkCheDf XH
-					hook   -- AHook
-					ada    -- SmallArchDepthA
-					adb    -- SmallArchDepthB
-					styTop -- styTop
-					styBot -- styBot
+			if (!styTop) : begin
+				create-glyph "cyrl/abk/Che.\(suffix).\(suffixSerif)" : glyph-proc
+					set-width 0
+					set-mark-anchor 'cvDecompose' 0 0
+					include : AbkCheShape false Body abkCheDf CAP
+						hook   -- Hook
+						ada    -- ArchDepthA
+						adb    -- ArchDepthB
+						styTop -- styTop
+						styBot -- styBot
+				create-glyph "cyrl/abk/che.\(suffix).\(suffixSerif)" : glyph-proc
+					set-width 0
+					set-mark-anchor 'cvDecompose' 0 0
+					include : AbkCheShape false Body abkCheDf XH
+						hook   -- AHook
+						ada    -- SmallArchDepthA
+						adb    -- SmallArchDepthB
+						styTop -- styTop
+						styBot -- styBot
+				create-glyph "cyrl/abk/CheDescender.\(suffix).\(suffixSerif)" : glyph-proc
+					set-width 0
+					set-mark-anchor 'cvDecompose' 0 0
+					include : AbkCheShape true Body abkCheDf CAP
+						hook   -- Hook
+						ada    -- ArchDepthA
+						adb    -- ArchDepthB
+						styTop -- styTop
+						styBot -- styBot
+				create-glyph "cyrl/abk/cheDescender.\(suffix).\(suffixSerif)" : glyph-proc
+					set-width 0
+					set-mark-anchor 'cvDecompose' 0 0
+					include : AbkCheShape true Body abkCheDf XH
+						hook   -- AHook
+						ada    -- SmallArchDepthA
+						adb    -- SmallArchDepthB
+						styTop -- styTop
+						styBot -- styBot
 
 		select-variant "Schwa.\(suffix)" (follow -- 'cyrl/E/topSerif')
 		select-variant "schwa.\(suffix)" (follow -- 'cyrl/e/topSerif')


### PR DESCRIPTION
Also reduce glyph count surrounding `ə`⁠/⁠`◌ⷵ`.

### Motivation and Context

These codepoints are [technically shared with a pair of unencoded `ɑo`/`ɑø` digraphs](https://www.unicode.org/L2/L2022/22097-latin-turned-letters.pdf), but I went with the default Unicode representation for compliance, since the consensus by the Unicode consortium seemed to be to keep the existing glyph representations in the charts.

These do not use CV features, so only one glyph is added per character.

### Influenced Characters

  - LATIN SMALL LETTER TURNED O OPEN-O (`U+AB43`).
  - LATIN SMALL LETTER TURNED O OPEN-O WITH STROKE (`U+AB44`).

### Glyph Quantity

+2 normally, but this also removes unused/inaccessible bottom-serifed glyphs for `ə` and top-serifed glyphs for the `с`-part in `◌ⷵ`, so this actually removes more glyphs than it adds.

### Samples

`aꜳꜷɯꭣꝏꭃꭄ`

Monospace (Sans):
<img width="1191" height="497" alt="image" src="https://github.com/user-attachments/assets/17f4b4e5-0195-4631-95b4-d834bc75c276" />
Quasi-Proportional (Aile):
<img width="2014" height="501" alt="image" src="https://github.com/user-attachments/assets/c057ac1e-c01d-4210-abce-dee6fb8599fc" />

