### PR TITLE
Make top serif of `A`-part of Latin Upper AE (`Æ`, `ᴁ`) respond to top-left serif of `E`-part.

### DIFF
--- a/packages/font-glyphs/src/letter/latin-ext/upper-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/upper-ae-oe.ptl
@@ -1,21 +1,26 @@
 $$include '../../meta/macros.ptl'
 
-import [mix linreg clamp fallback] from "@iosevka/util"
+import [mix linreg clamp fallback SuffixCfg] from "@iosevka/util"
+import [DependentSelector] from "@iosevka/glyph/relation"
 
 glyph-module
 
 glyph-block Letter-Latin-Upper-AE-OE : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Metrics : EFVJutLength EFMidBarPosY
+	glyph-block-import Letter-Shared : CreateDependentComposite
 
 	define [AEOEStroke df top] : Math.min df.mvs : AdviceStroke2 3 3 top df.adws
 
 	do "A subglyphs"
-		define SLAB-NONE    0
-		define SLAB-TOP     1
-		define SLAB-BASE    2
-		define SLAB-TRI     3
+		define BODY-CURLY      0
+		define BODY-STRAIGHT   1
+		define BODY-ROUND-TOP  2
+
+		define SLAB-NONE       0
+		define SLAB-TOP        1
+		define SLAB-BASE       2
+		define SLAB-TRI        3
 
 		define [AEAHalfCurly df top eLeft sw] : glyph-proc
 			define fine : Math.min sw : AdviceStroke2 3 4 top df.adws
@@ -80,53 +85,50 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 				arcvh
 				straight.right.end eLeft top [heading Rightward]
 
-		define [AEAHalfSerifs df top slabKind] : begin
-			define sw : AEOEStroke df top
-			define eLeft : df.middle - [HSwToV : 0.25 * sw]
-			return : composite-proc
-				match slabKind
-					([Just SLAB-BASE] || [Just SLAB-TRI]) : HSerif.mb (df.leftSB + [HSwToV : 0.5 * sw]) 0 Jut sw
-					__                                    : no-shape
-				match slabKind
-					[Just SLAB-TRI] : HSerif.lt df.middle top (MidJutSide + [HSwToV QuarterStroke])
-					[Just SLAB-TOP] : HSerif.lt df.middle top [mix MidJutSide LongJut 0.5]
-					__              : no-shape
-
 		define [AEAHalf df bodyShape top slabKind] : glyph-proc
 			define sw : AEOEStroke df top
 			define eLeft : df.middle - [HSwToV : 0.25 * sw]
 			include : match bodyShape
-				[Just 0] : AEAHalfCurly    df top eLeft sw
-				[Just 1] : AEAHalfStraight df top eLeft sw
-				[Just 2] : AEAHalfRoundTop df top eLeft sw
-			include : AEAHalfSerifs df top slabKind
+				[Just BODY-CURLY]     : AEAHalfCurly    df top eLeft sw
+				[Just BODY-STRAIGHT]  : AEAHalfStraight df top eLeft sw
+				[Just BODY-ROUND-TOP] : AEAHalfRoundTop df top eLeft sw
+			include : match slabKind
+				([Just SLAB-BASE] || [Just SLAB-TRI]) : HSerif.mb (df.leftSB + [HSwToV : 0.5 * sw]) 0 (Jut - [HSwToV : 0.5 * (Stroke - sw)]) sw
+				__                                    : no-shape
+			include : match slabKind
+				[Just SLAB-TRI] : HSerif.lt df.middle top      (MidJutSide              - [HSwToV : 0.5 * (HalfStroke - sw)]) sw
+				[Just SLAB-TOP] : HSerif.lt df.middle top ([mix MidJutSide LongJut 0.5] - [HSwToV : 0.5 * (Stroke     - sw)]) sw
+				__              : no-shape
 
-		define AConfig : object
-			straightSerifless     { 1  SLAB-NONE }
-			curlySerifless        { 0  SLAB-NONE }
-			roundTopSerifless     { 2  SLAB-NONE }
-			straightTopSerifed    { 1  SLAB-TOP  }
-			curlyTopSerifed       { 0  SLAB-TOP  }
-			straightBaseSerifed   { 1  SLAB-BASE }
-			curlyBaseSerifed      { 0  SLAB-BASE }
-			roundTopBaseSerifed   { 2  SLAB-BASE }
-			straightTriSerifed    { 1  SLAB-TRI  }
-			curlyTriSerifed       { 0  SLAB-TRI  }
+		define AConfig : SuffixCfg.combine
+			SuffixCfg.weave # standard (angular) variants
+				object # body
+					straight    BODY-STRAIGHT
+					curly       BODY-CURLY
+				object # slabs
+					serifless   SLAB-NONE
+					topSerifed  SLAB-TOP
+					baseSerifed SLAB-BASE
+					triSerifed  SLAB-TRI
+			object # round-top variants
+				roundTopSerifless   { BODY-ROUND-TOP SLAB-NONE }
+				roundTopBaseSerifed { BODY-ROUND-TOP SLAB-BASE }
 
 		foreach { suffix { bodyShape slabKind } } [Object.entries AConfig] : do
 			create-glyph "AE/A.\(suffix)" : glyph-proc
 				define df : include : DivFrame para.advanceScaleMM 3
 				include : df.markSet.capital
-				set-base-anchor 'cvDecompose' 0 0
 				include : AEAHalf df bodyShape CAP slabKind
 			create-glyph "smcpAE/smcpA.\(suffix)" : glyph-proc
 				define df : include : DivFrame para.advanceScaleM 3
 				include : df.markSet.e
-				set-base-anchor 'cvDecompose' 0 0
 				include : AEAHalf df bodyShape XH slabKind
 
-		select-variant 'AE/A'
-		select-variant 'smcpAE/smcpA' (follow -- 'AE/A')
+		select-variant 'AE/A/full'    (shapeFrom -- 'AE/A') (follow -- 'AE/E.serifless/A')
+		select-variant 'AE/A/reduced' (shapeFrom -- 'AE/A') (follow -- 'AE/E.topLeftSerifed/A')
+
+		select-variant 'smcpAE/smcpA/full'    (shapeFrom -- 'smcpAE/smcpA') (follow -- 'AE/E.serifless/A')
+		select-variant 'smcpAE/smcpA/reduced' (shapeFrom -- 'smcpAE/smcpA') (follow -- 'AE/E.topLeftSerifed/A')
 
 	do "O subglyphs"
 		glyph-block-import Letter-Shared-Shapes : OBarRight
@@ -182,7 +184,10 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 		select-variant 'cyrl/YaYe/Ya'
 
 	do "E subglyphs"
+		glyph-block-import Letter-Shared-Metrics : EFVJutLength EFMidBarPosY
+
 		define SLAB-NONE    0
+		define SLAB-MOTION  1
 		define SLAB-ALL     2
 		define SLAB-CAPPED  3
 
@@ -211,30 +216,50 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 					include : VSerif.mr xMidBarRight yBar jutMid swVJut
 
 		define EConfig : object
-			serifless     { SLAB-NONE   }
-			serifed       { SLAB-ALL    }
-			serifedCapped { SLAB-CAPPED }
+			serifless      { SLAB-NONE   }
+			topLeftSerifed { SLAB-MOTION }
+			serifed        { SLAB-ALL    }
+			serifedCapped  { SLAB-CAPPED }
 
 		foreach { suffix { slabKind } } [Object.entries EConfig] : do
 			create-glyph "AE/E.\(suffix)" : glyph-proc
-				define df : DivFrame para.advanceScaleMM 3
-				set-width 0
-				set-mark-anchor 'cvDecompose' 0 0
+				define df : include : DivFrame para.advanceScaleMM 3
+				include : df.markSet.capital
 				include : AEEHalf df CAP slabKind
+				DependentSelector.set currentGlyph : if (suffix === "serifless") 'full' 'reduced'
 			create-glyph "smcpAE/smcpE.\(suffix)" : glyph-proc
-				define df : DivFrame para.advanceScaleM 3
-				set-width 0
-				set-mark-anchor 'cvDecompose' 0 0
+				define df : include : DivFrame para.advanceScaleM 3
+				include : df.markSet.e
 				include : AEEHalf df XH slabKind
+				DependentSelector.set currentGlyph : if (suffix === "serifless") 'full' 'reduced'
+
+			if (suffix !== "topLeftSerifed") : begin
+				create-glyph "OE/E.\(suffix)" : glyph-proc
+					define df : DivFrame para.advanceScaleMM 3
+					set-width 0
+					set-mark-anchor 'cvDecompose' 0 0
+					include : AEEHalf df CAP slabKind
+				create-glyph "smcpOE/smcpE.\(suffix)" : glyph-proc
+					define df : DivFrame para.advanceScaleM 3
+					set-width 0
+					set-mark-anchor 'cvDecompose' 0 0
+					include : AEEHalf df XH slabKind
 
 		select-variant 'AE/E'
+		select-variant 'OE/E'
+
 		select-variant 'smcpAE/smcpE' (follow -- 'AE/E')
+		select-variant 'smcpOE/smcpE' (follow -- 'OE/E')
 
-	derive-composites "AE" 0xC6  'AE/A' 'AE/E'
-	derive-composites "OE" 0x152 'OE/O' 'AE/E'
+	CreateDependentComposite 'AE' 0xC6 'AE/E' : object
+		full    'AE/A/full'
+		reduced 'AE/A/reduced'
+	CreateDependentComposite 'smcpAE' 0x1D01 'smcpAE/smcpE' : object
+		full    'smcpAE/smcpA/full'
+		reduced 'smcpAE/smcpA/reduced'
 
-	derive-composites "smcpAE" 0x1D01 'smcpAE/smcpA' 'smcpAE/smcpE'
-	derive-composites "smcpOE" 0x276  'smcpOE/smcpO' 'smcpAE/smcpE'
+	derive-composites "OE"     0x152 'OE/O'         'OE/E'
+	derive-composites "smcpOE" 0x276 'smcpOE/smcpO' 'smcpOE/smcpE'
 
 	alias 'cyrl/AYe' 0x4D4 'AE'
-	derive-composites "cyrl/YaYe" 0x518 'cyrl/YaYe/Ya' 'AE/E'
+	derive-composites "cyrl/YaYe" 0x518 'cyrl/YaYe/Ya' 'OE/E'

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -565,21 +565,24 @@ rank = 1
 descriptionAffix = "straight shape"
 selectorAffix.A = "straight"
 selectorAffix."A/sansSerif" = "straight"
-selectorAffix."AE/A" = "straight"
+selectorAffix."AE/E.serifless/A" = "straight"
+selectorAffix."AE/E.topLeftSerifed/A" = "straight"
 
 [prime.capital-a.variants-buildup.stages.body.curly]
 rank = 2
 descriptionAffix = "curly shape"
 selectorAffix.A = "curly"
 selectorAffix."A/sansSerif" = "curly"
-selectorAffix."AE/A" = "curly"
+selectorAffix."AE/E.serifless/A" = "curly"
+selectorAffix."AE/E.topLeftSerifed/A" = "curly"
 
 [prime.capital-a.variants-buildup.stages.body.round-top]
 rank = 3
 descriptionAffix = "round top"
 selectorAffix.A = "roundTop"
 selectorAffix."A/sansSerif" = "roundTop"
-selectorAffix."AE/A" = "roundTop"
+selectorAffix."AE/E.serifless/A" = "roundTop"
+selectorAffix."AE/E.topLeftSerifed/A" = "roundTop"
 
 [prime.capital-a.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -587,30 +590,34 @@ descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix.A = "serifless"
 selectorAffix."A/sansSerif" = "serifless"
-selectorAffix."AE/A" = "serifless"
+selectorAffix."AE/E.serifless/A" = "serifless"
+selectorAffix."AE/E.topLeftSerifed/A" = { if = [{ body = "round-top" }], then = "serifless", else = "topSerifed" }
 
 [prime.capital-a.variants-buildup.stages.serifs.top-serifed]
 rank = 2
 descriptionAffix = "serifs at top"
-enableIf = [{ body = "NOT round-top" }]
+disableIf = [{ body = "round-top" }]
 selectorAffix.A = "topSerifed"
 selectorAffix."A/sansSerif" = "serifless"
-selectorAffix."AE/A" = "topSerifed"
+selectorAffix."AE/E.serifless/A" = "topSerifed"
+selectorAffix."AE/E.topLeftSerifed/A" = "topSerifed"
 
 [prime.capital-a.variants-buildup.stages.serifs.base-serifed]
 rank = 3
 descriptionAffix = "serifs at base"
 selectorAffix.A = "baseSerifed"
 selectorAffix."A/sansSerif" = "serifless"
-selectorAffix."AE/A" = "baseSerifed"
+selectorAffix."AE/E.serifless/A" = "baseSerifed"
+selectorAffix."AE/E.topLeftSerifed/A" = { if = [{ body = "round-top" }], then = "baseSerifed", else = "triSerifed" }
 
 [prime.capital-a.variants-buildup.stages.serifs.tri-serifed]
 rank = 4
 descriptionAffix = "serifs at both top and base"
-enableIf = [{ body = "NOT round-top" }]
+disableIf = [{ body = "round-top" }]
 selectorAffix.A = "triSerifed"
 selectorAffix."A/sansSerif" = "serifless"
-selectorAffix."AE/A" = "triSerifed"
+selectorAffix."AE/E.serifless/A" = "triSerifed"
+selectorAffix."AE/E.topLeftSerifed/A" = "triSerifed"
 
 
 
@@ -852,13 +859,15 @@ description = "E without serifs"
 selector.E = "serifless"
 selector."E/sansSerif" = "serifless"
 selector."AE/E" = "serifless"
+selector."OE/E" = "serifless"
 
 [prime.capital-e.variants.top-left-serifed]
 rank = 2
 description = "E with serif only at top left"
 selector.E = "topLeftSerifed"
 selector."E/sansSerif" = "serifless"
-selector."AE/E" = "serifless"
+selector."AE/E" = "topLeftSerifed"
+selector."OE/E" = "serifless"
 
 [prime.capital-e.variants.serifed]
 rank = 3
@@ -866,6 +875,7 @@ description = "E with serifs"
 selector.E = "serifed"
 selector."E/sansSerif" = "serifless"
 selector."AE/E" = "serifed"
+selector."OE/E" = "serifed"
 
 [prime.capital-e.variants.serifed-capped]
 rank = 4
@@ -873,6 +883,7 @@ description = "E with serifs and capped middle bar"
 selector.E = "serifedCapped"
 selector."E/sansSerif" = "serifless"
 selector."AE/E" = "serifedCapped"
+selector."OE/E" = "serifedCapped"
 
 
 


### PR DESCRIPTION
### Motivation and Context

This uses `DependentSelector` and `CreateDependentComposite` to make the `A`-part force its top serif when the top-left serif of the `E`-part is present (It does nothing when `A` uses `roundTop`{`Serifless`|`BaseSerifed`}, and does not block the natural `topSerifed` and `triSerifed` variants of `A`).

This also adjusts the jut length of the serifs based on the stroke width of the whole `Æ`/`ᴁ` character
(e.g. `Jut - [HSwToV : 0.5 * (Stroke - sw)]`, same as I've done for many other characters in the font already).

### Influenced Characters

  - LATIN CAPITAL LETTER AE (`U+00C6`).
  - LATIN LETTER SMALL CAPITAL AE (`U+1D01`).
  - MODIFIER LETTER CAPITAL AE (`U+1D2D`).

### Glyph Quantity

+6 for separating the `E`/`ᴇ` part of `Œ`/`ɶ` and +2 for adding `topLeftSerifed` variants for the `E`/`ᴇ` part of `Æ`/`ᴁ` in particular, yielding +8 total.

### Samples

`ÆᴁæŒɶœ`

Slab Monospace:
<img width="757" height="1212" alt="image" src="https://github.com/user-attachments/assets/c8508453-4dd1-48e2-ade0-731e3b4b70da" />
Etoile:
<img width="1307" height="1219" alt="image" src="https://github.com/user-attachments/assets/0696c317-8ce5-4ab7-8d54-c57efb77a81f" />

-----

Compared to DejaVu Serif:
<img width="1548" height="447" alt="image" src="https://github.com/user-attachments/assets/be1e40f6-3378-4d93-8388-c9098c6b1a4b" />
Compared to Liberation Serif:
<img width="1200" height="449" alt="image" src="https://github.com/user-attachments/assets/1e922c03-c0bb-4429-aeb1-aad5776552f8" />
Compared to Gentium:
<img width="1117" height="433" alt="image" src="https://github.com/user-attachments/assets/1546af85-e273-4411-8759-0bb0804fbb4c" />

