### PR TITLE
Unify `OBar`{`Left`|`Right`}`.`{`toothless`|`earless`}`Corner` to use `Arch.`{`lhs`|`rhs`}` `{`top`|`bot`}` (blend`{`Pre`|`Post`}` -- {})`.

### DIFF
--- a/packages/font-glyphs/src/letter/cyrillic/che.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/che.ptl
@@ -37,13 +37,14 @@ glyph-block Letter-Cyrillic-Che : begin
 		local-parameter : adb       -- ArchDepthB
 		local-parameter : stroke    -- Stroke
 
-		define xMid : [mix left right 0.5] + [HSwToV : (1 - DMBlend) * stroke]
+		define xMid : [mix left right 0.5] + [HSwToV : 0.2 * stroke]
 		define rise : DToothlessRise + 0.25 * stroke
 		return : dispiro
-			flat left top [widths.lhs.heading stroke Downward]
+			widths.lhs stroke
+			flat left top [heading Downward]
 			curl left [Math.min (bottom + adb) (top - TINY)]
 			Arch.lhs.centerAt.ltr.b xMid bottom (sw -- stroke)
-			g4 right (bottom + rise)
+			g4   right (bottom + rise)
 
 	glyph-block-export CyrCheShape
 	define [CyrCheShape] : with-params [df top pyBar bodyType slabType [sw df.mvs]] : glyph-proc

--- a/packages/font-glyphs/src/letter/cyrillic/dje-tshe.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/dje-tshe.ptl
@@ -43,7 +43,6 @@ glyph-block Letter-Cyrillic-Dje-Tshe : begin
 				ada    -- [ArchDepthAOf archDepth mockWidth]
 				adb    -- [ArchDepthBOf archDepth mockWidth]
 				stroke -- sw
-				rise   -- DToothlessRise
 
 			local xTopBarLeft : mix 0 df.leftSB : if doSerifLT 0.250 0.375
 			local xTopBarRight : Math.max

--- a/packages/font-glyphs/src/letter/cyrillic/shha.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/shha.ptl
@@ -25,7 +25,6 @@ glyph-block Letter-Cyrillic-Shha : begin
 			bottom -- 0
 			ada    -- ArchDepthA
 			adb    -- ArchDepthB
-			rise   -- DToothlessRise
 
 		local sf : SerifFrame.fromDf [DivFrame 1] CAP 0
 		include : tagged 'SerifLT' : match slabType

--- a/packages/font-glyphs/src/letter/latin/lower-a.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-a.ptl
@@ -142,6 +142,15 @@ glyph-block Letter-Latin-Lower-A : begin
 			[Just ToothlessRounded]    : ArcMask df 2 [ADoubleStoreySmoothA df] _sw
 			__                         : ArcMask df 0 0                         _sw
 
+	define [OverlayW bw _l _r] : glyph-proc
+		define l : fallback _l : mix 0     SB      0.3
+		define r : fallback _r : mix Width RightSB 0.3
+		local y : mix 0 XH 0.5
+		include : dispiro
+			widths.center bw
+			flat l y
+			curl r y
+
 	glyph-block-export DoubleStoreyConfig
 	define DoubleStoreyConfig : object
 		doubleStoreySerifless                            { DoubleStorey.Serifless           RightSB            HOOK-SLAB-NONE   }
@@ -261,8 +270,6 @@ glyph-block Letter-Latin-Lower-A : begin
 				fine  -- (ShoulderFine * (sw / Stroke))
 				ada   -- ada
 				adb   -- adb
-				rise  -- DToothlessRise
-				mBlend -- DMBlend
 			include : bar df (top - DToothlessRise) sw
 		export : define [EarlessRoundedBody df top bar _sw _ada _adb] : glyph-proc
 			local sw  : fallback _sw    df.mvs
@@ -339,7 +346,7 @@ glyph-block Letter-Latin-Lower-A : begin
 			include : RetroflexHook.rSideJut RightSB 0 (yOverflow -- Stroke)
 		create-glyph "aBar.\(suffix)" : glyph-proc
 			include [refer-glyph "a.\(suffix)"] AS_BASE ALSO_METRICS
-			include : HBar.m [mix 0 SB 0.3] [mix Width RightSB 0.3] (XH / 2) [Math.min OverlayStroke : AdviceStroke2 2 3 XH]
+			include : OverlayW [Math.min OverlayStroke : AdviceStroke2 2 3 XH]
 
 	select-variant 'a' 'a'
 	link-reduced-variant 'a/sansSerif' 'a' MathSansSerif

--- a/packages/font-glyphs/src/letter/latin/lower-b.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-b.ptl
@@ -26,7 +26,7 @@ glyph-block Letter-Latin-Lower-B : begin
 			corner (SB + [HSwToV Stroke]) HalfStroke
 
 	define [ToothlessCornerBody yTop] : union
-		OBarLeft.toothlessCorner (rise -- DToothlessRise) (mBlend -- DMBlend)
+		OBarLeft.toothlessCorner
 		VBar.l SB DToothlessRise yTop
 
 	define [ToothlessRoundedBody yTop] : begin

--- a/packages/font-glyphs/src/letter/latin/lower-d.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-d.ptl
@@ -36,7 +36,7 @@ glyph-block Letter-Latin-Lower-D : begin
 		tagged 'rightBar' : RightwardTailedBar df.rightSB 0 yTop df.mvs
 
 	define [ToothlessCornerBody df yTop] : union
-		OBarRight.toothlessCorner (rise -- DToothlessRise) (mBlend -- DMBlend)
+		OBarRight.toothlessCorner
 			left  -- df.leftSB
 			right -- df.rightSB
 			sw    -- df.mvs
@@ -46,7 +46,7 @@ glyph-block Letter-Latin-Lower-D : begin
 		tagged 'rightBar' : VBar.r df.rightSB DToothlessRise yTop df.mvs
 
 	define [ToothlessCornerRTBBody df yTop] : union
-		OBarRight.toothlessCorner (rise -- DToothlessRise) (mBlend -- DMBlend)
+		OBarRight.toothlessCorner
 			left  -- df.leftSB
 			right -- df.rightSB
 			sw    -- df.mvs
@@ -226,7 +226,6 @@ glyph-block Letter-Latin-Lower-D : begin
 		if SLAB : begin
 			local sf2 : [SerifFrame.fromDf df (XH / 2 + HalfStroke) 0].slice 1 2
 			include sf2.rt.full
-
 		create-forked-glyph "cyrl/djeKomi.toothlessRoundedTopSerifed" : HSerif.lt (df.middle - [HSwToV : 0.5 * df.mvs]) Ascender SideJut df.mvs
 
 	alias 'cyrl/deKomi' 0x501 'd'

--- a/packages/font-glyphs/src/letter/latin/lower-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-g.ptl
@@ -16,7 +16,10 @@ glyph-block Letter-Latin-Lower-G : begin
 	define [OverlayW bw] : glyph-proc
 		define l : mix 0     SB      0.3
 		define r : mix Width RightSB 0.3
-		include : HBar.m l r currentGlyph.baseAnchors.overlay.y bw
+		include : dispiro
+			widths.center bw
+			flat l currentGlyph.baseAnchors.overlay.y
+			curl r currentGlyph.baseAnchors.overlay.y
 
 	# overlay bar width for double-storey g
 	define obwDoubleStorey : Math.min ((XH - Descender) * (1 / 6) - Stroke * (2 / 3)) : AdviceStroke 5
@@ -37,9 +40,9 @@ glyph-block Letter-Latin-Lower-G : begin
 			flat [mix SB RightSB 0.435] groundy [widths.rhs Stroke]
 			curl [mix SB RightSB 0.565] groundy
 			archv 4
-			g4 grightx [mix (Descender + O) groundy (1.06 * SmallArchDepthA / (SmallArchDepthA + SmallArchDepthB))]
+			g4 grightx [mix (Descender + O) [YSmoothMidR groundy (Descender + O) SmallArchDepthA SmallArchDepthB] 1.06]
 			Arch.rhs Descender
-			g4 gleftx  [mix (Descender + O) groundy (1.06 * SmallArchDepthB / (SmallArchDepthA + SmallArchDepthB))]
+			g4 gleftx  [mix (Descender + O) [YSmoothMidL groundy (Descender + O) SmallArchDepthA SmallArchDepthB] 1.06]
 			arcvh
 			g4 [mix SB RightSB 0.435] groundy [heading Rightward]
 		local gm : mix SB [mix Width RightSB 1.3] 0.5
@@ -70,9 +73,9 @@ glyph-block Letter-Latin-Lower-G : begin
 			flat [mix SB RightSB 0.435] groundy [widths.rhs Stroke]
 			curl [mix SB RightSB 0.565] groundy
 			archv 4
-			g4 grightx [mix (Descender + O) groundy (1.06 * SmallArchDepthA / (SmallArchDepthA + SmallArchDepthB))]
+			g4 grightx [mix (Descender + O) [YSmoothMidR groundy (Descender + O) SmallArchDepthA SmallArchDepthB] 1.06]
 			HookEnd Descender
-			g4 gleftx  [mix (Descender + O) groundy (1.06 * SmallArchDepthB / (SmallArchDepthA + SmallArchDepthB))]
+			g4 gleftx  (Descender + SHook)
 		local gm : mix SB [mix Width RightSB 1.3] 0.5
 		include : spiro-outline
 			corner ([mix Width RightSB 0.75] - OX)  XH
@@ -149,8 +152,6 @@ glyph-block Letter-Latin-Lower-G : begin
 				top    -- top
 				left   -- df.leftSB
 				right  -- df.rightSB
-				rise   -- DToothlessRise
-				mBlend -- DMBlend
 				sw     -- df.mvs
 				fine   -- df.shoulderFine
 				ada    -- ada

--- a/packages/font-glyphs/src/letter/latin/lower-n.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-n.ptl
@@ -77,7 +77,6 @@ glyph-block Letter-Latin-Lower-N : begin
 			ada    -- ada
 			adb    -- adb
 			stroke -- sw
-			rise   -- DToothlessRise
 
 	define [EarlessRoundedBody top left right yBR sw _ada _adb] : glyph-proc
 		local ada : fallback _ada SmallArchDepthA
@@ -348,8 +347,7 @@ glyph-block Letter-Latin-Lower-N : begin
 	do "n with Apostrophe"
 		glyph-block-import Mark-Shared-Metrics : markMiddle
 		derive-glyphs 'nApostrophe/commaTL' null 'commaAbove/asPunctuation' : function [src gr] : glyph-proc
-			include : with-transform [Translate (SB - markMiddle) 0]
-				refer-glyph src
+			include : with-transform [Translate (SB - markMiddle) 0] [refer-glyph src]
 
 		derive-composites 'nApostrophe' 0x149 'n' 'nApostrophe/commaTL'
 

--- a/packages/font-glyphs/src/letter/latin/lower-p.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-p.ptl
@@ -28,7 +28,7 @@ glyph-block Letter-Latin-Lower-P : begin
 		include : tagged 'stemLeft' : VBar.l left Descender XH sw
 
 	define [EarlessCornerBody] : with-params [[left SB] [right RightSB] [sw Stroke] [ada SmallArchDepthA] [adb SmallArchDepthB]] : glyph-proc
-		include : tagged 'bowl' : OBarLeft.earlessCorner (rise -- DToothlessRise) (mBlend -- DMBlend)
+		include : tagged 'bowl' : OBarLeft.earlessCorner
 			left  -- left
 			right -- right
 			sw    -- sw

--- a/packages/font-glyphs/src/letter/latin/lower-q.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-q.ptl
@@ -55,8 +55,6 @@ glyph-block Letter-Latin-Lower-Q : begin
 			top -- top
 			ada -- ada
 			adb -- adb
-			rise -- DToothlessRise
-			mBlend -- DMBlend
 		include : match terminal
 			[Just TERMINAL-TAILED] : RightwardTailedBar     RightSB bottom (top - DToothlessRise)
 			[Just TERMINAL-DIAG]   : RightwardDiagTailedBar RightSB bottom (top - DToothlessRise)

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -62,7 +62,6 @@ glyph-block Letter-Latin-U : begin
 				stroke  -- sw
 				ada     -- ada
 				adb     -- adb
-				rise    -- DToothlessRise
 			if fHookLeft : include : TopHook.toLeft.lBarInner df.leftSB [Math.min (adb + TINY) (yTL - 0)] top (sw -- sw)
 			include : tagged 'strokeR' : VBar.r df.rightSB DToothlessRise yTR sw
 

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -442,19 +442,16 @@ glyph-block Letter-Shared-Shapes : begin
 			local-parameter : bot               -- 0
 			local-parameter : left              -- SB
 			local-parameter : right             -- RightSB
-			local-parameter : rise              -- SHook
+			local-parameter : rise              -- DToothlessRise
 			local-parameter : sw                -- Stroke
 			local-parameter : fine              -- ShoulderFine
-			local-parameter : mBlend            -- Math.SQRT1_2
 			local-parameter : ada               -- SmallArchDepthA
 			local-parameter : adb               -- SmallArchDepthB
 			local-parameter : ystart            -- ((top - ada) - TINY)
 
 			return : dispiro
 				g4   left (bot + rise) [widths.lhs sw]
-				alsoThru.g2 0.5 (0 + mBlend) important
-				Arch.lhs.centerAt.ltr.b [mix left right 0.5] bot (sw -- sw)
-				archv
+				Arch.lhs bot (sw -- sw) (blendPre -- {})
 				flatside.ru right bot top ada adb
 				Arch.lhs top (sw -- sw) (swAfter -- fine)
 				flat (left + [HSwToV : sw - fine]) [Math.max (top - ada) (ystart + TINY)] [widths.lhs fine]
@@ -486,10 +483,9 @@ glyph-block Letter-Shared-Shapes : begin
 			local-parameter : bot               -- 0
 			local-parameter : left              -- SB
 			local-parameter : right             -- RightSB
-			local-parameter : rise              -- SHook
+			local-parameter : rise              -- DToothlessRise
 			local-parameter : sw                -- Stroke
 			local-parameter : fine              -- ShoulderFine
-			local-parameter : mBlend            -- Math.SQRT1_2
 			local-parameter : ada               -- SmallArchDepthA
 			local-parameter : adb               -- SmallArchDepthB
 			local-parameter : yend              -- ((bot + adb) + TINY)
@@ -499,9 +495,7 @@ glyph-block Letter-Shared-Shapes : begin
 				curl (left + [HSwToV : sw - fine]) [Math.min (bot + adb) (yend - TINY)] [widths.lhs fine]
 				Arch.lhs bot (sw -- sw) (swBefore -- fine)
 				flatside.ru right bot top ada adb
-				arcvh
-				Arch.lhs.centerAt.rtl.t [mix left right 0.5] top (sw -- sw)
-				alsoThru.g2 0.5 (1 - mBlend) important
+				Arch.lhs top (sw -- sw) (blendPost -- {})
 				g4   left (top - rise) [widths.lhs sw]
 
 		export : define flex-params [earlessRounded] : begin
@@ -587,10 +581,9 @@ glyph-block Letter-Shared-Shapes : begin
 			local-parameter : bot               -- 0
 			local-parameter : left              -- SB
 			local-parameter : right             -- RightSB
-			local-parameter : rise              -- SHook
+			local-parameter : rise              -- DToothlessRise
 			local-parameter : sw                -- Stroke
 			local-parameter : fine              -- ShoulderFine
-			local-parameter : mBlend            -- Math.SQRT1_2
 			local-parameter : ada               -- SmallArchDepthA
 			local-parameter : adb               -- SmallArchDepthB
 			local-parameter : ystart            -- ((top - adb) - TINY)
@@ -604,7 +597,6 @@ glyph-block Letter-Shared-Shapes : begin
 					rise   -- rise
 					sw     -- sw
 					fine   -- fine
-					mBlend -- mBlend
 					ada    -- ada
 					adb    -- adb
 					yend   -- (top - ystart)
@@ -641,10 +633,9 @@ glyph-block Letter-Shared-Shapes : begin
 			local-parameter : bot               -- 0
 			local-parameter : left              -- SB
 			local-parameter : right             -- RightSB
-			local-parameter : rise              -- SHook
+			local-parameter : rise              -- DToothlessRise
 			local-parameter : sw                -- Stroke
 			local-parameter : fine              -- ShoulderFine
-			local-parameter : mBlend            -- Math.SQRT1_2
 			local-parameter : ada               -- SmallArchDepthA
 			local-parameter : adb               -- SmallArchDepthB
 			local-parameter : yend              -- ((bot + ada) + TINY)
@@ -658,7 +649,6 @@ glyph-block Letter-Shared-Shapes : begin
 					rise   -- rise
 					sw     -- sw
 					fine   -- fine
-					mBlend -- mBlend
 					ada    -- ada
 					adb    -- adb
 					ystart -- (top - yend)


### PR DESCRIPTION
This is for parity across the different terminal shapes in the font. Basically, it unifies `OBar`{`Left`|`Right`}`.`{`toothless`|`earless`}`Corner` with that of `nShoulder` and `uBowl` instead of using `DMBlend`. The changes here are completely invisible to my eyes.

Also make `DToothlessRise` the default `rise` argument instead of `SHook` since every instance of `OBar`{`Left`|`Right`}`.`{`toothless`|`earless`}`Corner` uses it.

Also make `g.doubleStoreyOpen` use `SHook`.
