### PR TITLE
Add letter variants with flat top and flat bottom.

### DIFF
--- a/changes/34.6.0.md
+++ b/changes/34.6.0.md
@@ -1,3 +1,5 @@
+* Add `flat-top` variants for `a`/`g`/`m`/`n`/`r`/`p`/`q`/`α`/`η`/`р`.
+* Add `flat-bottom` variants for `G`/`U`/`b`/`d`/`u`/`μ`/`µ`.
 * Refine shape of the following characters:
   - LATIN CAPITAL LIGATURE OE (`U+0152`).
   - LATIN LETTER SMALL CAPITAL OE (`U+0276`).

--- a/changes/34.6.0.md
+++ b/changes/34.6.0.md
@@ -1,4 +1,4 @@
-* Add `flat-top` variants for `a`/`g`/`m`/`n`/`r`/`p`/`q`/`α`/`η`/`р`.
+* Add `flat-top` variants for `a`/`g`/`m`/`n`/`p`/`q`/`r`/`α`/`η`/`а`/`р` (#1269) (#2519).
 * Add `flat-bottom` variants for `G`/`U`/`b`/`d`/`u`/`μ`/`µ`.
 * Refine shape of the following characters:
   - LATIN CAPITAL LIGATURE OE (`U+0152`).

--- a/packages/font-glyphs/src/auto-build/transformed-jobs-data.ptl
+++ b/packages/font-glyphs/src/auto-build/transformed-jobs-data.ptl
@@ -90,7 +90,7 @@ export : define Superscript : list
 	list 0x1DAA 'lPalatalHook'
 	list 0x1DAB 'smcpL'
 	list 0x1DAC 'meng'
-	list 0x1DAD 'turnmLeg'
+	list 0x1DAD 'turnmLongLeg'
 	list 0x1DAE 'nHookLeft'
 	list 0x1DAF 'nRTail'
 	list 0x1DB0 'smcpN'

--- a/packages/font-glyphs/src/letter/cyrillic/ze.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/ze.ptl
@@ -66,6 +66,7 @@ glyph-block Letter-Cyrillic-Ze : begin
 					[Just FLAT-CONNECTION] : list
 						flat (left - xo) top [widths.rhs.heading stroke Rightward]
 						curl [Arch.adjust-x.top middle stroke] top [heading Rightward]
+						archv
 					[Just OPEN-VERTICAL] : flat right top [widths.rhs.heading stroke Downward]
 					([Just CLOSED-CIRCLE] || [Just CLOSED-ROUND]) : list
 						flat (left + [if (slabTop === CLOSED-CIRCLE) xo 0]) midy [widths.rhs stroke]
@@ -96,6 +97,10 @@ glyph-block Letter-Cyrillic-Ze : begin
 				match slabBot
 					[Just SLAB-CLASSICAL] : SerifedArcEnd.RtlRhs left bot stroke hook (o -- yo)
 					[Just SLAB-INWARD] : InwardSlabArcEnd.RtlRhs left bot stroke hook (o -- yo)
+					[Just FLAT-CONNECTION] : list
+						arcvh
+						flat [Arch.adjust-x.bot middle stroke] bot [heading Leftward]
+						curl (left - xo) bot [heading Leftward]
 					[Just OPEN-HALF] : list
 					[Just OPEN-VERTICAL] : curl (right - xo * 2) bot [heading Downward]
 					([Just CLOSED-CIRCLE] || [Just CLOSED-ROUND]) : list
@@ -182,10 +187,15 @@ glyph-block Letter-Cyrillic-Ze : begin
 
 		export : define [UpperShape] : begin
 			define [object stroke midx midy fine shoulderFine] : Dim
+			local middle : mix left right 0.5
 			return : dispiro
 				match slabTop
 					[Just SLAB-CLASSICAL] : SerifedArcStart.RtlLhs right top stroke hook (o -- yo)
 					[Just SLAB-INWARD] : InwardSlabArcStart.RtlLhs right top stroke hook (o -- yo)
+					[Just FLAT-CONNECTION] : list
+						flat (right + xo) top [widths.lhs.heading stroke Leftward]
+						curl [Arch.adjust-x.top middle stroke] top [heading Leftward]
+						archv
 					[Just OPEN-VERTICAL] : flat left top [widths.lhs.heading stroke Downward]
 					([Just CLOSED-CIRCLE] || [Just CLOSED-ROUND]) : list
 						flat (right - [if (slabTop === CLOSED-CIRCLE) xo 0]) midy [widths.lhs stroke]
@@ -205,6 +215,7 @@ glyph-block Letter-Cyrillic-Ze : begin
 
 		export : define [LowerShape] : begin
 			define [object stroke midx midy fine shoulderFine] : Dim
+			local middle : mix left right 0.5
 			return : dispiro
 				flat midx   (midy - (stroke / 2 - fine)) [widths.heading fine 0 Leftward]
 				curl Middle (midy - (stroke / 2 - fine)) [heading Leftward]
@@ -213,6 +224,10 @@ glyph-block Letter-Cyrillic-Ze : begin
 				match slabBot
 					[Just SLAB-CLASSICAL] : SerifedArcEnd.LtrLhs right bot stroke hook (o -- yo)
 					[Just SLAB-INWARD] : InwardSlabArcEnd.LtrLhs right bot stroke hook (o -- yo)
+					[Just FLAT-CONNECTION] : list
+						arcvh
+						flat [Arch.adjust-x.bot middle stroke] bot [heading Rightward]
+						curl (right + xo) bot [heading Rightward]
 					[Just OPEN-VERTICAL] : curl (left + xo * 2) bot [heading Downward]
 					([Just CLOSED-CIRCLE] || [Just CLOSED-ROUND]) : list
 						Arch.lhs bot (sw -- stroke) (o -- yo)
@@ -574,6 +589,17 @@ glyph-block Letter-Cyrillic-Ze : begin
 				corner  df.rightSB                    (top - HalfStroke)
 				corner (df.rightSB - [HSwToV stroke]) (top - HalfStroke)
 
+		define [FlatTopBody df top bar hook ada adb] : glyph-proc
+			local revZe : CyrRevZe FLAT-CONNECTION CLOSED-STEM top 0
+				blend     -- VolBlend
+				hook      -- hook
+				xOverflow -- 0
+				ada       -- ada
+				adb       -- adb
+			define [object stroke] : revZe.Dim
+			include : revZe.Shape
+			include : bar df top stroke
+
 		define [EarlessCornerBody df top bar hook ada adb] : glyph-proc
 			local revZe : CyrRevZe SLAB-INWARD CLOSED-STEM top 0
 				blend     -- VolBlend
@@ -598,23 +624,28 @@ glyph-block Letter-Cyrillic-Ze : begin
 
 		define SingleStoreyConfig : object
 			singleStoreySerifless               { FullBarBody        SingleStorey.SeriflessBar     }
+			singleStoreyTopCutSerifless         { TopCutBody         SingleStorey.SeriflessBar     }
+			singleStoreyFlatTopSerifless        { FlatTopBody        SingleStorey.SeriflessBar     }
 			singleStoreyEarlessCornerSerifless  { EarlessCornerBody  SingleStorey.SeriflessBar     }
 			singleStoreyEarlessRoundedSerifless { EarlessRoundedBody SingleStorey.SeriflessBar     }
-			singleStoreyTopCutSerifless         { TopCutBody         SingleStorey.SeriflessBar     }
 
 			singleStoreySerifed                 { FullBarBody        SingleStorey.BottomSerifedBar }
+			singleStoreyTopCutSerifed           { TopCutBody         SingleStorey.BottomSerifedBar }
+			singleStoreyFlatTopSerifed          { FlatTopBody        SingleStorey.BottomSerifedBar }
 			singleStoreyEarlessCornerSerifed    { EarlessCornerBody  SingleStorey.BottomSerifedBar }
 			singleStoreyEarlessRoundedSerifed   { EarlessRoundedBody SingleStorey.BottomSerifedBar }
-			singleStoreyTopCutSerifed           { TopCutBody         SingleStorey.BottomSerifedBar }
 
 			singleStoreyDoubleSerifed           { FullBarBody        SingleStorey.DoubleSerifedBar }
+			singleStoreyFlatTopDoubleSerifed    { FlatTopBody        SingleStorey.DoubleSerifedBar }
 
 			singleStoreyTailed                  { FullBarBody        SingleStorey.TailedBar        }
+			singleStoreyTopCutTailed            { TopCutBody         SingleStorey.TailedBar        }
+			singleStoreyFlatTopTailed           { FlatTopBody        SingleStorey.TailedBar        }
 			singleStoreyEarlessCornerTailed     { EarlessCornerBody  SingleStorey.TailedBar        }
 			singleStoreyEarlessRoundedTailed    { EarlessRoundedBody SingleStorey.TailedBar        }
-			singleStoreyTopCutTailed            { TopCutBody         SingleStorey.TailedBar        }
 
 			singleStoreyTailedSerifed           { FullBarBody        SingleStorey.TailedSerifedBar }
+			singleStoreyFlatTopTailedSerifed    { FlatTopBody        SingleStorey.TailedSerifedBar }
 
 		foreach { suffix { body bar } } [Object.entries SingleStoreyConfig] : do
 			create-glyph "AeVolapuk.\(suffix)" : glyph-proc
@@ -659,8 +690,8 @@ glyph-block Letter-Cyrillic-Ze : begin
 			include : RightwardTailedBar df.rightSB 0 top stroke
 			include : slab df top stroke
 
-		define [UToothlessRounded df top slab hook ada adb] : glyph-proc
-			local revZe : CyrRevZe OPEN-VERTICAL CLOSED-ROUND top 0
+		define [UFlatBottom df top slab hook ada adb] : glyph-proc
+			local revZe : CyrRevZe OPEN-VERTICAL FLAT-CONNECTION top 0
 				blend     -- VolBlend
 				hook      -- hook
 				xOverflow -- 0
@@ -668,7 +699,7 @@ glyph-block Letter-Cyrillic-Ze : begin
 				adb       -- adb
 			define [object stroke] : revZe.Dim
 			include : revZe.Shape
-			include : VBar.r df.rightSB ada top stroke
+			include : VBar.r df.rightSB 0 top stroke
 			include : slab df top stroke
 
 		define [UToothlessCorner df top slab hook ada adb] : glyph-proc
@@ -683,22 +714,37 @@ glyph-block Letter-Cyrillic-Ze : begin
 			include : VBar.r df.rightSB DToothlessRise top stroke
 			include : slab df top stroke
 
+		define [UToothlessRounded df top slab hook ada adb] : glyph-proc
+			local revZe : CyrRevZe OPEN-VERTICAL CLOSED-ROUND top 0
+				blend     -- VolBlend
+				hook      -- hook
+				xOverflow -- 0
+				ada       -- ada
+				adb       -- adb
+			define [object stroke] : revZe.Dim
+			include : revZe.Shape
+			include : VBar.r df.rightSB ada top stroke
+			include : slab df top stroke
+
 		define SmallUConfig : SuffixCfg.weave
 			object # body
 				toothed           UToothed
 				tailed            UTailed
+				flatBottom        UFlatBottom
 				toothlessCorner   UToothlessCorner
 				toothlessRounded  UToothlessRounded
 			function [body] : object # serifs
 				serifless              no-shape
 				bottomRightSerifed     USerifs.BottomRight
 				motionSerifed : match body
-					[Just 'toothed']   USerifs.MotionToothed
-					__                 USerifs.MotionToothless
+					[Just 'toothed']    USerifs.MotionToothed
+					[Just 'flatBottom'] USerifs.MotionToothed
+					__                  USerifs.MotionToothless
 				serifed : match body
-					[Just 'toothed']   USerifs.Toothed
-					[Just 'tailed']    USerifs.Tailed
-					__                 USerifs.SmallToothless
+					[Just 'toothed']    USerifs.Toothed
+					[Just 'tailed']     USerifs.Tailed
+					[Just 'flatBottom'] USerifs.Toothed
+					__                  USerifs.SmallToothless
 
 		foreach { suffix { Base Slabs } } [Object.entries SmallUConfig] : do
 			create-glyph "UeVolapuk.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/lower-a.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-a.ptl
@@ -303,7 +303,7 @@ glyph-block Letter-Latin-Lower-A : begin
 		export : define [SeriflessBar df top _sw] : glyph-proc
 			set-base-anchor 'trailing' df.rightSB 0
 			include : VBar.r df.rightSB 0 top _sw
-		export : define [TopSerifedBar df top _sw] : glyph-proc
+		export : define [MotionSerifedBar df top _sw] : glyph-proc
 			include : SeriflessBar df top _sw
 			local sf : SerifFrame.fromDf df top 0 (swRef -- _sw)
 			include sf.rt.outer
@@ -331,8 +331,8 @@ glyph-block Letter-Latin-Lower-A : begin
 		singleStoreyEarlessCornerSerifless  { SingleStorey.EarlessCornerBody  SingleStorey.SeriflessBar     }
 		singleStoreyEarlessRoundedSerifless { SingleStorey.EarlessRoundedBody SingleStorey.SeriflessBar     }
 
-		singleStoreyTopSerifed              { SingleStorey.FullBarBody        SingleStorey.TopSerifedBar    }
-		singleStoreyFlatTopTopSerifed       { SingleStorey.FullBarBody        SingleStorey.TopSerifedBar    }
+		singleStoreyMotionSerifed           { SingleStorey.FullBarBody        SingleStorey.MotionSerifedBar }
+		singleStoreyFlatTopMotionSerifed    { SingleStorey.FlatTopBody        SingleStorey.MotionSerifedBar }
 
 		singleStoreySerifed                 { SingleStorey.FullBarBody        SingleStorey.BottomSerifedBar }
 		singleStoreyTopCutSerifed           { SingleStorey.TopCutBody         SingleStorey.BottomSerifedBar }

--- a/packages/font-glyphs/src/letter/latin/lower-a.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-a.ptl
@@ -258,6 +258,20 @@ glyph-block Letter-Latin-Lower-A : begin
 				corner  df.rightSB                 top
 				corner  df.rightSB                (top - HalfStroke)
 				corner (df.rightSB - [HSwToV sw]) (top - HalfStroke)
+		export : define [FlatTopBody df top bar _sw _ada _adb] : glyph-proc
+			local sw  : fallback _sw    df.mvs
+			local ada : fallback _ada : df.archDepthAOf SmallArchDepth sw
+			local adb : fallback _adb : df.archDepthBOf SmallArchDepth sw
+			include : OBarRight.earlessCorner
+				top   -- top
+				left  -- df.leftSB
+				right -- df.rightSB
+				sw    -- sw
+				fine  -- (ShoulderFine * (sw / Stroke))
+				ada   -- ada
+				adb   -- adb
+				rise  -- 0
+			include : bar df top sw
 		export : define [EarlessCornerBody df top bar _sw _ada _adb] : glyph-proc
 			local sw  : fallback _sw    df.mvs
 			local ada : fallback _ada : df.archDepthAOf SmallArchDepth sw
@@ -312,25 +326,31 @@ glyph-block Letter-Latin-Lower-A : begin
 	glyph-block-export SingleStoreyConfig
 	define SingleStoreyConfig : object
 		singleStoreySerifless               { SingleStorey.FullBarBody        SingleStorey.SeriflessBar     }
+		singleStoreyTopCutSerifless         { SingleStorey.TopCutBody         SingleStorey.SeriflessBar     }
+		singleStoreyFlatTopSerifless        { SingleStorey.FlatTopBody        SingleStorey.SeriflessBar     }
 		singleStoreyEarlessCornerSerifless  { SingleStorey.EarlessCornerBody  SingleStorey.SeriflessBar     }
 		singleStoreyEarlessRoundedSerifless { SingleStorey.EarlessRoundedBody SingleStorey.SeriflessBar     }
-		singleStoreyTopCutSerifless         { SingleStorey.TopCutBody         SingleStorey.SeriflessBar     }
 
 		singleStoreyTopSerifed              { SingleStorey.FullBarBody        SingleStorey.TopSerifedBar    }
+		singleStoreyFlatTopTopSerifed       { SingleStorey.FullBarBody        SingleStorey.TopSerifedBar    }
 
 		singleStoreySerifed                 { SingleStorey.FullBarBody        SingleStorey.BottomSerifedBar }
+		singleStoreyTopCutSerifed           { SingleStorey.TopCutBody         SingleStorey.BottomSerifedBar }
+		singleStoreyFlatTopSerifed          { SingleStorey.FlatTopBody        SingleStorey.BottomSerifedBar }
 		singleStoreyEarlessCornerSerifed    { SingleStorey.EarlessCornerBody  SingleStorey.BottomSerifedBar }
 		singleStoreyEarlessRoundedSerifed   { SingleStorey.EarlessRoundedBody SingleStorey.BottomSerifedBar }
-		singleStoreyTopCutSerifed           { SingleStorey.TopCutBody         SingleStorey.BottomSerifedBar }
 
 		singleStoreyDoubleSerifed           { SingleStorey.FullBarBody        SingleStorey.DoubleSerifedBar }
+		singleStoreyFlatTopDoubleSerifed    { SingleStorey.FlatTopBody        SingleStorey.DoubleSerifedBar }
 
 		singleStoreyTailed                  { SingleStorey.FullBarBody        SingleStorey.TailedBar        }
+		singleStoreyTopCutTailed            { SingleStorey.TopCutBody         SingleStorey.TailedBar        }
+		singleStoreyFlatTopTailed           { SingleStorey.FlatTopBody        SingleStorey.TailedBar        }
 		singleStoreyEarlessCornerTailed     { SingleStorey.EarlessCornerBody  SingleStorey.TailedBar        }
 		singleStoreyEarlessRoundedTailed    { SingleStorey.EarlessRoundedBody SingleStorey.TailedBar        }
-		singleStoreyTopCutTailed            { SingleStorey.TopCutBody         SingleStorey.TailedBar        }
 
 		singleStoreyTailedSerifed           { SingleStorey.FullBarBody        SingleStorey.TailedSerifedBar }
+		singleStoreyFlatTopTailedSerifed    { SingleStorey.FlatTopBody        SingleStorey.TailedSerifedBar }
 
 	foreach { suffix { body bar } } [Object.entries SingleStoreyConfig] : do
 		create-glyph "a.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/lower-b.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-b.ptl
@@ -25,6 +25,10 @@ glyph-block Letter-Latin-Lower-B : begin
 			corner  SB                    HalfStroke
 			corner (SB + [HSwToV Stroke]) HalfStroke
 
+	define [FlatBottomBody yTop] : union
+		OBarLeft.toothlessCorner (rise -- 0)
+		VBar.l SB 0 yTop
+
 	define [ToothlessCornerBody yTop] : union
 		OBarLeft.toothlessCorner
 		VBar.l SB DToothlessRise yTop
@@ -39,9 +43,10 @@ glyph-block Letter-Latin-Lower-B : begin
 	define BConfig : SuffixCfg.weave
 		object # body
 			""                ToothedBody
+			bottomCut         BottomCutBody
+			flatBottom        FlatBottomBody
 			toothlessCorner   ToothlessCornerBody
 			toothlessRounded  ToothlessRoundedBody
-			bottomCut         BottomCutBody
 		object # serifs
 			serifless       { no-shape   false  }
 			motionSerifed   { LTSerifs   true   }

--- a/packages/font-glyphs/src/letter/latin/lower-d.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-d.ptl
@@ -35,6 +35,17 @@ glyph-block Letter-Latin-Lower-D : begin
 			adb   -- df.smallArchDepthB
 		tagged 'rightBar' : RightwardTailedBar df.rightSB 0 yTop df.mvs
 
+	define [FlatBottomBody df yTop] : union
+		OBarRight.toothlessCorner
+			left  -- df.leftSB
+			right -- df.rightSB
+			sw    -- df.mvs
+			fine  -- df.shoulderFine
+			ada   -- df.smallArchDepthA
+			adb   -- df.smallArchDepthB
+			rise  -- 0
+		tagged 'rightBar' : VBar.r df.rightSB 0 yTop df.mvs
+
 	define [ToothlessCornerBody df yTop] : union
 		OBarRight.toothlessCorner
 			left  -- df.leftSB
@@ -71,11 +82,11 @@ glyph-block Letter-Latin-Lower-D : begin
 	define DConfig : SuffixCfg.weave
 		object # body
 			toothed                   ToothedBody
+			tailed                    TailedBody
+			flatBottom                FlatBottomBody
 			toothlessCorner           ToothlessCornerBody
 			toothlessCornerRTB        ToothlessCornerRTBBody
 			toothlessRounded          ToothlessRoundedBody
-			tailed                    TailedBody
-
 		function [body] : object # serifs
 			serifless                { null     null      }
 			topSerifed               { TopSerif null      }

--- a/packages/font-glyphs/src/letter/latin/lower-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-g.ptl
@@ -145,6 +145,23 @@ glyph-block Letter-Latin-Lower-G : begin
 				corner  df.rightSB                    (top - HalfStroke)
 				corner (df.rightSB - [HSwToV df.mvs]) (top - HalfStroke)
 
+		export : define [FlatTopSeriflessBody df top _ada _adb] : glyph-proc
+			local ada : fallback _ada df.smallArchDepthA
+			local adb : fallback _adb df.smallArchDepthB
+			include : OBarRight.earlessCorner
+				top    -- top
+				left   -- df.leftSB
+				right  -- df.rightSB
+				sw     -- df.mvs
+				fine   -- df.shoulderFine
+				ada    -- ada
+				adb    -- adb
+				rise   -- 0
+
+		export : define [FlatTopSerifedBody df top _ada _adb] : glyph-proc
+			include : FlatTopSeriflessBody df top _ada _adb
+			include : tagged 'serifRT' : HSerif.rt df.rightSB top SideJut df.mvs
+
 		export : define [EarlessCornerBody df top _ada _adb] : glyph-proc
 			local ada : fallback _ada df.smallArchDepthA
 			local adb : fallback _adb df.smallArchDepthB
@@ -175,12 +192,14 @@ glyph-block Letter-Latin-Lower-G : begin
 			singleStoreyBentHook    SingleStorey.BentHook
 			singleStoreyFlatHook    SingleStorey.FlatHook
 		object # ear/serif
-			serifless             { SingleStorey.SeriflessBody      0                      }
-			serifed               { SingleStorey.SerifedBody        0                      }
-			earlessCorner         { SingleStorey.EarlessCornerBody  DToothlessRise         }
-			earlessCornerHTB      { SingleStorey.EarlessCornerBody  0                      }
-			earlessRounded        { SingleStorey.EarlessRoundedBody (XH - SmallArchDepthA) }
-			topCut                { SingleStorey.TopCutBody         HalfStroke             }
+			serifless             { SingleStorey.SeriflessBody        0                      }
+			serifed               { SingleStorey.SerifedBody          0                      }
+			topCut                { SingleStorey.TopCutBody           HalfStroke             }
+			flatTopSerifless      { SingleStorey.FlatTopSeriflessBody 0                      }
+			flatTopSerifed        { SingleStorey.FlatTopSerifedBody   0                      }
+			earlessCorner         { SingleStorey.EarlessCornerBody    DToothlessRise         }
+			earlessCornerHTB      { SingleStorey.EarlessCornerBody    0                      }
+			earlessRounded        { SingleStorey.EarlessRoundedBody   (XH - SmallArchDepthA) }
 
 	foreach { suffix { hookShape {bodyShape hookStart} } } [Object.entries SingleStoreyConfig] : do
 		create-glyph "g.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/lower-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-m.ptl
@@ -146,6 +146,33 @@ glyph-block Letter-Latin-Lower-M : begin
 			stroke    -- sw
 			leftY0    -- mbot
 
+	define [FlatTopSmallMShape df top lbot mbot rbot _sw _ada _adb] : glyph-proc
+		local sw  : fallback _sw df.mvs
+		local ada : fallback _ada : SmallMSmoothA df nothing sw
+		local adb : fallback _adb : SmallMSmoothB df nothing sw
+		include : tagged 'barL' : VBar.l df.leftSB lbot top               sw
+		include : tagged 'barM' : VBar.m df.middle mbot (top - 0.25 * sw) sw
+		include : dispiro
+			widths.rhs sw
+			flat (df.leftSB + TINY) top [heading Rightward]
+			curl [Arch.adjust-x.top [mix (df.middle - [HSwToV : 0.5 * sw]) df.rightSB 0.5] (sw -- sw)] top
+			archv
+			flat df.rightSB [Math.max (top - adb) (rbot + TINY)]
+			curl df.rightSB rbot [heading Downward]
+
+	define [EarlessSingleArchSmallMShape df top lbot mbot rbot _sw _ada _adb] : glyph-proc
+		local sw  : fallback _sw df.mvs
+		local ada : fallback _ada : SmallMSmoothA df nothing sw
+		local adb : fallback _adb : SmallMSmoothB df nothing sw
+		include : tagged 'barL' : VBar.l df.leftSB lbot (top - DToothlessRise) sw
+		include : tagged 'barM' : VBar.m df.middle mbot (top - 0.25 * sw)      sw
+		include : dispiro
+			widths.rhs sw
+			g4 df.leftSB (top - DToothlessRise)
+			Arch.rhs top (sw -- sw) (blendPre -- {})
+			flat df.rightSB [Math.max (top - adb) (rbot + TINY)]
+			curl df.rightSB rbot [heading Downward]
+
 	glyph-block-export EarlessCornerDoubleArchSmallMShape
 	define [EarlessCornerDoubleArchSmallMShape df top lbot mbot rbot _sw _ada _adb] : glyph-proc
 		local sw  : fallback _sw df.mvs
@@ -202,19 +229,6 @@ glyph-block Letter-Latin-Lower-M : begin
 				stroke    -- sw
 				leftY0    -- mbot
 
-	define [EarlessSingleArchSmallMShape df top lbot mbot rbot _sw _ada _adb] : glyph-proc
-		local sw  : fallback _sw df.mvs
-		local ada : fallback _ada : SmallMSmoothA df nothing sw
-		local adb : fallback _adb : SmallMSmoothB df nothing sw
-		include : tagged 'barL' : VBar.l df.leftSB lbot (top - DToothlessRise) sw
-		include : tagged 'barM' : VBar.m df.middle mbot (top - 0.25 * sw)      sw
-		include : dispiro
-			widths.rhs sw
-			g4 df.leftSB (top - DToothlessRise)
-			Arch.rhs top (sw -- sw) (blendPre -- {})
-			flat df.rightSB [Math.max (top - adb) (rbot + TINY)]
-			curl df.rightSB rbot [heading Downward]
-
 	define [SmallMShortLegHeight df top _sw _ada _adb] : begin
 		local sw : fallback _sw df.mvs
 		return : mix 0 (top - sw) 0.45
@@ -233,9 +247,10 @@ glyph-block Letter-Latin-Lower-M : begin
 	define SmallMConfig : SuffixCfg.weave
 		object
 			""                             { SmallMArches                        0 }
+			"flatTop"                      { FlatTopSmallMShape                  0 }
+			"earlessSingleArch"            { EarlessSingleArchSmallMShape        1 }
 			"earlessCornerDoubleArch"      { EarlessCornerDoubleArchSmallMShape  1 }
 			"earlessRoundedDoubleArch"     { EarlessRoundedDoubleArchSmallMShape 1 }
-			"earlessSingleArch"            { EarlessSingleArchSmallMShape        1 }
 		object
 			""                             { 0 }
 			"shortLeg"                     { 1 }
@@ -374,6 +389,7 @@ glyph-block Letter-Latin-Lower-M : begin
 		object # body
 			toothed            { SmallMArches                        0 0 }
 			tailed             { SmallMArches                        0 1 }
+			flatBottom         { FlatTopSmallMShape                  0 0 }
 			toothlessCorner    { EarlessCornerDoubleArchSmallMShape  1 0 }
 			toothlessRounded   { EarlessRoundedDoubleArchSmallMShape 1 0 }
 		function [body] : object # serifs
@@ -411,7 +427,7 @@ glyph-block Letter-Latin-Lower-M : begin
 				include : Translate 0 (SB / 2)
 
 		if (!tailed) : begin
-			create-glyph "turnmLeg.\(suffix)" : glyph-proc
+			create-glyph "turnmLongLeg.\(suffix)" : glyph-proc
 				local df : include : dfM
 				include : df.markSet.p
 				include : turnMShapeBody df XH
@@ -436,15 +452,15 @@ glyph-block Letter-Latin-Lower-M : begin
 					eject-contour 'serifLT'
 					include : CyrCurlDescender.rSideJut df.rightSB 0 (refSw -- df.mvs)
 
-	select-variant 'turnm' 0x26F (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'turnm/full' 'turnm/reduced'])
-	select-variant 'turnm/reduced' (shapeFrom -- 'turnm')
+	select-variant 'turnm' 0x26F (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'uu/full' 'uu/reduced'])
+	select-variant 'turnm/reduced' (shapeFrom -- 'turnm') (follow -- 'uu/reduced')
 
-	select-variant 'turnmCap' 0x19C (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'turnm/full' 'turnm/reduced'])
+	select-variant 'turnmCap' 0x19C (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'uu/full' 'uu/reduced'])
 
-	select-variant 'turnmLeg' 0x270 (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'turnmLeg/full' 'turnmLeg/reduced'])
-	select-variant 'turnmLeg/reduced' (shapeFrom -- 'turnmLeg')
+	select-variant 'turnmLongLeg' 0x270 (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'uuLongLeg/full' 'uuLongLeg/reduced'])
+	select-variant 'turnmLongLeg/reduced' (shapeFrom -- 'turnmLongLeg') (follow -- 'uuLongLeg/reduced')
 
-	select-variant 'turnmSideways' 0x1D1F (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'turnm/full' 'turnm/reduced'])
+	select-variant 'turnmSideways' 0x1D1F (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'uu/full' 'uu/reduced'])
 
 	select-variant 'cyrl/sha.italic' (shapeFrom -- 'turnm') (follow -- [conditional-follow [MEnoughSpaceForFullSerifs : dfM] 'cyrl/sha.italic/full' 'cyrl/sha.italic/reduced'])
 	select-variant 'cyrl/sha/reduced.italic' (shapeFrom -- 'turnm') (follow -- 'cyrl/sha.italic/reduced')

--- a/packages/font-glyphs/src/letter/latin/lower-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-m.ptl
@@ -397,8 +397,8 @@ glyph-block Letter-Latin-Lower-M : begin
 			serifed            { FullTurnMSerifs  }
 			bottomRightSerifed { LtSerifs         } # The name-shaping mapping is swapped by design
 			motionSerifed : match body
-				[Just 'toothed'] { LtRbSerifs }
-				__               { RbSerifs   } # The name-shaping mapping is swapped by design
+				([Just 'toothed'] || [Just 'flatBottom']) { LtRbSerifs }
+				__                                        { RbSerifs   } # The name-shaping mapping is swapped by design
 
 	foreach { suffix { { Body toothless tailed } { Serifs } } } [pairs-of TurnMConfig] : do
 		define [turnMShapeBody df top _sw _ada _adb] : glyph-proc

--- a/packages/font-glyphs/src/letter/latin/lower-n.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-n.ptl
@@ -65,6 +65,20 @@ glyph-block Letter-Latin-Lower-N : begin
 			fine   -- (ShoulderFine * (sw / Stroke))
 			stroke -- sw
 
+	define [FlatTopBody top left right yBR sw _ada _adb] : glyph-proc
+		include : VBar.l left 0 top sw
+		local ada : fallback _ada SmallArchDepthA
+		local adb : fallback _adb SmallArchDepthB
+		include : nShoulder.earlessCorner
+			left   -- left
+			right  -- right
+			top    -- top
+			bottom -- yBR
+			ada    -- ada
+			adb    -- adb
+			stroke -- sw
+			rise   -- 0
+
 	define [EarlessCornerBody top left right yBR sw _ada _adb] : glyph-proc
 		include : VBar.l left 0 (top - DToothlessRise) sw
 		local ada : fallback _ada SmallArchDepthA
@@ -98,6 +112,7 @@ glyph-block Letter-Latin-Lower-N : begin
 	define NConfig : SuffixCfg.weave
 		object # body
 			""                  EaredBody
+			flatTop             FlatTopBody
 			earlessCorner       EarlessCornerBody
 			earlessRounded      EarlessRoundedBody
 			earlessCornerHTB    EarlessCornerBody
@@ -346,6 +361,7 @@ glyph-block Letter-Latin-Lower-N : begin
 
 	do "n with Apostrophe"
 		glyph-block-import Mark-Shared-Metrics : markMiddle
+
 		derive-glyphs 'nApostrophe/commaTL' null 'commaAbove/asPunctuation' : function [src gr] : glyph-proc
 			include : with-transform [Translate (SB - markMiddle) 0] [refer-glyph src]
 

--- a/packages/font-glyphs/src/letter/latin/lower-p.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-p.ptl
@@ -27,6 +27,17 @@ glyph-block Letter-Latin-Lower-P : begin
 			adb   -- adb
 		include : tagged 'stemLeft' : VBar.l left Descender XH sw
 
+	define [FlatTopBody] : with-params [[left SB] [right RightSB] [sw Stroke] [ada SmallArchDepthA] [adb SmallArchDepthB]] : glyph-proc
+		include : tagged 'bowl' : OBarLeft.earlessCorner
+			left  -- left
+			right -- right
+			sw    -- sw
+			fine  -- (ShoulderFine * (sw / Stroke))
+			ada   -- ada
+			adb   -- adb
+			rise  -- 0
+		include : tagged 'stemLeft' : VBar.l left Descender XH sw
+
 	define [EarlessCornerBody] : with-params [[left SB] [right RightSB] [sw Stroke] [ada SmallArchDepthA] [adb SmallArchDepthB]] : glyph-proc
 		include : tagged 'bowl' : OBarLeft.earlessCorner
 			left  -- left
@@ -57,6 +68,7 @@ glyph-block Letter-Latin-Lower-P : begin
 	define PConfig : SuffixCfg.weave
 		object # body
 			eared                EaredBody
+			flatTop              FlatTopBody
 			earlessCorner        EarlessCornerBody
 			earlessRounded       EarlessRoundedBody
 		object # serifs

--- a/packages/font-glyphs/src/letter/latin/lower-q.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-q.ptl
@@ -47,6 +47,20 @@ glyph-block Letter-Latin-Lower-Q : begin
 			corner  RightSB                    (top - HalfStroke)
 			corner (RightSB - [HSwToV Stroke]) (top - HalfStroke)
 
+	define [FlatTopBody terminal top bottom _ada _adb] : glyph-proc
+		local ada : fallback _ada SmallArchDepthA
+		local adb : fallback _adb SmallArchDepthB
+		set-base-anchor 'trailing' (RightSB - markHalfStroke) Descender
+		include : OBarRight.earlessCorner
+			top -- top
+			ada -- ada
+			adb -- adb
+			rise -- 0
+		include : match terminal
+			[Just TERMINAL-TAILED] : RightwardTailedBar     RightSB bottom top
+			[Just TERMINAL-DIAG]   : RightwardDiagTailedBar RightSB bottom top
+			__                     : VBar.r                 RightSB bottom top
+
 	define [EarlessCornerBody terminal top bottom _ada _adb] : glyph-proc
 		local ada : fallback _ada SmallArchDepthA
 		local adb : fallback _adb SmallArchDepthB
@@ -85,9 +99,10 @@ glyph-block Letter-Latin-Lower-Q : begin
 	define QConfig : SuffixCfg.weave
 		object # body
 			""                    EaredBody
+			topCut                TopCutBody
+			flatTop               FlatTopBody
 			earlessCorner         EarlessCornerBody
 			earlessRounded        EarlessRoundedBody
-			topCut                TopCutBody
 		object # tail
 			""                    TERMINAL-NORMAL
 			tailed                TERMINAL-TAILED

--- a/packages/font-glyphs/src/letter/latin/lower-r.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-r.ptl
@@ -47,7 +47,7 @@ glyph-block Letter-Latin-Lower-R : begin
 		local rSerifRightJut : rSerifLeftJut * 1.20
 		export : local [rBottomSerif y] : glyph-proc
 			include : tagged 'serifLB' : union
-				HSerif.lb  rSerifX y (rSerifLeftJut + [HSwToV : 0.5 * strokeBar])
+				HSerif.lb rSerifX y (rSerifLeftJut  + [HSwToV : 0.5 * strokeBar])
 				HSerif.rb rSerifX y (rSerifRightJut + [HSwToV : 0.5 * strokeBar])
 			local xAtt : rSerifX + rSerifRightJut + [HSwToV : 0.5 * strokeBar]
 			set-base-anchor 'palatalHookAttach' xAtt y
@@ -72,7 +72,8 @@ glyph-block Letter-Latin-Lower-R : begin
 		local mixpin : match mode
 			([Just rSerifed] || [Just rCornerHooked] || [Just rCornerHookedSerifed] || [Just rNarrowHookSerifed]) : begin
 				0.65 + 0.25 * strokeA / Width + 4 * TanSlope * strokeA / Width
-			__ : 0.65 + 4 * TanSlope * strokeA / Width
+			__ : begin
+				0.65 + 4 * TanSlope * strokeA / Width
 		local rmiddlein : [mix xBar (rHookX - [HSwToV : 1.05 * strokeA]) mixpin] - CorrectionOMidS
 		export : local skew : Math.max 0 : (xArchMiddle - rmiddlein) / stroke - TanSlope
 		export : local rHookY : RHook * rHookMultiplier + stroke * rHookSwMultiplier
@@ -146,6 +147,18 @@ glyph-block Letter-Latin-Lower-R : begin
 		if doBottomSerif : include : rBottomSerif 0
 		if doTopSerif    : include : rTopSerif    XH
 
+	define [FlatTopShape df md doTopSerif doBottomSerif] : glyph-proc
+		define [object xBar xArchMiddle rHookX rHookY hookSuperness rBottomSerif rTopSerif] : RDim df md
+		include : dispiro
+			widths.lhs
+			g4.up.start rHookX (XH - rHookY) [heading Upward]
+			arcvh nothing hookSuperness
+			flat [Arch.adjust-x.top xArchMiddle] XH
+			curl (xBar - [HSwToV Stroke] - O)    XH [heading Leftward]
+		include : VBar.r xBar 0 XH
+		if doBottomSerif : include : rBottomSerif 0
+		if doTopSerif    : include : rTopSerif    XH
+
 	define [EarlessCornerShape df md doTopSerif doBottomSerif] : glyph-proc
 		define [object xBar xArchMiddle rHookX rHookY hookSuperness rBottomSerif] : RDim df md
 		include : dispiro
@@ -182,6 +195,7 @@ glyph-block Letter-Latin-Lower-R : begin
 		# Body
 		object
 			''             { StandardShape       dfN rStraight     rSerifed             }
+			flatTop        { FlatTopShape        dfN rEarless      rEarless             }
 			earlessCorner  { EarlessCornerShape  dfN rEarless      rEarless             }
 			earlessRounded { EarlessRoundedShape dfN rEarless      rEarless             }
 			hookless       { CompactShape        dfN rNarrow       rNarrowSerifed       }
@@ -198,7 +212,7 @@ glyph-block Letter-Latin-Lower-R : begin
 			baseSerifed    { 0 1 }
 			serifed        { 1 1 }
 
-	foreach { suffix { {F df modeSans modeSerifed} {doTS doBS} } } [pairs-of SmallRConfig] : do
+	foreach { suffix { { F df modeSans modeSerifed } { doTS doBS } } } [pairs-of SmallRConfig] : do
 		local mode : if (doTS || doBS) modeSerifed modeSans
 		create-glyph "r.\(suffix)" : glyph-proc
 			set-width df.width

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -51,6 +51,21 @@ glyph-block Letter-Latin-U : begin
 			if fHookLeft : include : TopHook.toLeft.lBarInner df.leftSB [Math.min (adb + TINY) (yTL - 0)] top (sw -- sw)
 			include : tagged 'strokeR' : RightwardTailedBar df.rightSB 0 yTR (sw -- sw)
 
+		export : define [FlatBottom df top sw fHookLeft fShortLeg] : glyph-proc
+			local yTL : top - [if fHookLeft (TailY + HalfStroke) 0]
+			local yTR : if fShortLeg [mix [Math.min ada : YSmoothMidR top 0 ada adb] top 0.5] top
+			include : uBowl.toothlessCorner
+				top     -- yTL
+				bottom  -- 0
+				left    -- df.leftSB
+				right   -- df.rightSB
+				stroke  -- sw
+				ada     -- ada
+				adb     -- adb
+				rise    -- 0
+			if fHookLeft : include : TopHook.toLeft.lBarInner df.leftSB [Math.min (adb + TINY) (yTL - 0)] top (sw -- sw)
+			include : tagged 'strokeR' : VBar.r df.rightSB 0 yTR sw
+
 		export : define [ToothlessCorner df top sw fHookLeft fShortLeg] : glyph-proc
 			local yTL : top - [if fHookLeft (TailY + HalfStroke) 0]
 			local yTR : if fShortLeg [mix [Math.min ada : YSmoothMidR top 0 ada adb] top 0.5] top
@@ -139,19 +154,22 @@ glyph-block Letter-Latin-U : begin
 		object # body
 			toothed           shapeGroup.Toothed
 			tailed            shapeGroup.Tailed
+			flatBottom        shapeGroup.FlatBottom
 			toothlessCorner   shapeGroup.ToothlessCorner
 			toothlessRounded  shapeGroup.ToothlessRounded
 		function [body] : object # serifs
-			serifless                { no-shape                false }
-			bottomRightSerifed       { USerifs.BottomRight     false }
-			bilateralMotionSerifed   { USerifs.BilateralMotion true  }
+			serifless                   { no-shape                false }
+			bottomRightSerifed          { USerifs.BottomRight     false }
+			bilateralMotionSerifed      { USerifs.BilateralMotion true  }
 			unilateralMotionSerifed : match body
-				[Just 'toothed'] { USerifs.MotionToothed   true  }
-				__               { USerifs.MotionToothless true  }
+				[Just 'toothed']    { USerifs.MotionToothed   true  }
+				[Just 'flatBottom'] { USerifs.MotionToothed   true  }
+				__                  { USerifs.MotionToothless true  }
 			serifed : match body
-				[Just 'toothed'] { USerifs.Toothed         true  }
-				[Just 'tailed']  { USerifs.Tailed          true  }
-				__               { USerifs.Toothless       true  }
+				[Just 'toothed']    { USerifs.Toothed         true  }
+				[Just 'tailed']     { USerifs.Tailed          true  }
+				[Just 'flatBottom'] { USerifs.Toothed         true  }
+				__                  { USerifs.Toothless       true  }
 
 	foreach { suffix { Base {Slabs fLTSlab} } } [Object.entries : CapitalUConfigT UUpper] : do
 		create-glyph "U.\(suffix)" : glyph-proc
@@ -175,20 +193,23 @@ glyph-block Letter-Latin-U : begin
 		object # body
 			toothed           shapeGroup.Toothed
 			tailed            shapeGroup.Tailed
+			flatBottom        shapeGroup.FlatBottom
 			toothlessCorner   shapeGroup.ToothlessCorner
 			toothlessRounded  shapeGroup.ToothlessRounded
 			descBase          shapeGroup.Toothed
 		function [body] : object # serifs
-			serifless                  no-shape
-			bottomRightSerifed         USerifs.BottomRight
+			serifless                   no-shape
+			bottomRightSerifed          USerifs.BottomRight
 			motionSerifed : match body
-				[Just 'toothed']   USerifs.MotionToothed
-				__                 USerifs.MotionToothless
+				[Just 'toothed']    USerifs.MotionToothed
+				[Just 'flatBottom'] USerifs.MotionToothed
+				__                  USerifs.MotionToothless
 			serifed : match body
-				[Just 'toothed']   USerifs.Toothed
-				[Just 'tailed']    USerifs.Tailed
-				[Just 'descBase']  USerifs.DescBase
-				__                 USerifs.SmallToothless
+				[Just 'toothed']    USerifs.Toothed
+				[Just 'tailed']     USerifs.Tailed
+				[Just 'descBase']   USerifs.DescBase
+				[Just 'flatBottom'] USerifs.Toothed
+				__                  USerifs.SmallToothless
 
 	foreach { suffix { Base Slabs } } [Object.entries : SmallUConfigT ULower] : do
 		create-glyph "u.\(suffix)" : glyph-proc
@@ -315,13 +336,13 @@ glyph-block Letter-Latin-U : begin
 	link-reduced-variant 'u/sansSerif' 'u' MathSansSerif
 	select-variant 'u/descBase' (shapeFrom -- 'u')
 
-	select-variant 'turnh' 0x265
+	select-variant 'turnh' 0x265 (follow -- 'uLongLeg')
 
 	select-variant 'uShortLeg' 0xAB4E
 	select-variant 'uHookLeft' 0xAB52
 
-	select-variant 'turnhHookLeft'      0x2AE
-	select-variant 'turnhHookLeftRTail' 0x2AF
+	select-variant 'turnhHookLeft'      0x2AE (follow -- 'uHookLeftLongLeg')
+	select-variant 'turnhHookLeftRTail' 0x2AF (follow -- 'uHookLeftLongLegRTail')
 
 	select-variant 'uSideways' 0x1D1D (follow -- 'u')
 	select-variant 'uDieresisSideways/base' (follow -- 'u')
@@ -367,8 +388,6 @@ glyph-block Letter-Latin-U : begin
 				corner (SB + outStand) (yTurn + outStandY)
 				corner (SB - outStand) (yTurn - outStandY)
 			UShapeOutline XH 0 (SB - O) (RightSB + O) nothing SmallArchDepthA SmallArchDepthB
-		if SLAB : begin
-			include : HSerif.lt SB XH SideJut
 
 	CreateAccentedComposition 'uDieresis' 0xFC 'u' 'dieresisAbove'
 	CreateAccentedComposition 'uBar' 0x289 'u' 'hStrike'

--- a/packages/font-glyphs/src/letter/latin/u.ptl
+++ b/packages/font-glyphs/src/letter/latin/u.ptl
@@ -97,46 +97,42 @@ glyph-block Letter-Latin-U : begin
 	define UUpper : UShapeGroup ArchDepthA ArchDepthB
 	define ULower : UShapeGroup SmallArchDepthA SmallArchDepthB
 
-	define [UTopLeftSerif df yTop _sw] : begin
-		local sf : SerifFrame.fromDf df yTop 0 (swRef -- _sw)
-		return sf.lt.outer
-
-	define [UTopRightSerif df yTop _sw] : begin
-		local sf : SerifFrame.fromDf df yTop 0 (swRef -- _sw)
-		return sf.rt.inner
-
-	define [UBottomRightSerif df yTop _sw] : glyph-proc
-		local sf : SerifFrame.fromDf df yTop 0 (swRef -- _sw)
-		include sf.rb.outer
-		define trAnchor currentGlyph.baseAnchors.trailing
-		if trAnchor : begin
-			set-base-anchor 'trailing' (trAnchor.x + sf.sideJut) trAnchor.y
-
 	glyph-block-export USerifs
 	define USerifs : namespace
+		define [UTopLeftSerif df yTop _sw] : begin
+			local sf : SerifFrame.fromDf df yTop 0 (swRef -- _sw)
+			return sf.lt.outer
+
+		define [UTopRightSerif df yTop _sw] : begin
+			local sf : SerifFrame.fromDf df yTop 0 (swRef -- _sw)
+			return sf.rt.inner
+
+		define [UBottomRightSerif df yTop _sw] : glyph-proc
+			local sf : SerifFrame.fromDf df yTop 0 (swRef -- _sw)
+			include sf.rb.outer
+			define trAnchor currentGlyph.baseAnchors.trailing
+			if trAnchor : begin
+				set-base-anchor 'trailing' (trAnchor.x + sf.sideJut) trAnchor.y
+
 		export : define [Toothed df top _sw] : glyph-proc
-			include : UTopLeftSerif df top _sw
-			include : UTopRightSerif df top _sw
+			include : UTopLeftSerif     df top _sw
+			include : UTopRightSerif    df top _sw
 			include : UBottomRightSerif df top _sw
 
 		export : define [DescBase df top _sw] : glyph-proc
-			include : UTopLeftSerif df top _sw
+			include : UTopLeftSerif  df top _sw
 			include : UTopRightSerif df top _sw
 
 		export : define [Tailed df top _sw] : glyph-proc
-			include : UTopLeftSerif df top _sw
+			include : UTopLeftSerif  df top _sw
 			include : UTopRightSerif df top _sw
 
 		export : define [BilateralMotion df top _sw] : begin
 			local sf : SerifFrame.fromDf df top 0 (swRef -- _sw)
 			return : composite-proc sf.lt.outer sf.rt.outer
 
-		export : define [SmallToothless df top _sw] : glyph-proc
-			include : UTopLeftSerif df top _sw
-			include : UTopRightSerif df top _sw
-
 		export : define [MotionToothed df top _sw] : glyph-proc
-			include : UTopLeftSerif df top _sw
+			include : UTopLeftSerif     df top _sw
 			include : UBottomRightSerif df top _sw
 
 		export : define [BottomRight df top _sw] : glyph-proc
@@ -148,6 +144,14 @@ glyph-block Letter-Latin-U : begin
 		export : define [Toothless df top _sw] : begin
 			local sf : SerifFrame.fromDf df top 0 (swRef -- _sw)
 			return : composite-proc sf.lt.full sf.rt.full
+
+		export : define [SmallToothless df top _sw] : glyph-proc
+			include : UTopLeftSerif  df top _sw
+			include : UTopRightSerif df top _sw
+
+		export : define [FlatBottom df top _sw] : glyph-proc
+			include : Toothless         df top _sw
+			include : UBottomRightSerif df top _sw
 
 	glyph-block-export CapitalUConfigT
 	define [CapitalUConfigT shapeGroup] : SuffixCfg.weave
@@ -168,10 +172,10 @@ glyph-block Letter-Latin-U : begin
 			serifed : match body
 				[Just 'toothed']    { USerifs.Toothed         true  }
 				[Just 'tailed']     { USerifs.Tailed          true  }
-				[Just 'flatBottom'] { USerifs.Toothed         true  }
+				[Just 'flatBottom'] { USerifs.FlatBottom      true  }
 				__                  { USerifs.Toothless       true  }
 
-	foreach { suffix { Base {Slabs fLTSlab} } } [Object.entries : CapitalUConfigT UUpper] : do
+	foreach { suffix { Base { Slabs fSlabLT } } } [Object.entries : CapitalUConfigT UUpper] : do
 		create-glyph "U.\(suffix)" : glyph-proc
 			local df : include : DivFrame 1
 			include : MarkSet.capital
@@ -180,7 +184,7 @@ glyph-block Letter-Latin-U : begin
 
 		create-glyph "U/withTonos.\(suffix)" : glyph-proc
 			include [refer-glyph "U.\(suffix)"] AS_BASE ALSO_METRICS
-			include : SetGrekUpperTonos [if fLTSlab (-SideJut) 0]
+			include : SetGrekUpperTonos [if fSlabLT (-SideJut) 0]
 
 		create-glyph "smcpU.\(suffix)" : glyph-proc
 			local df : include : DivFrame 1

--- a/packages/font-glyphs/src/letter/latin/upper-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-g.ptl
@@ -43,9 +43,14 @@ glyph-block Letter-Latin-Upper-G : begin
 			[Just BODY-TOOTHED] : knots.push
 				Arch.lhs 0 (swAfter -- fine)
 				straight.up.end (RightSB - [HSwToV : Stroke - fine]) [Math.min ada : yBar - TINY] [widths.lhs.heading fine Upward]
-			[Just BODY-TOOTHLESS-CORNER] : knots.push
-				Arch.lhs 0 (blendPost -- {})
-				g4   RightSB rise
+			[Just BODY-TOOTHLESS-CORNER] : if rise
+				then : knots.push
+					Arch.lhs 0 (blendPost -- {})
+					g4   RightSB rise
+				else : knots.push
+					arcvh
+					flat [Arch.adjust-x.bot Middle] 0
+					curl (RightSB + O)              0 [heading Rightward]
 			__ : knots.push
 				Arch.lhs 0
 				flat RightSB [Math.min rise : yBar - TINY]
@@ -82,6 +87,7 @@ glyph-block Letter-Latin-Upper-G : begin
 	define GConfig : SuffixCfg.weave
 		object # body
 			toothed          { BODY-TOOTHED           0              }
+			flatBottom       { BODY-TOOTHLESS-CORNER  0              }
 			toothlessCorner  { BODY-TOOTHLESS-CORNER  DToothlessRise }
 			toothlessRounded { BODY-TOOTHLESS-ROUNDED ArchDepthA     }
 		object # slab

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -299,8 +299,15 @@ glyph-block Letter-Shared-Shapes : begin
 			local-parameter : rise              -- DToothlessRise
 
 			return : dispiro
-				g4   left  (top - rise) [widths.rhs stroke]
-				Arch.rhs top (sw -- stroke) (blendPre -- {})
+				widths.rhs stroke
+				if rise
+					list
+						g4   left  (top - rise)
+						Arch.rhs top (sw -- stroke) (blendPre -- {})
+					list
+						flat (left + TINY) top [heading Rightward]
+						curl [Arch.adjust-x.top [mix left right 0.5] (sw -- stroke)] top
+						archv
 				flat right [Math.max (top - adb) (bottom + TINY)]
 				curl right bottom [heading Downward]
 
@@ -364,8 +371,14 @@ glyph-block Letter-Shared-Shapes : begin
 			return : dispiro
 				flat left  top [widths.lhs.heading stroke Downward]
 				curl left  [Math.min (bottom + adb) (top - TINY)]
-				Arch.lhs bottom (sw -- stroke) (blendPost -- {})
-				g4   right (bottom + rise)
+				if rise
+					list
+						Arch.lhs bottom (sw -- stroke) (blendPost -- {})
+						g4   right (bottom + rise) [widths.lhs stroke]
+					list
+						arcvh
+						flat [Arch.adjust-x.bot [mix left right 0.5] (sw -- stroke)] bottom
+						curl (right - TINY) bottom [heading Rightward]
 
 		export : define flex-params [toothlessRounded] : begin
 			local-parameter : left
@@ -450,8 +463,15 @@ glyph-block Letter-Shared-Shapes : begin
 			local-parameter : ystart            -- ((top - ada) - TINY)
 
 			return : dispiro
-				g4   left (bot + rise) [widths.lhs sw]
-				Arch.lhs bot (sw -- sw) (blendPre -- {})
+				widths.lhs sw
+				if rise
+					list
+						g4   left (bot + rise)
+						Arch.lhs bot (sw -- sw) (blendPre -- {})
+					list
+						flat (left + TINY) bot [heading Rightward]
+						curl [Arch.adjust-x.bot [mix left right 0.5] (sw -- sw)] bot
+						archv
 				flatside.ru right bot top ada adb
 				Arch.lhs top (sw -- sw) (swAfter -- fine)
 				flat (left + [HSwToV : sw - fine]) [Math.max (top - ada) (ystart + TINY)] [widths.lhs fine]
@@ -495,8 +515,14 @@ glyph-block Letter-Shared-Shapes : begin
 				curl (left + [HSwToV : sw - fine]) [Math.min (bot + adb) (yend - TINY)] [widths.lhs fine]
 				Arch.lhs bot (sw -- sw) (swBefore -- fine)
 				flatside.ru right bot top ada adb
-				Arch.lhs top (sw -- sw) (blendPost -- {})
-				g4   left (top - rise) [widths.lhs sw]
+				if rise
+					list
+						Arch.lhs top (sw -- sw) (blendPost -- {})
+						g4   left (top - rise) [widths.lhs sw]
+					list
+						arcvh
+						flat [Arch.adjust-x.top [mix left right 0.5] (sw -- sw)] top
+						curl (left + TINY) top [heading Leftward]
 
 		export : define flex-params [earlessRounded] : begin
 			local-parameter : top               -- XH

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -939,16 +939,24 @@ selectorAffix.G = "toothed"
 selectorAffix."G/sansSerif" = "toothed"
 selectorAffix.GHookTop = "toothed"
 
-[prime.capital-g.variants-buildup.stages.body.toothless-corner]
+[prime.capital-g.variants-buildup.stages.body.flat-bottom]
 rank = 2
-descriptionAffix = "tootheless (corner) body"
+nonBreakingVariantAdditionPriority = 100
+descriptionAffix = "flat bottom"
+selectorAffix.G = "flatBottom"
+selectorAffix."G/sansSerif" = "flatBottom"
+selectorAffix.GHookTop = "flatBottom"
+
+[prime.capital-g.variants-buildup.stages.body.toothless-corner]
+rank = 3
+descriptionAffix = "toothless (corner) body"
 selectorAffix.G = "toothlessCorner"
 selectorAffix."G/sansSerif" = "toothlessCorner"
 selectorAffix.GHookTop = "toothlessCorner"
 
 [prime.capital-g.variants-buildup.stages.body.toothless-rounded]
-rank = 3
-descriptionAffix = "tootheless (rounded) body"
+rank = 4
+descriptionAffix = "toothless (rounded) body"
 selectorAffix.G = "toothlessRounded"
 selectorAffix."G/sansSerif" = "toothlessRounded"
 selectorAffix.GHookTop = "toothlessRounded"
@@ -1758,15 +1766,23 @@ selectorAffix.U = "tailed"
 selectorAffix."U/sansSerif" = "tailed"
 selectorAffix."AU/U" = "tailed"
 
-[prime.capital-u.variants-buildup.stages.body.toothless-corner]
+[prime.capital-u.variants-buildup.stages.body.flat-bottom]
 rank = 3
+nonBreakingVariantAdditionPriority = 100
+descriptionAffix = "flat bottom"
+selectorAffix.U = "flatBottom"
+selectorAffix."U/sansSerif" = "flatBottom"
+selectorAffix."AU/U" = "flatBottom"
+
+[prime.capital-u.variants-buildup.stages.body.toothless-corner]
+rank = 4
 descriptionAffix = "toothless (corner bottom-right) shape"
 selectorAffix.U = "toothlessCorner"
 selectorAffix."U/sansSerif" = "toothlessCorner"
 selectorAffix."AU/U" = "toothlessCorner"
 
 [prime.capital-u.variants-buildup.stages.body.toothless-rounded]
-rank = 4
+rank = 5
 descriptionAffix = "toothless (rounded) shape"
 selectorAffix.U = "toothlessRounded"
 selectorAffix."U/sansSerif" = "toothlessRounded"
@@ -1782,7 +1798,7 @@ selectorAffix."AU/U" = "serifless"
 
 [prime.capital-u.variants-buildup.stages.serifs.bottom-right-serifed]
 rank = 2
-disableIf = [{ body = "NOT toothed" }]
+enableIf = [{ body = "toothed" }, { body = "flat-bottom" }]
 descriptionAffix = "serif at bottom-right"
 selectorAffix.U = "bottomRightSerifed"
 selectorAffix."U/sansSerif" = "serifless"
@@ -1790,15 +1806,15 @@ selectorAffix."AU/U" = "bottomRightSerifed"
 
 [prime.capital-u.variants-buildup.stages.serifs.motion-serifed]
 rank = 3
-disableIf = [{ body = "toothless-corner" }, { body = "toothless-rounded" }]
+enableIf = [{ body = "toothed" }, { body = "flat-bottom" }, { body = "tailed" }]
 descriptionAffix = "motion serifs at top-left and bottom-right"
 selectorAffix.U = "unilateralMotionSerifed"
 selectorAffix."U/sansSerif" = "serifless"
-selectorAffix."AU/U" = { if = [{ body = "toothed" }], then = "bottomRightSerifed", else = "serifless" }
+selectorAffix."AU/U" = { if = [{ body = "tailed" }], then = "serifless", else = "bottomRightSerifed" }
 
 [prime.capital-u.variants-buildup.stages.serifs.unilateral-motion-serifed]
 rank = 4
-disableIf = [{ body = "toothed" }, { body = "tailed" }]
+enableIf = [{ body = "toothless-corner" }, { body = "toothless-rounded" }]
 descriptionAffix = "motion serifs at left side"
 selectorAffix.U = "unilateralMotionSerifed"
 selectorAffix."U/sansSerif" = "serifless"
@@ -1806,7 +1822,7 @@ selectorAffix."AU/U" = "serifless"
 
 [prime.capital-u.variants-buildup.stages.serifs.bilateral-motion-serifed]
 rank = 5
-disableIf = [{ body = "toothed" }, { body = "tailed" }]
+enableIf = [{ body = "toothless-corner" }, { body = "toothless-rounded" }]
 descriptionAffix = "motion serifs at both sides"
 selectorAffix.U = "bilateralMotionSerifed"
 selectorAffix."U/sansSerif" = "serifless"
@@ -2342,8 +2358,23 @@ selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "topCut"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "topCut"
 selectorAffix."ae/a" = ""
 
-[prime.a.variants-buildup.stages.ear.earless-corner]
+[prime.a.variants-buildup.stages.ear.flat-top]
 rank = 3
+nonBreakingVariantAdditionPriority = 200
+descriptionAffix = "flat top"
+selectorAffix.a = "flatTop"
+selectorAffix."a/sansSerif" = "flatTop"
+selectorAffix."aRetroflexHook" = "flatTop"
+selectorAffix."a/doubleStorey" = ""
+selectorAffix."aRetroflexHook/doubleStorey" = ""
+selectorAffix."a/singleStorey/autoSerifed/slab" = "flatTop"
+selectorAffix."a/singleStorey/autoSerifed/sans" = "flatTop"
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "flatTop"
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "flatTop"
+selectorAffix."ae/a" = ""
+
+[prime.a.variants-buildup.stages.ear.earless-corner]
+rank = 4
 descriptionAffix = "earless (cornered top-right)"
 selectorAffix.a = "earlessCorner"
 selectorAffix."a/sansSerif" = "earlessCorner"
@@ -2357,7 +2388,7 @@ selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "earlessCorner"
 selectorAffix."ae/a" = ""
 
 [prime.a.variants-buildup.stages.ear.earless-rounded]
-rank = 4
+rank = 5
 descriptionAffix = "earless (rounded top-right)"
 selectorAffix.a = "earlessRounded"
 selectorAffix."a/sansSerif" = "earlessRounded"
@@ -2401,7 +2432,7 @@ selectorAffix."ae/a" = "toothlessRounded"
 
 [prime.a.variants-buildup.stages.bar.double-serifed]
 rank = 3
-disableIf = [{ storey = "double-storey" }, { ear = "NOT eared" }]
+enableIf = [{ ear = "eared"}, { ear = "flat-top" }]
 descriptionAffix = "serifs at top and bottom"
 selectorAffix.a = "doubleSerifed"
 selectorAffix."a/sansSerif" = "serifless"
@@ -2430,7 +2461,7 @@ selectorAffix."ae/a" = "toothlessRounded"
 
 [prime.a.variants-buildup.stages.bar.tailed-serifed]
 rank = 5
-disableIf = [{ storey = "double-storey" }, { ear = "NOT eared" }]
+enableIf = [{ ear = "eared"}, { ear = "flat-top" }]
 descriptionAffix = "curly tail; with serifs at top and bottom"
 selectorAffix.a = "tailedSerifed"
 selectorAffix."a/sansSerif" = "tailed"
@@ -2446,7 +2477,7 @@ selectorAffix."ae/a" = "toothlessRounded"
 [prime.a.variants-buildup.stages.bar.flat-bottom-serifless]
 rank = 6
 nonBreakingVariantAdditionPriority = 100
-disableIf = [{ storey = "single-storey" }]
+enableIf = [{ storey = "double-storey" }]
 descriptionAffix = "flat bottom; without serif at terminal"
 selectorAffix.a = "flatBottomSerifless"
 selectorAffix."a/sansSerif" = "flatBottomSerifless"
@@ -2462,7 +2493,7 @@ selectorAffix."ae/a" = "toothlessRounded"
 [prime.a.variants-buildup.stages.bar.flat-bottom-serifed]
 rank = 7
 nonBreakingVariantAdditionPriority = 100
-disableIf = [{ storey = "single-storey" }]
+enableIf = [{ storey = "double-storey" }]
 descriptionAffix = "flat bottom; with serif at terminal"
 selectorAffix.a = "flatBottomSerifed"
 selectorAffix."a/sansSerif" = "flatBottomSerifless"
@@ -2477,7 +2508,7 @@ selectorAffix."ae/a" = "toothlessRounded"
 
 [prime.a.variants-buildup.stages.bar.toothless-corner]
 rank = 8
-disableIf = [{ storey = "single-storey" }]
+enableIf = [{ storey = "double-storey" }]
 descriptionAffix = "toothless (cornered bottom-right)"
 selectorAffix.a = "toothlessCorner"
 selectorAffix."a/sansSerif" = "toothlessCorner"
@@ -2492,7 +2523,7 @@ selectorAffix."ae/a" = "toothlessRounded"
 
 [prime.a.variants-buildup.stages.bar.toothless-rounded]
 rank = 9
-disableIf = [{ storey = "single-storey" }]
+enableIf = [{ storey = "double-storey" }]
 descriptionAffix = "toothless (rounded bottom-right)"
 selectorAffix.a = "toothlessRounded"
 selectorAffix."a/sansSerif" = "toothlessRounded"
@@ -2532,15 +2563,23 @@ selectorAffix.b = "bottomCut"
 selectorAffix."b/sansSerif" = "bottomCut"
 selectorAffix.bHookTop = "bottomCut"
 
-[prime.b.variants-buildup.stages.body.toothless-corner]
+[prime.b.variants-buildup.stages.body.flat-bottom]
 rank = 3
+nonBreakingVariantAdditionPriority = 100
+descriptionAffix = "flat bottom"
+selectorAffix.b = "flatBottom"
+selectorAffix."b/sansSerif" = "flatBottom"
+selectorAffix.bHookTop = "flatBottom"
+
+[prime.b.variants-buildup.stages.body.toothless-corner]
+rank = 4
 descriptionAffix = "toothless (cornered) shape"
 selectorAffix.b = "toothlessCorner"
 selectorAffix."b/sansSerif" = "toothlessCorner"
 selectorAffix.bHookTop = "toothlessCorner"
 
 [prime.b.variants-buildup.stages.body.toothless-rounded]
-rank = 4
+rank = 5
 descriptionAffix = "toothless (rounded) shape"
 selectorAffix.b = "toothlessRounded"
 selectorAffix."b/sansSerif" = "toothlessRounded"
@@ -2556,7 +2595,7 @@ selectorAffix.bHookTop = "serifless"
 
 [prime.b.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
-enableIf = [{ body = "toothed" }]
+enableIf = [{ body = "toothed" }, { body = "flat-bottom" }]
 descriptionAffix = "motion serifs"
 selectorAffix.b = "motionSerifed"
 selectorAffix."b/sansSerif" = "serifless"
@@ -2564,7 +2603,7 @@ selectorAffix.bHookTop = "serifless"
 
 [prime.b.variants-buildup.stages.serifs.serifed__toothed]
 rank = 3
-enableIf = [{ body = "toothed" }]
+enableIf = [{ body = "toothed" }, { body = "flat-bottom" }]
 keyAffix = "serifed"
 descriptionAffix = "serifs"
 selectorAffix.b = "serifed"
@@ -2573,7 +2612,7 @@ selectorAffix.bHookTop = "bottomSerifed"
 
 [prime.b.variants-buildup.stages.serifs.serifed__toothless]
 rank = 3
-enableIf = [{ body = "NOT toothed" }]
+enableIf = [{ body = "toothless-corner" }, { body = "toothless-rounded" }, { body = "bottom-cut" }]
 keyAffix = "serifed"
 descriptionAffix = "serifs"
 selectorAffix.b = "motionSerifed"
@@ -2690,8 +2729,22 @@ selectorAffix.dHookTop = "tailed"
 selectorAffix."dHookTop/rTailBase" = "toothed"
 selectorAffix."cyrl/djeKomi" = "toothlessRounded"
 
-[prime.d.variants-buildup.stages.body.toothless-corner]
+[prime.d.variants-buildup.stages.body.flat-bottom]
 rank = 3
+nonBreakingVariantAdditionPriority = 100
+descriptionAffix = "flat bottom"
+selectorAffix.d = "flatBottom"
+selectorAffix."d/sansSerif" = "flatBottom"
+selectorAffix."d/phoneticLeft" = "toothed"
+selectorAffix."d/descBase" = "toothed"
+selectorAffix."d/rTailBase" = "flatBottom"
+selectorAffix.dCurlyTail = "toothed"
+selectorAffix.dHookTop = "flatBottom"
+selectorAffix."dHookTop/rTailBase" = "flatBottom"
+selectorAffix."cyrl/djeKomi" = "toothlessRounded"
+
+[prime.d.variants-buildup.stages.body.toothless-corner]
+rank = 4
 descriptionAffix = "toothless (cornered) shape"
 selectorAffix.d = "toothlessCorner"
 selectorAffix."d/sansSerif" = "toothlessCorner"
@@ -2704,7 +2757,7 @@ selectorAffix."dHookTop/rTailBase" = "toothlessCornerRTB"
 selectorAffix."cyrl/djeKomi" = "toothlessRounded"
 
 [prime.d.variants-buildup.stages.body.toothless-rounded]
-rank = 4
+rank = 5
 descriptionAffix = "toothless (rounded) shape"
 selectorAffix.d = "toothlessRounded"
 selectorAffix."d/sansSerif" = "toothlessRounded"
@@ -2732,7 +2785,7 @@ selectorAffix."cyrl/djeKomi" = "serifless"
 
 [prime.d.variants-buildup.stages.serifs.top-serifed]
 rank = 2
-enableIf = [{ body = "toothed" }]
+enableIf = [{ body = "toothed" }, { body = "flat-bottom" }]
 descriptionAffix = "serif at top"
 selectorAffix.d = "topSerifed"
 selectorAffix."d/sansSerif" = "serifless"
@@ -2746,7 +2799,7 @@ selectorAffix."cyrl/djeKomi" = "topSerifed"
 
 [prime.d.variants-buildup.stages.serifs.bottom-serifed]
 rank = 3
-enableIf = [{ body = "toothed" }]
+enableIf = [{ body = "toothed" }, { body = "flat-bottom" }]
 descriptionAffix = "serif at bottom"
 selectorAffix.d = "bottomSerifed"
 selectorAffix."d/sansSerif" = "serifless"
@@ -2760,7 +2813,7 @@ selectorAffix."cyrl/djeKomi" = "serifless"
 
 [prime.d.variants-buildup.stages.serifs.serifed__toothed]
 rank = 4
-enableIf = [{ body = "toothed" }]
+enableIf = [{ body = "toothed" }, { body = "flat-bottom" }]
 keyAffix = "serifed"
 descriptionAffix = "serifs"
 selectorAffix.d = "serifed"
@@ -2775,7 +2828,7 @@ selectorAffix."cyrl/djeKomi" = "topSerifed"
 
 [prime.d.variants-buildup.stages.serifs.serifed__toothless]
 rank = 4
-enableIf = [{ body = "NOT toothed" }]
+enableIf = [{ body = "toothless-corner" }, { body = "toothless-rounded" }, { body = "tailed" }]
 keyAffix = "serifed"
 descriptionAffix = "serifs"
 selectorAffix.d = "topSerifed"
@@ -3104,8 +3157,34 @@ selectorAffix."g/singleStorey/autoSerifed/sans" = "topCut"
 selectorAffix."g/singleStoreyBentHook/autoSerifed/slab" = "topCut"
 selectorAffix."g/singleStoreyBentHook/autoSerifed/sans" = "topCut"
 
-[prime.g.variants-buildup.stages.ear.earless-corner]
+[prime.g.variants-buildup.stages.ear.flat-top-serifless]
 rank = 4
+nonBreakingVariantAdditionPriority = 100
+descriptionAffix = "flat top"
+selectorAffix.g = "flatTopSerifless"
+selectorAffix."g/sansSerif" = "flatTopSerifless"
+selectorAffix."g/hookTopBase" = "flatTopSerifless"
+selectorAffix."g/doubleStorey" = ""
+selectorAffix."g/singleStorey/autoSerifed/slab" = "flatTopSerifless"
+selectorAffix."g/singleStorey/autoSerifed/sans" = "flatTopSerifless"
+selectorAffix."g/singleStoreyBentHook/autoSerifed/slab" = "flatTopSerifless"
+selectorAffix."g/singleStoreyBentHook/autoSerifed/sans" = "flatTopSerifless"
+
+[prime.g.variants-buildup.stages.ear.flat-top-serifed]
+rank = 5
+nonBreakingVariantAdditionPriority = 100
+descriptionAffix = "flat top; with top-right serif"
+selectorAffix.g = "flatTopSerifed"
+selectorAffix."g/sansSerif" = "flatTopSerifless"
+selectorAffix."g/hookTopBase" = "flatTopSerifless"
+selectorAffix."g/doubleStorey" = ""
+selectorAffix."g/singleStorey/autoSerifed/slab" = "flatTopSerifed"
+selectorAffix."g/singleStorey/autoSerifed/sans" = "flatTopSerifed"
+selectorAffix."g/singleStoreyBentHook/autoSerifed/slab" = "flatTopSerifed"
+selectorAffix."g/singleStoreyBentHook/autoSerifed/sans" = "flatTopSerifed"
+
+[prime.g.variants-buildup.stages.ear.earless-corner]
+rank = 6
 descriptionAffix = "earless (cornered top-right)"
 selectorAffix.g = "earlessCorner"
 selectorAffix."g/sansSerif" = "earlessCorner"
@@ -3117,7 +3196,7 @@ selectorAffix."g/singleStoreyBentHook/autoSerifed/slab" = "earlessCorner"
 selectorAffix."g/singleStoreyBentHook/autoSerifed/sans" = "earlessCorner"
 
 [prime.g.variants-buildup.stages.ear.earless-rounded]
-rank = 5
+rank = 7
 descriptionAffix = "earless (rounded top-right)"
 selectorAffix.g = "earlessRounded"
 selectorAffix."g/sansSerif" = "earlessRounded"
@@ -3806,9 +3885,24 @@ selectorAffix."cyrl/tje.italic/base/corner" =  ""
 selectorAffix."cyrl/tje.italic/base/cursive" =  ""
 selectorAffix.meng = ""
 
-[prime.m.variants-buildup.stages.body.earless-corner-double-arch]
+[prime.m.variants-buildup.stages.body.flat-top]
 rank = 2
 groupRank = 20
+nonBreakingVariantAdditionPriority = 100
+descriptionAffix = "flat top"
+selectorAffix.m = "flatTop"
+selectorAffix."m/sansSerif" = "flatTop"
+selectorAffix."m/descBase" = "flatTop"
+selectorAffix."cyrl/te.italic" = ""
+selectorAffix."cyrl/este/te.italic" = ""
+selectorAffix."cyrl/tjeKomi.italic" = ""
+selectorAffix."cyrl/tje.italic/base/corner" =  ""
+selectorAffix."cyrl/tje.italic/base/cursive" =  ""
+selectorAffix.meng = "flatTop"
+
+[prime.m.variants-buildup.stages.body.earless-corner-double-arch]
+rank = 3
+groupRank = 30
 descriptionAffix = "earless (corner top-left) double-arch body shape"
 selectorAffix.m = "earlessCornerDoubleArch"
 selectorAffix."m/sansSerif" = "earlessCornerDoubleArch"
@@ -3821,8 +3915,8 @@ selectorAffix."cyrl/tje.italic/base/cursive" =  ""
 selectorAffix.meng = "earlessCornerDoubleArch"
 
 [prime.m.variants-buildup.stages.body.earless-rounded-double-arch]
-rank = 3
-groupRank = 30
+rank = 4
+groupRank = 40
 descriptionAffix = "earless (rounded top-left) double-arch body shape"
 selectorAffix.m = "earlessRoundedDoubleArch"
 selectorAffix."m/sansSerif" = "earlessRoundedDoubleArch"
@@ -3835,9 +3929,9 @@ selectorAffix."cyrl/tje.italic/base/cursive" =  ""
 selectorAffix.meng = "earlessRoundedDoubleArch"
 
 [prime.m.variants-buildup.stages.body.earless-single-arch]
-rank = 4
-groupRank = 40
-descriptionAffix = "earless (corner top-left) body shape"
+rank = 5
+groupRank = 50
+descriptionAffix = "earless (corner top-left) single-arch body shape"
 selectorAffix.m = "earlessSingleArch"
 selectorAffix."m/sansSerif" = "earlessSingleArch"
 selectorAffix."m/descBase" = "earlessSingleArch"
@@ -3869,7 +3963,7 @@ selectorAffix.meng = ""
 
 [prime.m.variants-buildup.stages.leg.short-leg]
 rank = 2
-groupRank = { if = [{ body = "eared" }], then = 2, else = 1 }
+groupRank = { if = [{ body = "eared" }, { body = "flat-top" }], then = 2, else = 1 }
 descriptionAffix = "shorter middle leg (like Ubuntu Mono)"
 selectorAffix.m = "shortLeg"
 selectorAffix."m/sansSerif" = "shortLeg"
@@ -3931,7 +4025,7 @@ selectorAffix.meng = "serifless"
 [prime.m.variants-buildup.stages.serifs.top-left-serifed]
 rank = 2
 descriptionAffix = "serif at top left"
-disableIf = [{ body = "NOT eared" }]
+enableIf = [{ body = "eared"}, { body = "flat-top" }]
 selectorAffix.m = "topLeftSerifed"
 selectorAffix."m/sansSerif" = "serifless"
 selectorAffix."m/descBase" = "topLeftSerifed"
@@ -3946,7 +4040,7 @@ selectorAffix.meng = "topLeftSerifed"
 [prime.m.variants-buildup.stages.serifs.top-left-and-bottom-right-serifed]
 rank = 3
 descriptionAffix = "serifs at top left and bottom right"
-disableIf = [{ body = "NOT eared" }, { tail = "tailed" }]
+enableIf = [{ body = "eared", tail = "NOT tailed"}, { body = "flat-top", tail = "NOT tailed" }]
 selectorAffix.m = "topLeftAndBottomRightSerifed"
 selectorAffix."m/sansSerif" = "serifless"
 selectorAffix."m/descBase" = "topLeftSerifed"
@@ -3961,7 +4055,7 @@ selectorAffix.meng = "topLeftSerifed"
 [prime.m.variants-buildup.stages.serifs.bottom-right-serifed]
 rank = 3
 descriptionAffix = "serifs at bottom right"
-disableIf = [{ body = "eared" }, { tail = "tailed" }]
+disableIf = [{ body = "eared" }, { body = "flat-top"}, { tail = "tailed" }]
 selectorAffix.m = "bottomRightSerifed"
 selectorAffix."m/sansSerif" = "serifless"
 selectorAffix."m/descBase" = "serifless"
@@ -4015,8 +4109,24 @@ selectorAffix."cyrl/pe.italic/descBase" = ""
 selectorAffix."cyrl/yat.italic/base/corner" =  ""
 selectorAffix."cyrl/yat.italic/base/cursive" =  ""
 
-[prime.n.variants-buildup.stages.body.earless-corner]
+[prime.n.variants-buildup.stages.body.flat-top]
 rank = 2
+nonBreakingVariantAdditionPriority = 100
+descriptionAffix = "flat top"
+selectorAffix.n = "flatTop"
+selectorAffix."n/sansSerif" = "flatTop"
+selectorAffix."n/descBase" = "flatTop"
+selectorAffix.nHookLeft = "flatTop"
+selectorAffix.eng = "flatTop"
+selectorAffix."eng/phoneticRight" = "flatTop"
+selectorAffix.engHookLeft = "flatTop"
+selectorAffix."cyrl/pe.italic" = ""
+selectorAffix."cyrl/pe.italic/descBase" = ""
+selectorAffix."cyrl/yat.italic/base/corner" = ""
+selectorAffix."cyrl/yat.italic/base/cursive" = ""
+
+[prime.n.variants-buildup.stages.body.earless-corner]
+rank = 3
 descriptionAffix = "earless (corner top-left) body shape"
 selectorAffix.n = "earlessCorner"
 selectorAffix."n/sansSerif" = "earlessCorner"
@@ -4031,7 +4141,7 @@ selectorAffix."cyrl/yat.italic/base/corner" = ""
 selectorAffix."cyrl/yat.italic/base/cursive" = ""
 
 [prime.n.variants-buildup.stages.body.earless-rounded]
-rank = 3
+rank = 4
 descriptionAffix = "earless (rounded top-left) body shape"
 selectorAffix.n = "earlessRounded"
 selectorAffix."n/sansSerif" = "earlessRounded"
@@ -4097,7 +4207,7 @@ selectorAffix."cyrl/yat.italic/base/cursive" = "serifless"
 [prime.n.variants-buildup.stages.serifs.top-left-serifed]
 rank = 2
 descriptionAffix = "serif at top left"
-enableIf = [{ body = "eared", terminal = "NOT tailed" }]
+enableIf = [{ body = "eared", terminal = "NOT tailed" }, { body = "flat-top", terminal = "NOT tailed" }]
 selectorAffix.n = "topLeftSerifed"
 selectorAffix."n/sansSerif" = "serifless"
 selectorAffix."n/descBase" = "topLeftSerifed"
@@ -4113,14 +4223,14 @@ selectorAffix."cyrl/yat.italic/base/cursive" = "topLeftSerifed"
 [prime.n.variants-buildup.stages.serifs.motion-serifed]
 rank = 3
 descriptionAffix = "serif at top left and bottom right"
-disableIf = [{ body = "NOT eared", terminal = "tailed" }]
+disableIf = [{ body = "earless-corner", terminal = "tailed" }, { body = "earless-rounded", terminal = "tailed" }]
 selectorAffix.n = "motionSerifed"
 selectorAffix."n/sansSerif" = "serifless"
-selectorAffix."n/descBase" = { if = [{ body = "eared" }], then = "topLeftSerifed", else = "serifless" }
-selectorAffix.nHookLeft = { if = [{ terminal = "straight" }], then = "motionSerifed", else = { if = [{ body = "eared" }], then = "topLeftSerifed", else = "serifless" } }
-selectorAffix.eng = { if = [{ body = "eared" }], then = "topLeftSerifed", else = "serifless" }
+selectorAffix."n/descBase" = { if = [{ body = "eared" }, { body = "flat-top" }], then = "topLeftSerifed", else = "serifless" }
+selectorAffix.nHookLeft = { if = [{ terminal = "straight" }], then = "motionSerifed", else = { if = [{ body = "eared" }, { body = "flat-top" }], then = "topLeftSerifed", else = "serifless" } }
+selectorAffix.eng = { if = [{ body = "eared" }, { body = "flat-top" }], then = "topLeftSerifed", else = "serifless" }
 selectorAffix."eng/phoneticRight" = "topLeftSerifed"
-selectorAffix.engHookLeft = { if = [{ body = "eared" }], then = "topLeftSerifed", else = "serifless" }
+selectorAffix.engHookLeft = { if = [{ body = "eared" }, { body = "flat-top" }], then = "topLeftSerifed", else = "serifless" }
 selectorAffix."cyrl/pe.italic" = "motionSerifed"
 selectorAffix."cyrl/pe.italic/descBase" = "topLeftSerifed"
 selectorAffix."cyrl/yat.italic/base/corner" = "topLeftSerifed"
@@ -4132,10 +4242,10 @@ descriptionAffix = "serifs"
 selectorAffix.n = "serifed"
 selectorAffix."n/sansSerif" = "serifless"
 selectorAffix."n/descBase" = "serifed"
-selectorAffix.nHookLeft = { if = [{ terminal = "straight" }], then = "serifed", else = { if = [{ body = "eared" }], then = "topLeftSerifed", else = "serifless" } }
+selectorAffix.nHookLeft = { if = [{ terminal = "straight" }], then = "serifed", else = { if = [{ body = "eared" }, { body = "flat-top" }], then = "topLeftSerifed", else = "serifless" } }
 selectorAffix.eng = "serifed"
 selectorAffix."eng/phoneticRight" = "serifed"
-selectorAffix.engHookLeft = { if = [{ body = "eared" }], then = "topLeftSerifed", else = "serifless" }
+selectorAffix.engHookLeft = { if = [{ body = "eared" }, { body = "flat-top" }], then = "topLeftSerifed", else = "serifless" }
 selectorAffix."cyrl/pe.italic" = "serifed"
 selectorAffix."cyrl/pe.italic/descBase" = "serifed"
 selectorAffix."cyrl/yat.italic/base/corner" = "serifedItalicYatCorner"
@@ -4161,15 +4271,23 @@ selectorAffix.p = "eared"
 selectorAffix."p/sansSerif" = "eared"
 selectorAffix."p/hookTopBase" = "eared"
 
-[prime.p.variants-buildup.stages.body.earless-corner]
+[prime.p.variants-buildup.stages.body.flat-top]
 rank = 2
+nonBreakingVariantAdditionPriority = 100
+descriptionAffix = "flat top"
+selectorAffix.p = "flatTop"
+selectorAffix."p/sansSerif" = "flatTop"
+selectorAffix."p/hookTopBase" = "flatTop"
+
+[prime.p.variants-buildup.stages.body.earless-corner]
+rank = 3
 descriptionAffix = "earless (cornered) shape"
 selectorAffix.p = "earlessCorner"
 selectorAffix."p/sansSerif" = "earlessCorner"
 selectorAffix."p/hookTopBase" = "earlessCorner"
 
 [prime.p.variants-buildup.stages.body.earless-rounded]
-rank = 3
+rank = 4
 descriptionAffix = "earless (rounded) shape"
 selectorAffix.p = "earlessRounded"
 selectorAffix."p/sansSerif" = "earlessRounded"
@@ -4185,7 +4303,7 @@ selectorAffix."p/hookTopBase" = "serifless"
 
 [prime.p.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
-enableIf = [{ body = "eared" }]
+enableIf = [{ body = "eared" }, { body = "flat-top" }]
 descriptionAffix = "motion serifs"
 selectorAffix.p = "motionSerifed"
 selectorAffix."p/sansSerif" = "serifless"
@@ -4193,7 +4311,7 @@ selectorAffix."p/hookTopBase" = "serifless"
 
 [prime.p.variants-buildup.stages.serifs.serifed__eared]
 rank = 3
-enableIf = [{ body = "eared" }]
+enableIf = [{ body = "eared" }, { body = "flat-top" }]
 keyAffix = "serifed"
 descriptionAffix = "serifs"
 selectorAffix.p = "serifed"
@@ -4202,7 +4320,7 @@ selectorAffix."p/hookTopBase" = "bottomSerifed"
 
 [prime.p.variants-buildup.stages.serifs.serifed__earless]
 rank = 3
-enableIf = [{ body = "NOT eared" }]
+enableIf = [{ body = "earless-corner"}, { body = "earless-rounded" }]
 keyAffix = "serifed"
 descriptionAffix = "serifs"
 selectorAffix.p = "bottomSerifed"
@@ -4240,8 +4358,18 @@ selectorAffix."q/hookTopBase" = ""
 selectorAffix.qRTail = "topCut"
 selectorAffix.gha = ""
 
-[prime.q.variants-buildup.stages.body.earless-corner]
+[prime.q.variants-buildup.stages.body.flat-top]
 rank = 3
+nonBreakingVariantAdditionPriority = 200
+descriptionAffix = "flat top"
+selectorAffix.q = "flatTop"
+selectorAffix."q/sansSerif" = "flatTop"
+selectorAffix."q/hookTopBase" = "flatTop"
+selectorAffix.qRTail = "flatTop"
+selectorAffix.gha = ""
+
+[prime.q.variants-buildup.stages.body.earless-corner]
+rank = 4
 descriptionAffix = "earless (cornered) shape"
 selectorAffix.q = "earlessCorner"
 selectorAffix."q/sansSerif" = "earlessCorner"
@@ -4250,7 +4378,7 @@ selectorAffix.qRTail = "earlessCorner"
 selectorAffix.gha = ""
 
 [prime.q.variants-buildup.stages.body.earless-rounded]
-rank = 4
+rank = 5
 descriptionAffix = "earless (rounded) shape"
 selectorAffix.q = "earlessRounded"
 selectorAffix."q/sansSerif" = "earlessRounded"
@@ -4300,7 +4428,7 @@ selectorAffix.gha = "serifless"
 
 [prime.q.variants-buildup.stages.serifs.bottom-serifed]
 rank = 2
-enableIf = [{ body = "eared", terminal = "straight" }]
+enableIf = [{ body = "eared", terminal = "straight" }, { body = "flat-top", terminal = "straight" }]
 descriptionAffix = "serif at bottom"
 selectorAffix.q = "bottomSerifed"
 selectorAffix."q/sansSerif" = "serifless"
@@ -4310,7 +4438,7 @@ selectorAffix.gha = "bottomSerifed"
 
 [prime.q.variants-buildup.stages.serifs.motion-serifed__eared]
 rank = 3
-enableIf = [{ body = "eared" }]
+enableIf = [{ body = "eared" }, { body = "flat-top" }]
 keyAffix = "motion-serifed"
 descriptionAffix = "motion serifs (top-right)"
 selectorAffix.q = "motionSerifed"
@@ -4322,7 +4450,7 @@ selectorAffix.gha = "serifless"
 [prime.q.variants-buildup.stages.serifs.motion-serifed__earless]
 rank = 3
 nonBreakingVariantAdditionPriority = 100
-enableIf = [{ body = "NOT eared", terminal = "straight" }]
+disableIf = [{ body = "eared"}, { body = "flat-top" }, { terminal = "NOT straight" }]
 keyAffix = "motion-serifed"
 descriptionAffix = "motion serifs at terminal (bottom-right)"
 selectorAffix.q = "motionBottomSerifed"
@@ -4334,7 +4462,7 @@ selectorAffix.gha = "motionBottomSerifed"
 [prime.q.variants-buildup.stages.serifs.motion-bottom-serifed]
 rank = 4
 nonBreakingVariantAdditionPriority = 100
-enableIf = [{ body = "eared", terminal = "straight" }]
+enableIf = [{ body = "eared", terminal = "straight" }, { body = "flat-top", terminal = "straight" }]
 descriptionAffix = "motion serifs at terminal (bottom-right)"
 selectorAffix.q = "motionBottomSerifed"
 selectorAffix."q/sansSerif" = "serifless"
@@ -4344,7 +4472,7 @@ selectorAffix.gha = "motionBottomSerifed"
 
 [prime.q.variants-buildup.stages.serifs.serifed__eared]
 rank = 5
-enableIf = [{ body = "eared", terminal = "straight" }]
+enableIf = [{ body = "eared", terminal = "straight" }, { body = "flat-top", terminal = "straight" }]
 keyAffix = "serifed"
 descriptionAffix = "serifs"
 selectorAffix.q = "serifed"
@@ -4355,7 +4483,7 @@ selectorAffix.gha = "bottomSerifed"
 
 [prime.q.variants-buildup.stages.serifs.serifed__earless]
 rank = 5
-enableIf = [{ body = "NOT eared", terminal = "straight" }]
+disableIf = [{ body = "eared"}, { body = "flat-top" }, { terminal = "NOT straight" }]
 keyAffix = "serifed"
 descriptionAffix = "serifs"
 selectorAffix.q = "bottomSerifed"
@@ -4387,9 +4515,20 @@ selectorAffix.rRTail = ""
 selectorAffix."r/ascBase" = ""
 selectorAffix."rFlap" = "earlessRounded"
 
-[prime.r.variants-buildup.stages.body.earless-corner]
+[prime.r.variants-buildup.stages.body.flat-top]
 rank = 2
 groupRank = 2
+nonBreakingVariantAdditionPriority = 200
+descriptionAffix = "flat top"
+selectorAffix.r = "flatTop"
+selectorAffix."r/sansSerif" = "flatTop"
+selectorAffix.rRTail = "flatTop"
+selectorAffix."r/ascBase" = ""
+selectorAffix."rFlap" = "earlessRounded"
+
+[prime.r.variants-buildup.stages.body.earless-corner]
+rank = 3
+groupRank = 3
 descriptionAffix = "earless (corner top-left) body shape"
 selectorAffix.r = "earlessCorner"
 selectorAffix."r/sansSerif" = "earlessCorner"
@@ -4398,8 +4537,8 @@ selectorAffix."r/ascBase" = ""
 selectorAffix."rFlap" = "earlessRounded"
 
 [prime.r.variants-buildup.stages.body.earless-rounded]
-rank = 3
-groupRank = 2
+rank = 4
+groupRank = 4
 descriptionAffix = "earless (rounded top-left) body shape"
 selectorAffix.r = "earlessRounded"
 selectorAffix."r/sansSerif" = "earlessRounded"
@@ -4408,7 +4547,7 @@ selectorAffix."r/ascBase" = ""
 selectorAffix."rFlap" = "earlessRounded"
 
 [prime.r.variants-buildup.stages.body.hookless]
-rank = 4
+rank = 5
 descriptionAffix = "hookless body shape"
 selectorAffix.r = "hookless"
 selectorAffix."r/sansSerif" = "hookless"
@@ -4417,7 +4556,7 @@ selectorAffix."r/ascBase" = "hookless"
 selectorAffix."rFlap" = "hooklessFlap"
 
 [prime.r.variants-buildup.stages.body.corner-hooked]
-rank = 5
+rank = 6
 descriptionAffix = "corner-hooked body shape"
 selectorAffix.r = "cornerHooked"
 selectorAffix."r/sansSerif" = "hookless"
@@ -4426,7 +4565,7 @@ selectorAffix."r/ascBase" = "cornerHooked"
 selectorAffix."rFlap" = "hooklessFlap"
 
 [prime.r.variants-buildup.stages.body.compact]
-rank = 6
+rank = 7
 descriptionAffix = "compact body shape (identical to 'hookless' for monospace fonts)"
 selectorAffix.r = "compact"
 selectorAffix."r/sansSerif" = "compact"
@@ -4435,7 +4574,7 @@ selectorAffix."r/ascBase" = "compact"
 selectorAffix."rFlap" = "compactFlap"
 
 [prime.r.variants-buildup.stages.body.narrow-hook]
-rank = 7
+rank = 8
 nonBreakingVariantAdditionPriority = 100
 descriptionAffix = "narrow hook body shape"
 selectorAffix.r = "narrowHook"
@@ -4716,14 +4855,14 @@ selectorAffix.u = "toothed"
 selectorAffix."u/sansSerif" = "toothed"
 selectorAffix."u/descBase" = "descBase"
 selectorAffix.uShortLeg = "toothed"
+selectorAffix.uLongLeg = "toothed"
 selectorAffix.uHookLeft = "toothed"
-selectorAffix.turnh = "toothed"
-selectorAffix.turnhHookLeft = "toothed"
-selectorAffix.turnhHookLeftRTail = "toothed"
-selectorAffix."turnm/full" = "toothed"
-selectorAffix."turnm/reduced" = "toothed"
-selectorAffix."turnmLeg/full" = "toothed"
-selectorAffix."turnmLeg/reduced" = "toothed"
+selectorAffix.uHookLeftLongLeg = "toothed"
+selectorAffix.uHookLeftLongLegRTail = "toothed"
+selectorAffix."uu/full" = "toothed"
+selectorAffix."uu/reduced" = "toothed"
+selectorAffix."uuLongLeg/full" = "toothed"
+selectorAffix."uuLongLeg/reduced" = "toothed"
 selectorAffix."cyrl/i.italic" = "toothed"
 selectorAffix."cyrl/i.italic/descBase" = "descBase"
 selectorAffix."cyrl/sha.italic/full" = "toothed"
@@ -4743,14 +4882,14 @@ selectorAffix.u = "tailed"
 selectorAffix."u/sansSerif" = "tailed"
 selectorAffix."u/descBase" = "descBase"
 selectorAffix.uShortLeg = "tailed"
+selectorAffix.uLongLeg = "toothed"
 selectorAffix.uHookLeft = "tailed"
-selectorAffix.turnh = "toothed"
-selectorAffix.turnhHookLeft = "toothed"
-selectorAffix.turnhHookLeftRTail = "toothed"
-selectorAffix."turnm/full" = "tailed"
-selectorAffix."turnm/reduced" = "tailed"
-selectorAffix."turnmLeg/full" = "toothed"
-selectorAffix."turnmLeg/reduced" = "toothed"
+selectorAffix.uHookLeftLongLeg = "toothed"
+selectorAffix.uHookLeftLongLegRTail = "toothed"
+selectorAffix."uu/full" = "tailed"
+selectorAffix."uu/reduced" = "tailed"
+selectorAffix."uuLongLeg/full" = "toothed"
+selectorAffix."uuLongLeg/reduced" = "toothed"
 selectorAffix."cyrl/i.italic" = "tailed"
 selectorAffix."cyrl/i.italic/descBase" = "descBase"
 selectorAffix."cyrl/sha.italic/full" = "tailed"
@@ -4763,21 +4902,49 @@ selectorAffix."cyrl/revtse.italic" = "tailed"
 selectorAffix."ue/u" = "toothlessRounded"
 selectorAffix."au/u" = "tailed"
 
-[prime.u.variants-buildup.stages.body.toothless-corner]
+[prime.u.variants-buildup.stages.body.flat-bottom]
 rank = 3
+nonBreakingVariantAdditionPriority = 100
+descriptionAffix = "toothless (corner bottom-right) shape"
+selectorAffix.u = "flatBottom"
+selectorAffix."u/sansSerif" = "flatBottom"
+selectorAffix."u/descBase" = "descBase"
+selectorAffix.uShortLeg = "flatBottom"
+selectorAffix.uLongLeg = "flatBottom"
+selectorAffix.uHookLeft = "flatBottom"
+selectorAffix.uHookLeftLongLeg = "flatBottom"
+selectorAffix.uHookLeftLongLegRTail = "flatBottom"
+selectorAffix."uu/full" = "flatBottom"
+selectorAffix."uu/reduced" = "flatBottom"
+selectorAffix."uuLongLeg/full" = "flatBottom"
+selectorAffix."uuLongLeg/reduced" = "flatBottom"
+selectorAffix."cyrl/i.italic" = "toothed"
+selectorAffix."cyrl/i.italic/descBase" = "descBase"
+selectorAffix."cyrl/sha.italic/full" = "toothed"
+selectorAffix."cyrl/sha.italic/reduced" = "toothed"
+selectorAffix."cyrl/shcha.italic/full" = "toothed"
+selectorAffix."cyrl/shcha.italic/reduced" = "toothed"
+selectorAffix."cyrl/dzhe.italic" = "toothed"
+selectorAffix."cyrl/tse.italic" = "toothed"
+selectorAffix."cyrl/revtse.italic" = "toothed"
+selectorAffix."ue/u" = "toothlessRounded"
+selectorAffix."au/u" = "flatBottom"
+
+[prime.u.variants-buildup.stages.body.toothless-corner]
+rank = 4
 descriptionAffix = "toothless (corner bottom-right) shape"
 selectorAffix.u = "toothlessCorner"
 selectorAffix."u/sansSerif" = "toothlessCorner"
 selectorAffix."u/descBase" = "descBase"
 selectorAffix.uShortLeg = "toothlessCorner"
+selectorAffix.uLongLeg = "toothlessCorner"
 selectorAffix.uHookLeft = "toothlessCorner"
-selectorAffix.turnh = "toothlessCorner"
-selectorAffix.turnhHookLeft = "toothlessCorner"
-selectorAffix.turnhHookLeftRTail = "toothlessCorner"
-selectorAffix."turnm/full" = "toothlessCorner"
-selectorAffix."turnm/reduced" = "toothlessCorner"
-selectorAffix."turnmLeg/full" = "toothlessCorner"
-selectorAffix."turnmLeg/reduced" = "toothlessCorner"
+selectorAffix.uHookLeftLongLeg = "toothlessCorner"
+selectorAffix.uHookLeftLongLegRTail = "toothlessCorner"
+selectorAffix."uu/full" = "toothlessCorner"
+selectorAffix."uu/reduced" = "toothlessCorner"
+selectorAffix."uuLongLeg/full" = "toothlessCorner"
+selectorAffix."uuLongLeg/reduced" = "toothlessCorner"
 selectorAffix."cyrl/i.italic" = "toothed"
 selectorAffix."cyrl/i.italic/descBase" = "descBase"
 selectorAffix."cyrl/sha.italic/full" = "toothed"
@@ -4791,20 +4958,20 @@ selectorAffix."ue/u" = "toothlessRounded"
 selectorAffix."au/u" = "toothlessCorner"
 
 [prime.u.variants-buildup.stages.body.toothless-rounded]
-rank = 4
+rank = 5
 descriptionAffix = "toothless (rounded) shape"
 selectorAffix.u = "toothlessRounded"
 selectorAffix."u/sansSerif" = "toothlessRounded"
 selectorAffix."u/descBase" = "descBase"
 selectorAffix.uShortLeg = "toothlessRounded"
+selectorAffix.uLongLeg = "toothed"
 selectorAffix.uHookLeft = "toothlessRounded"
-selectorAffix.turnh = "toothed"
-selectorAffix.turnhHookLeft = "toothed"
-selectorAffix.turnhHookLeftRTail = "toothed"
-selectorAffix."turnm/full" = "toothlessRounded"
-selectorAffix."turnm/reduced" = "toothlessRounded"
-selectorAffix."turnmLeg/full" = "toothed"
-selectorAffix."turnmLeg/reduced" = "toothed"
+selectorAffix.uHookLeftLongLeg = "toothed"
+selectorAffix.uHookLeftLongLegRTail = "toothed"
+selectorAffix."uu/full" = "toothlessRounded"
+selectorAffix."uu/reduced" = "toothlessRounded"
+selectorAffix."uuLongLeg/full" = "toothed"
+selectorAffix."uuLongLeg/reduced" = "toothed"
 selectorAffix."cyrl/i.italic" = "toothed"
 selectorAffix."cyrl/i.italic/descBase" = "descBase"
 selectorAffix."cyrl/sha.italic/full" = "toothed"
@@ -4825,14 +4992,14 @@ selectorAffix.u = "serifless"
 selectorAffix."u/sansSerif" = "serifless"
 selectorAffix."u/descBase" = "serifless"
 selectorAffix.uShortLeg = "serifless"
+selectorAffix.uLongLeg = "serifless"
 selectorAffix.uHookLeft = "serifless"
-selectorAffix.turnh = "serifless"
-selectorAffix.turnhHookLeft = "serifless"
-selectorAffix.turnhHookLeftRTail = "serifless"
-selectorAffix."turnm/full" = "serifless"
-selectorAffix."turnm/reduced" = "serifless"
-selectorAffix."turnmLeg/full" = "serifless"
-selectorAffix."turnmLeg/reduced" = "serifless"
+selectorAffix.uHookLeftLongLeg = "serifless"
+selectorAffix.uHookLeftLongLegRTail = "serifless"
+selectorAffix."uu/full" = "serifless"
+selectorAffix."uu/reduced" = "serifless"
+selectorAffix."uuLongLeg/full" = "serifless"
+selectorAffix."uuLongLeg/reduced" = "serifless"
 selectorAffix."cyrl/i.italic" = "serifless"
 selectorAffix."cyrl/i.italic/descBase" = "serifless"
 selectorAffix."cyrl/sha.italic/full" = "serifless"
@@ -4847,20 +5014,20 @@ selectorAffix."au/u" = "serifless"
 
 [prime.u.variants-buildup.stages.serifs.bottom-right-serifed]
 rank = 2
-disableIf = [{ body = "NOT toothed" }]
+enableIf = [{ body = "toothed"}, { body = "flat-bottom" }]
 descriptionAffix = "serif at bottom-right"
 selectorAffix.u = "bottomRightSerifed"
 selectorAffix."u/sansSerif" = "serifless"
 selectorAffix."u/descBase" = "serifless"
 selectorAffix.uShortLeg = "bottomRightSerifed"
+selectorAffix.uLongLeg = "bottomRightSerifed"
 selectorAffix.uHookLeft = "bottomRightSerifed"
-selectorAffix.turnh = "bottomRightSerifed"
-selectorAffix.turnhHookLeft = "bottomRightSerifed"
-selectorAffix.turnhHookLeftRTail = "serifless"
-selectorAffix."turnm/full" = "bottomRightSerifed"
-selectorAffix."turnm/reduced" = "bottomRightSerifed"
-selectorAffix."turnmLeg/full" = "bottomRightSerifed"
-selectorAffix."turnmLeg/reduced" = "bottomRightSerifed"
+selectorAffix.uHookLeftLongLeg = "bottomRightSerifed"
+selectorAffix.uHookLeftLongLegRTail = "serifless"
+selectorAffix."uu/full" = "bottomRightSerifed"
+selectorAffix."uu/reduced" = "bottomRightSerifed"
+selectorAffix."uuLongLeg/full" = "bottomRightSerifed"
+selectorAffix."uuLongLeg/reduced" = "bottomRightSerifed"
 selectorAffix."cyrl/i.italic" = "bottomRightSerifed"
 selectorAffix."cyrl/i.italic/descBase" = "serifless"
 selectorAffix."cyrl/sha.italic/full" = "bottomRightSerifed"
@@ -4880,14 +5047,14 @@ selectorAffix.u = "motionSerifed"
 selectorAffix."u/sansSerif" = "serifless"
 selectorAffix."u/descBase" = "motionSerifed"
 selectorAffix.uShortLeg = "motionSerifed"
-selectorAffix.uHookLeft = { if = [{ body = "toothed" }], then = "bottomRightSerifed", else = "serifless" }
-selectorAffix.turnh = "motionSerifed"
-selectorAffix.turnhHookLeft = "bottomRightSerifed"
-selectorAffix.turnhHookLeftRTail = "serifless"
-selectorAffix."turnm/full" = "motionSerifed"
-selectorAffix."turnm/reduced" = "motionSerifed"
-selectorAffix."turnmLeg/full" = "motionSerifed"
-selectorAffix."turnmLeg/reduced" = "motionSerifed"
+selectorAffix.uLongLeg = "motionSerifed"
+selectorAffix.uHookLeft = { if = [{ body = "toothed" }, { body = "flat-bottom" }], then = "bottomRightSerifed", else = "serifless" }
+selectorAffix.uHookLeftLongLeg = "bottomRightSerifed"
+selectorAffix.uHookLeftLongLegRTail = "serifless"
+selectorAffix."uu/full" = "motionSerifed"
+selectorAffix."uu/reduced" = "motionSerifed"
+selectorAffix."uuLongLeg/full" = "motionSerifed"
+selectorAffix."uuLongLeg/reduced" = "motionSerifed"
 selectorAffix."cyrl/i.italic" = "motionSerifed"
 selectorAffix."cyrl/i.italic/descBase" = "motionSerifed"
 selectorAffix."cyrl/sha.italic/full" = "motionSerifed"
@@ -4898,7 +5065,7 @@ selectorAffix."cyrl/dzhe.italic" = "motionSerifed"
 selectorAffix."cyrl/tse.italic" = "motionSerifed"
 selectorAffix."cyrl/revtse.italic" = "motionSerifed"
 selectorAffix."ue/u" = "motionSerifed"
-selectorAffix."au/u" = { if = [{ body = "toothed" }], then = "bottomRightSerifed", else = "serifless" }
+selectorAffix."au/u" = { if = [{ body = "toothed" }, { body = "flat-bottom" }], then = "bottomRightSerifed", else = "serifless" }
 
 [prime.u.variants-buildup.stages.serifs.serifed]
 rank = 4
@@ -4907,14 +5074,14 @@ selectorAffix.u = "serifed"
 selectorAffix."u/sansSerif" = "serifless"
 selectorAffix."u/descBase" = "serifed"
 selectorAffix.uShortLeg = "motionSerifed"
+selectorAffix.uLongLeg = "serifed"
 selectorAffix.uHookLeft = "serifed"
-selectorAffix.turnh = "serifed"
-selectorAffix.turnhHookLeft = "serifed"
-selectorAffix.turnhHookLeftRTail = "serifed"
-selectorAffix."turnm/full" = "serifed"
-selectorAffix."turnm/reduced" = "motionSerifed"
-selectorAffix."turnmLeg/full" = "serifed"
-selectorAffix."turnmLeg/reduced" = "motionSerifed"
+selectorAffix.uHookLeftLongLeg = "serifed"
+selectorAffix.uHookLeftLongLegRTail = "serifed"
+selectorAffix."uu/full" = "serifed"
+selectorAffix."uu/reduced" = "motionSerifed"
+selectorAffix."uuLongLeg/full" = "serifed"
+selectorAffix."uuLongLeg/reduced" = "motionSerifed"
 selectorAffix."cyrl/i.italic" = "serifed"
 selectorAffix."cyrl/i.italic/descBase" = "serifed"
 selectorAffix."cyrl/sha.italic/full" = "serifed"
@@ -5917,14 +6084,21 @@ descriptionAffix = "a diagonal cut at top"
 selectorAffix."grek/alpha" = "topCut"
 selectorAffix."grek/alpha/sansSerif" = "topCut"
 
-[prime.lower-alpha.variants-buildup.stages.ear.earless-corner]
+[prime.lower-alpha.variants-buildup.stages.ear.flat-top]
 rank = 3
+nonBreakingVariantAdditionPriority = 100
+descriptionAffix = "flat top"
+selectorAffix."grek/alpha" = "flatTop"
+selectorAffix."grek/alpha/sansSerif" = "flatTop"
+
+[prime.lower-alpha.variants-buildup.stages.ear.earless-corner]
+rank = 4
 descriptionAffix = "earless (cornered top-right)"
 selectorAffix."grek/alpha" = "earlessCorner"
 selectorAffix."grek/alpha/sansSerif" = "earlessCorner"
 
 [prime.lower-alpha.variants-buildup.stages.ear.earless-rounded]
-rank = 4
+rank = 5
 descriptionAffix = "earless (rounded top-right)"
 selectorAffix."grek/alpha" = "earlessRounded"
 selectorAffix."grek/alpha/sansSerif" = "earlessRounded"
@@ -5943,7 +6117,7 @@ selectorAffix."grek/alpha/sansSerif" = "serifless"
 
 [prime.lower-alpha.variants-buildup.stages.bar.double-serifed]
 rank = 3
-disableIf = [{ ear = "NOT eared" }]
+enableIf = [{ ear = "eared"}, { ear = "flat-top" }]
 descriptionAffix = "serifs at top and bottom"
 selectorAffix."grek/alpha" = "doubleSerifed"
 selectorAffix."grek/alpha/sansSerif" = "serifless"
@@ -5956,7 +6130,7 @@ selectorAffix."grek/alpha/sansSerif" = "tailed"
 
 [prime.lower-alpha.variants-buildup.stages.bar.tailed-serifed]
 rank = 5
-disableIf = [{ ear = "NOT eared" }]
+enableIf = [{ ear = "eared"}, { ear = "flat-top" }]
 descriptionAffix = "curly tail; with serifs at top and bottom"
 selectorAffix."grek/alpha" = "tailedSerifed"
 selectorAffix."grek/alpha/sansSerif" = "tailed"
@@ -6133,14 +6307,21 @@ keyAffix = ""
 selectorAffix."grek/eta" = "straight"
 selectorAffix."grek/eta/sansSerif" = "straight"
 
-[prime.lower-eta.variants-buildup.stages.body.earless-corner]
+[prime.lower-eta.variants-buildup.stages.body.flat-top]
 rank = 2
+nonBreakingVariantAdditionPriority = 100
+descriptionAffix = "flat top"
+selectorAffix."grek/eta" = "flatTopStraight"
+selectorAffix."grek/eta/sansSerif" = "flatTopStraight"
+
+[prime.lower-eta.variants-buildup.stages.body.earless-corner]
+rank = 3
 descriptionAffix = "earless (corner top-left) body shape"
 selectorAffix."grek/eta" = "earlessCornerStraight"
 selectorAffix."grek/eta/sansSerif" = "earlessCornerStraight"
 
 [prime.lower-eta.variants-buildup.stages.body.earless-rounded]
-rank = 3
+rank = 4
 descriptionAffix = "earless (rounded top-left) body shape"
 selectorAffix."grek/eta" = "earlessRoundedStraight"
 selectorAffix."grek/eta/sansSerif" = "earlessRoundedStraight"
@@ -6155,7 +6336,7 @@ selectorAffix."grek/eta/sansSerif" = "serifless"
 [prime.lower-eta.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
 descriptionAffix = "serif at top left"
-enableIf = [{ body = "eared" }]
+enableIf = [{ body = "eared" }, { body = "flat-top" }]
 selectorAffix."grek/eta" = "topLeftSerifed"
 selectorAffix."grek/eta/sansSerif" = "serifless"
 
@@ -6501,14 +6682,21 @@ descriptionAffix = "tailed shape"
 selectorAffix."grek/mu" = "tailed"
 selectorAffix."grek/mu/sansSerif" = "tailed"
 
-[prime.lower-mu.variants-buildup.stages.body.toothless-corner]
+[prime.lower-mu.variants-buildup.stages.body.flat-bottom]
 rank = 3
+nonBreakingVariantAdditionPriority = 100
+descriptionAffix = "flat bottom"
+selectorAffix."grek/mu" = "flatBottom"
+selectorAffix."grek/mu/sansSerif" = "flatBottom"
+
+[prime.lower-mu.variants-buildup.stages.body.toothless-corner]
+rank = 4
 descriptionAffix = "toothless (corner bottom-right) shape"
 selectorAffix."grek/mu" = "toothlessCorner"
 selectorAffix."grek/mu/sansSerif" = "toothlessCorner"
 
 [prime.lower-mu.variants-buildup.stages.body.toothless-rounded]
-rank = 4
+rank = 5
 descriptionAffix = "toothless (rounded) shape"
 selectorAffix."grek/mu" = "toothlessRounded"
 selectorAffix."grek/mu/sansSerif" = "toothlessRounded"
@@ -6522,7 +6710,7 @@ selectorAffix."grek/mu/sansSerif" = "serifless"
 
 [prime.lower-mu.variants-buildup.stages.serifs.bottom-right-serifed]
 rank = 2
-disableIf = [{ body = "NOT toothed" }]
+enableIf = [{ body = "toothed"}, { body = "flat-bottom" }]
 descriptionAffix = "serif at bottom-right"
 selectorAffix."grek/mu" = "bottomRightSerifed"
 selectorAffix."grek/mu/sansSerif" = "serifless"
@@ -7047,14 +7235,21 @@ descriptionAffix = "a diagonal cut at top"
 selectorAffix."cyrl/a" = "topCut"
 selectorAffix."cyrl/aye/a" = ""
 
-[prime.cyrl-a.variants-buildup.stages.ear.earless-corner]
+[prime.cyrl-a.variants-buildup.stages.ear.flat-top]
 rank = 3
+nonBreakingVariantAdditionPriority = 200
+descriptionAffix = "flat top"
+selectorAffix."cyrl/a" = "flatTop"
+selectorAffix."cyrl/aye/a" = ""
+
+[prime.cyrl-a.variants-buildup.stages.ear.earless-corner]
+rank = 4
 descriptionAffix = "earless (cornered top-right)"
 selectorAffix."cyrl/a" = "earlessCorner"
 selectorAffix."cyrl/aye/a" = ""
 
 [prime.cyrl-a.variants-buildup.stages.ear.earless-rounded]
-rank = 4
+rank = 5
 descriptionAffix = "earless (rounded top-right)"
 selectorAffix."cyrl/a" = "earlessRounded"
 selectorAffix."cyrl/aye/a" = ""
@@ -7074,7 +7269,7 @@ selectorAffix."cyrl/aye/a" = "toothlessRounded"
 
 [prime.cyrl-a.variants-buildup.stages.bar.double-serifed]
 rank = 3
-disableIf = [{ storey = "double-storey" }, { ear = "NOT eared" }]
+enableIf = [{ ear = "eared" }, { ear = "flat-top" }]
 descriptionAffix = "serifs at top and bottom"
 selectorAffix."cyrl/a" = "doubleSerifed"
 selectorAffix."cyrl/aye/a" = "toothlessRounded"
@@ -7087,7 +7282,7 @@ selectorAffix."cyrl/aye/a" = "toothlessRounded"
 
 [prime.cyrl-a.variants-buildup.stages.bar.tailed-serifed]
 rank = 5
-disableIf = [{ storey = "double-storey" }, { ear = "NOT eared" }]
+enableIf = [{ ear = "eared" }, { ear = "flat-top" }]
 descriptionAffix = "curly tail; with serifs at top and bottom"
 selectorAffix."cyrl/a" = "tailedSerifed"
 selectorAffix."cyrl/aye/a" = "toothlessRounded"
@@ -7095,7 +7290,7 @@ selectorAffix."cyrl/aye/a" = "toothlessRounded"
 [prime.cyrl-a.variants-buildup.stages.bar.flat-bottom-serifless]
 rank = 6
 nonBreakingVariantAdditionPriority = 100
-disableIf = [{ storey = "single-storey" }]
+enableIf = [{ storey = "double-storey" }]
 descriptionAffix = "flat bottom; without serif at terminal"
 selectorAffix."cyrl/a" = "flatBottomSerifless"
 selectorAffix."cyrl/aye/a" = "toothlessRounded"
@@ -7103,21 +7298,21 @@ selectorAffix."cyrl/aye/a" = "toothlessRounded"
 [prime.cyrl-a.variants-buildup.stages.bar.flat-bottom-serifed]
 rank = 7
 nonBreakingVariantAdditionPriority = 100
-disableIf = [{ storey = "single-storey" }]
+enableIf = [{ storey = "double-storey" }]
 descriptionAffix = "flat bottom; with serif at terminal"
 selectorAffix."cyrl/a" = "flatBottomSerifed"
 selectorAffix."cyrl/aye/a" = "toothlessRounded"
 
 [prime.cyrl-a.variants-buildup.stages.bar.toothless-corner]
 rank = 8
-disableIf = [{ storey = "single-storey" }]
+enableIf = [{ storey = "double-storey" }]
 descriptionAffix = "toothless (cornered bottom-right)"
 selectorAffix."cyrl/a" = "toothlessCorner"
 selectorAffix."cyrl/aye/a" = "toothlessRounded"
 
 [prime.cyrl-a.variants-buildup.stages.bar.toothless-rounded]
 rank = 9
-disableIf = [{ storey = "single-storey" }]
+enableIf = [{ storey = "double-storey" }]
 descriptionAffix = "toothless (rounded bottom-right)"
 selectorAffix."cyrl/a" = "toothlessRounded"
 selectorAffix."cyrl/aye/a" = "toothlessRounded"
@@ -8032,13 +8227,19 @@ rank = 1
 descriptionAffix = "eared shape"
 selectorAffix."cyrl/er" = "eared"
 
-[prime.cyrl-er.variants-buildup.stages.body.earless-corner]
+[prime.cyrl-er.variants-buildup.stages.body.flat-top]
 rank = 2
+nonBreakingVariantAdditionPriority = 100
+descriptionAffix = "flat top"
+selectorAffix."cyrl/er" = "flatTop"
+
+[prime.cyrl-er.variants-buildup.stages.body.earless-corner]
+rank = 3
 descriptionAffix = "earless (cornered) shape"
 selectorAffix."cyrl/er" = "earlessCorner"
 
 [prime.cyrl-er.variants-buildup.stages.body.earless-rounded]
-rank = 3
+rank = 4
 descriptionAffix = "earless (rounded) shape"
 selectorAffix."cyrl/er" = "earlessRounded"
 
@@ -8050,20 +8251,20 @@ selectorAffix."cyrl/er" = "serifless"
 
 [prime.cyrl-er.variants-buildup.stages.serifs.motion-serifed]
 rank = 2
-enableIf = [{ body = "eared" }]
+enableIf = [{ body = "eared" }, { body = "flat-top" }]
 descriptionAffix = "motion serifs"
 selectorAffix."cyrl/er" = "motionSerifed"
 
 [prime.cyrl-er.variants-buildup.stages.serifs.serifed__eared]
 rank = 3
-enableIf = [{ body = "eared" }]
+enableIf = [{ body = "eared" }, { body = "flat-top" }]
 keyAffix = "serifed"
 descriptionAffix = "serifs"
 selectorAffix."cyrl/er" = "serifed"
 
 [prime.cyrl-er.variants-buildup.stages.serifs.serifed__earless]
 rank = 3
-enableIf = [{ body = "NOT eared" }]
+enableIf = [{ body = "earless-corner"}, { body = "earless-rounded" }]
 keyAffix = "serifed"
 descriptionAffix = "serifs"
 selectorAffix."cyrl/er" = "bottomSerifed"
@@ -9627,44 +9828,50 @@ next = "serifs"
 [prime.micro-sign.variants-buildup.stages.body.toothed]
 rank = 1
 descriptionAffix = "toothed shape"
-selectorAffix."micro" = "toothed"
+selectorAffix.micro = "toothed"
 
 [prime.micro-sign.variants-buildup.stages.body.tailed]
 rank = 2
 descriptionAffix = "tailed shape"
-selectorAffix."micro" = "tailed"
+selectorAffix.micro = "tailed"
+
+[prime.micro-sign.variants-buildup.stages.body.flat-bottom]
+rank = 3
+nonBreakingVariantAdditionPriority = 100
+descriptionAffix = "flat bottom"
+selectorAffix.micro = "flatBottom"
 
 [prime.micro-sign.variants-buildup.stages.body.toothless-corner]
-rank = 3
+rank = 4
 descriptionAffix = "toothless (corner bottom-right) shape"
-selectorAffix."micro" = "toothlessCorner"
+selectorAffix.micro = "toothlessCorner"
 
 [prime.micro-sign.variants-buildup.stages.body.toothless-rounded]
-rank = 4
+rank = 5
 descriptionAffix = "toothless (rounded) shape"
-selectorAffix."micro" = "toothlessRounded"
+selectorAffix.micro = "toothlessRounded"
 
 [prime.micro-sign.variants-buildup.stages.serifs.serifless]
 rank = 1
 descriptionAffix = "serifs"
 descriptionJoiner = "without"
-selectorAffix."micro" = "serifless"
+selectorAffix.micro = "serifless"
 
 [prime.micro-sign.variants-buildup.stages.serifs.bottom-right-serifed]
 rank = 2
-disableIf = [{ body = "NOT toothed" }]
+enableIf = [{ body = "toothed"}, { body = "flat-bottom" }]
 descriptionAffix = "serif at bottom-right"
-selectorAffix."micro" = "bottomRightSerifed"
+selectorAffix.micro = "bottomRightSerifed"
 
 [prime.micro-sign.variants-buildup.stages.serifs.motion-serifed]
 rank = 3
 descriptionAffix = "motion serifs at top-left and bottom-right"
-selectorAffix."micro" = "motionSerifed"
+selectorAffix.micro = "motionSerifed"
 
 [prime.micro-sign.variants-buildup.stages.serifs.serifed]
 rank = 4
 descriptionAffix = "serifs"
-selectorAffix."micro" = "serifed"
+selectorAffix.micro = "serifed"
 
 
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2426,7 +2426,7 @@ selectorAffix."a/doubleStorey" = "serifed"
 selectorAffix."aRetroflexHook/doubleStorey" = "serifless"
 selectorAffix."a/singleStorey/autoSerifed/slab" = { if = [{ storey = "double-storey" }], then = "doubleSerifed", else = "serifed" }
 selectorAffix."a/singleStorey/autoSerifed/sans" = "serifed"
-selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = { if = [{ storey = "double-storey" }], then = "topSerifed", else = "serifless" }
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = { if = [{ storey = "double-storey" }], then = "motionSerifed", else = "serifless" }
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "serifless"
 selectorAffix."ae/a" = "toothlessRounded"
 
@@ -2436,13 +2436,13 @@ enableIf = [{ ear = "eared"}, { ear = "flat-top" }]
 descriptionAffix = "serifs at top and bottom"
 selectorAffix.a = "doubleSerifed"
 selectorAffix."a/sansSerif" = "serifless"
-selectorAffix."aRetroflexHook" = "topSerifed"
+selectorAffix."aRetroflexHook" = "motionSerifed"
 selectorAffix."a/doubleStorey" = "serifed"
 selectorAffix."aRetroflexHook/doubleStorey" = "serifless"
 selectorAffix."a/singleStorey/autoSerifed/slab" = "doubleSerifed"
 selectorAffix."a/singleStorey/autoSerifed/sans" = "doubleSerifed"
-selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "topSerifed"
-selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "topSerifed"
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "motionSerifed"
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "motionSerifed"
 selectorAffix."ae/a" = "toothlessRounded"
 
 [prime.a.variants-buildup.stages.bar.tailed]
@@ -2455,7 +2455,7 @@ selectorAffix."a/doubleStorey" = "tailed"
 selectorAffix."aRetroflexHook/doubleStorey" = "serifless"
 selectorAffix."a/singleStorey/autoSerifed/slab" = { if = [{ storey = "double-storey" }], then = "tailedSerifed", else = "tailed" }
 selectorAffix."a/singleStorey/autoSerifed/sans" = "tailed"
-selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = { if = [{ storey = "double-storey" }], then = "topSerifed", else = "serifless" }
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = { if = [{ storey = "double-storey" }], then = "motionSerifed", else = "serifless" }
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "serifless"
 selectorAffix."ae/a" = "toothlessRounded"
 
@@ -2465,13 +2465,13 @@ enableIf = [{ ear = "eared"}, { ear = "flat-top" }]
 descriptionAffix = "curly tail; with serifs at top and bottom"
 selectorAffix.a = "tailedSerifed"
 selectorAffix."a/sansSerif" = "tailed"
-selectorAffix."aRetroflexHook" = "topSerifed"
+selectorAffix."aRetroflexHook" = "motionSerifed"
 selectorAffix."a/doubleStorey" = "tailed"
 selectorAffix."aRetroflexHook/doubleStorey" = "serifless"
 selectorAffix."a/singleStorey/autoSerifed/slab" = "tailedSerifed"
 selectorAffix."a/singleStorey/autoSerifed/sans" = "tailedSerifed"
-selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "topSerifed"
-selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "topSerifed"
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "motionSerifed"
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "motionSerifed"
 selectorAffix."ae/a" = "toothlessRounded"
 
 [prime.a.variants-buildup.stages.bar.flat-bottom-serifless]
@@ -2502,7 +2502,7 @@ selectorAffix."a/doubleStorey" = "flatBottomSerifed"
 selectorAffix."aRetroflexHook/doubleStorey" = "serifless"
 selectorAffix."a/singleStorey/autoSerifed/slab" = "doubleSerifed"
 selectorAffix."a/singleStorey/autoSerifed/sans" = "serifed"
-selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "topSerifed"
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "motionSerifed"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "serifless"
 selectorAffix."ae/a" = "toothlessRounded"
 
@@ -2517,7 +2517,7 @@ selectorAffix."a/doubleStorey" = "toothlessCorner"
 selectorAffix."aRetroflexHook/doubleStorey" = "serifless"
 selectorAffix."a/singleStorey/autoSerifed/slab" = "doubleSerifed"
 selectorAffix."a/singleStorey/autoSerifed/sans" = "serifless"
-selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "topSerifed"
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "motionSerifed"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "serifless"
 selectorAffix."ae/a" = "toothlessRounded"
 
@@ -2532,7 +2532,7 @@ selectorAffix."a/doubleStorey" = "toothlessRounded"
 selectorAffix."aRetroflexHook/doubleStorey" = "serifless"
 selectorAffix."a/singleStorey/autoSerifed/slab" = "doubleSerifed"
 selectorAffix."a/singleStorey/autoSerifed/sans" = "serifless"
-selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "topSerifed"
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "motionSerifed"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "serifless"
 selectorAffix."ae/a" = "toothlessRounded"
 


### PR DESCRIPTION
### Motivation and Context

Resolves #2519 and #1269 .

This is a new type of {toothless|earless}-like terminal similar to #3169 ; This, like in that PR, is also implemented as an alternate "mode" of {`toothless`|`earless`}`Corner` that is accessed when the `rise` argument is `0` or undefined. It may also be serifed, unlike the original {`toothless`|`earless`}`Corner` shapes.

### Samples

```
ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ
abc.def.ghi.jkl.mno.pqrs.tuv.wxyz
!iIlL17|¦ ¢coO08BDQ $5SZ2zs ∂96µm
float il1[]={1-2/3.4,5+6=7/8%90};
1234567890 ,._-+= >< «¯-¬_» ~–÷+×
{*}[]()<>`+-=$/#_%^@\&|~?'" !,.;:
g9q¶ Þẞðþſß ΓΔΛαβγδηθικλμνξπτυφχψ
ЖЗКНРУЭЯавжзклмнруфчьыэя <= != ==
```

Example build under **sans**:

Upright:
<img width="1809" height="1082" alt="image" src="https://github.com/user-attachments/assets/82f01f2d-f033-448c-bd33-157607208844" />
Italic:
<img width="1815" height="1086" alt="image" src="https://github.com/user-attachments/assets/3353aa00-9003-4e77-bc38-bc4ed444553f" />

Example build under **slab**:

Upright:
<img width="1798" height="1077" alt="image" src="https://github.com/user-attachments/assets/4144be7d-9ac9-431e-89af-765acf15fc52" />
Italic:
<img width="1807" height="1085" alt="image" src="https://github.com/user-attachments/assets/e8d17724-f471-4782-a35b-cf581cdd687f" />

