### PR TITLE
Fix stroke width consistency across wave arrows

### DIFF
--- a/packages/font-glyphs/src/symbol/arrow/wave.ptl
+++ b/packages/font-glyphs/src/symbol/arrow/wave.ptl
@@ -76,7 +76,7 @@ glyph-block Symbol-Arrow-Wave : for-width-kinds WideWidth1
 		local mag : arrowRSB - arrowSB
 		local p : (mag - o - halfArrowSw) / mag
 
-		define waveMagnitude : waveDist * (3 / 4) - arrowSw / 2
+		define waveMagnitude : waveDist * (3 / 4) - WaveSw / 2
 		define waveSpan : ((MosaicUnitWidth * MosaicWidthScalar) / 2) / (mag * p)
 		define waveBias : 6 / 8
 		define waveSamples 256
@@ -95,7 +95,7 @@ glyph-block Symbol-Arrow-Wave : for-width-kinds WideWidth1
 			knots.push : g2 [mix wr r (1 / 2)] SymbolMid
 			knots.push : g2 r SymbolMid
 			include : dispiro
-				widths.center arrowSw
+				widths.center WaveSw
 				begin knots
 
 		create-glyph [MangleName 'waveArrowDirectLeft'] [MangleUnicode 0x2B3F] : glyph-proc


### PR DESCRIPTION
### Motivation and Context

Follow up to https://github.com/be5invis/Iosevka/pull/3185#issuecomment-4472327222.

Fixes the new wave arrows so that they match the stroke width of the preexisting wave arrows in heavier weights.

### Influenced Characters

- U+2933: WAVE ARROW POINTING DIRECTLY RIGHT
- U+2B3F: WAVE ARROW POINTING DIRECTLY LEFT

### Glyph Quantity

2

### Samples

Comparison of different wave arrows in Heavy variant:

Before:
<img width="560" height="260" alt="image" src="https://github.com/user-attachments/assets/53ab8430-00f6-4454-8b3a-47bb2a5b4c77" />

After:
<img width="560" height="260" alt="wave-arrows-heavy-compare" src="https://github.com/user-attachments/assets/79c925c7-e136-4f27-83fe-edf2129c3245" />


