### PR TITLE
Fixes broken U+2BD1 and U+1F18A (#3195).

### DIFF
--- a/changes/34.6.1.md
+++ b/changes/34.6.1.md
@@ -1,2 +1,3 @@
+* Fixes broken U+2BD1 and U+1F18A (#3195).
 * Add Characters:
   - LATIN SMALL LETTER R WITHOUT HANDLE (`U+AB47`).

--- a/packages/geometry-cache/src/index.mjs
+++ b/packages/geometry-cache/src/index.mjs
@@ -4,7 +4,7 @@ import zlib from "node:zlib";
 
 import { decode, encode } from "@msgpack/msgpack";
 
-const Edition = 72;
+const Edition = 73;
 const MAX_AGE = 32;
 
 class GfEntry {

--- a/packages/geometry/src/index.mjs
+++ b/packages/geometry/src/index.mjs
@@ -591,7 +591,11 @@ export class StrokeGeometry extends GeometryBase {
 		const fairizedArcs = TypoGeom.Fairize.fairizeBezierShape(arcs);
 
 		// Stroke the arcs
-		return strokeArcs(fairizedArcs, this.m_radius, this.m_contrast, this.m_fInside);
+		const out = strokeArcs(fairizedArcs, this.m_radius, this.m_contrast, this.m_fInside);
+
+		// Transform back
+		CurveUtil.InPlaceTransformBez3Shape(this.m_gizmo, out);
+		return out;
 	}
 	toReferences() {
 		return null;
@@ -661,6 +665,9 @@ export class RemoveHolesGeometry extends GeometryBase {
 
 			arcs = TypoGeom.Boolean.combineStack(stack, CurveUtil.BOOLE_RESOLUTION);
 		}
+
+		// Transform back
+		CurveUtil.InPlaceTransformBez3Shape(this.m_gizmo, arcs);
 		return arcs;
 	}
 	toReferences() {


### PR DESCRIPTION
BEFORE
<img width="999" height="428" alt="image" src="https://github.com/user-attachments/assets/a8b447f1-23af-430f-9c0a-f8b2b83e9580" />

AFTER
<img width="999" height="428" alt="image" src="https://github.com/user-attachments/assets/54e84ae6-806e-48a9-bd5e-ce6d294a6371" />
