### PR TITLE
Continue to clean up `letter/latin/lower-r.ptl`, Add `rCrossedTail` (`ꭉ`).

### DIFF
--- a/changes/34.6.2.md
+++ b/changes/34.6.2.md
@@ -1,3 +1,5 @@
+* Add Characters:
+  - LATIN SMALL LETTER R WITH CROSSED-TAIL (`U+AB49`).
 * Refine shape of the following characters:
   - LATIN SMALL LETTER R WITH FISHHOOK (`U+027E`).
   - LATIN SMALL LETTER R WITH FISHHOOK AND MIDDLE TILDE (`U+1D73`).

--- a/packages/font-glyphs/src/letter/latin/lower-r.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-r.ptl
@@ -9,8 +9,7 @@ glyph-block Letter-Latin-Lower-R : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Adjustment : LeaningAnchor
-	glyph-block-import Letter-Shared-Shapes : PalatalHook RetroflexHook
-	glyph-block-import Letter-Blackboard : BBS BBD BBBarRight
+	glyph-block-import Letter-Shared-Shapes : CurlyTail PalatalHook RetroflexHook
 
 	local dfN : DivFrame 1
 	local dfR : DivFrame para.advanceScaleF 1 0.75
@@ -27,21 +26,22 @@ glyph-block Letter-Latin-Lower-R : begin
 	local rNarrowHookSerifed    8
 	local rNeedle               9
 
-	define [RDim df mode _stroke _strokeBar] : namespace
+	define [RDim df mode _stroke _strokeBar _fine] : namespace
 		local stroke    : fallback _stroke    Stroke
 		local strokeBar : fallback _strokeBar stroke
-		local strokeA : mix strokeBar stroke 0.5
-		local { rBalanceMultiplier rHookMultiplier rHookSwMultiplier rSerifLeftExtender hookSuperness } : match mode
-			[Just rStraight]            {  1                     1       (1 / 2)   0.3       2.35 }
-			[Just rSerifed]             { (4 / 3)               (2 / 3)  (3 / 4)  (19 / 30)  2.35 }
-			[Just rNarrow]              { (2 * (df.adws - 0.5))  1        0        0.3       2.35 }
-			[Just rNarrowSerifed]       { (2 * (df.adws - 0.5))  1        0        0.3       2.35 }
-			[Just rCornerHooked]        { (5 / 8)                1        0        0.3       2.35 }
-			[Just rCornerHookedSerifed] { (4 / 3)               (2 / 3)  (1 / 4)  (19 / 30)  2.35 }
-			[Just rEarless]             {  1                     1       (1 / 2)   0.3       2.35 }
-			[Just rNarrowHook]          {  1                     1       (1 / 2)   0.3       2.35 }
-			[Just rNarrowHookSerifed]   { (4 / 3)               (2 / 3)  (3 / 4)  (19 / 30)  2.35 }
-			[Just rNeedle]              {  0                     1        0        0         2.35 }
+		local strokeA   : mix strokeBar stroke 0.5
+		local fine      : fallback _fine : ShoulderFine * (strokeA / Stroke)
+		local { rBalanceMultiplier rHookMultiplier rHookSwMultiplier rSerifLeftExtender } : match mode
+			[Just rStraight]            {  1                     1       (1 / 2)   0.3      }
+			[Just rSerifed]             { (4 / 3)               (2 / 3)  (3 / 4)  (19 / 30) }
+			[Just rNarrow]              { (2 * (df.adws - 0.5))  1        0        0.3      }
+			[Just rNarrowSerifed]       { (2 * (df.adws - 0.5))  1        0        0.3      }
+			[Just rCornerHooked]        { (5 / 8)                1        0        0.3      }
+			[Just rCornerHookedSerifed] { (4 / 3)               (2 / 3)  (1 / 4)  (19 / 30) }
+			[Just rEarless]             {  1                     1       (1 / 2)   0.3      }
+			[Just rNarrowHook]          {  1                     1       (1 / 2)   0.3      }
+			[Just rNarrowHookSerifed]   { (4 / 3)               (2 / 3)  (3 / 4)  (19 / 30) }
+			[Just rNeedle]              {  0                     1        0        0        }
 
 		export : local xBar : match mode
 			[Just rNeedle] : df.middle + [HSwToV : 0.5 * strokeBar] - [IBalance2 df]
@@ -58,7 +58,6 @@ glyph-block Letter-Latin-Lower-R : begin
 		export : local [rBottomSerif y] : tagged 'serifLB' : union
 			HSerif.lb rSerifX y rSerifBottomLeftJut
 			HSerif.rb rSerifX y rSerifBottomRightJut
-		export : local fine ShoulderFine
 		local rHookXFull : match mode
 			[Just rNeedle] : Math.max
 				xBar + [HSwToV : 0.125 * stroke] + TINY + [Math.abs : TanSlope * stroke]
@@ -86,9 +85,13 @@ glyph-block Letter-Latin-Lower-R : begin
 			[Just rNarrowSerifed] : mix df.width rHookX df.adws
 			[Just rNarrow]        : xArchMiddle + TINY
 			__                    : begin rHookX
+		export : local hookSuperness 2.35
+		export : local xCor : match mode
+			([Just rCornerHooked] || [Just rCornerHookedSerifed]) : begin 0
+			__ : CorrectionOMidS * [linreg 72 0.75 108 1 stroke]
 
 		export : define [setMarks top bottom doTopSerif doBottomSerif] : glyph-proc
-			include : LeaningAnchor.Below.VBar.l (xBar - [HSwToV strokeBar])
+			include : LeaningAnchor.Below.VBar.l (xBar - [HSwToV strokeBar]) strokeBar
 			include : match mode
 				[Just rNeedle] : LeaningAnchor.Above.At xArchMiddle
 				__             : LeaningAnchor.Above.Hook
@@ -103,7 +106,7 @@ glyph-block Letter-Latin-Lower-R : begin
 			currentGlyph.copyBaseAnchorIfAbsent 'leaningBelow' 'below'
 
 		export : define [setTurnedMarks top bottom doTopSerif doBottomSerif] : glyph-proc
-			include : LeaningAnchor.Above.VBar.r (df.width - (xBar - [HSwToV strokeBar]))
+			include : LeaningAnchor.Above.VBar.r (df.width - (xBar - [HSwToV strokeBar])) strokeBar
 			include : match mode
 				[Just rNeedle] : LeaningAnchor.Below.At (df.width - xArchMiddle)
 				__             : LeaningAnchor.Below.Hook
@@ -117,11 +120,9 @@ glyph-block Letter-Latin-Lower-R : begin
 			currentGlyph.copyBaseAnchorIfAbsent 'leaningAbove' 'above'
 			currentGlyph.copyBaseAnchorIfAbsent 'leaningBelow' 'below'
 
-		export hookSuperness
-
 	define SmallRShape : namespace
 		export : define [Standard df md top bottom doTopSerif doBottomSerif _ada _adb] : glyph-proc
-			define [object xBar rBottomSerif rTopSerif fine xArchMiddle skew rHookX rHookY hookSuperness] : RDim df md
+			define [object xBar rBottomSerif rTopSerif xArchMiddle skew rHookX rHookY hookSuperness xCor] : RDim df md
 			local ada : ArchDepthAClamped top bottom
 				fallback _ada : ArchDepthAOf : 0.47 * (XH - 0)
 				fallback _adb : ArchDepthBOf : 0.47 * (XH - 0)
@@ -129,19 +130,18 @@ glyph-block Letter-Latin-Lower-R : begin
 				widths.lhs
 				g4.up.start rHookX (top - rHookY) [heading Upward]
 				arcvh 32 hookSuperness
-				g4.left.mid (xArchMiddle - CorrectionOMidS * [linreg 72 0.75 108 1 Stroke]) (top - O) [widths.lhs.heading Stroke {.y (-1) .x (-skew)}]
+				g4.left.mid (xArchMiddle - xCor) (top - O) [widths.lhs.heading Stroke {.y (-1) .x (-skew)}]
 				archv 32
-				straight.down.end (xBar - [HSwToV fine]) (top - ada) [widths.lhs.heading fine Downward]
+				straight.down.end (xBar - [HSwToV ShoulderFine]) [Math.max (bottom + TINY) (top - ada)] [widths.lhs.heading ShoulderFine Downward]
 			include : VBar.l (xBar - [HSwToV Stroke]) bottom top
 			if doBottomSerif : include : rBottomSerif bottom
 			if doTopSerif    : include : rTopSerif    top
 
 		define [CompactShapeImpl doHookSerif] : function [df md top bottom doTopSerif doBottomSerif _ada _adb] : glyph-proc
-			define [object xBar rBottomSerif rTopSerif fine xArchMiddle rHookXN] : RDim df md
+			define [object xBar rBottomSerif rTopSerif xArchMiddle rHookXN xCor] : RDim df md
 			local ada : ArchDepthAClamped top bottom
 				fallback _ada : ArchDepthAOf : 0.47 * (XH - 0)
 				fallback _adb : ArchDepthBOf : 0.47 * (XH - 0)
-			define xCor : if doHookSerif 0 : CorrectionOMidS * [linreg 72 0.75 108 1 Stroke]
 			define arcTopShift : match md
 				[Just rNarrow] : O * [clamp 0 1 : StrokeWidthBlend 0 16]
 				__             : begin 0
@@ -149,7 +149,7 @@ glyph-block Letter-Latin-Lower-R : begin
 				flat (rHookXN     - xCor) (top - arcTopShift) [if doHookSerif [heading Leftward] null]
 				curl (xArchMiddle - xCor) (top - arcTopShift) [if doHookSerif [heading Leftward] null]
 				archv
-				straight.down.end (xBar - [HSwToV fine]) (top - ada) [widths.lhs.heading fine Downward]
+				straight.down.end (xBar - [HSwToV ShoulderFine]) [Math.max (bottom + TINY) (top - ada)] [widths.lhs.heading ShoulderFine Downward]
 			include : dispiro
 				widths.lhs (Stroke - arcTopShift)
 				ArcKnots
@@ -158,7 +158,7 @@ glyph-block Letter-Latin-Lower-R : begin
 				VSerif.dr (rHookXN - xCor) top VJut
 				spiro-outline
 					ArcKnots
-					corner (xBar - [HSwToV fine]) bottom
+					corner (xBar - [HSwToV ShoulderFine]) bottom
 					corner VERY-FAR bottom
 					corner VERY-FAR top
 			if doBottomSerif : include : rBottomSerif bottom
@@ -202,7 +202,7 @@ glyph-block Letter-Latin-Lower-R : begin
 				widths.lhs
 				g4   [Math.max rHookX : xBar + [HSwToV : 1.25 * Stroke]] (top - rHookY)
 				HookStart top
-				flat (xBar - [HSwToV Stroke]) (top - ada)
+				flat (xBar - [HSwToV Stroke]) [Math.max (bottom + TINY + [HSwToV : Math.abs : TanSlope * Stroke]) (top - ada)]
 				curl (xBar - [HSwToV Stroke]) bottom [heading Downward]
 			if doBottomSerif : include : rBottomSerif bottom
 
@@ -218,10 +218,10 @@ glyph-block Letter-Latin-Lower-R : begin
 			compact          { SmallRShape.Compact          dfR rNarrow       rNarrowSerifed       }
 			narrowHook       { SmallRShape.Standard         dfR rNarrowHook   rNarrowHookSerifed   }
 		object # Serifs
-			serifless      { 0 0 }
-			topSerifed     { 1 0 }
-			baseSerifed    { 0 1 }
-			serifed        { 1 1 }
+			serifless        { 0 0 }
+			topSerifed       { 1 0 }
+			baseSerifed      { 0 1 }
+			serifed          { 1 1 }
 
 	foreach { suffix { { Body df modeSans modeSerifed } { doTS doBS } } } [pairs-of SmallRConfig] : do
 		local mode : if (doTS || doBS) modeSerifed modeSans
@@ -298,6 +298,25 @@ glyph-block Letter-Latin-Lower-R : begin
 				define [object xBar] : RDim df mode
 				include : RetroflexHook.rExt xBar 0
 
+			create-glyph "rCrossedTail.\(suffix)" : glyph-proc
+				set-width df.width
+				include : df.markSet.e
+
+				define [object xBar setMarks] : RDim df mode
+				include : setMarks XH 0 doTS doBS
+
+				local sw : AdviceStroke 3
+				local fine : AdviceStroke 4
+				local rinner : XH * 0.15 - fine * 0.75
+				local m2 : xBar - [HSwToV : Stroke - sw] - (RightSB - SB) / 2 - [HSwToV : 0.5 * fine]
+				local x2 : xBar + SideJut
+				local y2 : rinner * 2 + fine - O
+				include : Body df mode XH (y2 + O) doTS doBS
+				include : dispiro
+					widths.rhs
+					straight.down.start xBar y2 [heading Downward]
+					CurlyTail.f fine 0 m2 x2 (swBefore -- Stroke)
+
 			create-glyph "turnrHookTop.\(suffix)" : glyph-proc
 				set-width df.width
 				include : df.markSet.b
@@ -338,6 +357,7 @@ glyph-block Letter-Latin-Lower-R : begin
 
 	select-variant 'rPalatalHook' 0x1D89 (follow -- 'r')
 	select-variant 'turnrHookTop' 0x2C79 (follow -- 'r/rTailBase')
+	select-variant 'rCrossedTail' 0xAB49 (follow -- 'r/rTailBase')
 
 	select-variant 'turnrLongLegRTail' 0x1DF08 (follow -- 'r/hookTopBase')
 	select-variant 'turnrPalatalHook'  0x1DF15 (follow -- 'r/ascBase')
@@ -349,7 +369,7 @@ glyph-block Letter-Latin-Lower-R : begin
 
 	define NeedleRShape : namespace
 		export : define [Standard df md top bottom doTopSerif doBottomSerif _ada _adb] : glyph-proc
-			define [object xBar rBottomSerif rTopSerif fine rHookX] : RDim df md
+			define [object xBar rBottomSerif rTopSerif rHookX] : RDim df md
 			local ada : ArchDepthAClamped top bottom
 				fallback _ada : ArchDepthAOf Hook
 				fallback _adb : ArchDepthBOf Hook
@@ -357,7 +377,7 @@ glyph-block Letter-Latin-Lower-R : begin
 				widths.lhs
 				g4.left.start rHookX (top - O)
 				archv
-				straight.down.end (xBar - [HSwToV fine]) (top - ada) [widths.lhs.heading fine Downward]
+				straight.down.end (xBar - [HSwToV ShoulderFine]) [Math.max (bottom + TINY) (top - ada)] [widths.lhs.heading ShoulderFine Downward]
 			include : VBar.l (xBar - [HSwToV Stroke]) bottom top
 			if doBottomSerif : include : rBottomSerif bottom
 			if doTopSerif    : include : rTopSerif    top
@@ -390,7 +410,7 @@ glyph-block Letter-Latin-Lower-R : begin
 				widths.lhs
 				g4.left.start rHookX (top - O)
 				archv
-				flat (xBar - [HSwToV Stroke]) (top - ada)
+				flat (xBar - [HSwToV Stroke]) [Math.max (bottom + TINY + [HSwToV : Math.abs : TanSlope * Stroke]) (top - ada)]
 				curl (xBar - [HSwToV Stroke]) bottom [heading Downward]
 			if doBottomSerif : include : rBottomSerif bottom
 
@@ -426,8 +446,9 @@ glyph-block Letter-Latin-Lower-R : begin
 	select-variant 'rFlap' 0x27E (shapeFrom -- 'rNeedle')
 	select-variant 'rFlapPalatalHook' 0x1DF16 (shapeFrom -- 'rNeedlePalatalHook') (follow -- 'rFlap')
 
+	glyph-block-import Letter-Blackboard : BBS BBD BBBarRight
 	define [BBRShape df md doTopSerif doBottomSerif _ada _adb] : glyph-proc
-		define [object xBar fine xArchMiddle skew rHookX rHookY hookSuperness] : RDim df md BBS BBD
+		define [object xBar xArchMiddle skew rHookX rHookY hookSuperness xCor] : RDim df md BBS BBD ShoulderFine
 		local ada : ArchDepthAClamped XH 0
 			fallback _ada : ArchDepthAOf : 0.47 * (XH - 0)
 			fallback _adb : ArchDepthBOf : 0.47 * (XH - 0)
@@ -435,9 +456,9 @@ glyph-block Letter-Latin-Lower-R : begin
 			widths.lhs BBS
 			g4.up.start rHookX (XH - rHookY) [heading Upward]
 			arcvh nothing hookSuperness
-			g4.left.mid (xArchMiddle - CorrectionOMidS * [linreg 72 0.75 108 1 BBS]) (XH - O) [widths.heading BBS 0 {.y (-1) .x (-skew)}]
+			g4.left.mid (xArchMiddle - xCor) (XH - O) [widths.lhs.heading BBS {.y (-1) .x (-skew)}]
 			archv
-			straight.down.end (xBar - [HSwToV fine]) (XH - ada) [widths.lhs.heading fine Downward]
+			straight.down.end (xBar - [HSwToV ShoulderFine]) [Math.max (0 + TINY) (XH - ada)] [widths.lhs.heading ShoulderFine Downward]
 		include : BBBarRight xBar 0 XH
 		set-base-anchor 'overlay' (xBar - [HSwToV : BBD * 0.25 + BBS * 0.5]) [mix 0 XH 0.5]
 


### PR DESCRIPTION
### Motivation and Context

This _nearly_ completes the non-IPA "crossed-tail" set in Latin Extended-E (`ꬺ`, `ꬻ`, `ꬼ`, `ꭉ`, `ꭊ`), with the exception of `ꭊ` (the base character `ꭈ` is not yet supported).

### Influenced Characters

  - LATIN SMALL LETTER R WITH CROSSED-TAIL (`U+AB49`).

### Glyph Quantity

9 * (4 - 2) = +18 glyphs.

### Samples

`rṛ̇ ꭉꭉ̣̇ `

Sans Monospace:
<img width="621" height="413" alt="image" src="https://github.com/user-attachments/assets/4ae8fce6-6585-4a9f-8f4e-e87f6002fcad" />
Slab Monospace:
<img width="619" height="413" alt="image" src="https://github.com/user-attachments/assets/e57d3501-b6c9-4b7f-b7f6-80066e79e1be" />
Aile:
<img width="574" height="411" alt="image" src="https://github.com/user-attachments/assets/e52d80c0-fa5f-4707-b745-280a3d2f6679" />
Etoile:
<img width="656" height="413" alt="image" src="https://github.com/user-attachments/assets/005c3ec5-ca6e-47b1-b950-38c7a3663595" />

