### PR TITLE
Simplify the building of question mark. Reducing 47 glyphs.

### DIFF
--- a/packages/font-glyphs/src/auto-build/composite.ptl
+++ b/packages/font-glyphs/src/auto-build/composite.ptl
@@ -1464,7 +1464,7 @@ glyph-block AutoBuild-Accented-Equal : begin
 
 	createAccentedOp 'equal' 7 0.4 0 aboveMarkBot : list
 		list 0x225e {"m"}
-		list 0x225F {"question/hookPart" "question/dotPart"}
+		list 0x225F {"question"}
 	createAccentedOp 'equal' 5 0.8 0 aboveMarkBot : list
 		list 0x2258 {"symbolMidTie"}
 	createAccentedOp 'equal' 7 0.5 0 (aboveMarkBot - (SymbolMid - XH / 2)) : list
@@ -1840,19 +1840,17 @@ glyph-block Autobuild-Double-Emotions : begin
 		define df1 : CreateDerivedFontFromJobs jobs {} : lambda [gs] : Thinner gs shrink1 true
 		define df2 : CreateDerivedFontFromJobs jobs {} : lambda [gs] : Thinner gs shrink2 true
 
-		foreach [{gn unicode { c1 m1 c2 m2 } mak} : items-of jobs.nonDecomposable] : if [not : query-glyph gn] : begin
+		foreach [{gn unicode { c1 c2 } mak} : items-of jobs.nonDecomposable] : if [not : query-glyph gn] : begin
 			create-glyph gn [MangleUnicode unicode] : glyph-proc
 				set-width CWidth
 				if mak : include : [DivFrame (CWidth / Width)].markSet.(mak)
 				define dfg1 : df1.queryByNameEnsured c1
-				define dfm1 : df1.queryByNameEnsured m1
 				define dfg2 : df2.queryByNameEnsured c2
-				define dfm2 : df2.queryByNameEnsured m2
 				local sumChildrenWidth : dfg1.advanceWidth * wadj1 + dfg2.advanceWidth * wadj2
 				local refW : sumChildrenWidth - kern
-				include : union dfg2 [with-transform [Translate (dfg2.advanceWidth) 0] dfm2]
+				include : union dfg2
 				include : Translate (dfg1.advanceWidth * wadj1 - kern) 0
-				include : union dfg1 [with-transform [Translate (dfg1.advanceWidth) 0] dfm1]
+				include : union dfg1
 				include : Ungizmo
 				include : Translate (refW   * (-0.5)) 0
 				include : Scale [clamp 0 1 ((CWidth - SB * 1.25) / (CWidth - SB * 2) * CWidth / refW)] 1
@@ -1863,10 +1861,10 @@ glyph-block Autobuild-Double-Emotions : begin
 
 	define stdShrink : clamp 0.625 0.9 : StrokeWidthBlend 0.625 0.9
 	createDoubleEmotions 'doubleemotion' para.advanceScaleM stdShrink stdShrink 1 1 : list
-		list 0x203c { 'exclam' 'zwsp' 'exclam' 'zwsp' }
-		list 0x2047 { 'question/hookPart' 'question/dotPart' 'question/hookPart' 'question/dotPart' }
-		list 0x2048 { 'question/hookPart' 'question/dotPart' 'exclam' 'zwsp' }
-		list 0x2049 { 'exclam' 'zwsp' 'question/hookPart' 'question/dotPart' }
+		list 0x203c { 'exclam' 'exclam' }
+		list 0x2047 { 'question' 'question' }
+		list 0x2048 { 'question' 'exclam' }
+		list 0x2049 { 'exclam' 'question' }
 
 glyph-block Autobuild-Grouped-Digits : begin
 	glyph-block-import CommonShapes

--- a/packages/font-glyphs/src/common/derivatives.ptl
+++ b/packages/font-glyphs/src/common/derivatives.ptl
@@ -1,5 +1,5 @@
 $$include '../meta/macros.ptl'
-
+import as util from "util"
 import [mix linreg clamp fallback] from "@iosevka/util"
 import [Cv AnyCv AnyDerivingCv Dotless Zero SvInheritableRelations PseudoCvDecompose getGrMesh] from "@iosevka/glyph/relation"
 
@@ -108,8 +108,8 @@ glyph-block Common-Derivatives : begin
 					local dstGlyph : query-glyph dstName
 					if [not dstGlyph] : throw : new Error "Cannot find glyph '\(dstName)'"
 
-					cv.variant.set dstGlyph dstName
-					if cv.variant.nonDeriving : cv.variant.setPreventDeriving dstGlyph
+					cv.variant.set fromGlyph dstName
+					if cv.variant.nonDeriving : cv.variant.setPreventDeriving fromGlyph
 
 					if product.isTarget : begin
 						cv.variant.set g dstName

--- a/packages/font-glyphs/src/symbol/punctuation/emotion.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/emotion.ptl
@@ -1,7 +1,7 @@
 ### Punctuation symbols
 $$include '../../meta/macros.ptl'
 
-import [mix linreg clamp fallback] from "@iosevka/util"
+import [mix clamp SuffixCfg] from "@iosevka/util"
 
 glyph-module
 
@@ -124,24 +124,31 @@ glyph-block Symbol-Punctuation-Emotion : begin
 				straight.right.end [mix left right 0.5] (questionYConnect - Stroke) [heading Rightward]
 			include : VBar.m [mix left right 0.5] emotionBottom questionYConnect
 
-		define Config : object
+		define HookConfig : object
 			smooth           { SmoothShape     RevSmoothShape }
 			corner           { CornerShape     RevCornerShape }
 			cornerFlatHooked { CornerFlatShape RevCornerFlatShape }
-
-		foreach { suffix { Body RevBody } } [Object.entries Config] : do
-			create-glyph "question/hookPart.\(suffix)" : glyph-proc
+		foreach { suffix { Body RevBody } } [Object.entries HookConfig] : do
+			create-glyph "mdfGlottalStop/base.\(suffix)" : glyph-proc
+				include : MarkSet.capital
 				include : Body CAP emotionBottom SB RightSB
-				set-base-anchor 'cvDecompose' 0 0
-
-			create-glyph "questionDown/hookPart.\(suffix)" : glyph-proc
-				include : Body CAP emotionBottom SB RightSB
-				include : FlipAround Middle (XH / 2)
-				set-base-anchor 'cvDecompose' 0 0
-
-			create-glyph "revQuestion/hookPart.\(suffix)" : glyph-proc
+			create-glyph "mdfRevGlottalStop/base.\(suffix)" : glyph-proc
+				include : MarkSet.capital
 				include : RevBody CAP emotionBottom SB RightSB
-				set-base-anchor 'cvDecompose' 0 0
+
+		define Config : SuffixCfg.dotWeave DotVariants HookConfig
+		foreach { suffix { { DrawAt kdr overshoot } { Body RevBody } } } [Object.entries Config] : do
+			create-glyph "question.\(suffix)" : glyph-proc
+				include : Body CAP emotionBottom SB RightSB
+				include : DrawAt Middle (DotRadius * kdr) (DotRadius * kdr - overshoot)
+
+			create-glyph "questionDown.\(suffix)" : glyph-proc
+				include [refer-glyph "question.\(suffix)"] AS_BASE ALSO_METRICS
+				include : FlipAround Middle (XH / 2)
+
+			create-glyph "revQuestion.\(suffix)" : glyph-proc
+				include : RevBody CAP emotionBottom SB RightSB
+				include : DrawAt Middle (DotRadius * kdr) (DotRadius * kdr - overshoot)
 
 			define [InterroBangBodyImpl] : glyph-proc
 				local angle : 12 / 180 * Math.PI
@@ -154,30 +161,24 @@ glyph-block Symbol-Punctuation-Emotion : begin
 				include : Rotate (1.2 * angle)
 				include : Translate Middle DotRadius
 
-			create-glyph "interrobang/bodyPart.\(suffix)" : glyph-proc
+			create-glyph "interrobang.\(suffix)" : glyph-proc
 				include : InterroBangBodyImpl
-				set-base-anchor 'cvDecompose' 0 0
+				include : DrawAt Middle (DotRadius * kdr) (DotRadius * kdr - overshoot)
 
-			create-glyph "interrobangDown/bodyPart.\(suffix)" : glyph-proc
-				include : InterroBangBodyImpl
+			create-glyph "gnaborretni.\(suffix)" : glyph-proc
+				include : refer-glyph "interrobang.\(suffix)" AS_BASE ALSO_METRICS
 				include : FlipAround Middle (XH / 2)
-				set-base-anchor 'cvDecompose' 0 0
 
-		select-variant 'question/hookPart' (follow -- 'question')
-		derive-composites 'question' '?' 'question/hookPart' 'question/dotPart'
+		select-multi-dimensional-variant 'question' '?'
+			follows -- { 'punctuationDot' 'question' }
+		select-multi-dimensional-variant 'questionDown' 0xBF
+			follows -- { 'punctuationDot' 'question' }
+		select-multi-dimensional-variant 'revQuestion' 0x2E2E
+			follows -- { 'punctuationDot' 'question' }
+		select-multi-dimensional-variant 'interrobang' 0x203D
+			follows -- { 'punctuationDot' 'question' }
+		select-multi-dimensional-variant 'gnaborretni'  0x2E18
+			follows -- { 'punctuationDot' 'question' }
 
-		select-variant 'questionDown/hookPart' (follow -- 'question')
-		derive-composites 'questionDown' 0xBF 'questionDown/hookPart' 'questionDown/dotPart'
-
-		select-variant 'revQuestion/hookPart' (follow -- 'question')
-		derive-composites 'revQuestion' 0x2E2E 'revQuestion/hookPart' 'question/dotPart'
-		alias 'symbolForSubstituteFormTwo' 0x2426 'revQuestion'
-
-		select-variant 'interrobang/bodyPart' (follow -- 'question')
-		derive-composites 'interrobang' 0x203D 'interrobang/bodyPart' 'question/dotPart'
-
-		select-variant 'interrobangDown/bodyPart' (follow -- 'question')
-		derive-composites 'gnaborretni'  0x2E18 'interrobangDown/bodyPart' 'questionDown/dotPart'
-
-		create-glyph 'mdfGlottalStop/base'    : composite-proc [MarkSet.capital] [refer-glyph 'question/hookPart.smooth']
-		create-glyph 'mdfRevGlottalStop/base' : composite-proc [MarkSet.capital] [refer-glyph 'revQuestion/hookPart.smooth']
+		select-variant 'mdfGlottalStop/base' null (follow -- 'question')
+		select-variant 'mdfRevGlottalStop/base' null (follow -- 'question')

--- a/packages/font-glyphs/src/symbol/punctuation/emotion.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/emotion.ptl
@@ -24,21 +24,8 @@ glyph-block Symbol-Punctuation-Emotion : begin
 				create-forked-glyph "alveolarClick.\(suffix)" : df.markSet.capital
 				create-forked-glyph "exclamDown.\(suffix)" : FlipAround df.middle (XH / 2)
 
-			create-glyph "question/dotPart.\(suffix)" : glyph-proc
-				set-width 0
-				include : DrawAt (Middle - Width) dr (dr - overshoot)
-				set-mark-anchor 'cvDecompose' (0 - Width) 0
-
-			create-glyph "questionDown/dotPart.\(suffix)" : glyph-proc
-				set-width 0
-				include : DrawAt (Middle - Width) (XH - dr) (dr - overshoot)
-				set-mark-anchor 'cvDecompose' (0 - Width) 0
-
 		select-variant 'exclam' '!' (follow -- 'punctuationDot')
 		select-variant 'exclamDown' 0xA1 (follow -- 'punctuationDot')
-
-		select-variant 'question/dotPart' (follow -- 'punctuationDot')
-		select-variant 'questionDown/dotPart' (follow -- 'punctuationDot')
 
 		select-variant 'alveolarClick' 0x1C3 (follow -- 'diacriticDot')
 		CreateTurnedLetter 'alveolarPercussive'          null 'alveolarClick' HalfAdvance (XH  / 2)

--- a/packages/util/src/index.mjs
+++ b/packages/util/src/index.mjs
@@ -67,8 +67,12 @@ export function joinCamel(a, b) {
 	if (!b) return a;
 	return a + b[0].toUpperCase() + b.slice(1);
 }
-
-function joinSuffixListImpl(sink, k, v, telescope, configs) {
+function joinDot(a, b) {
+	if (!a) return b;
+	if (!b) return a;
+	return `${a}.${b}`;
+}
+function joinSuffixListImpl(sink, joiner, k, v, telescope, configs) {
 	if (!configs.length) {
 		sink[k] = v;
 		return;
@@ -79,17 +83,22 @@ function joinSuffixListImpl(sink, k, v, telescope, configs) {
 	if (!item) return;
 
 	for (const [keySuffix, valueSuffix] of Object.entries(item)) {
-		const k1 = joinCamel(k, keySuffix);
+		const k1 = joiner(k, keySuffix);
 		const v1 = [...v, valueSuffix];
 		const telescope1 = [...telescope, keySuffix];
-		joinSuffixListImpl(sink, k1, v1, telescope1, rest);
+		joinSuffixListImpl(sink, joiner, k1, v1, telescope1, rest);
 	}
 }
 
 export const SuffixCfg = {
 	weave: (...configs) => {
 		const ans = {};
-		joinSuffixListImpl(ans, "", [], [], configs);
+		joinSuffixListImpl(ans, joinCamel, "", [], [], configs);
+		return ans;
+	},
+	dotWeave: (...configs) => {
+		const ans = {};
+		joinSuffixListImpl(ans, joinDot, "", [], [], configs);
 		return ans;
 	},
 	combine: (...configs) => {


### PR DESCRIPTION
Utilize `select-multi-dimensional-variant` to simplify building of question mark and related glyphs.

Reducing 47 glyphs.