### PR TITLE
Adjust vertical radius of `[FlatSlashShape]`.

### DIFF
--- a/packages/font-glyphs/src/common/shapes.ptl
+++ b/packages/font-glyphs/src/common/shapes.ptl
@@ -401,8 +401,8 @@ glyph-block CommonShapes : begin
 	define [FlatSlashShape middlex middle fine kx ky] : glyph-proc
 		include : dispiro
 			widths.center (2 * fine)
-			flat (middlex - LongJut * [fallback kx 0.8]) (middle - LongJut * [fallback ky 0.4])
-			curl (middlex + LongJut * [fallback kx 0.8]) (middle + LongJut * [fallback ky 0.4])
+			flat (middlex - LongJut * [fallback kx 0.8]) (middle - LongVJut * [fallback ky 0.4])
+			curl (middlex + LongJut * [fallback kx 0.8]) (middle + LongVJut * [fallback ky 0.4])
 
 	glyph-block-export VBar
 	define VBar : namespace

--- a/packages/font-glyphs/src/letter/latin/upper-l.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-l.ptl
@@ -9,9 +9,7 @@ glyph-block Letter-Latin-Upper-L : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Shared-Metrics : markMiddle
-	glyph-block-import Mark-Above : aboveMarkMid
 	glyph-block-import Mark-Adjustment : LeaningAnchor
-	glyph-block-import Letter-Blackboard : BBS BBD
 	glyph-block-import Letter-Shared : CreateAccentedComposition CreateTurnedLetter
 	glyph-block-import Letter-Shared-Shapes : BeltOverlay LetterBarOverlay
 
@@ -21,11 +19,21 @@ glyph-block Letter-Latin-Upper-L : begin
 	define [LShape df top sgr swv] : glyph-proc
 		include : VBar.l [xLBarLeft df] 0 top swv
 		include : HBar.b ([xLBarLeft df] - O) [xLRight df] 0
+		if (sgr > 0) : begin
+			include : VSerif.ur [xLRight df] 0 VJut
 		if (sgr > 1) : begin
-			include : HSerif.lb ([xLBarLeft df] + [HSwToV : 0.5 * swv]) 0   Jut
-			include : HSerif.lt ([xLBarLeft df] + [HSwToV : 0.5 * swv]) top Jut
-			include : HSerif.rt ([xLBarLeft df] + [HSwToV : 0.5 * swv]) top MidJutSide
-		if (sgr > 0) : include : VSerif.ur [xLRight df] 0 VJut
+			include : HSerif.lb ([xLBarLeft df] + [HSwToV : 0.5 * swv]) 0 (Jut - [HSwToV : 0.5 * (Stroke - swv)])
+			include : union
+				HSerif.lt ([xLBarLeft df] + [HSwToV : 0.5 * swv]) top (Jut        - [HSwToV : 0.5 * (Stroke - swv)])
+				HSerif.rt ([xLBarLeft df] + [HSwToV : 0.5 * swv]) top (MidJutSide - [HSwToV : 0.5 * (Stroke - swv)])
+
+	define [LSlashOverlay df top sgr] : begin
+		local fine : 0.5 * OverlayStroke
+		local yMiddle : mix (0 + Stroke) (top - [if (sgr > 1) Stroke 0]) 0.5
+		return : dispiro
+			widths.center (2 * fine)
+			flat  [mix 0 df.leftSB 0.5]                  (yMiddle - LongVJut * 0.4)
+			curl ([mix 0 df.leftSB 0.5] + 1.6 * LongJut) (yMiddle + LongVJut * 0.4)
 
 	define LConfig : object
 		serifless     { 0 }
@@ -42,11 +50,19 @@ glyph-block Letter-Latin-Upper-L : begin
 				[mix df.leftSB df.rightSB 0.65] + [HSwToV QuarterStroke]
 				mix Stroke CAP 0.5
 
+		create-glyph "LSlash.\(suffix)" : glyph-proc
+			include [refer-glyph "L.\(suffix)"] AS_BASE ALSO_METRICS
+			include : LSlashOverlay [DivFrame 1] CAP serifGrade
+
 		create-glyph "smcpL.\(suffix)" : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.e
 			include : LeaningAnchor.Above.VBar.l [xLBarLeft df]
 			include : LShape df XH serifGrade Stroke
+
+		create-glyph "smcpLSlash.\(suffix)" : glyph-proc
+			include [refer-glyph "smcpL.\(suffix)"] AS_BASE ALSO_METRICS
+			include : LSlashOverlay [DivFrame 1] XH serifGrade
 
 		create-glyph "LLWelsh.\(suffix)" : glyph-proc
 			local df : include : DivFrame 1
@@ -66,11 +82,13 @@ glyph-block Letter-Latin-Upper-L : begin
 
 	select-variant 'L' 'L'
 	link-reduced-variant 'L/sansSerif' 'L' MathSansSerif
-	select-variant 'smcpL' 0x29F (follow -- 'L')
-	select-variant 'LLWelsh' 0x1EFA (follow -- 'L')
-	select-variant 'LHighBar' 0xA748 (follow -- 'L')
+	select-variant 'LSlash'     0x141  (follow -- 'L')
+	select-variant 'smcpL'      0x29F  (follow -- 'L')
+	select-variant 'smcpLSlash' 0x1D0C (follow -- 'L')
+	select-variant 'LLWelsh'    0x1EFA (follow -- 'L')
+	select-variant 'LHighBar'   0xA748 (follow -- 'L')
 
-	CreateTurnedLetter 'turnL' 0xA780 'L' HalfAdvance (CAP / 2)
+	CreateTurnedLetter 'turnL'           0xA780 'L'           HalfAdvance (CAP / 2)
 	CreateTurnedLetter 'turnL/sansSerif' 0x2142 'L/sansSerif' HalfAdvance (CAP / 2)
 
 	derive-multi-part-glyphs 'LCaron' 0x13D { 'L' 'commaAbove' } : lambda [srcs gr] : glyph-proc
@@ -80,27 +98,7 @@ glyph-block Letter-Latin-Upper-L : begin
 
 	CreateAccentedComposition 'LWedge' null 'L' 'caronAbove'
 
-	define [LSlashOverlay top] : begin
-		local fine : 0.5 * OverlayStroke
-		local middle : mix Stroke top 0.5
-		return : dispiro
-			widths.center (2 * fine)
-			flat  [mix 0 SB 0.5]                  (middle - LongJut * 0.4)
-			curl ([mix 0 SB 0.5] + 1.6 * LongJut) (middle + LongJut * 0.4)
-
-	derive-glyphs 'LSlash' 0x141 'L' : lambda [src gr] : glyph-proc
-		include [refer-glyph src] AS_BASE ALSO_METRICS
-		include : LSlashOverlay CAP
-
-	derive-glyphs 'smcpLSlash' 0x1D0C 'smcpL' : lambda [src gr] : glyph-proc
-		include [refer-glyph src] AS_BASE ALSO_METRICS
-		include : LSlashOverlay XH
-
-	derive-glyphs 'LTildeOver' 0x2C62 'L' : lambda [src gr] : glyph-proc
-		include [refer-glyph src] AS_BASE ALSO_METRICS
-		include : new-glyph : glyph-proc
-			include : refer-glyph "tildeOver"
-			include : ApparentTranslate ([xLBarLeft : DivFrame 1] + [HSwToV HalfStroke] - markMiddle) (CAP * 0.525 - XH / 2)
+	derive-composites 'LDot' 0x13F 'L' 'LDot/dot'
 
 	create-glyph 'LBar/overlay' : LetterBarOverlay.l.in [xLBarLeft : DivFrame 1] 0 CAP
 	derive-composites 'LBar' 0x23D  'L' 'LBar/overlay'
@@ -110,14 +108,19 @@ glyph-block Letter-Latin-Upper-L : begin
 		LetterBarOverlay.l.in [xLBarLeft : DivFrame 1] 0 CAP (py -- 0.4)
 	derive-composites 'LDoubleBar' 0x2C60 'L' 'LDoubleBar/overlay'
 
+	derive-glyphs 'LTildeOver' 0x2C62 'L' : lambda [src gr] : glyph-proc
+		include [refer-glyph src] AS_BASE ALSO_METRICS
+		include : new-glyph : glyph-proc
+			include : refer-glyph "tildeOver"
+			include : ApparentTranslate ([xLBarLeft : DivFrame 1] + [HSwToV HalfStroke] - markMiddle) ([mix 0 CAP 0.525] - XH / 2)
+
 	create-glyph 'LBelt/overlay' : BeltOverlay CAP ([xLBarLeft : DivFrame 1] + [HSwToV HalfStroke])
 	derive-composites 'LBelt' 0xA7AD 'L' 'LBelt/overlay'
 
 	create-glyph 'smcpLBelt/overlay' : BeltOverlay XH ([xLBarLeft : DivFrame 1] + [HSwToV HalfStroke])
 	derive-composites 'smcpLBelt' 0x1DF04 'smcpL' 'smcpLBelt/overlay'
 
-	derive-composites 'LDot' 0x13F 'L' 'LDot/dot'
-
+	glyph-block-import Letter-Blackboard : BBS BBD
 	create-glyph 'mathbb/L' 0x1D543 : glyph-proc
 		local df : include : DivFrame 1
 		include : df.markSet.capital


### PR DESCRIPTION
### Motivation and Context

Somewhat of a continuation of #3213 for letters that use `[FlatSlashShape]`. This change is not visible under normal width (500) but becomes visible under extended width (600).

Also Improve vertical position of overlay of Latin Upper L with Stroke (`Ł`, `ᴌ`) when `L` is fully-`serifed`. This change is visible under all widths, at least under slab.

### Influenced Characters

  - LATIN CAPITAL LETTER L WITH STROKE (`U+0141`).
  - LATIN SMALL LETTER L WITH STROKE (`U+0142`).
  - LATIN SMALL LETTER LAMBDA WITH STROKE (`U+019B`).
  - LATIN LETTER SMALL CAPITAL L WITH STROKE (`U+1D0C`).
  - LATIN SMALL LETTER LONG S WITH DIAGONAL STROKE (`U+1E9C`).

### Glyph Quantity

N/A

### Samples

`ŁᴌłꟜƛꟌẜꟍ`

Sans Monospace:
<img width="1929" height="1088" alt="image" src="https://github.com/user-attachments/assets/aea075f1-5e42-4ac2-9556-4011b06d9368" />
Slab Monospace:
<img width="1920" height="1078" alt="image" src="https://github.com/user-attachments/assets/7654882a-65fa-4624-8fff-5d7919bb29a4" />
Aile:
<img width="1982" height="1085" alt="image" src="https://github.com/user-attachments/assets/55b3f881-f771-4594-8528-5acf486a20e5" />
Etoile:
<img width="2017" height="1085" alt="image" src="https://github.com/user-attachments/assets/e28122a4-03d3-4060-a9d7-3674a1ced52c" />