### PR TITLE
Cleanup surrounding #3216 , make Cyrillic De (`Д`, `д`) use `DesignParameters.serifShiftX`.

### DIFF
--- a/packages/font-glyphs/src/common/shapes.ptl
+++ b/packages/font-glyphs/src/common/shapes.ptl
@@ -265,7 +265,7 @@ glyph-block CommonShapes : begin
 			include : dispiro
 				widths.lhs sw
 				flat (x + [HSwToV : 0.5 * swRef]) y [heading Leftward]
-				curl (x - length - TanSlope * (sw * DesignParameters.serifShiftX)) y
+				curl (x - length - TanSlope * sw * DesignParameters.serifShiftX) y
 
 		export : define [lb x y length _sw _swRef] : glyph-proc
 			local sw : fallback _sw Stroke
@@ -273,7 +273,7 @@ glyph-block CommonShapes : begin
 			include : dispiro
 				widths.rhs sw
 				flat (x + [HSwToV : 0.5 * swRef]) y [heading Leftward]
-				curl (x - length + TanSlope * (sw * DesignParameters.serifShiftX)) y
+				curl (x - length + TanSlope * sw * DesignParameters.serifShiftX) y
 
 		export : define [rt x y length _sw _swRef] : glyph-proc
 			local sw : fallback _sw Stroke
@@ -281,7 +281,7 @@ glyph-block CommonShapes : begin
 			include : dispiro
 				widths.rhs sw
 				flat (x - [HSwToV : 0.5 * swRef]) y [heading Rightward]
-				curl (x + length - TanSlope * (sw * DesignParameters.serifShiftX)) y
+				curl (x + length - TanSlope * sw * DesignParameters.serifShiftX) y
 
 		export : define [rb x y length _sw _swRef] : glyph-proc
 			local sw : fallback _sw Stroke
@@ -289,7 +289,7 @@ glyph-block CommonShapes : begin
 			include : dispiro
 				widths.lhs sw
 				flat (x - [HSwToV : 0.5 * swRef]) y [heading Rightward]
-				curl (x + length + TanSlope * (sw * DesignParameters.serifShiftX)) y
+				curl (x + length + TanSlope * sw * DesignParameters.serifShiftX) y
 
 		export : define [mt x y length _sw] : mtAsymmetric x y length length _sw
 
@@ -297,16 +297,16 @@ glyph-block CommonShapes : begin
 			local sw : fallback _sw Stroke
 			return : dispiro
 				widths.lhs sw
-				flat (x + r - TanSlope * (sw * DesignParameters.serifShiftX)) y
-				curl (x - l - TanSlope * (sw * DesignParameters.serifShiftX)) y
+				flat (x + r - TanSlope * sw * DesignParameters.serifShiftX) y
+				curl (x - l - TanSlope * sw * DesignParameters.serifShiftX) y
 
 		export : define [mb x y length _sw] : mbAsymmetric x y length length _sw
 		export : define [mbAsymmetric x y l r _sw] : begin
 			local sw : fallback _sw Stroke
 			return : dispiro
 				widths.rhs sw
-				flat (x + r + TanSlope * (sw * DesignParameters.serifShiftX)) y
-				curl (x - l + TanSlope * (sw * DesignParameters.serifShiftX)) y
+				flat (x + r + TanSlope * sw * DesignParameters.serifShiftX) y
+				curl (x - l + TanSlope * sw * DesignParameters.serifShiftX) y
 
 	glyph-block-export VSerif
 	define VSerif : namespace

--- a/packages/font-glyphs/src/letter/cyrillic/de.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/de.ptl
@@ -36,7 +36,9 @@ glyph-block Letter-Cyrillic-De : begin
 		local xTopLeft  : mix left right : StrokeWidthBlend 0.15 0.10
 		local xTopRight : mix left right : StrokeWidthBlend 0.95 0.96
 		local swOuter : fallback _sw Stroke
-		local swInner : [AdviceStroke 2.75] * (swOuter / Stroke)
+		local swInner : Math.min
+			[AdviceStroke 2.75] * (swOuter / Stroke)
+			VSwToH : 0.375 * (xTopRight - xTopLeft)
 		local desc : fallback _desc BottomExtension
 
 		include : CyrDeBottom left right swOuter desc
@@ -44,39 +46,23 @@ glyph-block Letter-Cyrillic-De : begin
 		include : VBar.r xTopRight 0 top swInner
 		include : dispiro
 			widths.lhs swInner
-			flat xTopLeft top
+			flat xTopLeft top [heading Downward]
 			curl xTopLeft [mix top (0 + swOuter + TailY - swInner / 2) 0.75]
 			g4   left     (0 + swOuter)
 
+		local xSerifShift : TanSlope * swOuter * DesignParameters.serifShiftX
 		include : if SLAB
 			dispiro
 				widths.rhs swOuter
-				flat (xTopLeft - descenderOverflow) top
+				flat (xTopLeft - descenderOverflow - xSerifShift) top
 				if (fCapital || !para.isItalic)
-					list [curl (xTopRight + descenderOverflow) top]
-					list [curl xTopRight top [heading Rightward]]
+					list
+						curl (xTopRight + descenderOverflow - xSerifShift) top
+					list
+						curl xTopRight top [heading Rightward]
 			HBar.t xTopLeft xTopRight top swOuter
 
-		return : object desc xTopLeft xTopRight swOuter swInner
-
-	define [CyrSoftDeShape vSlab] : function [fCapital df top _sw _desc] : glyph-proc
-		local descenderOverflow : if SLAB SideJut : (df.rightSB - df.leftSB) * 0.075
-		local sw : fallback _sw Stroke
-		local xm : if SLAB
-			[mix df.leftSB df.rightSB 0.625] + [HSwToV : 0.25 * sw]
-			mix df.leftSB df.rightSB : if (df.adws > 1) (2 / 3) (3 / 4)
-		local xTopRight : mix df.leftSB xm : StrokeWidthBlend 0.95 0.96
-		local xTopBarRightEnd : mix df.width df.rightSB : if vSlab 0.25 0.375
-
-		include : CyrDeShape fCapital top df.leftSB xm sw _desc
-
-		include : if (SLAB && (fCapital || !para.isItalic))
-			HBar.t (xTopRight + descenderOverflow) xTopBarRightEnd top sw
-			HBar.t xTopRight xTopBarRightEnd top sw
-
-		if vSlab : begin
-			local swVJut : Math.min (VJutStroke * (sw / Stroke)) : VSwToH : 0.625 * (xTopBarRightEnd - xTopRight)
-			include : VSerif.dr xTopBarRightEnd top VJut swVJut
+		return : object xTopLeft xTopRight swOuter swInner desc
 
 	create-glyph 'cyrl/De' 0x414 : glyph-proc
 		include : MarkSet.capital
@@ -92,22 +78,36 @@ glyph-block Letter-Cyrillic-De : begin
 		include : MarkSet.p
 		include : CyrDeShape false XH SB RightSB nothing Descender
 
+	define [CyrSoftDeShape vSlab] : function [fCapital df top _sw _desc] : glyph-proc
+		local sw : fallback _sw Stroke
+		local xm : if SLAB
+			[mix df.leftSB df.rightSB 0.625] + [HSwToV : 0.25 * sw]
+			mix df.leftSB df.rightSB : if (df.adws > 1) (2 / 3) (3 / 4)
+
+		local [object xTopRight] : include : CyrDeShape fCapital top df.leftSB xm sw _desc
+		local xTopBarRightEnd : mix df.width df.rightSB : if vSlab 0.250 0.375
+
+		include : HBar.t (xTopRight + O) xTopBarRightEnd top sw
+		if vSlab : begin
+			local swVJut : Math.min (VJutStroke * (sw / Stroke)) : VSwToH : 0.625 * (xTopBarRightEnd - xTopRight)
+			include : VSerif.dr xTopBarRightEnd top VJut swVJut
+
 	create-glyph : glyph-proc
 		local df : include : DivFrame para.advanceScaleM 3
 		include : df.markSet.capital
 		include : ExtendBelowBaseAnchors BottomExtension
-		create-forked-glyph 'cyrl/DeSoft.serifless'       : [CyrSoftDeShape false] true df CAP df.mvs
-		create-forked-glyph 'cyrl/DeSoft.topRightSerifed' : [CyrSoftDeShape true]  true df CAP df.mvs
+		create-forked-glyph "cyrl/DeSoft.serifless"       : [CyrSoftDeShape false] true df CAP df.mvs
+		create-forked-glyph "cyrl/DeSoft.topRightSerifed" : [CyrSoftDeShape true]  true df CAP df.mvs
 
 	create-glyph : glyph-proc
 		local df : include : DivFrame para.advanceScaleM 3
 		include : df.markSet.e
 		include : ExtendBelowBaseAnchors BottomExtension
-		create-forked-glyph 'cyrl/deSoft.serifless'       : [CyrSoftDeShape false] false df XH df.mvs
-		create-forked-glyph 'cyrl/deSoft.topRightSerifed' : [CyrSoftDeShape true]  false df XH df.mvs
+		create-forked-glyph "cyrl/deSoft.serifless"       : [CyrSoftDeShape false] false df XH df.mvs
+		create-forked-glyph "cyrl/deSoft.topRightSerifed" : [CyrSoftDeShape true]  false df XH df.mvs
 
-	select-variant 'cyrl/DeSoft' 0xA662 (follow -- 'cyrl/EnGhe/GhePart')
-	select-variant 'cyrl/deSoft' 0xA663 (follow -- 'cyrl/enghe/ghePart')
+	select-variant 'cyrl/DeSoft' 0xA662 (follow -- 'cyrl/EnGhe/Ghe')
+	select-variant 'cyrl/deSoft' 0xA663 (follow -- 'cyrl/enghe/ghe')
 
 	foreach { suffix { { desc } { st sb } } } [Object.entries ZeConfig] : do
 		define [DzzeDescendershape de ada adb] : begin

--- a/packages/font-glyphs/src/letter/cyrillic/el.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/el.ptl
@@ -26,23 +26,24 @@ glyph-block Letter-Cyrillic-El : begin
 	glyph-block-export CyrElShape
 	define [CyrElShape left right top bodyType slabType _sw] : glyph-proc
 		local sw : fallback _sw Stroke
-		local xCutLeft : mix left right 0.075
+		local xTopLeft : mix left right 0.075
+		local xBotLeft : mix SB 0 : if SLAB 1.00 0.75
 		include : match bodyType
 			[Just BODY-TAILED]   : RightwardTailedBar right 0 top sw
 			[Just BODY-STRAIGHT] : VBar.r             right 0 top sw
 			__                   : glyph-proc
-		include : HBar.t xCutLeft right top sw
+		include : HBar.t xTopLeft right top sw
 		include : LegShape
-			ztop -- [Point.fromXY Point.Type.Corner xCutLeft top]
-			zbot -- [Point.fromXY Point.Type.Corner [mix SB 0 : if SLAB 1 0.75] 0]
-			xb   -- xCutLeft
-			fine -- sw
+			ztop -- [Point.fromXY Point.Type.Corner xTopLeft top]
+			zbot -- [Point.fromXY Point.Type.Corner xBotLeft 0]
+			xmid -- xTopLeft
+			sw   -- sw
 
 		include : tagged 'serifLT' : match slabType
-			[Just SLAB-ALL]      : HSerif.lt xCutLeft top SideJut sw
-			[Just SLAB-LOWER]    : HSerif.lt xCutLeft top SideJut sw
-			[Just SLAB-TAILED-U] : HSerif.lt xCutLeft top SideJut sw
-			[Just SLAB-TAILED-I] : HSerif.lt xCutLeft top SideJut sw
+			[Just SLAB-ALL]      : HSerif.lt xTopLeft top SideJut sw
+			[Just SLAB-LOWER]    : HSerif.lt xTopLeft top SideJut sw
+			[Just SLAB-TAILED-U] : HSerif.lt xTopLeft top SideJut sw
+			[Just SLAB-TAILED-I] : HSerif.lt xTopLeft top SideJut sw
 			__                   : glyph-proc
 		include : tagged 'SerifRT' : match slabType
 			[Just SLAB-ALL]      : HSerif.rt right top SideJut sw
@@ -89,7 +90,7 @@ glyph-block Letter-Cyrillic-El : begin
 		create-forked-glyph "cyrl/ElSoft.serifless"       : [CyrSoftElShape false] df CAP BODY-STRAIGHT [if SLAB SLAB-ALL SLAB-NONE] df.mvs
 		create-forked-glyph "cyrl/ElSoft.topRightSerifed" : [CyrSoftElShape true]  df CAP BODY-STRAIGHT [if SLAB SLAB-ALL SLAB-NONE] df.mvs
 
-	select-variant 'cyrl/ElSoft' 0xA664 (follow -- 'cyrl/EnGhe/GhePart')
+	select-variant 'cyrl/ElSoft' 0xA664 (follow -- 'cyrl/EnGhe/Ghe')
 
 	define ElConfig : object
 		straight  { BODY-STRAIGHT SLAB-ALL      SLAB-LOWER    }
@@ -123,7 +124,7 @@ glyph-block Letter-Cyrillic-El : begin
 				set-mark-anchor 'cvDecompose' 0 0
 				include : [CyrSoftElShape cyrSoftElVSlab] cyrSoftElDf XH body [if SLAB [if para.isItalic slabItalic slabUpright] SLAB-NONE] cyrSoftElDf.mvs
 
-		select-variant "cyrl/elSoft.\(suffix)" (follow -- 'cyrl/enghe/ghePart')
+		select-variant "cyrl/elSoft.\(suffix)" (follow -- 'cyrl/enghe/ghe')
 
 	select-variant 'cyrl/el' 0x43B
 	select-variant 'cyrl/elMidHook' 0x521 (follow -- 'cyrl/el')

--- a/packages/font-glyphs/src/letter/cyrillic/lje.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/lje.ptl
@@ -14,15 +14,15 @@ glyph-block Letter-Cyrillic-Lje : begin
 	define [CyrLjeShape Yeri df top] : glyph-proc
 		local sw : Math.min df.mvs : AdviceStroke2 3 3 top df.adws
 		local xTopLeft : mix df.leftSB df.rightSB 0.025
-		local xBotLeft : mix df.leftSB 0 [if SLAB 1.00 0.75]
+		local xBotLeft : mix df.leftSB 0 : if SLAB 1.00 0.75
 		local jut : Math.min
 			Jut - [HSwToV : 0.5 * (Stroke - sw)]
 			mix [HSwToV : 0.5 * sw] Jut ((2 / df.hPack) * df.adws)
 		include : LegShape
 			ztop -- [Point.fromXY Point.Type.Corner xTopLeft top]
 			zbot -- [Point.fromXY Point.Type.Corner xBotLeft 0]
-			xb   -- xTopLeft
-			fine -- sw
+			xmid -- xTopLeft
+			sw   -- sw
 		include : Yeri top
 			left   -- (df.middle - [HSwToV : 0.5 * sw])
 			right  -- (df.rightSB - O)
@@ -42,5 +42,5 @@ glyph-block Letter-Cyrillic-Lje : begin
 			include : df.markSet.e
 			include : CyrLjeShape Lc df XH
 
-	select-variant 'cyrl/Lje' 0x409
-	select-variant 'cyrl/lje' 0x459
+	select-variant 'cyrl/Lje' 0x409 (follow -- 'cyrl/Lje/rightHalf')
+	select-variant 'cyrl/lje' 0x459 (follow -- 'cyrl/lje/rightHalf')

--- a/packages/font-glyphs/src/letter/greek/upper-gamma.ptl
+++ b/packages/font-glyphs/src/letter/greek/upper-gamma.ptl
@@ -113,8 +113,8 @@ glyph-block Letter-Greek-Upper-Gamma: begin
 			eject-contour 'strokeV'
 			include : LegShape
 				ztop -- [Point.fromXY Point.Type.Corner xGammaBarLeft XH]
-				zbot -- [Point.fromXY Point.Type.Corner [mix SB 0 : if doST 1 0.75] 0]
-				xb   -- xGammaBarLeft
+				zbot -- [Point.fromXY Point.Type.Corner [mix SB 0 : if doST 1.00 0.75] 0]
+				xmid -- xGammaBarLeft
 
 		create-glyph "cyrl/GheMidHook.\(suffix)" : glyph-proc
 			include [refer-glyph "grek/Gamma.\(suffix)"] AS_BASE ALSO_METRICS

--- a/packages/font-glyphs/src/letter/latin/upper-h.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-h.ptl
@@ -257,8 +257,8 @@ glyph-block Letter-Latin-Upper-H : begin
 				set-mark-anchor 'cvDecompose' 0 0
 				include : EnGheShape enGheDf XH slabType fTailed (serifTR -- serifGhe)
 
-		select-variant "cyrl/EnGhe.\(suffix)" (follow -- 'cyrl/EnGhe/GhePart')
-		select-variant "cyrl/enghe.\(suffix)" (follow -- 'cyrl/enghe/ghePart')
+		select-variant "cyrl/EnGhe.\(suffix)" (follow -- 'cyrl/EnGhe/Ghe')
+		select-variant "cyrl/enghe.\(suffix)" (follow -- 'cyrl/enghe/ghe')
 
 		define hwairDf : DivFrame para.advanceScaleMM 3
 

--- a/packages/font-glyphs/src/letter/latin/upper-m.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-m.ptl
@@ -178,8 +178,8 @@ glyph-block Letter-Latin-Upper-M : begin
 				set-mark-anchor 'cvDecompose' 0 0
 				include : CyrSoftEmShape XH cyrSoftemDf form slab slanted cyrSoftEmVSlab
 
-		select-variant "cyrl/EmSoft.\(suffix)" (follow -- 'cyrl/EnGhe/GhePart')
-		select-variant "cyrl/emSoft.\(suffix)" (follow -- 'cyrl/enghe/ghePart')
+		select-variant "cyrl/EmSoft.\(suffix)" (follow -- 'cyrl/EnGhe/Ghe')
+		select-variant "cyrl/emSoft.\(suffix)" (follow -- 'cyrl/enghe/ghe')
 
 	select-variant 'M' 'M'
 	link-reduced-variant 'M/sansSerif' 'M' MathSansSerif

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -1018,13 +1018,13 @@ glyph-block Letter-Shared-Shapes : begin
 			Rect [mix box.t box.b 0.5] box.b (leftCenter - Jut + adj) (rightCenter + Jut)
 
 	glyph-block-export LegShape
-	define [LegShape] : with-params [ztop zbot xb [fine Stroke]] : glyph-proc
+	define [LegShape] : with-params [ztop zbot xmid [sw Stroke]] : glyph-proc
 		include : dispiro
-			widths.lhs fine
+			widths.lhs sw
 			flat ztop.x ztop.y [heading Downward]
-			curl xb [mix ztop.y (zbot.y + fine / 2 + TailY) 0.75]
-			alsoThruThem {{0.2 0.76} {0.3 0.85} {0.5 0.94}}
-			straight.left.end zbot.x (zbot.y + fine) [heading Leftward]
+			curl xmid [mix ztop.y (zbot.y + sw / 2 + TailY) 0.75]
+			alsoThruThem { { 0.2 0.76 } { 0.3 0.85 } { 0.5 0.94 } }
+			straight.left.end zbot.x (zbot.y + sw) [heading Leftward]
 
 	glyph-block-export UpwardHookShape
 	define [UpwardHookShape] : with-params [left right ybegin yend [bottom 0] [ada ArchDepthA] [adb ArchDepthB] [sw Stroke]] : glyph-proc

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -6192,8 +6192,8 @@ selector."cyrl/Ghe" = "serifless"
 selector."cyrl/ghe.upright" = "serifless"
 selector."cyrl/Ge" = "serifless"
 selector."cyrl/ge" = "serifless"
-selector."cyrl/EnGhe/GhePart" = "serifless"
-selector."cyrl/enghe/ghePart" = "serifless"
+selector."cyrl/EnGhe/Ghe" = "serifless"
+selector."cyrl/enghe/ghe" = "serifless"
 
 [prime.capital-gamma.variants.top-right-serifed]
 rank = 2
@@ -6204,8 +6204,8 @@ selector."cyrl/Ghe" = "topRightSerifed"
 selector."cyrl/ghe.upright" = "topRightSerifed"
 selector."cyrl/Ge" = "serifless"
 selector."cyrl/ge" = "serifless"
-selector."cyrl/EnGhe/GhePart" = "topRightSerifed"
-selector."cyrl/enghe/ghePart" = "topRightSerifed"
+selector."cyrl/EnGhe/Ghe" = "topRightSerifed"
+selector."cyrl/enghe/ghe" = "topRightSerifed"
 
 [prime.capital-gamma.variants.bottom-serifed]
 rank = 3
@@ -6216,8 +6216,8 @@ selector."cyrl/Ghe" = "bottomSerifed"
 selector."cyrl/ghe.upright" = "serifless"
 selector."cyrl/Ge" = "bottomSerifed"
 selector."cyrl/ge" = "serifless"
-selector."cyrl/EnGhe/GhePart" = "serifless"
-selector."cyrl/enghe/ghePart" = "serifless"
+selector."cyrl/EnGhe/Ghe" = "serifless"
+selector."cyrl/enghe/ghe" = "serifless"
 
 [prime.capital-gamma.variants.serifed]
 rank = 4
@@ -6228,8 +6228,8 @@ selector."cyrl/Ghe" = "serifed"
 selector."cyrl/ghe.upright" = "serifed"
 selector."cyrl/Ge" = "serifed"
 selector."cyrl/ge" = "serifed"
-selector."cyrl/EnGhe/GhePart" = "topRightSerifed"
-selector."cyrl/enghe/ghePart" = "topRightSerifed"
+selector."cyrl/EnGhe/Ghe" = "topRightSerifed"
+selector."cyrl/enghe/ghe" = "topRightSerifed"
 
 
 
@@ -8581,25 +8581,25 @@ selector."cyrl/che" = "tailed"
 rank = 1
 selector."cyrl/Yer"  = "corner"
 selector."cyrl/Yeri" = "corner"
-selector."cyrl/Nje/rightHalf"  = "corner"
-selector."cyrl/Lje"  = "corner"
-selector."cyrl/Tje/rightHalf"  = "corner"
+selector."cyrl/Nje/rightHalf" = "corner"
+selector."cyrl/Lje/rightHalf" = "corner"
+selector."cyrl/Tje/rightHalf" = "corner"
 
 [prime.cyrl-capital-yeri.variants.round]
 rank = 2
 selector."cyrl/Yer"  = "round"
 selector."cyrl/Yeri" = "round"
-selector."cyrl/Nje/rightHalf"  = "round"
-selector."cyrl/Lje"  = "round"
-selector."cyrl/Tje/rightHalf"  = "round"
+selector."cyrl/Nje/rightHalf" = "round"
+selector."cyrl/Lje/rightHalf" = "round"
+selector."cyrl/Tje/rightHalf" = "round"
 
 [prime.cyrl-capital-yeri.variants.cursive]
 rank = 3
 selector."cyrl/Yer"  = "cursive"
 selector."cyrl/Yeri" = "cursive"
-selector."cyrl/Nje/rightHalf"  = "cursive"
-selector."cyrl/Lje"  = "cursive"
-selector."cyrl/Tje/rightHalf"  = "cursive"
+selector."cyrl/Nje/rightHalf" = "cursive"
+selector."cyrl/Lje/rightHalf" = "cursive"
+selector."cyrl/Tje/rightHalf" = "cursive"
 
 
 
@@ -8613,8 +8613,8 @@ rank = 1
 description = "Cyrillic Lower Yeri (`ь`) with corner at bottom left"
 selector."cyrl/yer"  = "corner"
 selector."cyrl/yeri" = "corner"
-selector."cyrl/nje/rightHalf"  = "corner"
-selector."cyrl/lje"  = "corner"
+selector."cyrl/nje/rightHalf" = "corner"
+selector."cyrl/lje/rightHalf" = "corner"
 selector."cyrl/tje/rightHalf" = "corner"
 
 [prime.cyrl-yeri.variants.round]
@@ -8622,8 +8622,8 @@ rank = 2
 description = "Cyrillic Lower Yeri (`ь`) with rounded shape"
 selector."cyrl/yer"  = "round"
 selector."cyrl/yeri" = "round"
-selector."cyrl/nje/rightHalf"  = "round"
-selector."cyrl/lje"  = "round"
+selector."cyrl/nje/rightHalf" = "round"
+selector."cyrl/lje/rightHalf" = "round"
 selector."cyrl/tje/rightHalf" = "round"
 
 [prime.cyrl-yeri.variants.cursive]
@@ -8631,8 +8631,8 @@ rank = 3
 description = "Cyrillic Lower Yeri (`ь`) with cursive shape"
 selector."cyrl/yer"  = "cursive"
 selector."cyrl/yeri" = "cursive"
-selector."cyrl/nje/rightHalf"  = "cursive"
-selector."cyrl/lje"  = "cursive"
+selector."cyrl/nje/rightHalf" = "cursive"
+selector."cyrl/lje/rightHalf" = "cursive"
 selector."cyrl/tje/rightHalf" = "cursive"
 
 


### PR DESCRIPTION
### Motivation and Context

This makes the serifs of Cyrillic De (`Д`, `д`) respond to changes of `TanSlope` like other serif shape functions.

Also general code cleanup surrounding `letter/cyrillic/de.ptl`.
Also cleanup parameter names for `[LegShape]`.
Also rerout: `cyrl/`{`EnGhe`|`enghe`}`/`{`Ghe`|`ghe`}`Part` → `cyrl/`{`EnGhe`|`enghe`}`/`{`Ghe`|`ghe`}.

### Influenced Characters

  - CYRILLIC CAPITAL LETTER DE (`U+0414`).
  - CYRILLIC SMALL LETTER DE (`U+0434`).
  - CYRILLIC CAPITAL LETTER DZZHE (`U+052A`) ... CYRILLIC SMALL LETTER DCHE (`U+052D`).
  - CYRILLIC SMALL LETTER LONG-LEGGED DE (`U+1C81`).
  - COMBINING CYRILLIC LETTER DE (`U+2DE3`).
  - CYRILLIC CAPITAL LETTER SOFT DE (`U+A662`).
  - CYRILLIC SMALL LETTER SOFT DE (`U+A663`).
  - CYRILLIC CAPITAL LETTER DWE (`U+A680`).
  - CYRILLIC SMALL LETTER DWE (`U+A681`).
  - CYRILLIC CAPITAL LETTER DZZE (`U+A688`).
  - CYRILLIC SMALL LETTER DZZE (`U+A689`).
  - MODIFIER LETTER CYRILLIC SMALL DE (`U+1E034`).
  - MODIFIER LETTER CYRILLIC SMALL DZZE (`U+1E04A`).
  - CYRILLIC SUBSCRIPT SMALL LETTER DE (`U+1E055`).

### Glyph Quantity

N/A

### Samples

`ДдᲁꙢꙣꚀꚁꚈꚉԬԭԪԫ`

Slab Monospace:
<img width="966" height="1130" alt="image" src="https://github.com/user-attachments/assets/1fbe8ab2-1222-4659-b106-b6b23dda2abc" />
Etoile:
<img width="1293" height="1132" alt="image" src="https://github.com/user-attachments/assets/44c69ac8-da20-4c9c-b38e-b1b5ea80c307" />

