### PR TITLE
Fix #3221 .

### DIFF
--- a/changes/34.6.3.md
+++ b/changes/34.6.3.md
@@ -1,0 +1,2 @@
+* Add Characters:
+  - SYMBOL FOR SUBSTITUTE FORM TWO (`U+2426`) (#3221).

--- a/packages/font-glyphs/src/symbol/punctuation/emotion.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/emotion.ptl
@@ -164,8 +164,10 @@ glyph-block Symbol-Punctuation-Emotion : begin
 			follows -- { 'punctuationDot' 'question' }
 		select-multi-dimensional-variant 'interrobang' 0x203D
 			follows -- { 'punctuationDot' 'question' }
-		select-multi-dimensional-variant 'gnaborretni'  0x2E18
+		select-multi-dimensional-variant 'gnaborretni' 0x2E18
 			follows -- { 'punctuationDot' 'question' }
+
+		alias 'symbolForSubstituteFormTwo' 0x2426 'revQuestion'
 
 		select-variant 'mdfGlottalStop/base' null (follow -- 'question')
 		select-variant 'mdfRevGlottalStop/base' null (follow -- 'question')


### PR DESCRIPTION
### Influenced Characters

  - SYMBOL FOR SUBSTITUTE FORM TWO (`U+2426`).

### Glyph Quantity

3~6

### Samples

`␦`

<img width="215" height="389" alt="image" src="https://github.com/user-attachments/assets/f05d0e96-9878-432c-8faf-dca1f64d45ab" />
