### PR TITLE
Add Sideways U Brackets (`⸦`, `⸧`).

### DIFF
--- a/changes/34.6.4.md
+++ b/changes/34.6.4.md
@@ -1,0 +1,3 @@
+* Add Characters:
+  - LEFT SIDEWAYS U BRACKET (`U+2E26`).
+  - RIGHT SIDEWAYS U BRACKET (`U+2E27`).

--- a/packages/font-glyphs/src/meta/aesthetics.ptl
+++ b/packages/font-glyphs/src/meta/aesthetics.ptl
@@ -54,6 +54,7 @@ export : define [calculateMetrics para] : begin
 	define SinSlope : Math.sin : para.slopeAngle / 180 * Math.PI
 	define CosSlope : Math.cos : para.slopeAngle / 180 * Math.PI
 	define HVContrast : Contrast * CosSlope + SinSlope * TanSlope
+	define VHContrast : 1 / HVContrast
 	define [HSwToV sw] : sw * HVContrast
 	define [VSwToH sw] : sw / HVContrast
 
@@ -147,7 +148,7 @@ export : define [calculateMetrics para] : begin
 	define DefaultTightBendInnerDiameter : Math.max (XH / 32) : AdviceStroke2 24 32 XH
 	define DefaultTightBendInnerRadius   : DefaultTightBendInnerDiameter / 2
 
-	define [StrokeWidthBlend min max sw] : linreg para.canonicalStrokeWidthMin min para.canonicalStrokeWidthMax max [fallback sw Stroke]
+	define [StrokeWidthBlend lo hi sw] : linreg para.canonicalStrokeWidthMin lo para.canonicalStrokeWidthMax hi [fallback sw Stroke]
 
 	define SmoothAdjust : StrokeWidthBlend 80 144
 	define [ArchDepthAOf archDepth width] : archDepth - TanSlope * SmoothAdjust * ([fallback width Width] / Width)
@@ -178,11 +179,15 @@ export : define [calculateMetrics para] : begin
 		return : yNotAdjusted + delta * [Math.min 1 : (top - bot) / (ada + adb)]
 	set YSmoothMidL.cr : function [c r _ada _adb] : YSmoothMidL (c + r) (c - r) _ada _adb
 
-	define [ArchDepthAClamped top bot ada adb] : begin
+	define [ArchDepthAClamped top bot _ada _adb] : begin
 		local height : Math.abs : top - bot
+		local ada : fallback _ada ArchDepthA
+		local adb : fallback _adb ArchDepthB
 		return : if (ada + adb < height) ada : YSmoothMidR height 0 ada adb
-	define [ArchDepthBClamped top bot ada adb] : begin
+	define [ArchDepthBClamped top bot _ada _adb] : begin
 		local height : Math.abs : top - bot
+		local ada : fallback _ada ArchDepthA
+		local adb : fallback _adb ArchDepthB
 		return : if (ada + adb < height) adb : YSmoothMidL height 0 ada adb
 
 	define CorrectionOMidX : TanSlope * 0.9 * [StrokeWidthBlend 1.3 0.9]
@@ -207,8 +212,8 @@ export : define [calculateMetrics para] : begin
 		DesignParameters UPM HalfUPM Width SB CAP XH Ascender Descender Contrast SymbolMid ParenTop
 		ParenBot OperTop OperBot TackTop TackBot PlusTop PlusBot PictTop PictBot BgOpTop BgOpBot
 		BgTkTop BgTkBot Italify Upright Scale Translate ApparentTranslate Rotate GlobalTransform
-		TanSlope HVContrast Upward Downward Rightward Leftward O OX OXHook Hook AHook SHook RHook
-		JHook HookX TailX TailY DiagTailAngle DiagTailDepth ArchDepth SmallArchDepth Stroke
+		TanSlope HVContrast VHContrast Upward Downward Rightward Leftward O OX OXHook Hook AHook SHook
+		RHook JHook HookX TailX TailY DiagTailAngle DiagTailDepth ArchDepth SmallArchDepth Stroke
 		HalfStroke QuarterStroke DotSize PeriodSize HBarPos OverlayPos Jut LongJut VJut LongVJut
 		VJutStroke AccentStackOffset AccentWidth AccentClearance AccentHeight CThin CThinB SLAB
 		IBalance IBalance2 JBalance JBalance2 TBalance TBalance2 RBalance RBalance2 FBalance

--- a/packages/font-glyphs/src/meta/macros.ptl
+++ b/packages/font-glyphs/src/meta/macros.ptl
@@ -393,12 +393,12 @@ define-macro glyph-block : syntax-rules
 		define metricImports `[DesignParameters UPM HalfUPM Width SB CAP XH Ascender Descender
 			Contrast SymbolMid ParenTop ParenBot OperTop OperBot TackTop TackBot PlusTop PlusBot
 			PictTop PictBot BgOpTop BgOpBot BgTkTop BgTkBot Italify Upright Scale Translate
-			ApparentTranslate Rotate GlobalTransform TanSlope HVContrast Upward Downward Rightward
-			Leftward O OX OXHook Hook AHook SHook RHook JHook HookX TailX TailY DiagTailAngle
-			DiagTailDepth ArchDepth SmallArchDepth Stroke HalfStroke QuarterStroke DotSize
-			PeriodSize HBarPos OverlayPos Jut LongJut VJut LongVJut VJutStroke AccentStackOffset
-			AccentWidth AccentClearance AccentHeight CThin CThinB SLAB IBalance IBalance2
-			JBalance JBalance2 TBalance TBalance2 RBalance RBalance2 FBalance OneBalance
+			ApparentTranslate Rotate GlobalTransform TanSlope HVContrast VHContrast Upward
+			Downward Rightward Leftward O OX OXHook Hook AHook SHook RHook JHook HookX TailX TailY
+			DiagTailAngle DiagTailDepth ArchDepth SmallArchDepth Stroke HalfStroke QuarterStroke
+			DotSize PeriodSize HBarPos OverlayPos Jut LongJut VJut LongVJut VJutStroke
+			AccentStackOffset AccentWidth AccentClearance AccentHeight CThin CThinB SLAB IBalance
+			IBalance2 JBalance JBalance2 TBalance TBalance2 RBalance RBalance2 FBalance OneBalance
 			WideWidth0 WideWidth1 WideWidth2 WideWidth3 WideWidth4 EssUpper EssLower EssQuestion
 			RightSB Middle DotRadius PeriodRadius ArchDepthA ArchDepthB SmallArchDepthA
 			SmallArchDepthB CorrectionOMidX CorrectionOMidS AdviceStroke

--- a/packages/font-glyphs/src/symbol/punctuation/brackets.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/brackets.ptl
@@ -18,7 +18,7 @@ glyph-block Symbol-Punctuation-Brackets : begin
 	define Paren : namespace
 		export : define [Dim] : with-params [df [delta 0] [dp DesignParameters] [sw Stroke]] : object
 			outside : [mix df.leftSB df.rightSB dp.parenOutside] - delta - [HSwToV dp.parenOutsideSwAdj] * sw + O
-			inside  : [mix df.leftSB df.rightSB dp.parenInside] - [HSwToV dp.parenInsideSwAdj] * sw
+			inside  : [mix df.leftSB df.rightSB dp.parenInside]          - [HSwToV dp.parenInsideSwAdj]  * sw
 			bottom  : [mix SymbolMid ParenBot (1 + dp.parenOvershoot)] - delta
 			top     : [mix SymbolMid ParenTop (1 + dp.parenOvershoot)] + delta
 			mid       SymbolMid
@@ -47,14 +47,14 @@ glyph-block Symbol-Punctuation-Brackets : begin
 		export : define [LowerShape df sw] : let [dim : Dim df 0 (sw -- sw)] : dispiro
 			widths.lhs sw
 			g4.down.start dim.outside MosaicTop [heading Downward]
-			quadControls 0 DesignParameters.parenCurliness
+			quadControls 0 (0 + DesignParameters.parenCurliness)
 			g4 dim.inside dim.bottom
 
 		export : define [ShapeMask df sw delta] : let [dim : Dim df delta (sw -- sw)] : spiro-outline
 			corner dim.inside dim.top
 			quadControls 1 (1 - DesignParameters.parenCurliness)
 			g4 dim.outside dim.mid
-			quadControls 0 DesignParameters.parenCurliness
+			quadControls 0 (0 + DesignParameters.parenCurliness)
 			corner dim.inside dim.bottom
 
 	do "Paren glyphs"
@@ -99,7 +99,7 @@ glyph-block Symbol-Punctuation-Brackets : begin
 				include : shape subDf
 				include : with-transform [ApparentTranslate (df.width - subDf.width) 0] : shape subDf
 
-			turned "parenRight.\(suffix)" null "parenLeft.\(suffix)" Middle SymbolMid
+			turned "parenRight.\(suffix)"       null "parenLeft.\(suffix)"       Middle SymbolMid
 			turned "doubleParenRight.\(suffix)" null "doubleParenLeft.\(suffix)" Middle SymbolMid
 
 			create-glyph "parenLeftUHalf.\(suffix)" : intersection
@@ -137,9 +137,9 @@ glyph-block Symbol-Punctuation-Brackets : begin
 			include : ForceUpright
 			include : Paren.LowerShape [DivFrame 1] Stroke
 
-		turned 'parenRightLower' 0x23A0 'parenLeftUpper' Middle SymbolMid
+		turned 'parenRightupper'     0x239E 'parenLeftLower'     Middle SymbolMid
 		turned 'parenRightExtension' 0x239F 'parenLeftExtension' Middle SymbolMid
-		turned 'parenRightupper' 0x239E 'parenLeftLower' Middle SymbolMid
+		turned 'parenRightLower'     0x23A0 'parenLeftUpper'     Middle SymbolMid
 
 		create-glyph 'zNotationParenLeft' 0x2987 : glyph-proc
 			local df : DivFrame 1
@@ -157,7 +157,7 @@ glyph-block Symbol-Punctuation-Brackets : begin
 
 	define Bracket : namespace
 		export : define [HDim barLeft ext] : namespace
-			export : define l : fallback barLeft : [mix SB RightSB DesignParameters.bracketOutside] - [HSwToV DesignParameters.bracketOutsideSwAdj] * Stroke
+			export : define l : fallback barLeft : [mix SB RightSB DesignParameters.bracketOutside] - [HSwToV : DesignParameters.bracketOutsideSwAdj * Stroke]
 			export : define r : [fallback ext 0] + [mix SB RightSB DesignParameters.bracketInside]
 
 		export : define [Mask] : Rect MosaicTop MosaicBottom (-Width) (2 * Width)
@@ -203,15 +203,15 @@ glyph-block Symbol-Punctuation-Brackets : begin
 			include : union
 				HBar.b hDim.l hDim.r ParenBot
 				HBar.t hDim.l hDim.r ParenTop
-				VBar.l hDim.l ParenBot ParenTop sw
+				VBar.l      hDim.l                 ParenBot ParenTop sw
 				VBar.m [mix hDim.l hDim.r (1 / 2)] ParenBot ParenTop sw
 
 		create-glyph 'bracketBarLeft' 0x2045 : glyph-proc
 			local hDim : Bracket.HDim
 			include : union
-				HBar.b hDim.l hDim.r ParenBot
-				HBar.t hDim.l hDim.r ParenTop
+				HBar.b hDim.l hDim.r      ParenBot
 				HBar.m hDim.l hDim.r [mix ParenBot ParenTop 0.5]
+				HBar.t hDim.l hDim.r               ParenTop
 				VBar.l hDim.l ParenBot ParenTop
 
 		create-glyph 'barBarLeft' 0x2E20 : glyph-proc
@@ -226,14 +226,14 @@ glyph-block Symbol-Punctuation-Brackets : begin
 				Bracket.Shape [mix SymbolMid ParenTop p] [mix SymbolMid ParenBot p]
 
 		turned 'bracketRight' ']' 'bracketLeft' Middle SymbolMid
-		turned 'bracketRightUHalf' 0x2E23 'bracketLeftLHalf' Middle SymbolMid
-		turned 'bracketRightLHalf' 0x2E25 'bracketLeftUHalf' Middle SymbolMid
-		turned 'bracketRightLower' 0x23A6 'bracketLeftUpper' Middle SymbolMid
+		turned 'bracketBarRight'       0x2046 'bracketBarLeft'       Middle SymbolMid
+		turned 'bracketRightUpper'     0x23A4 'bracketLeftLower'     Middle SymbolMid
 		turned 'bracketRightExtension' 0x23A5 'bracketLeftExtension' Middle SymbolMid
-		turned 'bracketRightUpper' 0x23A4 'bracketLeftLower' Middle SymbolMid
-		turned 'dblBracketRight' 0x27E7 'dblBracketLeft' Middle SymbolMid
-		turned 'bracketBarRight' 0x2046 'bracketBarLeft' Middle SymbolMid
-		turned 'barBarRight' 0x2E21 'barBarLeft' Middle SymbolMid
+		turned 'bracketRightLower'     0x23A6 'bracketLeftUpper'     Middle SymbolMid
+		turned 'dblBracketRight'       0x27E7 'dblBracketLeft'       Middle SymbolMid
+		turned 'barBarRight'           0x2E21 'barBarLeft'           Middle SymbolMid
+		turned 'bracketRightUHalf'     0x2E23 'bracketLeftLHalf'     Middle SymbolMid
+		turned 'bracketRightLHalf'     0x2E25 'bracketLeftUHalf'     Middle SymbolMid
 
 		create-glyph 'ligExtBracketRight' : glyph-proc
 			include [refer-glyph 'ligExtBracketLeft'] AS_BASE ALSO_METRICS
@@ -244,8 +244,8 @@ glyph-block Symbol-Punctuation-Brackets : begin
 		local dp : Object.assign {.} DesignParameters : fallback _dpOverride {.}
 
 		define [Dim] : begin
-			local parenCenter [mix SB RightSB [mix dp.braceInside dp.braceOutside 0.5]]
-			local radius    : Math.min
+			local parenCenter : mix SB RightSB [mix dp.braceInside dp.braceOutside 0.5]
+			local radius : Math.min
 				[mix SB RightSB dp.braceInside] - parenCenter
 				(ParenTop - SymbolMid - Stroke * 1.5) / 2
 			return : object parenCenter radius
@@ -256,9 +256,9 @@ glyph-block Symbol-Punctuation-Brackets : begin
 			define xTip : mix SB RightSB dp.braceOutside
 			include : dispiro
 				flat (xIns + [fallback ext 0]) top [widths.center.heading sw Leftward]
-				curl (xIns - TINY) top [heading Leftward]
+				curl (xIns - TINY)             top [heading Leftward]
 				archv
-				flat parenCenter (top - radius) [heading Downward]
+				flat parenCenter (top    - radius) [heading Downward]
 				curl parenCenter (bottom + radius) [heading Downward]
 				arcvh
 				straight.left.end xTip bottom [heading Leftward]
@@ -269,10 +269,10 @@ glyph-block Symbol-Punctuation-Brackets : begin
 			define xTip : mix SB RightSB dp.braceOutside
 			include : dispiro
 				flat (xIns + [fallback ext 0]) bottom [widths.center.heading sw Leftward]
-				curl (xIns - TINY) bottom [heading Leftward]
+				curl (xIns - TINY)             bottom [heading Leftward]
 				archv
 				flat parenCenter (bottom + radius) [heading Upward]
-				curl parenCenter (top - radius) [heading Upward]
+				curl parenCenter (top    - radius) [heading Upward]
 				arcvh
 				straight.left.end xTip top [heading Leftward]
 
@@ -290,7 +290,7 @@ glyph-block Symbol-Punctuation-Brackets : begin
 			define [object parenCenter radius] : Dim
 			include : intersection [Bracket.Mask]
 				union
-					UpperHalfShape (top + MosaicHeight) [mix bottom top 0.5] sw
+					UpperHalfShape (top + MosaicHeight) [mix bottom top 0.5]    sw
 					LowerHalfShape [mix bottom top 0.5] (bottom - MosaicHeight) sw
 
 		export : define [ExtensionShape top bottom sw] : glyph-proc
@@ -308,37 +308,37 @@ glyph-block Symbol-Punctuation-Brackets : begin
 			local m1   : mix xIns xOus (dp.braceCurlyM1 * (1 + 0.5 * pFlatIn))
 			local m2   : mix xIns xOus (dp.braceCurlyM2 * (1 + 0.5 * pFlatOut))
 			local braceRadiusLowLimit : (ParenTop - SymbolMid - sw) * (1 / 3) + hs
-			local radius1 : (sw / 16) + [mix [Math.min (xIns - m1) braceRadiusLowLimit] sw (0.75 * pFlatIn)]
-			local radius2 : (sw / 16) + [mix [Math.min (m2 - xOus) braceRadiusLowLimit] sw (0.75 * pFlatOut)] - hs
+			local radius1 : (sw / 16) + [mix [Math.min (xIns - m1)   braceRadiusLowLimit] sw (0.75 * pFlatIn)]
+			local radius2 : (sw / 16) + [mix [Math.min (m2   - xOus) braceRadiusLowLimit] sw (0.75 * pFlatOut)] - hs
 			local ess : mix sw (EssUpper * sw / Stroke) 0.25
 			local top : mix SymbolMid ParenTop (1 + dp.braceOvershoot)
 			local bot : mix SymbolMid ParenBot (1 + dp.braceOvershoot)
 
-			local flatLengthIn  : Math.max 0.1 : pFlatIn * (xIns - xOus)
+			local flatLengthIn  : Math.max 0.1 : pFlatIn  * (xIns - xOus)
 			local flatLengthOut : Math.max 0.1 : pFlatOut * (xIns - xOus)
 			local fine : sw * CThin
 
 			include : dispiro
 				flat (xIns + [fallback ext 0]) (top - hs) [widths.center.heading sw Leftward]
-				curl (xIns - flatLengthIn) (top - hs) [heading Leftward]
+				curl (xIns - flatLengthIn)     (top - hs) [heading Leftward]
 				archv.superness (2.2 + pFlatIn)
-				g4.down.mid m1 (top - radius1) [heading Downward]
+				g4.down.mid m1 (top       - radius1) [heading Downward]
 				alsoThru 0.5 0.5 [widths.center ess]
 				g4.down.mid m2 (SymbolMid + radius2) [widths.center.heading sw Downward]
 				arcvh
 				flat (xOus + flatLengthOut) (SymbolMid + (sw - fine) / 2) [widths.center.heading fine Leftward]
-				curl xOus (SymbolMid + (sw - fine) / 2) [heading Leftward]
+				curl  xOus                  (SymbolMid + (sw - fine) / 2) [heading Leftward]
 
 			include : dispiro
 				flat (xIns + [fallback ext 0]) (bot + hs) [widths.center.heading sw Leftward]
-				curl (xIns - flatLengthIn) (bot + hs) [heading Leftward]
+				curl (xIns - flatLengthIn)     (bot + hs) [heading Leftward]
 				archv.superness (2.2 + pFlatIn)
-				g4.up.mid m1 (bot + radius1) [heading Upward]
+				g4.up.mid m1 (bot       + radius1) [heading Upward]
 				alsoThru 0.5 0.5 [widths.center ess]
 				g4.up.mid m2 (SymbolMid - radius2) [widths.center.heading sw Upward]
 				arcvh
 				flat (xOus + flatLengthOut) (SymbolMid - (sw - fine) / 2) [widths.center.heading fine Leftward]
-				curl xOus (SymbolMid - (sw - fine) / 2) [heading Leftward]
+				curl  xOus                  (SymbolMid - (sw - fine) / 2) [heading Leftward]
 
 	define Brace : BraceT
 	define BraceLarge : BraceT {
@@ -430,13 +430,13 @@ glyph-block Symbol-Punctuation-Brackets : begin
 				turned "whiteBraceRight.\(suffix)" null "whiteBraceLeft.\(suffix)" Middle SymbolMid
 
 
-		select-variant 'braceLeft' '{'
+		select-variant 'braceLeft'  '{'
 		select-variant 'braceRight' '}'
 
-		select-variant 'ligExtBraceLeft' (follow -- 'braceLeft')
+		select-variant 'ligExtBraceLeft'  (follow -- 'braceLeft')
 		select-variant 'ligExtBraceRight' (follow -- 'braceRight')
 
-		select-variant 'whiteBraceLeft' 0x2983 (follow -- 'braceLeft')
+		select-variant 'whiteBraceLeft'  0x2983 (follow -- 'braceLeft')
 		select-variant 'whiteBraceRight' 0x2984 (follow -- 'braceRight')
 
 	do "Angle Bracket"
@@ -481,9 +481,9 @@ glyph-block Symbol-Punctuation-Brackets : begin
 						AngleLeftShapeMask dim.outside dim.inside fine
 
 		turned 'zNotationAngleRight' 0x298A 'zNotationAngleLeft' Middle SymbolMid
-		turned 'angleRight' 0x232A 'angleLeft' Middle SymbolMid
-		turned 'dblAngleRight' 0x27EB 'dblAngleLeft' Middle SymbolMid
-		alias 'mathAngleLeft' 0x27E8 'angleLeft'
+		turned 'angleRight'          0x232A 'angleLeft'          Middle SymbolMid
+		turned 'dblAngleRight'       0x27EB 'dblAngleLeft'       Middle SymbolMid
+		alias 'mathAngleLeft'  0x27E8 'angleLeft'
 		alias 'mathAngleRight' 0x27E9 'angleRight'
 
 	do "Sideways U Bracket"
@@ -504,5 +504,5 @@ glyph-block Symbol-Punctuation-Brackets : begin
 			include : HBar.b [mix SB RightSB DesignParameters.bracketOutside] [mix SB RightSB DesignParameters.bracketInside] ParenBot
 			include : VBar.l [mix SB RightSB DesignParameters.bracketOutside] ParenBot ParenTop
 
-		turned 'floorRight' 0x230B 'ceilingLeft' Middle SymbolMid
-		turned 'ceilingRight' 0x2309 'floorLeft' Middle SymbolMid
+		turned 'floorRight'   0x230B 'ceilingLeft' Middle SymbolMid
+		turned 'ceilingRight' 0x2309 'floorLeft'   Middle SymbolMid

--- a/packages/font-glyphs/src/symbol/punctuation/brackets.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/brackets.ptl
@@ -486,14 +486,23 @@ glyph-block Symbol-Punctuation-Brackets : begin
 		alias 'mathAngleLeft' 0x27E8 'angleLeft'
 		alias 'mathAngleRight' 0x27E9 'angleRight'
 
+	do "Sideways U Bracket"
+		create-glyph 'uSidewaysBracketLeft' 0x2E26 : with-transform [ApparentTranslate 0 (SymbolMid - XH / 2)]
+			PointingTo Width XH Width 0 : function [] : glyph-proc
+				local df : DivFrame (XH / Width) 2 ((XH * 0.1) / SB)
+				include : UShape [mix Width RightSB 0.5] [mix 0 SB 0.5] df.leftSB df.rightSB Stroke
+				include : FlipAround df.middle Middle
+
+		turned 'uSidewaysBracketRight' 0x2E27 'uSidewaysBracketLeft' Middle SymbolMid
+
 	do "Floor and Ceiling"
 		create-glyph 'ceilingLeft' 0x2308 : glyph-proc
-			include : HBar.t    [mix SB RightSB DesignParameters.bracketOutside] [mix SB RightSB DesignParameters.bracketInside] ParenTop
-			include : VBar.l   [mix SB RightSB DesignParameters.bracketOutside] ParenBot ParenTop
+			include : HBar.t [mix SB RightSB DesignParameters.bracketOutside] [mix SB RightSB DesignParameters.bracketInside] ParenTop
+			include : VBar.l [mix SB RightSB DesignParameters.bracketOutside] ParenBot ParenTop
 
 		create-glyph 'floorLeft' 0x230A : glyph-proc
 			include : HBar.b [mix SB RightSB DesignParameters.bracketOutside] [mix SB RightSB DesignParameters.bracketInside] ParenBot
-			include : VBar.l   [mix SB RightSB DesignParameters.bracketOutside] ParenBot ParenTop
+			include : VBar.l [mix SB RightSB DesignParameters.bracketOutside] ParenBot ParenTop
 
 		turned 'floorRight' 0x230B 'ceilingLeft' Middle SymbolMid
 		turned 'ceilingRight' 0x2309 'floorLeft' Middle SymbolMid

--- a/packages/font-glyphs/src/symbol/punctuation/brackets.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/brackets.ptl
@@ -490,7 +490,8 @@ glyph-block Symbol-Punctuation-Brackets : begin
 		create-glyph 'uSidewaysBracketLeft' 0x2E26 : with-transform [ApparentTranslate 0 (SymbolMid - XH / 2)]
 			PointingTo Width XH Width 0 : function [] : glyph-proc
 				local df : DivFrame (XH / Width) 2 ((XH * 0.1) / SB)
-				include : UShape [mix Width RightSB 0.5] [mix 0 SB 0.5] df.leftSB df.rightSB Stroke
+				include : UShape [mix Width RightSB 0.5] [mix 0 SB 0.5] df.leftSB df.rightSB
+					Stroke * [StrokeWidthBlend HVContrast VHContrast]
 				include : FlipAround df.middle Middle
 
 		turned 'uSidewaysBracketRight' 0x2E27 'uSidewaysBracketLeft' Middle SymbolMid


### PR DESCRIPTION
### Motivation and Context

This fills a two-character-wide gap in coverage within a range of supported characters in the Supplemental Punctuation block.
It's constructed differently than {Super|Sub}set (`⊂`, `⊃`}.

### Influenced Characters

  - LEFT SIDEWAYS U BRACKET (`U+2E26`).
  - RIGHT SIDEWAYS U BRACKET (`U+2E27`).

### Glyph Quantity

2

### Samples

`⸦Hx⸧`

<img width="1473" height="1017" alt="image" src="https://github.com/user-attachments/assets/2ffcbe0d-7048-4693-8b6e-bc92144e085a" />

