### PR TITLE
Add `et-flat-bottom` and `flat-top-serifed` variants for Ampersand (`&`).

### DIFF
--- a/changes/34.7.0.md
+++ b/changes/34.7.0.md
@@ -1,3 +1,4 @@
+* Add `et-flat-bottom` and `flat-top-serifed` variants for Ampersand (`&`).
 * Add Characters:
   - LEFT SIDEWAYS U BRACKET (`U+2E26`).
   - RIGHT SIDEWAYS U BRACKET (`U+2E27`).

--- a/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
@@ -333,10 +333,11 @@ glyph-block Letter-Latin-Ezh : begin
 	define flex-params [RevEzhShape] : glyph-proc
 		local-parameter : top
 		local-parameter : bottom
+		local-parameter : fSerifed      -- false
 		local-parameter : pxTopLeft     -- 0.075
 		local-parameter : pxMidRight    -- 0.800
-		local-parameter : pyMidRight    -- 0.6
-		local-parameter : hookless      -- false
+		local-parameter : pyMidRight    -- 0.550
+		local-parameter : hook          -- Hook
 		local-parameter : ada           -- SmallArchDepthA
 		local-parameter : adb           -- SmallArchDepthB
 
@@ -353,15 +354,15 @@ glyph-block Letter-Latin-Ezh : begin
 			flat xMidRight yMidRight [heading Leftward]
 			curl [Arch.adjust-x.bot Middle] yMidRight
 			archv
-			if hookless
+			if hook
 			: then : list
-				g4.down.mid (SB + OX) [RevEzhShape.yArcMid top bottom pyMidRight ada adb]
-			: else : list
-				g4 (SB + OX) [RevEzhShape.yArcMid top bottom pyMidRight ada adb]
+				g4   (SB + OX) [RevEzhShape.yArcMid top bottom pyMidRight ada adb]
 				HookEnd bottom
-				g4 RightSB (bottom + Hook * ((top - bottom) / CAP))
-		if SLAB : begin
-			local { jutTop jutBot jutMid } : EFVJutLength top bottom pyMidRight nothing nothing (Hook * ((top - bottom) / CAP))
+				g4   RightSB (bottom + hook)
+			: else : list
+				g4.down.mid (SB + OX) [RevEzhShape.yArcMid top bottom pyMidRight ada adb]
+		if fSerifed : begin
+			local { jutTop jutBot jutMid } : EFVJutLength top bottom pyMidRight nothing nothing (hook || nothing)
 			include : VSerif.dr RightSB top jutTop
-	set RevEzhShape.yMidRight : lambda [top bottom pyMidRight] : mix bottom top pyMidRight
+	set RevEzhShape.yMidRight : lambda [top bottom pyMidRight] : [mix bottom top pyMidRight] + HalfStroke
 	set RevEzhShape.yArcMid   : lambda [top bottom pyMidRight ada adb] : YSmoothMidL [RevEzhShape.yMidRight top bottom pyMidRight] bottom ada adb

--- a/packages/font-glyphs/src/symbol/punctuation/ampersand.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/ampersand.ptl
@@ -68,7 +68,7 @@ glyph-block Symbol-Punctuation-Ampersand : begin
 			corner [mix xUpperLoopLeft xTerminal 4]            [mix yMockUpperLoopLeftBottom 0 pStraightBar]
 
 
-	create-glyph 'ampersand.closed' : union
+	create-glyph "ampersand.closed" : union
 		intersection
 			ClosedAmpersandLead SwAmpersand ClosedTipSw
 			ClosedAmpersandLeadMask
@@ -90,7 +90,7 @@ glyph-block Symbol-Punctuation-Ampersand : begin
 				curl [mix xUpperLoopLeft xTerminal 2] (-yMockUpperLoopLeftBottom)
 			Rect 0 ((-CAP) * 2) xTerminal (Width * 2)
 
-	create-glyph 'ampersand.upperOpen' : union
+	create-glyph "ampersand.upperOpen" : union
 		intersection
 			ClosedAmpersandLead SwAmpersand ClosedTipSw
 			ClosedAmpersandLeadMask
@@ -141,7 +141,7 @@ glyph-block Symbol-Punctuation-Ampersand : begin
 		corner (xLowerOpenBarLeft  + TanSlope * fineAmp / 2) y
 		corner (xLowerOpenBarRight + TanSlope * fineAmp / 2) y
 
-	create-glyph 'ampersand.lowerOpen' : union
+	create-glyph "ampersand.lowerOpen" : union
 		LowerOpenCrossbar yLowerOpenEnd
 		dispiro
 			widths.rhs SwAmpersand
@@ -184,9 +184,10 @@ glyph-block Symbol-Punctuation-Ampersand : begin
 	define xEtCenterBarRight : mix xEtRight Width 0.5
 	define yEtRightBarTop : mix (yEtMiddle + SwAmpersand / 2) (CAP - SHook) 0.375
 
-	define FORM-TOOTHLESS-CORNER  1
-	define FORM-TOOTHLESS-ROUNDED 2
-	define FORM-TOOTHED           3
+	define FORM-TOOTHED           0
+	define FORM-FLAT-BOTTOM       1
+	define FORM-TOOTHLESS-CORNER  2
+	define FORM-TOOTHLESS-ROUNDED 3
 
 	define [EtUpperHalf] : dispiro
 		g4 xEtRight (CAP - SHook) [widths.lhs]
@@ -202,51 +203,72 @@ glyph-block Symbol-Punctuation-Ampersand : begin
 		archv
 		g4 (xEtLeft + O * 2) adbEt [widths.lhs]
 		match form
+			[Just FORM-TOOTHED] : begin
+				SerifedArcEnd.LtrLhs xEtRight 0 Stroke adaEt Stroke
+			[Just FORM-FLAT-BOTTOM] : list
+				arcvh
+				flat [Arch.adjust-x.bot [mix xEtLeft xEtRight 0.5]] 0
+				curl (xEtRight + O) 0 [heading Rightward]
 			[Just FORM-TOOTHLESS-CORNER] : list
 				Arch.lhs 0 (blendPost -- {})
 				g4   xEtRight DToothlessRise
-
 			[Just FORM-TOOTHLESS-ROUNDED] : list
 				Arch.lhs 0
 				flat xEtRight adaEt
 				curl xEtRight yEtRightBarTop [heading Upward]
-
-			[Just FORM-TOOTHED] : begin
-				SerifedArcEnd.LtrLhs xEtRight 0 Stroke adaEt Stroke
-			_ : list
+			__ : list
 
 
-	create-glyph 'ampersand.etToothlessCorner' : union
-		EtUpperHalf
-		EtLowerHalf FORM-TOOTHLESS-CORNER
-		VBar.r xEtRight DToothlessRise yEtRightBarTop
-
-	create-glyph 'ampersand.etToothlessRounded' : union
-		EtUpperHalf
-		EtLowerHalf FORM-TOOTHLESS-ROUNDED
-
-	create-glyph 'ampersand.etToothed' : union
+	create-glyph "ampersand.etToothed" : union
 		EtUpperHalf
 		EtLowerHalf FORM-TOOTHED
 		VBar.r xEtRight (adaEt + O) yEtRightBarTop
 		VBar.r xEtRight adaEt 0 [Math.max [AdviceStroke 5] (Stroke - ShoulderFine / 2)]
 
-	create-glyph 'ampersand.etTailed' : union
+	create-glyph "ampersand.etTailed" : union
 		EtUpperHalf
 		EtLowerHalf FORM-TOOTHED
 		RightwardTailedBar xEtRight 0 yEtRightBarTop
 
-	define yEtFlatTopEnd : Math.max (ArchDepthA + fineAmp) (CAP * 0.4)
-	define yEtFlatTopBarPos : (OverlayPos * CAP + Stroke * 0.625) / CAP
+	create-glyph "ampersand.etFlatBottom" : union
+		EtUpperHalf
+		EtLowerHalf FORM-FLAT-BOTTOM
+		VBar.r xEtRight 0 yEtRightBarTop
 
-	create-glyph 'ampersand.flatTop' : union
+	create-glyph "ampersand.etToothlessCorner" : union
+		EtUpperHalf
+		EtLowerHalf FORM-TOOTHLESS-CORNER
+		VBar.r xEtRight DToothlessRise yEtRightBarTop
+
+	create-glyph "ampersand.etToothlessRounded" : union
+		EtUpperHalf
+		EtLowerHalf FORM-TOOTHLESS-ROUNDED
+
+	define yEtFlatTopEnd : Math.max (0 + ArchDepthA + fineAmp) [mix 0 CAP 0.4]
+	define pyEtFlatTopBarPos : ([mix 0 CAP OverlayPos] + Stroke * 0.125) / (CAP - 0)
+
+	define [EtFlatTopLowerHalf] : dispiro
+		widths.lhs
+		g4.down.start (SB + OX) [RevEzhShape.yArcMid CAP 0 pyEtFlatTopBarPos adaEt adbEt]
+		Arch.lhs 0 (swAfter -- fineAmp)
+		flat (xLowerOpenRight - OX) adaEt [widths.lhs fineAmp]
+		curl (xLowerOpenRight - OX) yEtFlatTopEnd [heading Upward]
+
+	define [EtFlatTopUpperHalf slab] : RevEzhShape CAP 0
+		fSerifed   -- slab
+		hook       -- 0
+		ada        -- adaEt
+		adb        -- adbEt
+		pyMidRight -- pyEtFlatTopBarPos
+
+	create-glyph "ampersand.flatTopSerifless" : union
 		LowerOpenCrossbar yEtFlatTopEnd
-		RevEzhShape CAP 0 (hookless -- true) (ada -- ArchDepthA) (adb -- ArchDepthB) (pyMidRight -- yEtFlatTopBarPos)
-		dispiro
-			widths.lhs
-			g4.down.start (SB + OX) [RevEzhShape.yArcMid CAP 0 yEtFlatTopBarPos adaEt adbEt]
-			Arch.lhs 0 (swAfter -- fineAmp)
-			flat (xLowerOpenRight - OX) adaEt [widths.lhs fineAmp]
-			curl (xLowerOpenRight - OX) yEtFlatTopEnd [heading Upward]
+		EtFlatTopUpperHalf false
+		EtFlatTopLowerHalf
+
+	create-glyph "ampersand.flatTopSerifed" : union
+		LowerOpenCrossbar yEtFlatTopEnd
+		EtFlatTopUpperHalf true
+		EtFlatTopLowerHalf
 
 	select-variant 'ampersand' '&'

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -9541,45 +9541,90 @@ selector."numberSign/cap" = "slantedOpen"
 sampler = "&"
 tagKind = "symbol"
 
-[prime.ampersand.variants.closed]
+[prime.ampersand.variants-buildup]
+entry = "body"
+descriptionLeader = "Ampersand (`&`)"
+
+[prime.ampersand.variants-buildup.stages.body.closed]
 rank = 1
-description = "Ampersand (`&`) with a closed contour"
-selector.ampersand = "closed"
+groupRank = 1
+next = "END"
+descriptionAffix = "closed contour"
+selectorAffix.ampersand = "closed"
 
-[prime.ampersand.variants.upper-open]
+[prime.ampersand.variants-buildup.stages.body.upper-open]
 rank = 2
-description = "Ampersand (`&`) with an open contour at upper half"
-selector.ampersand = "upperOpen"
+groupRank = 1
+next = "END"
+descriptionAffix = "open contour at upper half"
+selectorAffix.ampersand = "upperOpen"
 
-[prime.ampersand.variants.lower-open]
+[prime.ampersand.variants-buildup.stages.body.lower-open]
 rank = 3
-description = "Ampersand (`&`) with an open contour at lower half"
-selector.ampersand = "lowerOpen"
+groupRank = 1
+next = "END"
+descriptionAffix = "open contour at lower half"
+selectorAffix.ampersand = "lowerOpen"
 
-[prime.ampersand.variants.flat-top]
+[prime.ampersand.variants-buildup.stages.body.flat-top]
 rank = 4
-description = "Ampersand (`&`) drawn with a flat top"
-selector.ampersand = "flatTop"
+groupRank = 1
+next = "serifs"
+descriptionAffix = "flat top"
+selectorAffix.ampersand = "flatTop"
 
-[prime.ampersand.variants.et-toothed]
+[prime.ampersand.variants-buildup.stages.body.et]
 rank = 5
-description = "Ampersand (`&`) drawn like a ligature of Ɛ and t with tooth"
-selector.ampersand = "etToothed"
+groupRank = 2
+next = "terminal"
+descriptionAffix = "body shape drawn like a ligature of `Ɛ` and `t`"
+selectorAffix.ampersand = "et"
 
-[prime.ampersand.variants.et-toothless-corner]
-rank = 6
-description = "Ampersand (`&`) drawn like a ligature of Ɛ and t without tooth (corner)"
-selector.ampersand = "etToothlessCorner"
+[prime.ampersand.variants-buildup.stages.serifs."*"]
+next = "END"
 
-[prime.ampersand.variants.et-toothless-rounded]
-rank = 7
-description = "Ampersand (`&`) drawn like a ligature of Ɛ and t without tooth (rounded)"
-selector.ampersand = "etToothlessRounded"
+[prime.ampersand.variants-buildup.stages.serifs.serifless]
+rank = 1
+keyAffix = ""
+selectorAffix.ampersand = "serifless"
 
-[prime.ampersand.variants.et-tailed]
-rank = 8
-description = "Ampersand (`&`) drawn like a ligature of Ɛ and t with tail"
-selector.ampersand = "etTailed"
+[prime.ampersand.variants-buildup.stages.serifs.serifed]
+rank = 2
+nonBreakingVariantAdditionPriority = 20
+descriptionAffix = "serif at top-right"
+selectorAffix.ampersand = "serifed"
+
+[prime.ampersand.variants-buildup.stages.terminal."*"]
+next = "END"
+
+[prime.ampersand.variants-buildup.stages.terminal.toothed]
+rank = 1
+descriptionAffix = "tooth"
+selectorAffix.ampersand = "toothed"
+
+[prime.ampersand.variants-buildup.stages.terminal.tailed]
+rank = 2
+nonBreakingVariantAdditionPriority = 10
+descriptionAffix = "tail"
+selectorAffix.ampersand = "tailed"
+
+[prime.ampersand.variants-buildup.stages.terminal.flat-bottom]
+rank = 3
+nonBreakingVariantAdditionPriority = 10
+descriptionAffix = "flat bottom"
+selectorAffix.ampersand = "flatBottom"
+
+[prime.ampersand.variants-buildup.stages.terminal.toothless-corner]
+rank = 4
+descriptionAffix = "tooth (corner)"
+descriptionJoiner = "without"
+selectorAffix.ampersand = "toothlessCorner"
+
+[prime.ampersand.variants-buildup.stages.terminal.toothless-rounded]
+rank = 5
+descriptionAffix = "tooth (rounded)"
+descriptionJoiner = "without"
+selectorAffix.ampersand = "toothlessRounded"
 
 
 


### PR DESCRIPTION
### Motivation and Context

These are niche variants intended to complete the sets that were previously left unfinished by both #2193 and #3186 .

New variants are added at the end of the stack, facilitated by changing `variants` to `variants-buildup` in the variants tree.

### Influenced Characters

  - AMPERSAND (`U+0026`).
  - TURNED AMPERSAND (`U+214B`).

### Glyph Quantity

2 (or 4 total if Turned Ampersand `⅋` counts)

### Samples

```
&⅋ &⅋ &⅋ &⅋ &⅋
&⅋ &⅋ &⅋ &⅋ &⅋
```

All `ampersand` variants:
(rearranged into the order they will take up in future versions after `nonBreakingVariantAdditionPriority = …` is removed)

<img width="1014" height="1062" alt="image" src="https://github.com/user-attachments/assets/fb9c7ca8-90e5-44cf-a6cf-9349e1db93ad" />

