### PR TITLE
Use more sophisticated glyph for Lower Ezh With Tail (`ƺ`).

### DIFF
--- a/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
@@ -9,11 +9,13 @@ glyph-block Letter-Latin-Ezh : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Metrics : EFVJutLength
 	glyph-block-import Letter-Shared-Shapes : CurlyTail SerifedArcEnd PalatalHook RetroflexHook
+	glyph-block-import Letter-Latin-S : SNeck
 
 	define TERMINAL-NONE 0
 	define TERMINAL-HOOK 1
 	define TERMINAL-DESC 2
 	define TERMINAL-CURL 3
+	define TERMINAL-TAIL 4
 
 	glyph-block-export Ezh
 	define flex-params [Ezh] : namespace
@@ -110,6 +112,12 @@ glyph-block Letter-Latin-Ezh : begin
 							CurlyTail.n fine bottom df.leftSB df.width (bottom + 0.5 * fine)
 								yLoopTop -- ([mix yMidLeft bottom 0.5] + 0.25 * fine)
 								swBefore -- stroke
+						[Just TERMINAL-TAIL] : let [desc : bottom - (0 - Descender)] : list
+							g4 xArcMid yArcMid
+							~~~ [SNeck df (yMidLeft - desc) stroke (stroke * EssRatioLower)]
+							g4 (df.leftSB  + OX) [YSmoothMidL (bottom + stroke) desc ada adb] [widths.lhs stroke]
+							HookEnd desc (sw -- stroke)
+							g4 (df.rightSB - OX) (desc + SHook)
 						__ : list
 							g4 xArcMid yArcMid
 							HookEnd bottom (sw -- stroke)
@@ -282,33 +290,16 @@ glyph-block Letter-Latin-Ezh : begin
 
 		create-glyph "ezhTail.\(suffix)" : glyph-proc
 			include : MarkSet.p
-			local stroke : AdviceStroke2 2 3 (XH - 0)
 			define ezh : Ezh [DivFrame 1] XH 0
 				fCursive  -- fCursive
 				fSerifed  -- fSerifed
 				pyMidLeft -- [if fCursive 0.50 0.52]
-				stroke    -- stroke
+				stroke    -- [AdviceStroke2 2 3 (XH - 0)]
 				hook      -- SHook
 				ada       -- SmallArchDepthA
 				adb       -- SmallArchDepthB
-				terminal  -- TERMINAL-NONE
+				terminal  -- TERMINAL-TAIL
 			include : ezh.Shape
-			define [object xArcMid yArcMid] : ezh.Dim
-			include : dispiro
-				widths.rhs stroke
-				g4.down.mid xArcMid yArcMid [heading Downward]
-				arcvh
-				let [gap : 2 * (stroke * CorrectionOMidX)] : if (gap > TINY)
-					list
-						flat [Math.min (xArcMid - [HSwToV : 1.125 * stroke] - TINY - [Math.abs : TanSlope * stroke]) (Middle + gap / 2)] 0
-						curl [Math.max (SB + OX + [HSwToV : 1.125 * stroke] + TINY + [Math.abs : TanSlope * stroke]) (Middle - gap / 2)] 0
-					list
-						straight.left.mid Middle 0
-				archv
-				g4   (SB + OX + [HSwToV stroke]) [YSmoothMidL stroke Descender SmallArchDepthA SmallArchDepthB]
-				arcvh
-				flat [Math.max (SB + [HSwToV : 1.125 * stroke] + TINY + [Math.abs : TanSlope * stroke]) : Arch.adjust-x.bot Middle (sw -- stroke)] (Descender + stroke)
-				curl RightSB (Descender + stroke)
 
 		create-glyph "ezhCurlyTail.\(suffix)" : glyph-proc
 			include : MarkSet.p

--- a/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
@@ -9,7 +9,7 @@ glyph-block Letter-Latin-Ezh : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Metrics : EFVJutLength
 	glyph-block-import Letter-Shared-Shapes : CurlyTail SerifedArcEnd PalatalHook RetroflexHook
-	glyph-block-import Letter-Latin-S : SNeck
+	glyph-block-import Letter-Latin-S : AdviceSArchDepth SNeck
 
 	define TERMINAL-NONE 0
 	define TERMINAL-HOOK 1
@@ -112,12 +112,12 @@ glyph-block Letter-Latin-Ezh : begin
 							CurlyTail.n fine bottom df.leftSB df.width (bottom + 0.5 * fine)
 								yLoopTop -- ([mix yMidLeft bottom 0.5] + 0.25 * fine)
 								swBefore -- stroke
-						[Just TERMINAL-TAIL] : let [desc : bottom - (0 - Descender)] : list
-							g4 xArcMid yArcMid
-							~~~ [SNeck df (yMidLeft - desc) stroke (stroke * EssRatioLower)]
-							g4 (df.leftSB  + OX) [YSmoothMidL (bottom + stroke) desc ada adb] [widths.lhs stroke]
-							HookEnd desc (sw -- stroke)
-							g4 (df.rightSB - OX) (desc + SHook)
+						[Just TERMINAL-TAIL] : let [adb2 : AdviceSArchDepth (yMidLeft - bottom) (+1) stroke] : list
+							g4 xArcMid (yMidLeft - adb2)
+							~~~ [SNeck df (yMidLeft - bottom) stroke (stroke * EssRatioLower)]
+							g4 (df.leftSB  + OX) (bottom + adb2) [widths.lhs stroke]
+							HookEnd bottom (sw -- stroke)
+							g4 (df.rightSB - OX) (bottom + hook)
 						__ : list
 							g4 xArcMid yArcMid
 							HookEnd bottom (sw -- stroke)
@@ -290,10 +290,10 @@ glyph-block Letter-Latin-Ezh : begin
 
 		create-glyph "ezhTail.\(suffix)" : glyph-proc
 			include : MarkSet.p
-			define ezh : Ezh [DivFrame 1] XH 0
+			define ezh : Ezh [DivFrame 1] XH Descender
 				fCursive  -- fCursive
 				fSerifed  -- fSerifed
-				pyMidLeft -- [if fCursive 0.50 0.52]
+				pyMidLeft -- (([mix 0 XH : if fCursive 0.50 0.52] - Descender) / (XH - Descender))
 				stroke    -- [AdviceStroke2 2 3 (XH - 0)]
 				hook      -- SHook
 				ada       -- SmallArchDepthA

--- a/packages/font-glyphs/src/letter/latin/k.ptl
+++ b/packages/font-glyphs/src/letter/latin/k.ptl
@@ -377,7 +377,7 @@ glyph-block Letter-Latin-K : begin
 			define xDTStart : dim.arcTerminalX + [HSwToV swDiagTail] + xDTGap
 			define xDTEnd : dim.kshRight - 0.8 * Hook + xDTGap * 0.625
 			define tailAngle : Math.min 85 (DiagTailAngle + 3)
-			define dtInnerRadius : [clamp 0.125 1 : mix 1 (Width / HalfUPM) 3] * DefaultTightBendInnerRadius
+			define dtInnerRadius : [clamp 0.125 1 : mix 1 (Width / HalfUPM) 3] * TightBendInnerRadius
 
 			set-base-anchor 'legOverlay' [mix xDTStart xDTEnd : StrokeWidthBlend 0.65 0.75] [mix dim.arcTerminalY 0 : StrokeWidthBlend 0.6 0.65]
 			define innerX : xDTEnd + 0.5 * swDiagTailAdj

--- a/packages/font-glyphs/src/letter/latin/s.ptl
+++ b/packages/font-glyphs/src/letter/latin/s.ptl
@@ -35,6 +35,7 @@ glyph-block Letter-Latin-S : begin
 		local ss : y * 0.22 + 0.12 * strokeFactor + 0.05 * widthFactor
 		return : ss + sign * TanSlope * SmoothAdjust
 
+	glyph-block-export SNeck
 	define [SNeck df height stroke ess] : begin
 		local adjustFactor : 0.1 * (df.rightSB - df.leftSB) / height
 		return : list

--- a/packages/font-glyphs/src/letter/latin/v.ptl
+++ b/packages/font-glyphs/src/letter/latin/v.ptl
@@ -241,7 +241,7 @@ glyph-block Letter-Latin-V : begin
 		define yArcRight : [mix 0  top     0.6] - sw * 0.2
 		define xArcEnd   : [mix SB RightSB 0.8] + sw * 0.375
 		define yArcEnd   : top - O
-		define rInY : 1 * DefaultTightBendInnerRadius
+		define rInY : 1 * TightBendInnerRadius
 		define xArcMidBottom : Arch.adjust-x.bot (xBar + [HSwToV : sw + rInY]) sw
 		define yArcMidBottom : 0 + O
 

--- a/packages/font-glyphs/src/letter/latin/w.ptl
+++ b/packages/font-glyphs/src/letter/latin/w.ptl
@@ -349,7 +349,7 @@ glyph-block Letter-Latin-W : begin
 		define x1 : df.leftSB + 0 * OX
 		define y3 : mix fine top 0.375
 		define y4 : WMidHeight df top bodyType midHClass
-		define rInY : 1 * DefaultTightBendInnerRadius
+		define rInY : 1 * TightBendInnerRadius
 
 		include : dispiro
 			widths.lhs fine

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -880,7 +880,7 @@ glyph-block Letter-Shared-Shapes : begin
 				curl (cx + sign * (dxTailStart + dxDepth)) (cy + O + dyTailStart + dyDepth)
 
 		export : define [R cx cy depth sw] : begin
-			define rInY : 1 * DefaultTightBendInnerRadius
+			define rInY : 1 * TightBendInnerRadius
 			define innerX : cx + [HSwToV : 0.5 * sw]
 			return : list
 				curl innerX (cy + [FineSw sw] + rInY) [widths.rhs sw]
@@ -888,7 +888,7 @@ glyph-block Letter-Shared-Shapes : begin
 				F (+1) innerX cy rInY DiagTailAngle depth sw
 
 		export : define [L cx cy depth sw] : begin
-			define rInY : 1 * DefaultTightBendInnerRadius
+			define rInY : 1 * TightBendInnerRadius
 			define innerX : cx - [HSwToV : 0.5 * sw]
 			return : list
 				curl innerX (cy + [FineSw sw] + rInY) [widths.lhs sw]

--- a/packages/font-glyphs/src/meta/aesthetics.ptl
+++ b/packages/font-glyphs/src/meta/aesthetics.ptl
@@ -132,9 +132,12 @@ export : define [calculateMetrics para] : begin
 	define [NarrowUnicodeT wd] : function [u] : if (wd === Width) u null
 	define [WideUnicodeT   wd] : function [u] : if (wd !== Width) u null
 
-	define EssUpper    : Stroke * [fallback para.essRatioUpper    para.essRatio Contrast]
-	define EssLower    : Stroke * [fallback para.essRatioLower    para.essRatio Contrast]
-	define EssQuestion : Stroke * [fallback para.essRatioQuestion para.essRatio Contrast]
+	define EssRatioUpper    : fallback para.essRatioUpper    para.essRatio Contrast
+	define EssRatioLower    : fallback para.essRatioLower    para.essRatio Contrast
+	define EssRatioQuestion : fallback para.essRatioQuestion para.essRatio Contrast
+	define EssUpper    : Stroke * EssRatioUpper
+	define EssLower    : Stroke * EssRatioLower
+	define EssQuestion : Stroke * EssRatioQuestion
 	define RightSB : Width - SB
 	define Middle : Width / 2
 	define DotRadius : DotSize / 2
@@ -142,11 +145,10 @@ export : define [calculateMetrics para] : begin
 	define SideJut : Jut - [HSwToV HalfStroke]
 
 	define DToothlessRise : Hook / 4 + Stroke / 16
-	define DMBlend          0.80
 
 	define ShoulderFine : Math.min (Stroke * para.shoulderFineMin) : AdviceStroke 24
-	define DefaultTightBendInnerDiameter : Math.max (XH / 32) : AdviceStroke2 24 32 XH
-	define DefaultTightBendInnerRadius   : DefaultTightBendInnerDiameter / 2
+	define TightBendInnerDiameter : Math.max (XH / 32) : AdviceStroke2 24 32 XH
+	define TightBendInnerRadius   : TightBendInnerDiameter / 2
 
 	define [StrokeWidthBlend lo hi sw] : linreg para.canonicalStrokeWidthMin lo para.canonicalStrokeWidthMax hi [fallback sw Stroke]
 
@@ -217,13 +219,14 @@ export : define [calculateMetrics para] : begin
 		HalfStroke QuarterStroke DotSize PeriodSize HBarPos OverlayPos Jut LongJut VJut LongVJut
 		VJutStroke AccentStackOffset AccentWidth AccentClearance AccentHeight CThin CThinB SLAB
 		IBalance IBalance2 JBalance JBalance2 TBalance TBalance2 RBalance RBalance2 FBalance
-		OneBalance WideWidth0 WideWidth1 WideWidth2 WideWidth3 WideWidth4 EssUpper EssLower
-		EssQuestion RightSB Middle DotRadius PeriodRadius ArchDepthA ArchDepthB SmallArchDepthA
-		SmallArchDepthB CorrectionOMidX CorrectionOMidS AdviceStrokeInSpace AdviceStroke AdviceStroke2
-		OverlayStroke OperatorStroke GeometryStroke UnicodeWeightGrade StrokeWidthBlend ArchDepthAOf
-		ArchDepthBOf ArchDepthAClamped ArchDepthBClamped SmoothAdjust SideJut MidJutSide MidJutCenter
-		YSmoothMidR YSmoothMidL DToothlessRise DMBlend ShoulderFine DefaultTightBendInnerRadius HSwToV
-		VSwToH NarrowUnicodeT WideUnicodeT VERY-FAR TINY]
+		OneBalance WideWidth0 WideWidth1 WideWidth2 WideWidth3 WideWidth4 EssRatioUpper EssRatioLower
+		EssRatioQuestion EssUpper EssLower EssQuestion RightSB Middle DotRadius PeriodRadius
+		ArchDepthA ArchDepthB SmallArchDepthA SmallArchDepthB CorrectionOMidX CorrectionOMidS
+		AdviceStroke AdviceStroke2 AdviceStrokeInSpace OverlayStroke OperatorStroke GeometryStroke
+		UnicodeWeightGrade StrokeWidthBlend ArchDepthAOf ArchDepthBOf ArchDepthAClamped
+		ArchDepthBClamped SmoothAdjust SideJut MidJutSide MidJutCenter YSmoothMidR YSmoothMidL
+		DToothlessRise ShoulderFine TightBendInnerRadius HSwToV VSwToH NarrowUnicodeT WideUnicodeT
+		VERY-FAR TINY]
 
 export : define [setFontMetrics para metrics fm] : begin
 	define [object CAP Descender XH Width SymbolMid] metrics

--- a/packages/font-glyphs/src/meta/macros.ptl
+++ b/packages/font-glyphs/src/meta/macros.ptl
@@ -399,14 +399,14 @@ define-macro glyph-block : syntax-rules
 			DotSize PeriodSize HBarPos OverlayPos Jut LongJut VJut LongVJut VJutStroke
 			AccentStackOffset AccentWidth AccentClearance AccentHeight CThin CThinB SLAB IBalance
 			IBalance2 JBalance JBalance2 TBalance TBalance2 RBalance RBalance2 FBalance OneBalance
-			WideWidth0 WideWidth1 WideWidth2 WideWidth3 WideWidth4 EssUpper EssLower EssQuestion
-			RightSB Middle DotRadius PeriodRadius ArchDepthA ArchDepthB SmallArchDepthA
-			SmallArchDepthB CorrectionOMidX CorrectionOMidS AdviceStroke
-			AdviceStroke2 AdviceStrokeInSpace OverlayStroke OperatorStroke GeometryStroke
-			UnicodeWeightGrade StrokeWidthBlend ArchDepthAOf ArchDepthBOf ArchDepthAClamped
-			ArchDepthBClamped SmoothAdjust SideJut MidJutSide MidJutCenter YSmoothMidR
-			YSmoothMidL DToothlessRise DMBlend ShoulderFine DefaultTightBendInnerRadius
-			HSwToV VSwToH NarrowUnicodeT WideUnicodeT VERY-FAR TINY]
+			WideWidth0 WideWidth1 WideWidth2 WideWidth3 WideWidth4 EssRatioUpper EssRatioLower
+			EssRatioQuestion EssUpper EssLower EssQuestion RightSB Middle DotRadius PeriodRadius
+			ArchDepthA ArchDepthB SmallArchDepthA SmallArchDepthB CorrectionOMidX CorrectionOMidS
+			AdviceStroke AdviceStroke2 AdviceStrokeInSpace OverlayStroke OperatorStroke
+			GeometryStroke UnicodeWeightGrade StrokeWidthBlend ArchDepthAOf ArchDepthBOf
+			ArchDepthAClamped ArchDepthBClamped SmoothAdjust SideJut MidJutSide MidJutCenter
+			YSmoothMidR YSmoothMidL DToothlessRise ShoulderFine TightBendInnerRadius HSwToV VSwToH
+			NarrowUnicodeT WideUnicodeT VERY-FAR TINY]
 
 		define spiroFnImports `[g4 g2 corner flat curl virt close end straight g2c cg2 flatc ccurl
 			widths disable-contrast heading unimportant important alsoThru alsoThruThem bezControls


### PR DESCRIPTION
### Motivation and Context

This uses a full `HookEnd` terminal, pointing to the right side, facilitated by exporting `SNeck` out of `letter/latin/s.ptl`.

Gentium for comparison:
`ƷᴣʒƺƸƹ`
<img width="1503" height="473" alt="image" src="https://github.com/user-attachments/assets/4a4d1f7b-ccd8-4d3f-a8df-7b496e071c53" />

### Influenced Characters

  - LATIN SMALL LETTER EZH WITH TAIL (`U+01BA`).

### Glyph Quantity

N/A (zero new glyphs; Glyphs for this one specific character are simply reworked).

### Samples

`ƷᴣʒƺƸƹ`

Sans:
<img width="1850" height="1239" alt="image" src="https://github.com/user-attachments/assets/ea7d2e22-75e3-4c7c-824c-bc0a78d9e4e6" />
Slab:
<img width="1837" height="1234" alt="image" src="https://github.com/user-attachments/assets/42b0ef42-886a-4401-a488-2fdf02e8e368" />
