### PR TITLE
Make Latin⁠/⁠Cyrillic Iota (`Ɩ`, `ɩ`, `Ꙇ`, `ꙇ`) follow variants of `i`, make Greek Lower Iota⁠/⁠Tau (`ι`, `τ`) use `flat-tailed` variants under upright.

### DIFF
--- a/changes/34.7.0.md
+++ b/changes/34.7.0.md
@@ -1,4 +1,6 @@
 * Add `et-flat-bottom` and `flat-top-serifed` variants for Ampersand (`&`).
+* Make Make Latin/Cyrillic Iota (`Ɩ`, `ɩ`, `Ꙇ`, `ꙇ`) follow variants of `i` (`cv44`).
+  - Make Greek Lower Iota/Tau (`ι`, `τ`) use `flat-tailed` variants under upright.
 * Add Characters:
   - LEFT SIDEWAYS U BRACKET (`U+2E26`).
   - RIGHT SIDEWAYS U BRACKET (`U+2E27`).

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -3301,6 +3301,7 @@ description = "`i` like a straight line"
 selector.dotlessi = "serifless"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "hooky"
+selector."latn/iota" = "flatTailed"
 selector."cyrl/ghe.SRB" = "flatTailed"
 
 [prime.i.variants.hooky]
@@ -3310,6 +3311,7 @@ description = "Hooky `i`"
 selector.dotlessi = "hooky"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "hooky"
+selector."latn/iota" = "serifedFlatTailed"
 selector."cyrl/ghe.SRB" = "serifedFlatTailed"
 
 [prime.i.variants.hooky-bottom]
@@ -3319,6 +3321,7 @@ description = "`i` with a sharp-turning horizontal tail"
 selector.dotlessi = "hookyBottom"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "zshaped"
+selector."latn/iota" = "flatTailed"
 selector."cyrl/ghe.SRB" = "hookyBottom"
 
 [prime.i.variants.zshaped]
@@ -3328,6 +3331,7 @@ description = "Z-shaped `i`"
 selector.dotlessi = "zshaped"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "zshaped"
+selector."latn/iota" = "serifedFlatTailed"
 selector."cyrl/ghe.SRB" = "zshaped"
 
 [prime.i.variants.serifed]
@@ -3337,6 +3341,7 @@ description = "Serifed `i`"
 selector.dotlessi = "serifed"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "serifed"
+selector."latn/iota" = "serifedFlatTailed"
 selector."cyrl/ghe.SRB" = "zshaped"
 
 [prime.i.variants.serifed-asymmetric]
@@ -3346,6 +3351,7 @@ description = "`i` with shorter top serif and full bottom serif"
 selector.dotlessi = "serifedAsymmetric"
 selector."dotlessi/sansSerif" = "serifless"
 selector."dotlessi/compLigRight" = "serifed"
+selector."latn/iota" = "serifedFlatTailed"
 selector."cyrl/ghe.SRB" = "zshapedAsymmetric"
 
 [prime.i.variants.tailed]
@@ -3355,6 +3361,7 @@ description = "`i` with curly tail"
 selector.dotlessi = "tailed"
 selector."dotlessi/sansSerif" = "tailed"
 selector."dotlessi/compLigRight" = "tailedSerifed"
+selector."latn/iota" = "tailed"
 selector."cyrl/ghe.SRB" = "tailed"
 
 [prime.i.variants.tailed-serifed]
@@ -3364,6 +3371,7 @@ description = "`i` with top serif and curly tail"
 selector.dotlessi = "tailedSerifed"
 selector."dotlessi/sansSerif" = "tailed"
 selector."dotlessi/compLigRight" = "tailedSerifed"
+selector."latn/iota" = "tailedSerifed"
 selector."cyrl/ghe.SRB" = "tailedSerifed"
 
 [prime.i.variants.flat-tailed]
@@ -3373,6 +3381,7 @@ description = "`i` with curly-then-flat tail"
 selector.dotlessi = "flatTailed"
 selector."dotlessi/sansSerif" = "flatTailed"
 selector."dotlessi/compLigRight" = "serifedFlatTailed"
+selector."latn/iota" = "flatTailed"
 selector."cyrl/ghe.SRB" = "flatTailed"
 
 [prime.i.variants.serifed-flat-tailed]
@@ -3382,6 +3391,7 @@ description = "`i` with top serif and curly-then-flat tail"
 selector.dotlessi = "serifedFlatTailed"
 selector."dotlessi/sansSerif" = "flatTailed"
 selector."dotlessi/compLigRight" = "serifedFlatTailed"
+selector."latn/iota" = "serifedFlatTailed"
 selector."cyrl/ghe.SRB" = "serifedFlatTailed"
 
 [prime.i.variants.diagonal-tailed]
@@ -3391,6 +3401,7 @@ description = "`i` with diagonal tail"
 selector.dotlessi = "diagonalTailed"
 selector."dotlessi/sansSerif" = "diagonalTailed"
 selector."dotlessi/compLigRight" = "serifedDiagonalTailed"
+selector."latn/iota" = "diagonalTailed"
 selector."cyrl/ghe.SRB" = "diagonalTailed"
 
 [prime.i.variants.serifed-diagonal-tailed]
@@ -3400,6 +3411,7 @@ description = "`i` with top serif and diagonal tail"
 selector.dotlessi = "serifedDiagonalTailed"
 selector."dotlessi/sansSerif" = "diagonalTailed"
 selector."dotlessi/compLigRight" = "serifedDiagonalTailed"
+selector."latn/iota" = "serifedDiagonalTailed"
 selector."cyrl/ghe.SRB" = "serifedDiagonalTailed"
 
 [prime.i.variants.semi-tailed]
@@ -3409,6 +3421,7 @@ description = "`i` with slightly curly tail"
 selector.dotlessi = "semiTailed"
 selector."dotlessi/sansSerif" = "semiTailed"
 selector."dotlessi/compLigRight" = "serifedSemiTailed"
+selector."latn/iota" = "semiTailed"
 selector."cyrl/ghe.SRB" = "semiTailed"
 
 [prime.i.variants.serifed-semi-tailed]
@@ -3418,6 +3431,7 @@ description = "`i` with top serif and slightly curly tail"
 selector.dotlessi = "serifedSemiTailed"
 selector."dotlessi/sansSerif" = "semiTailed"
 selector."dotlessi/compLigRight" = "serifedSemiTailed"
+selector."latn/iota" = "serifedSemiTailed"
 selector."cyrl/ghe.SRB" = "serifedSemiTailed"
 
 
@@ -6413,84 +6427,72 @@ rank = 1
 description = "Greek lower Iota (`ι`) like a straight line"
 selector."grek/iota" = "serifless"
 selector."grek/iota/sansSerif" = "serifless"
-selector."latn/iota" = "flatTailed"
 
 [prime.lower-iota.variants.tailless-serifed]
 rank = 2
 description = "Greek lower Iota (`ι`) like a straight line with top serif"
 selector."grek/iota" = "hooky"
 selector."grek/iota/sansSerif" = "serifless"
-selector."latn/iota" = "serifedFlatTailed"
 
 [prime.lower-iota.variants.hooky-bottom]
 rank = 3
 description = "Greek lower Iota (`ι`) with a sharp-turning horizontal tail"
 selector."grek/iota" = "hookyBottom"
 selector."grek/iota/sansSerif" = "serifless"
-selector."latn/iota" = "flatTailed"
 
 [prime.lower-iota.variants.zshaped]
 rank = 4
 description = "Z-shaped Greek lower Iota (`ι`)"
 selector."grek/iota" = "zshaped"
 selector."grek/iota/sansSerif" = "serifless"
-selector."latn/iota" = "serifedFlatTailed"
 
 [prime.lower-iota.variants.tailed]
 rank = 5
 description = "Greek lower Iota (`ι`) with curly tail"
 selector."grek/iota" = "tailed"
 selector."grek/iota/sansSerif" = "tailed"
-selector."latn/iota" = "tailed"
 
 [prime.lower-iota.variants.tailed-serifed]
 rank = 6
 description = "Greek lower Iota (`ι`) with top serif and curly tail"
 selector."grek/iota" = "tailedSerifed"
 selector."grek/iota/sansSerif" = "tailed"
-selector."latn/iota" = "tailedSerifed"
 
 [prime.lower-iota.variants.flat-tailed]
 rank = 7
 description = "Greek lower Iota (`ι`) with a curly-then-flat tail"
 selector."grek/iota" = "flatTailed"
 selector."grek/iota/sansSerif" = "flatTailed"
-selector."latn/iota" = "flatTailed"
 
 [prime.lower-iota.variants.serifed-flat-tailed]
 rank = 8
 description = "Greek lower Iota (`ι`) with top serif and a curly-then-flat tail"
 selector."grek/iota" = "serifedFlatTailed"
 selector."grek/iota/sansSerif" = "flatTailed"
-selector."latn/iota" = "serifedFlatTailed"
 
 [prime.lower-iota.variants.diagonal-tailed]
 rank = 9
 description = "Greek lower Iota (`ι`) with a diagonal tail"
 selector."grek/iota" = "diagonalTailed"
 selector."grek/iota/sansSerif" = "diagonalTailed"
-selector."latn/iota" = "diagonalTailed"
 
 [prime.lower-iota.variants.serifed-diagonal-tailed]
 rank = 10
 description = "Greek lower Iota (`ι`) with top serif and a diagonal tail"
 selector."grek/iota" = "serifedDiagonalTailed"
 selector."grek/iota/sansSerif" = "diagonalTailed"
-selector."latn/iota" = "serifedDiagonalTailed"
 
 [prime.lower-iota.variants.semi-tailed]
 rank = 11
 description = "Greek lower Iota (`ι`) with a slightly curly tail"
 selector."grek/iota" = "semiTailed"
 selector."grek/iota/sansSerif" = "semiTailed"
-selector."latn/iota" = "semiTailed"
 
 [prime.lower-iota.variants.serifed-semi-tailed]
 rank = 12
 description = "Greek lower Iota (`ι`) with top serif and a slightly curly tail"
 selector."grek/iota" = "serifedSemiTailed"
 selector."grek/iota/sansSerif" = "semiTailed"
-selector."latn/iota" = "serifedSemiTailed"
 
 
 
@@ -10226,7 +10228,7 @@ capital-delta = "straight"
 lower-delta = "rounded"
 lower-eta = "serifless"
 lower-theta = "oval"
-lower-iota = "serifed-semi-tailed"
+lower-iota = "serifed-flat-tailed"
 lower-kappa = "straight-serifless"
 capital-lambda = "straight-serifless"
 lower-lambda = "straight"
@@ -10234,7 +10236,7 @@ lower-mu = "tailed-serifless"
 lower-nu = "casual"
 lower-xi = "flat-top"
 lower-pi = "tailed"
-lower-tau = "semi-tailed"
+lower-tau = "flat-tailed"
 lower-upsilon = "casual-serifless"
 lower-phi = "cursive"
 lower-chi = "straight-serifless"


### PR DESCRIPTION
### Motivation and Context

Using Script A (`Ɑ`, `ɑ`) as precedent, this makes Latin⁠/⁠Cyrillic Iota (`Ɩ`, `ɩ`, `Ꙇ`, `ꙇ`) follow variants of `i` (`cv44`), using `flat-tailed` variants when `i` has a non-tailed bottom, and then makes Greek Lower Iota⁠/⁠Tau (`ι`, `τ`) use `flat-tailed` variants under upright to match (italics are unchanged). This was also one of their older defaults.

### Influenced Characters

  - LATIN CAPITAL LETTER IOTA (`U+0196`).
  - LATIN SMALL LETTER IOTA (`U+0269`).
  - GREEK SMALL LETTER IOTA (`U+03B9`).
  - GREEK SMALL LETTER TAU (`U+03C4`).
  - LATIN SMALL LETTER IOTA WITH STROKE (`U+1D7C`).
  - MODIFIER LETTER SMALL IOTA (`U+1DA5`).
  - TURNED GREEK SMALL LETTER IOTA (`U+2129`).
  - APL FUNCTIONAL SYMBOL IOTA (`U+2373`).
  - APL FUNCTIONAL SYMBOL IOTA UNDERBAR (`U+2378`).
  - CYRILLIC CAPITAL LETTER IOTA (`U+A646`).
  - CYRILLIC SMALL LETTER IOTA (`U+A647`).

### Glyph Quantity

N/A (Zero new glyphs; Variants are simply rerouted.)

### Samples

```
ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ
abc.def.ghi.jkl.mno.pqrs.tuv.wxyz
!iIlL17|¦ ¢coO08BDQ $5SZ2zs ∂96µm
float il1[]={1-2/3.4,5+6=7/8%90};
1234567890 ,._-+= >< «¯-¬_» ~–÷+×
{*}[]()<>`+-=$/#_%^@\&|~?'" !,.;:
g9q¶ Þẞðþſß ΓΔΛαβγδηθικλμνξπτυφχψ
ЖЗКНРУЭЯавжзклмнруфчьыэя <= != ==
```

Before:
<img width="1894" height="1142" alt="image" src="https://github.com/user-attachments/assets/de0291fd-5646-4584-bc2c-6ac6aefc5540" />

After:
<img width="1909" height="1138" alt="image" src="https://github.com/user-attachments/assets/2cb35154-b3fa-4e99-a1a3-48d28eb04169" />

