### PR TITLE
Fix longstanding defect involving `para.canonicalStrokeWidthMax`.

### DIFF
--- a/params/shape-weight.toml
+++ b/params/shape-weight.toml
@@ -1,6 +1,6 @@
 [shapeWeight]
 canonicalStrokeWidthMin = 18  # sync with 100 entry below
-canonicalStrokeWidthMax = 108 # sync with 900 entry below
+canonicalStrokeWidthMax = 114 # sync with 900 entry below
 
 [shapeWeight.blend.400]
 stroke = 70        # Primary stroke width


### PR DESCRIPTION
### Motivation and Context

The commit b1a1de5ba4bc7f0304d1d400623ab549f4146a33 in April 2021 updated the maximum stroke width under heavy but did not update `para.canonicalStrokeWidthMax` to match.

### Influenced Characters

Anything using `[StrokeWidthBlend]`, `[UnicodeWeightGrade]`, `SmoothAdjust`, {`Small`}`ArchDepth`{`A`|`B`}, `[ArchDepth`{`A`|`B`}`Of]`, `[ArchDepth`{`A`|`B`}`Clamped]`, `[YSmoothMid`{`L`|`R`}`]`, etc.

### Glyph Quantity

N/A .

### Samples

```
ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ
abc.def.ghi.jkl.mno.pqrs.tuv.wxyz
!iIlL17|¦ ¢coO08BDQ $5SZ2zs ∂96µm
float il1[]={1-2/3.4,5+6=7/8%90};
1234567890 ,._-+= >< «¯-¬_» ~–÷+×
{*}[]()<>`+-=$/#_%^@\&|~?'" !,.;:
g9q¶ Þẞðþſß ΓΔΛαβγδηθικλμνξπτυφχψ
ЖЗКНРУЭЯавжзклмнруфчьыэя <= != ==
```

Sans Monospace Heavy Upright:
<img width="1907" height="1130" alt="image" src="https://github.com/user-attachments/assets/f2b2e48e-6069-460b-9fef-7848db3a5a9e" />
Sans Monospace Heavy Italic:
<img width="1906" height="1138" alt="image" src="https://github.com/user-attachments/assets/21e47dad-e274-4d9d-b362-53cb9e4845f3" />
Slab Monospace Heavy Upright:
<img width="1898" height="1134" alt="image" src="https://github.com/user-attachments/assets/f7bd22d3-fafc-4e04-800c-520008b5d69b" />
Slab Monospace Heavy Italic:
<img width="1914" height="1128" alt="image" src="https://github.com/user-attachments/assets/24616632-4ef8-412f-9c1b-137f9ff118b3" />
Aile Heavy Upright:
<img width="2287" height="1132" alt="image" src="https://github.com/user-attachments/assets/e3dbc4c4-b4e6-4fed-8a4d-3540e19e3324" />
Aile Heavy Italic:
<img width="2302" height="1136" alt="image" src="https://github.com/user-attachments/assets/266e4b7d-ff9d-4347-89fc-f7446c66a02c" />
Etoile Heavy Upright:
<img width="2304" height="1149" alt="image" src="https://github.com/user-attachments/assets/127a4a37-6218-484e-a3de-29407ae8f220" />
Etoile Heavy Italic:
<img width="2311" height="1139" alt="image" src="https://github.com/user-attachments/assets/6bd4e25c-3201-4d8d-82c0-7b274a4c427c" />

