### PR TITLE
Add new parameter `refStroke` to `params/shape-weight.toml`.

### DIFF
--- a/packages/font-glyphs/src/meta/aesthetics.ptl
+++ b/packages/font-glyphs/src/meta/aesthetics.ptl
@@ -42,7 +42,7 @@ export : define [calculateMetrics para] : begin
 	# Transform constructors
 	define [Italify angle shift] : begin
 		local slope : Math.tan : [fallback angle para.slopeAngle] / 180 * Math.PI
-		return : new Transform 1 slope 0 1 [fallback shift : (-slope) * SymbolMid] 0
+		return : new Transform 1 slope 0 1 [fallback shift ((-slope) * SymbolMid)] 0
 	define [Upright angle shift] [Italify angle shift].inverse
 	define [Scale sx sy] : new Transform sx 0 0 [fallback sy sx] 0 0
 	define [Translate x y] : new Transform 1 0 0 1 x y
@@ -65,10 +65,10 @@ export : define [calculateMetrics para] : begin
 	define Leftward  : new Vec2   0          (-1)
 
 	# Style parameters
-	define O para.overshoot
+	define O  para.overshoot
 	define OX para.overshootx
 	define OXHook para.oxhook
-	define Hook para.hook
+	define Hook  para.hook
 	define AHook para.ahook
 	define SHook para.shook
 	define RHook para.rhook
@@ -150,11 +150,17 @@ export : define [calculateMetrics para] : begin
 	define TightBendInnerDiameter : Math.max (XH / 32) : AdviceStroke2 24 32 XH
 	define TightBendInnerRadius   : TightBendInnerDiameter / 2
 
-	define [StrokeWidthBlend lo hi sw] : linreg para.canonicalStrokeWidthMin lo para.canonicalStrokeWidthMax hi [fallback sw Stroke]
+	define [StrokeWidthBlend lo hi sw] : begin
+		local swRef : ([fallback sw Stroke] / Stroke) * para.refStroke
+		return : linreg para.canonicalStrokeWidthMin lo para.canonicalStrokeWidthMax hi swRef
 
 	define SmoothAdjust : StrokeWidthBlend 80 144
-	define [ArchDepthAOf archDepth width] : archDepth - TanSlope * SmoothAdjust * ([fallback width Width] / Width)
-	define [ArchDepthBOf archDepth width] : archDepth + TanSlope * SmoothAdjust * ([fallback width Width] / Width)
+	define [ArchDepthAOf archDepth width] : begin
+		local adws : [fallback width Width] / Width
+		return : archDepth - TanSlope * SmoothAdjust * adws
+	define [ArchDepthBOf archDepth width] : begin
+		local adws : [fallback width Width] / Width
+		return : archDepth + TanSlope * SmoothAdjust * adws
 	define ArchDepthA : ArchDepthAOf ArchDepth
 	define ArchDepthB : ArchDepthBOf ArchDepth
 	define SmallArchDepthA : ArchDepthAOf SmallArchDepth
@@ -198,13 +204,13 @@ export : define [calculateMetrics para] : begin
 	define OperatorStroke : AdviceStroke 2.75
 	define GeometryStroke : AdviceStroke 4
 
-	define [UnicodeWeightGrade n00 _adws _swRef] : begin
+	define [UnicodeWeightGrade n00 _adws _sw] : begin
 		local n : n00 / 100
 		local adws : fallback _adws 1
 		local kw : 10 - adws - n / 2
 		define [mulPow s] : (0.25 + s / 8) * [StrokeWidthBlend 2 1]
 		local kMul : [Math.pow n : mulPow adws] / [Math.pow 4 : mulPow 2]
-		local kAdj : [fallback _swRef Stroke] / [AdviceStroke 6]
+		local kAdj : [fallback _sw Stroke] / [AdviceStroke 6]
 		return : kMul * kAdj * [AdviceStroke kw]
 
 	define VERY-FAR : UPM * 16

--- a/params/shape-weight.toml
+++ b/params/shape-weight.toml
@@ -4,9 +4,10 @@ canonicalStrokeWidthMax = 114 # sync with 900 entry below
 
 [shapeWeight.blend.400]
 stroke = 70        # Primary stroke width
+refStroke = 70     # Copy of `stroke`; Independent of `[shapeWidth.multiplies.blend."*"]` etc.
 contrast = 1.11    # Stroke width contrast
 sb = 64            # Primary sidebearings
-essRatio = 1.12    # Proportion of widen of center of "S"
+essRatio = 1.12    # Proportion of widen of center of `S`
 dotSize = 125      # Size of dots
 periodSize = 140   # Size of period
 
@@ -27,12 +28,12 @@ fbalance = 6
 onebalance = 30
 
 hook  = 180 # Hook depth for most letters
-ahook = 145 # Hook depth for "a"
-shook = 135 # Hook depth for "s"
-jhook = 150 # Hook depth for "j"
+ahook = 145 # Hook depth for `a`
+shook = 135 # Hook depth for `s`
+jhook = 150 # Hook depth for `j`
 
 hookx = 170
-rhook = 110 # Hook depth for "r". Not weight-variable.
+rhook = 110 # Hook depth for `r`; Not weight-variable.
 
 # Size of attchment tail (X and Y)
 tailX = 145
@@ -49,6 +50,7 @@ vtipfineSlab = 0.9
 
 [shapeWeight.blend.100]
 stroke = 18
+refStroke = 18
 contrast = 1.08
 sb = 72
 essRatio = 1.12
@@ -87,12 +89,14 @@ rbalance2 = 15
 
 [shapeWeight.blend.700]
 stroke = 96
+refStroke = 96
 
 [shapeWeight.blend.800]
 # Interpolated
 
 [shapeWeight.blend.900]
 stroke = 114
+refStroke = 114
 contrast = 1.20
 sb = 56
 essRatio = 1.05


### PR DESCRIPTION
### Motivation and Context

Continuation of #3235 .

This stabilizes the upper/lower bounds of `[StrokeWidthBlend …]` when any expansions/contractions made to `para.stroke` defined in `params/shape-width.toml` would normally push the function's default `sw` argument (`Stroke`) below `para.canonicalStrokeWidthMin` or above `para.canonicalStrokeWidthMax`, when under e.g. 'condensed' or 'extended' widths respectfully.

### Influenced Characters

Anything using `[StrokeWidthBlend …]`, `SmoothAdjust`, `[ArchDepth`{`A`|`B`}`Of …]`, {`Small`}`ArchDepth`{`A`|`B`}, `[YSmoothMid`{`L`|`R`}` …]`, `[ArchDepth`{`A`|`B`}`Clamped …]`, `CorrectionOMidX`, `CorrectionOMidS`, `[UnicodeWeightGrade …]`, etc.

### Glyph Quantity

N/A .

### Samples

```
ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ
abc.def.ghi.jkl.mno.pqrs.tuv.wxyz
!iIlL17|¦ ¢coO08BDQ $5SZ2zs ∂96µm
float il1[]={1-2/3.4,5+6=7/8%90};
1234567890 ,._-+= >< «¯-¬_» ~–÷+×
{*}[]()<>`+-=$/#_%^@\&|~?'" !,.;:
g9q¶ Þẞðþſß ΓΔΛαβγδηθικλμνξπτυφχψ
ЖЗКНРУЭЯавжзклмнруфчьыэя <= != ==
```

Sans Monospace Extended Heavy Upright:
<img width="2278" height="1141" alt="image" src="https://github.com/user-attachments/assets/bdc2016b-14b8-46d8-b3c8-59ccd22de6ca" />
Sans Monospace Extended Heavy Italic:
<img width="2276" height="1144" alt="image" src="https://github.com/user-attachments/assets/3e0e8018-387c-4854-9341-2427c74dbfdd" />
Slab Monospace Extended Heavy Upright:
<img width="2276" height="1134" alt="image" src="https://github.com/user-attachments/assets/33960af7-d3bc-4e96-b5ba-f750d1745b50" />
Slab Monospace Extended Heavy Italic:
<img width="2278" height="1147" alt="image" src="https://github.com/user-attachments/assets/4cbe23ea-49d1-4990-8532-26e95ed33c2d" />
Aile Heavy Upright:
<img width="2300" height="1143" alt="image" src="https://github.com/user-attachments/assets/034e5ccd-17a5-4e64-9593-f08c2dc024a6" />
Aile Heavy Italic:
<img width="2293" height="1140" alt="image" src="https://github.com/user-attachments/assets/ed5607eb-32e9-44a3-9e38-0202a8cda425" />
Etoile Heavy Upright:
<img width="2310" height="1151" alt="image" src="https://github.com/user-attachments/assets/6a704cbd-2be8-4674-958b-773c2a38d680" />
Etoile Heavy Italic:
<img width="2315" height="1138" alt="image" src="https://github.com/user-attachments/assets/1fe2ce16-4748-4982-ac69-f84c81519c33" />