### PR TITLE
Add new function `[adviceThinnerStroke2 …]` to `[DivFrame]`.

### DIFF
--- a/packages/font-glyphs/src/letter/armenian/feh.ptl
+++ b/packages/font-glyphs/src/letter/armenian/feh.ptl
@@ -32,7 +32,7 @@ glyph-block Letter-Armenian-Feh : begin
 	create-glyph 'armn/Feh' 0x556 : glyph-proc
 		local df : include : DivFrame para.advanceScaleM 3
 		include : df.markSet.capital
-		local sw : Math.min df.mvs : AdviceStroke2 3 3 CAP df.adws
+		local sw : df.adviceThinnerStroke2 3 3 CAP
 		local ada : df.archDepthAOf ArchDepth sw
 		local adb : df.archDepthBOf ArchDepth sw
 		include : FehBody df CAP 0 sw Hook ada adb
@@ -44,7 +44,7 @@ glyph-block Letter-Armenian-Feh : begin
 	create-glyph 'armn/feh' 0x586 : glyph-proc
 		local df : include : DivFrame para.advanceScaleM 3
 		include : df.markSet.bp
-		local sw : Math.min df.mvs : AdviceStroke2 3 3 Ascender df.adws
+		local sw : df.adviceThinnerStroke2 3 3 Ascender
 		local ada : df.archDepthAOf SmallArchDepth sw
 		local adb : df.archDepthBOf SmallArchDepth sw
 		include : FehBody df Ascender 0 sw Hook ada adb

--- a/packages/font-glyphs/src/letter/cyrillic/iotified-a.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/iotified-a.ptl
@@ -135,7 +135,7 @@ glyph-block Letter-Cyrillic-Iotified-A : begin
 				define df : include : DivFrame para.advanceScaleM 3
 				include : df.markSet.e
 
-				local sw : Math.min df.mvs : AdviceStroke2 2 3 XH (0.75 * df.adws)
+				local sw : df.adviceThinnerStroke2 2 3 XH 0.75
 				local gap : 0.375 * (df.rightSB - df.leftSB) - [HSwToV : 0.25 * sw] + sw / 16
 				local subDf : DivFrame [Math.min ((df.width - gap) / Width) (0.75 * df.adws)] 2
 
@@ -168,7 +168,7 @@ glyph-block Letter-Cyrillic-Iotified-A : begin
 
 		foreach { suffix { sty styBot } } [Object.entries CConfig] : do
 			define [IotifiedEShape fCapital fMidSerif df top ada adb] : glyph-proc
-				local sw : Math.min df.mvs : AdviceStroke2 2 3 top (0.75 * df.adws)
+				local sw : df.adviceThinnerStroke2 2 3 top 0.75
 				local gap : 0.375 * (df.rightSB - df.leftSB) - [HSwToV : 0.25 * sw] + sw / 16
 				local subDf : DivFrame [Math.min ((df.width - gap) / Width) (0.75 * df.adws)] 2
 
@@ -221,7 +221,7 @@ glyph-block Letter-Cyrillic-Iotified-A : begin
 				define df : include : DivFrame para.advanceScaleM 3
 				include : df.markSet.e
 
-				local sw : Math.min df.mvs : AdviceStroke2 2 3 XH (0.75 * df.adws)
+				local sw : df.adviceThinnerStroke2 2 3 XH 0.75
 				local gap : 0.375 * (df.rightSB - df.leftSB) - [HSwToV : 0.25 * sw] + sw / 16
 				local subDf : DivFrame [Math.min ((df.width - gap) / Width) (0.75 * df.adws)] 2
 

--- a/packages/font-glyphs/src/letter/cyrillic/lje.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/lje.ptl
@@ -12,7 +12,7 @@ glyph-block Letter-Cyrillic-Lje : begin
 	glyph-block-import Letter-Cyrillic-Yeri : YeriConfig
 
 	define [CyrLjeShape Yeri df top] : glyph-proc
-		local sw : Math.min df.mvs : AdviceStroke2 3 3 top df.adws
+		local sw : df.adviceThinnerStroke2 3 3 top
 		local xTopLeft : mix df.leftSB df.rightSB 0.025
 		local xBotLeft : mix df.leftSB 0 : if SLAB 1.00 0.75
 		local jut : Math.min

--- a/packages/font-glyphs/src/letter/cyrillic/nje.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/nje.ptl
@@ -18,7 +18,7 @@ glyph-block Letter-Cyrillic-Nje : begin
 	define SLAB-TAILED-CYRILLIC        3
 	define SLAB-ALL                    4
 
-	define [CyrNjeStroke df top] : Math.min df.mvs : AdviceStroke2 3 3 top df.adws
+	define [CyrNjeStroke df top] : df.adviceThinnerStroke2 3 3 top
 
 	define [LeftHalf slabType df top] : glyph-proc
 		local sw : CyrNjeStroke df top

--- a/packages/font-glyphs/src/letter/cyrillic/tje.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/tje.ptl
@@ -16,7 +16,7 @@ glyph-block Letter-Cyrillic-Tje : begin
 	define [xTeMidBarLeft  df] : [mix df.leftSB df.rightSB 0.3] + OX
 	define [xYeriBowlRight df] : df.rightSB - OX
 
-	define [CyrTjeStroke df top] : Math.min df.mvs : AdviceStroke2 2.75 3 top df.adws
+	define [CyrTjeStroke df top] : df.adviceThinnerStroke2 2.75 3 top
 
 	define [LeftHalf df top sw slabTop slabBot] : glyph-proc
 		local left  : xTeMidBarLeft  df

--- a/packages/font-glyphs/src/letter/cyrillic/yat.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/yat.ptl
@@ -108,14 +108,14 @@ glyph-block Letter-Cyrillic-Yat : begin
 			include : YatShape df Uc CAP
 				pBar     -- 0.5
 				fCapital -- true
-				stroke   -- [Math.min df.mvs : AdviceStroke2 2.75 3 CAP df.adws]
+				stroke   -- [df.adviceThinnerStroke2 2.75 3 CAP]
 
 		create-glyph "cyrl/yat.upright.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleT 2
 			include : df.markSet.b
 			include : YatShape df Lc Ascender
 				pBar   -- ([mix 0 XH YeriBarPos] / Ascender)
-				stroke -- [Math.min df.mvs : AdviceStroke2 2.75 3 XH df.adws]
+				stroke -- [df.adviceThinnerStroke2 2.75 3 XH]
 				yCrossbarPos -- XH
 
 		create-glyph "cyrl/yatTall.\(suffix)" : glyph-proc
@@ -125,7 +125,7 @@ glyph-block Letter-Cyrillic-Yat : begin
 			include : ExtendAboveBaseAnchors asc
 			include : YatShape df Lc asc
 				pBar   -- ([mix 0 XH YeriBarPos] / asc)
-				stroke -- [Math.min df.mvs : AdviceStroke2 2.75 3 XH df.adws]
+				stroke -- [df.adviceThinnerStroke2 2.75 3 XH]
 				yCrossbarPos -- Ascender
 
 		create-glyph "cyrl/YatIotified.\(suffix)" : glyph-proc
@@ -134,14 +134,14 @@ glyph-block Letter-Cyrillic-Yat : begin
 			include : IotifiedYatShape df Uc CAP
 				pBar     -- 0.5
 				fCapital -- true
-				stroke   -- [Math.min df.mvs : AdviceStroke2 2.75 3 CAP (df.adws * (7 / 9))]
+				stroke   -- [df.adviceThinnerStroke2 2.75 3 CAP (7 / 9)]
 
 		create-glyph "cyrl/yatIotified.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleMM 3
 			include : df.markSet.b
 			include : IotifiedYatShape df Lc Ascender
 				pBar   -- ([mix 0 XH YeriBarPos] / Ascender)
-				stroke -- [Math.min df.mvs : AdviceStroke2 2.75 3 XH (df.adws * (7 / 9))]
+				stroke -- [df.adviceThinnerStroke2 2.75 3 XH (7 / 9)]
 				yCrossbarPos -- XH
 
 		create-glyph "latn/yatSakha.upright.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/letter/cyrillic/yery.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/yery.ptl
@@ -12,9 +12,9 @@ glyph-block Letter-Cyrillic-Yery : begin
 	glyph-block-import Letter-Cyrillic-Yer : CyrYerShape
 
 	define [CyrYeryShape fBackYer] : function [Yeri df top fTailed] : glyph-proc
-		local stroke : Math.min df.mvs : if fBackYer
-			AdviceStroke2 2.75 3 top : df.adws * (7 / 9)
-			AdviceStroke2 2.00 3 top : df.adws * (3 / 4)
+		local stroke : if fBackYer
+			df.adviceThinnerStroke2 2.75 3 top (7 / 9)
+			df.adviceThinnerStroke2 2.00 3 top (3 / 4)
 		local jut : Jut - [HSwToV : 0.5 * (Stroke - stroke)]
 
 		local xMiddleSym : mix 0 df.width : if fBackYer (5 / 9) (1 / 2)

--- a/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
@@ -267,8 +267,8 @@ glyph-block Letter-Latin-Ezh : begin
 		create-glyph "revEzh.\(suffix)" : glyph-proc
 			include : MarkSet.capital
 			define revEzh : RevEzh CAP 0
-				fCursive  -- fCursive
-				fSerifed  -- fSerifed
+				fCursive   -- fCursive
+				fSerifed   -- fSerifed
 				pyMidRight -- [if fCursive 0.50 0.52]
 				stroke     -- [AdviceStroke2 2 3 (CAP - 0)]
 				hook       -- Hook

--- a/packages/font-glyphs/src/letter/latin-ext/upper-ae-oe.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/upper-ae-oe.ptl
@@ -10,7 +10,7 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared : CreateDependentComposite
 
-	define [AEOEStroke df top] : Math.min df.mvs : AdviceStroke2 3 3 top df.adws
+	define [AEOEStroke df top] : df.adviceThinnerStroke2 3 3 top
 
 	do "A subglyphs"
 		define BODY-CURLY      0
@@ -23,7 +23,7 @@ glyph-block Letter-Latin-Upper-AE-OE : begin
 		define SLAB-TRI        3
 
 		define [AEAHalfCurly df top eLeft sw] : glyph-proc
-			define fine : Math.min sw : AdviceStroke2 3 4 top df.adws
+			define fine : Math.min sw : df.adviceStroke2 3 4 top
 
 			# A half
 			include : dispiro

--- a/packages/font-glyphs/src/letter/latin/c.ptl
+++ b/packages/font-glyphs/src/letter/latin/c.ptl
@@ -98,9 +98,9 @@ glyph-block Letter-Latin-C : begin
 		__ : glyph-proc
 
 	define [CCurlyTailShape df slabType top bot] : glyph-proc
-		local sw   : AdviceStroke2 2 3 XH
-		local fine : AdviceStroke2 3 3 XH
-		local loopTop : bot + 0.45 * XH
+		local sw   : df.adviceStroke2 2 3 (XH - 0)
+		local fine : df.adviceStroke2 3 3 (XH - 0)
+		local loopTop : bot + 0.45 * (XH - 0)
 
 		include : dispiro
 			match slabType
@@ -260,7 +260,7 @@ glyph-block Letter-Latin-C : begin
 			include : lf.full
 
 		define [CyrEShepe fCapital fMidSerif df top ada adb] : glyph-proc
-			local sw : Math.min df.mvs : AdviceStroke2 2 3 top df.adws
+			local sw : df.adviceThinnerStroke2 2 3 top
 			local lf : CLetterForm df sty styBot top 0
 				ada -- ada
 				adb -- adb
@@ -279,7 +279,7 @@ glyph-block Letter-Latin-C : begin
 				include : VSerif.ml (xMidBarLeft - [if fCapital 0 : HSwToV : 0.5 * swVJut]) (top / 2) jutMid swVJut
 
 		define [CyrYeShape fCapital fMidSerif df top ada adb] : glyph-proc
-			local sw : Math.min df.mvs : AdviceStroke2 2 3 top df.adws
+			local sw : df.adviceThinnerStroke2 2 3 top
 			local lf : CLetterForm df sty styBot top 0
 				ada -- ada
 				adb -- adb

--- a/packages/font-glyphs/src/letter/latin/lower-a.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-a.ptl
@@ -19,7 +19,7 @@ glyph-block Letter-Latin-Lower-A : begin
 
 	glyph-block-export DoubleStorey
 	define DoubleStorey : namespace
-		define [ADoubleStoreyStroke df] : AdviceStroke2 2 3 XH df.adws
+		define [ADoubleStoreyStroke df] : df.adviceStroke2 2 3 XH
 		export : define SwAboveBar 0.425
 
 		define [ADoubleStoreySmoothA df] : begin
@@ -142,9 +142,9 @@ glyph-block Letter-Latin-Lower-A : begin
 			[Just ToothlessRounded]    : ArcMask df 2 [ADoubleStoreySmoothA df] _sw
 			__                         : ArcMask df 0 0                         _sw
 
-	define [OverlayW bw _l _r] : glyph-proc
-		define l : fallback _l : mix 0     SB      0.3
-		define r : fallback _r : mix Width RightSB 0.3
+	define [OverlayW bw] : glyph-proc
+		define l : mix 0     SB      0.3
+		define r : mix Width RightSB 0.3
 		local y : mix 0 XH 0.5
 		include : dispiro
 			widths.center bw
@@ -303,10 +303,6 @@ glyph-block Letter-Latin-Lower-A : begin
 		export : define [SeriflessBar df top _sw] : glyph-proc
 			set-base-anchor 'trailing' df.rightSB 0
 			include : VBar.r df.rightSB 0 top _sw
-		export : define [MotionSerifedBar df top _sw] : glyph-proc
-			include : SeriflessBar df top _sw
-			local sf : SerifFrame.fromDf df top 0 (swRef -- _sw)
-			include sf.rt.outer
 		export : define [BottomSerifedBar df top _sw] : glyph-proc
 			include : SeriflessBar df top _sw
 			local sf : SerifFrame.fromDf df top 0 (swRef -- _sw)
@@ -330,9 +326,6 @@ glyph-block Letter-Latin-Lower-A : begin
 		singleStoreyFlatTopSerifless        { SingleStorey.FlatTopBody        SingleStorey.SeriflessBar     }
 		singleStoreyEarlessCornerSerifless  { SingleStorey.EarlessCornerBody  SingleStorey.SeriflessBar     }
 		singleStoreyEarlessRoundedSerifless { SingleStorey.EarlessRoundedBody SingleStorey.SeriflessBar     }
-
-		singleStoreyMotionSerifed           { SingleStorey.FullBarBody        SingleStorey.MotionSerifedBar }
-		singleStoreyFlatTopMotionSerifed    { SingleStorey.FlatTopBody        SingleStorey.MotionSerifedBar }
 
 		singleStoreySerifed                 { SingleStorey.FullBarBody        SingleStorey.BottomSerifedBar }
 		singleStoreyTopCutSerifed           { SingleStorey.TopCutBody         SingleStorey.BottomSerifedBar }
@@ -363,6 +356,7 @@ glyph-block Letter-Latin-Lower-A : begin
 			include : body df CAP bar nothing ArchDepthA ArchDepthB
 		create-glyph "aRetroflexHook.\(suffix)" : glyph-proc
 			include [refer-glyph "a.\(suffix)"] AS_BASE ALSO_METRICS
+			eject-contour 'serifRB'
 			include : RetroflexHook.rSideJut RightSB 0 (yOverflow -- Stroke)
 		create-glyph "aBar.\(suffix)" : glyph-proc
 			include [refer-glyph "a.\(suffix)"] AS_BASE ALSO_METRICS

--- a/packages/font-glyphs/src/letter/latin/lower-e.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-e.ptl
@@ -183,7 +183,7 @@ glyph-block Letter-Latin-Lower-E : begin
 		local-parameter : Body
 		local-parameter : df
 		local-parameter : top
-		local-parameter : stroke   -- [Math.min df.mvs : AdviceStroke2 2 3 top (0.75 * df.adws)]
+		local-parameter : stroke   -- [df.adviceThinnerStroke2 2 3 top 0.75]
 		local-parameter : hook     -- AHook
 		local-parameter : ada      -- SmallArchDepthA
 		local-parameter : adb      -- SmallArchDepthB

--- a/packages/font-glyphs/src/letter/latin/s.ptl
+++ b/packages/font-glyphs/src/letter/latin/s.ptl
@@ -198,7 +198,7 @@ glyph-block Letter-Latin-S : begin
 		create-glyph "S.\(suffix)" : glyph-proc
 			local df : include DfCapital
 			include : df.markSet.capital
-			local sw : AdviceStroke2 2 3 CAP df.adws
+			local sw : df.adviceStroke2 2 3 (CAP - 0)
 			include : SStrokeImpl df CAP 0 doTS doBS sw EssUpper
 			include : SAutoSlabStart df doTS CAP sw Hook
 			include : SAutoSlabEnd   df doBS 0   sw Hook
@@ -206,7 +206,7 @@ glyph-block Letter-Latin-S : begin
 		create-glyph "smcpS.\(suffix)" : glyph-proc
 			local df : include DfCapital
 			include : df.markSet.e
-			local sw : AdviceStroke2 2 3 CAP df.adws
+			local sw : df.adviceStroke2 2 3 (CAP - 0)
 			include : SStrokeImpl df XH 0 doTS doBS sw EssUpper
 			include : SAutoSlabStart df doTS XH sw Hook
 			include : SAutoSlabEnd   df doBS 0  sw Hook
@@ -218,7 +218,7 @@ glyph-block Letter-Latin-S : begin
 
 			define top : mix 0 CAP 0.95
 			define bot : mix 0 CAP 0.05
-			local sw : AdviceStroke2 2 3 (top - bot) df.adws
+			local sw : df.adviceStroke2 2 3 (top - bot)
 			include : SStrokeImpl df top bot doTS doBS sw EssUpper
 			include : SAutoSlabStart df doTS top sw Hook
 			include : SAutoSlabEnd   df doBS bot sw Hook
@@ -230,7 +230,7 @@ glyph-block Letter-Latin-S : begin
 
 			define top : mix 0 CAP 0.88
 			define bot : mix 0 CAP 0.12
-			local sw : AdviceStroke2 2 3 (top - bot) df.adws
+			local sw : df.adviceStroke2 2 3 (top - bot)
 			include : SStrokeImpl df top bot doTS doBS sw EssUpper
 			include : SAutoSlabStart df doTS top sw Hook
 			include : SAutoSlabEnd   df doBS bot sw Hook
@@ -238,7 +238,7 @@ glyph-block Letter-Latin-S : begin
 		create-glyph "s.\(suffix)" : glyph-proc
 			local df : include DfLower
 			include : df.markSet.e
-			local sw : AdviceStroke2 2 3 XH df.adws
+			local sw : df.adviceStroke2 2 3 (XH - 0)
 			include : SmallSStrokeImpl df XH 0 doTS doBS sw EssLower
 			include : SAutoSlabStart df doTS XH sw Hook
 			include : SAutoSlabEnd   df doBS 0  sw [if fDesc SHook Hook]
@@ -246,14 +246,14 @@ glyph-block Letter-Latin-S : begin
 		create-glyph "s/phoneticRight.\(suffix)" : glyph-proc
 			local df : include DfLower
 			include : df.markSet.e
-			local sw : AdviceStroke2 2 3 XH df.adws
+			local sw : df.adviceStroke2 2 3 (XH - 0)
 			include : SmallSStrokeImpl df XH 0 doTS PHONETIC-RIGHT sw EssLower
 			include : SAutoSlabStart df doTS XH sw Hook
 
 		create-glyph "revS.\(suffix)" : glyph-proc
 			local df : include DfCapital
 			include : df.markSet.capital
-			local sw : AdviceStroke2 2 3 CAP df.adws
+			local sw : df.adviceStroke2 2 3 (CAP - 0)
 			include : RevSStrokeImpl df CAP 0 doTS doBS sw EssUpper
 			include : RevSAutoSlabStart df doTS CAP sw Hook
 			include : RevSAutoSlabEnd   df doBS 0   sw Hook
@@ -261,7 +261,7 @@ glyph-block Letter-Latin-S : begin
 		create-glyph "revs.\(suffix)" : glyph-proc
 			local df : include DfLower
 			include : df.markSet.e
-			local sw : AdviceStroke2 2 3 XH df.adws
+			local sw : df.adviceStroke2 2 3 (XH - 0)
 			include : RevSmallSStrokeImpl df XH 0 doTS doBS sw EssLower
 			include : RevSAutoSlabStart df doTS XH sw Hook
 			include : RevSAutoSlabEnd   df doBS 0  sw [if fDesc SHook Hook]
@@ -280,7 +280,7 @@ glyph-block Letter-Latin-S : begin
 			local df : include DfCapital
 			include : df.markSet.capDesc
 
-			local sw : AdviceStroke2 2 3 CAP df.adws
+			local sw : df.adviceStroke2 2 3 (CAP - 0)
 			local start : include : UpperSBaseWithAttach df sw
 			include : dispiro
 				widths.lhs [AdviceStroke 4.5]
@@ -293,7 +293,7 @@ glyph-block Letter-Latin-S : begin
 			local df : include DfLower
 			include : df.markSet.p
 
-			local sw : AdviceStroke2 2 3 XH df.adws
+			local sw : df.adviceStroke2 2 3 (XH - 0)
 			local start : include : LowerSBaseWithAttach df sw
 			include : dispiro
 				widths.lhs [AdviceStroke 4.5]
@@ -305,14 +305,14 @@ glyph-block Letter-Latin-S : begin
 		if [not doBS] : create-glyph "sCurlyTail.\(suffix)" : glyph-proc
 			local df : include DfLower
 			include : df.markSet.e
-			local sw : AdviceStroke2 2 3 XH df.adws
+			local sw : df.adviceStroke2 2 3 (XH - 0)
 			include : SmallSStrokeImpl df XH 0 doTS CURLY-TAIL sw EssLower
 			include : SAutoSlabStart df doTS XH sw Hook
 
 		create-glyph "cyrl/Dzwe.\(suffix)" : glyph-proc
 			local df : include DfCapital
 			include : df.markSet.capDesc
-			local sw : AdviceStroke2 2 3 (CAP - Descender) df.adws
+			local sw : df.adviceStroke2 2 3 (CAP - Descender)
 			include : SStrokeImpl df CAP Descender doTS doBS sw EssUpper
 			include : SAutoSlabStart df doTS CAP       sw Hook
 			include : SAutoSlabEnd   df doBS Descender sw Hook
@@ -320,7 +320,7 @@ glyph-block Letter-Latin-S : begin
 		create-glyph "cyrl/dzwe.\(suffix)" : glyph-proc
 			local df : include DfLower
 			include : df.markSet.bp
-			local sw : AdviceStroke2 2 3 (Ascender - Descender) df.adws
+			local sw : df.adviceStroke2 2 3 (Ascender - Descender)
 			include : SmallSStrokeImpl df Ascender Descender doTS doBS sw EssLower
 			include : SAutoSlabStart df doTS Ascender  sw Hook
 			include : SAutoSlabEnd   df doBS Descender sw [if fDesc SHook Hook]
@@ -511,7 +511,7 @@ glyph-block Letter-Latin-S : begin
 				flat  @x1                              (@y5 + archDepthB)
 
 		define [InterruptMask df] : begin
-			local gap : (swBarThick / Stroke * EssUpper) + [Math.max ((top - bot) / 6) : AdviceStroke2 3 3 (top - bot)]
+			local gap : (swBarThick * EssRatioUpper) + [Math.max ((top - bot) / 6) : AdviceStroke2 3 3 (top - bot)]
 			local yMid : mix bot top 0.5
 			local yTermLeft  : mix yMid (top - [AdviceSArchDepth (top - bot) (-1) swBarThick]) 0.5
 			local yTermRight : mix yMid (bot + [AdviceSArchDepth (top - bot) (-1) swBarThick]) 0.5

--- a/packages/font-glyphs/src/letter/latin/upper-h.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-h.ptl
@@ -135,7 +135,7 @@ glyph-block Letter-Latin-Upper-H : begin
 		local-parameter : top
 		local-parameter : slabType
 		local-parameter : fTailed  -- false
-		local-parameter : stroke   -- [Math.min df.mvs [df.adviceStroke 2.75] [df.adviceStroke 2 0.75]]
+		local-parameter : stroke   -- [Math.min [df.adviceThinnerStroke 2.75 1.00] [df.adviceThinnerStroke 2.00 0.75]]
 		local-parameter : serifTR  -- SLAB
 
 		local subDf : DivFrame (0.75 * df.adws) 2

--- a/packages/font-kits/src/letter-model.mjs
+++ b/packages/font-kits/src/letter-model.mjs
@@ -1,6 +1,6 @@
 import { Anchor } from "@iosevka/geometry/anchor";
 import { Box } from "@iosevka/geometry/box";
-import { mix } from "@iosevka/util";
+import { mix, clamp } from "@iosevka/util";
 
 export function SetupBuilders(bindings) {
 	const F = (_adws, _hPack, _sbMul) => {
@@ -36,9 +36,7 @@ class DivFrame {
 			bindings.HVContrast,
 			1,
 		);
-		const sb = _sbMul
-			? bindings.SB * _sbMul
-			: bindings.SB * Math.min(1, (width - hPack * mvs) / (2 * hPack * bindings.SB));
+		const sb = bindings.SB * (_sbMul ?? clamp(0, 1, (width / hPack - mvs) / (2 * bindings.SB)));
 
 		return new DivFrame(bindings, new DivFrameParams(width, sb, hPack, mvs, 0));
 	}
@@ -52,10 +50,10 @@ class DivFrame {
 		this.hPack = hPack;
 		this.width = width;
 		this.middle = 0.5 * width;
-		this.sb = this.leftSB = sb;
+		this.leftSB = this.sb = sb;
 		this.rightSB = width - sb;
 		this.mvs = mvs;
-		this.shoulderFine = (bindings.ShoulderFine * mvs) / bindings.Stroke;
+		this.shoulderFine = bindings.ShoulderFine * (mvs / bindings.Stroke);
 		this.markSet = new MarksetDiv(bindings, this);
 
 		this.ox = ox;
@@ -167,6 +165,19 @@ class DivFrame {
 
 	adviceStroke2(c, d, h, extraScalar = 1) {
 		return Math.min(
+			this.bindings.AdviceStrokeInSpace(h, d, 1, 1),
+			this.bindings.AdviceStrokeInSpace(
+				extraScalar * this.width - 2 * this.bindings.SB,
+				c,
+				this.bindings.HVContrast,
+				1,
+			),
+		);
+	}
+
+	adviceThinnerStroke2(c, d, h, extraScalar = 1) {
+		return Math.min(
+			this.mvs,
 			this.bindings.AdviceStrokeInSpace(h, d, 1, 1),
 			this.bindings.AdviceStrokeInSpace(
 				extraScalar * this.width - 2 * this.bindings.SB,

--- a/packages/font-kits/src/weight-control.mjs
+++ b/packages/font-kits/src/weight-control.mjs
@@ -35,7 +35,7 @@ export function CreateWeightControl(para, bindings) {
 	function AdviceStrokeInSpace(availSpace, crowdedness, contrast = HVContrast, mul = 1) {
 		const nonAdjustedFillRate = (crowdedness * contrast * stroke) / availSpace;
 		const adjustedFillRate = StrokeWeightControlSigmoid(nonAdjustedFillRate);
-		const strokeWidthScalar = Math.min(1, (mul * adjustedFillRate) / nonAdjustedFillRate);
+		const strokeWidthScalar = Math.min(1, mul * (adjustedFillRate / nonAdjustedFillRate));
 		return stroke * strokeWidthScalar;
 	}
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -2426,7 +2426,7 @@ selectorAffix."a/doubleStorey" = "serifed"
 selectorAffix."aRetroflexHook/doubleStorey" = "serifless"
 selectorAffix."a/singleStorey/autoSerifed/slab" = { if = [{ storey = "double-storey" }], then = "doubleSerifed", else = "serifed" }
 selectorAffix."a/singleStorey/autoSerifed/sans" = "serifed"
-selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = { if = [{ storey = "double-storey" }], then = "motionSerifed", else = "serifless" }
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = { if = [{ storey = "double-storey" }], then = "doubleSerifed", else = "serifless" }
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "serifless"
 selectorAffix."ae/a" = "toothlessRounded"
 
@@ -2436,13 +2436,13 @@ enableIf = [{ ear = "eared"}, { ear = "flat-top" }]
 descriptionAffix = "serifs at top and bottom"
 selectorAffix.a = "doubleSerifed"
 selectorAffix."a/sansSerif" = "serifless"
-selectorAffix."aRetroflexHook" = "motionSerifed"
+selectorAffix."aRetroflexHook" = "doubleSerifed"
 selectorAffix."a/doubleStorey" = "serifed"
 selectorAffix."aRetroflexHook/doubleStorey" = "serifless"
 selectorAffix."a/singleStorey/autoSerifed/slab" = "doubleSerifed"
 selectorAffix."a/singleStorey/autoSerifed/sans" = "doubleSerifed"
-selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "motionSerifed"
-selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "motionSerifed"
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "doubleSerifed"
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "doubleSerifed"
 selectorAffix."ae/a" = "toothlessRounded"
 
 [prime.a.variants-buildup.stages.bar.tailed]
@@ -2455,7 +2455,7 @@ selectorAffix."a/doubleStorey" = "tailed"
 selectorAffix."aRetroflexHook/doubleStorey" = "serifless"
 selectorAffix."a/singleStorey/autoSerifed/slab" = { if = [{ storey = "double-storey" }], then = "tailedSerifed", else = "tailed" }
 selectorAffix."a/singleStorey/autoSerifed/sans" = "tailed"
-selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = { if = [{ storey = "double-storey" }], then = "motionSerifed", else = "serifless" }
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = { if = [{ storey = "double-storey" }], then = "doubleSerifed", else = "serifless" }
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "serifless"
 selectorAffix."ae/a" = "toothlessRounded"
 
@@ -2465,13 +2465,13 @@ enableIf = [{ ear = "eared"}, { ear = "flat-top" }]
 descriptionAffix = "curly tail; with serifs at top and bottom"
 selectorAffix.a = "tailedSerifed"
 selectorAffix."a/sansSerif" = "tailed"
-selectorAffix."aRetroflexHook" = "motionSerifed"
+selectorAffix."aRetroflexHook" = "doubleSerifed"
 selectorAffix."a/doubleStorey" = "tailed"
 selectorAffix."aRetroflexHook/doubleStorey" = "serifless"
 selectorAffix."a/singleStorey/autoSerifed/slab" = "tailedSerifed"
 selectorAffix."a/singleStorey/autoSerifed/sans" = "tailedSerifed"
-selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "motionSerifed"
-selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "motionSerifed"
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "doubleSerifed"
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "doubleSerifed"
 selectorAffix."ae/a" = "toothlessRounded"
 
 [prime.a.variants-buildup.stages.bar.flat-bottom-serifless]
@@ -2502,7 +2502,7 @@ selectorAffix."a/doubleStorey" = "flatBottomSerifed"
 selectorAffix."aRetroflexHook/doubleStorey" = "serifless"
 selectorAffix."a/singleStorey/autoSerifed/slab" = "doubleSerifed"
 selectorAffix."a/singleStorey/autoSerifed/sans" = "serifed"
-selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "motionSerifed"
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "doubleSerifed"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "serifless"
 selectorAffix."ae/a" = "toothlessRounded"
 
@@ -2517,7 +2517,7 @@ selectorAffix."a/doubleStorey" = "toothlessCorner"
 selectorAffix."aRetroflexHook/doubleStorey" = "serifless"
 selectorAffix."a/singleStorey/autoSerifed/slab" = "doubleSerifed"
 selectorAffix."a/singleStorey/autoSerifed/sans" = "serifless"
-selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "motionSerifed"
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "doubleSerifed"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "serifless"
 selectorAffix."ae/a" = "toothlessRounded"
 
@@ -2532,7 +2532,7 @@ selectorAffix."a/doubleStorey" = "toothlessRounded"
 selectorAffix."aRetroflexHook/doubleStorey" = "serifless"
 selectorAffix."a/singleStorey/autoSerifed/slab" = "doubleSerifed"
 selectorAffix."a/singleStorey/autoSerifed/sans" = "serifless"
-selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "motionSerifed"
+selectorAffix."aRetroflexHook/singleStorey/autoSerifed/slab" = "doubleSerifed"
 selectorAffix."aRetroflexHook/singleStorey/autoSerifed/sans" = "serifless"
 selectorAffix."ae/a" = "toothlessRounded"
 


### PR DESCRIPTION
### Motivation and Context

This adds a missing function to `[DivFrame]` in analogue to `[adviceThinnerStroke …]`, equivalent to `[Math.min [DivFrame].mvs : [DivFrame].adviceStroke2 …]`

Also reduce unused/inaccessible glyphs surrounding single-storey `a` (top-serifed variants intended exclusively for `ᶏ` that could more efficiently be handled with `double-serifed` variants using `eject-contour`).

### Influenced Characters

N/A.

### Glyph Quantity

Normally this would be N/A but since I trimmed the unused `a` glyphs, it's net-negative 10 glyphs.

### Samples

N/A (visuals don't change; The new functions are equivalent to existing code)
