### PR TITLE
Add italic form for Cyrillic Lower Tche (`ꚓ`) inspired by Brill V5.00.

### DIFF
--- a/packages/font-glyphs/src/letter/cyrillic/che.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/che.ptl
@@ -9,7 +9,7 @@ glyph-block Letter-Cyrillic-Che : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Adjustment : LeaningAnchor
-	glyph-block-import Letter-Shared : CreateSelectorVariants DefineSelectorGlyph
+	glyph-block-import Letter-Shared : CreateAccentedComposition CreateSelectorVariants DefineSelectorGlyph
 	glyph-block-import Letter-Shared-Shapes : SerifFrame RightwardTailedBar CyrDescender
 
 	glyph-block-export BODY
@@ -184,7 +184,7 @@ glyph-block Letter-Cyrillic-Che : begin
 				if SLAB SERIFS.ALL SERIFS.NONE
 				teSerifs -- doST
 
-	select-variant 'cyrl/Tche' 0xA692 (follow -- 'T/rtailBase')
+	select-variant 'cyrl/Tche' 0xA692 (follow -- 'T/rTailBase')
 
 	create-glyph 'cyrl/CheDescender' 0x4B6 : composite-proc
 		refer-glyph 'cyrl/Che'
@@ -220,10 +220,10 @@ glyph-block Letter-Cyrillic-Che : begin
 
 		define cyrTcheDf : DivFrame para.advanceScaleT
 
-		DefineSelectorGlyph "cyrl/tche" suffix cyrTcheDf 'e'
+		DefineSelectorGlyph "cyrl/tche.upright" suffix cyrTcheDf 'e'
 
 		foreach { suffixTe { doST doSB } } [Object.entries TcheConfig] : do
-			create-glyph "cyrl/tche.\(suffix).\(suffixTe)" : glyph-proc
+			create-glyph "cyrl/tche.upright.\(suffix).\(suffixTe)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'cvDecompose' 0 0
 				include : LeaningAnchor.Below.VBar.r cyrTcheDf.rightSB
@@ -231,14 +231,15 @@ glyph-block Letter-Cyrillic-Che : begin
 					if SLAB [if para.isItalic slabItalic slabUpright] SERIFS.NONE
 					teSerifs -- doST
 
-		select-variant "cyrl/tche.\(suffix)" (follow -- 'T/rtailBase')
+		select-variant "cyrl/tche.upright.\(suffix)" (follow -- 'T/rTailBase')
 
 	select-variant 'cyrl/che' 0x447
 	select-variant 'cyrl/che.BGR' (follow -- 'cyrl/che')
 
 	select-variant 'cyrl/cche' 0xA687 (follow -- 'cyrl/che')
 
-	CreateSelectorVariants 'cyrl/tche' 0xA693 [Object.keys ItalicConfig] (follow -- 'cyrl/che')
+	CreateSelectorVariants 'cyrl/tche.upright' null [Object.keys ItalicConfig] (follow -- 'cyrl/che')
+	CreateAccentedComposition 'cyrl/tche.italic' null 'cyrl/che' 'tildeAbove'
 
 	create-glyph 'cyrl/cheDescender' 0x4B7 : composite-proc
 		refer-glyph 'cyrl/che.standard'

--- a/packages/font-glyphs/src/letter/cyrillic/tje.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/tje.ptl
@@ -82,10 +82,10 @@ glyph-block Letter-Cyrillic-Tje : begin
 		follow    -- 'T'
 		shapeFrom -- 'cyrl/tje.upright/leftHalf'
 	select-variant 'cyrl/Tje/leftHalf/reduced'
-		follow    -- 'T/rtailBase'
+		follow    -- 'T/rTailBase'
 		shapeFrom -- 'cyrl/Tje/leftHalf'
 	select-variant 'cyrl/tje.upright/leftHalf/reduced'
-		follow    -- 'T/rtailBase'
+		follow    -- 'T/rTailBase'
 		shapeFrom -- 'cyrl/tje.upright/leftHalf'
 
 	select-variant 'cyrl/Tje/rightHalf'

--- a/packages/font-glyphs/src/letter/cyrillic/tse.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/tse.ptl
@@ -83,8 +83,8 @@ glyph-block Letter-Cyrillic-Tse : begin
 			include : df.markSet.e
 			include : CyrTeTseShape df XH doST
 
-	select-variant 'cyrl/TeTse' 0x4B4 (follow -- 'T/rtailBase')
-	select-variant 'cyrl/tetse.upright' (follow -- 'T/rtailBase')
+	select-variant 'cyrl/TeTse' 0x4B4 (follow -- 'T/rTailBase')
+	select-variant 'cyrl/tetse.upright' (follow -- 'T/rTailBase')
 
 	define [CyrTsweShape top] : glyph-proc
 		include : VBar.l SB 0 top

--- a/packages/font-glyphs/src/letter/latin/upper-t.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-t.ptl
@@ -205,13 +205,13 @@ glyph-block Letter-Latin-Upper-T : begin
 	alias 'cyrl/te/reduced.upright' null 'smcpT'
 	select-variant 'cyrl/teDescender.upright' (follow -- 'T')
 
-	select-variant 'TRTail' 0x1AE (follow -- 'T/rtailBase')
+	select-variant 'TRTail' 0x1AE (follow -- 'T/rTailBase')
 
-	select-variant 'cyrl/TjeKomi' 0x50E (follow -- 'T/rtailBase')
-	select-variant 'cyrl/tjeKomi.upright' null (follow -- 'T/rtailBase')
+	select-variant 'cyrl/TjeKomi' 0x50E (follow -- 'T/rTailBase')
+	select-variant 'cyrl/tjeKomi.upright' null (follow -- 'T/rTailBase')
 
-	select-variant 'cyrl/Twe/upper' (follow -- 'T/rtailBase')
-	select-variant 'cyrl/twe/upper' (follow -- 'T/rtailBase')
+	select-variant 'cyrl/Twe/upper' (follow -- 'T/rTailBase')
+	select-variant 'cyrl/twe/upper' (follow -- 'T/rTailBase')
 	derive-composites 'cyrl/Twe' 0xA68C 'cyrl/Twe/upper' 'cyrl/Twe/middle'
 	derive-composites 'cyrl/twe' 0xA68D 'cyrl/twe/upper' 'cyrl/twe/middle'
 

--- a/packages/font-glyphs/src/orthography/index.ptl
+++ b/packages/font-glyphs/src/orthography/index.ptl
@@ -123,6 +123,7 @@ glyph-block Orthography : begin
 	orthographic-italic 'cyrl/dzze'           0xA689
 	orthographic-italic 'cyrl/teMidHook'      0xA68B
 	orthographic-italic 'cyrl/tswe'           0xA68F
+	orthographic-italic 'cyrl/tche'           0xA693
 	orthographic-italic 'cyrl/shwe'           0xA697
 	orthographic-italic 'latn/yatSakha'       0xAB60
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1723,21 +1723,21 @@ rank = 1
 description = "Serifless T"
 selector.T = "serifless"
 selector."T/sansSerif" = "serifless"
-selector."T/rtailBase" = "serifless"
+selector."T/rTailBase" = "serifless"
 
 [prime.capital-t.variants.motion-serifed]
 rank = 2
 description = "Motion-Serifed T"
 selector.T = "motionSerifed"
 selector."T/sansSerif" = "serifless"
-selector."T/rtailBase" = "motionSerifed"
+selector."T/rTailBase" = "motionSerifed"
 
 [prime.capital-t.variants.serifed]
 rank = 3
 description = "Serifed T"
 selector.T = "serifed"
 selector."T/sansSerif" = "serifless"
-selector."T/rtailBase" = "motionSerifed"
+selector."T/rTailBase" = "motionSerifed"
 
 
 


### PR DESCRIPTION
### Motivation and Context

This letter was used in an early version of the Abkhaz Cyrillic alphabet. Its italic form is in analogue to Cyrillic Ttse (`Ҵ`, `ҵ`).

Also rerout `T/rtailBase` → `T/rTailBase`.

Compared to historic Abkhaz alphabet chart:
<img width="960" height="1420" alt="image" src="https://github.com/user-attachments/assets/d85df54e-7c53-4544-915b-8ea90c520cc7" />

Compared to Brill V5.00:
`ҴҵꚒꚓ`
<img width="1611" height="981" alt="image" src="https://github.com/user-attachments/assets/d99f34f8-76bc-4f3b-aa85-f7566a47a321" />

### Influenced Characters

  - CYRILLIC SMALL LETTER TCHE (`U+A693`).

### Glyph Quantity

1 * 2 = ~2

### Samples

`ИиЦцꚎꚏҴҵꚒꚓꚆꚇШшЩщꚖꚗ`

Sans:
<img width="2525" height="929" alt="image" src="https://github.com/user-attachments/assets/27571ace-a7a7-4f8a-861d-a3bfbcb9fa25" />
Slab:
<img width="2533" height="936" alt="image" src="https://github.com/user-attachments/assets/bcaefbb5-5860-4466-944b-9ca1ccc2cd35" />

