### PR TITLE
Return glyph shape of Latin Upper Eng (`Ŋ`) and Cyrillic Upper Dje (`Ђ`) to before 37b68a3 and 3b8d681 respectively.

### DIFF
--- a/changes/34.7.1.md
+++ b/changes/34.7.1.md
@@ -1,3 +1,6 @@
 * Add Characters:
   - LATIN CAPITAL LETTER VISIGOTHIC Z (`U+A762`).
   - LATIN SMALL LETTER VISIGOTHIC Z (`U+A763`).
+* Refine shape of the following characters:
+  - LATIN CAPITAL LETTER ENG (`U+014A`).
+  - CYRILLIC CAPITAL LETTER DJE (`U+0402`).

--- a/packages/font-glyphs/src/letter/cyrillic/dje-tshe.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/dje-tshe.ptl
@@ -1,6 +1,6 @@
 $$include '../../meta/macros.ptl'
 
-import [mix linreg clamp fallback] from "@iosevka/util"
+import [mix linreg clamp fallback boole] from "@iosevka/util"
 
 glyph-module
 
@@ -8,7 +8,7 @@ glyph-block Letter-Cyrillic-Dje-Tshe : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Letter-Shared-Metrics : EFVJutLength
-	glyph-block-import Letter-Shared-Shapes : nShoulder SerifFrame EngHook
+	glyph-block-import Letter-Shared-Shapes : nShoulder SerifFrame VerticalHook
 	glyph-block-import Letter-Cyrillic-Yeri : YeriBarPos
 
 	define HConfig : object
@@ -22,17 +22,27 @@ glyph-block Letter-Cyrillic-Dje-Tshe : begin
 		define df : DivFrame para.advanceScaleT 2
 		define sw : df.adviceStroke2 2.75 3 CAP
 
+		define xMidBarLeft : Math.max (df.rightSB - (RightSB - SB)) : if doSerifLT
+			[mix df.leftSB df.rightSB 0.35] - [HSwToV : 0.50 * sw]
+			[mix df.leftSB df.rightSB 0.20] - [HSwToV : 0.25 * sw]
+
+		define mockWidth : (df.rightSB - xMidBarLeft) + SB * 2
+		define mockAdws  : mockWidth / Width
+		define archDepth : ArchDepth * mockAdws
+
+		define ada : ArchDepthAOf archDepth mockWidth
+		define adb : ArchDepthBOf archDepth mockWidth
+
+		define xTopBarLeft : mix 0 df.leftSB : if doSerifLT 0.250 0.375
+		define xTopBarRight : Math.max
+			mix xTopBarLeft (xMidBarLeft + [HSwToV : 0.5 * sw]) 2
+			mix xMidBarLeft df.rightSB 0.475
+
+		define sf : SerifFrame CAP 0 xMidBarLeft df.rightSB (swRef -- sw) (adws -- mockAdws)
+
 		create-glyph "cyrl/Tshe.\(suffix)" : glyph-proc
 			set-width df.width
 			include : df.markSet.capital
-
-			local xMidBarLeft : Math.max (df.rightSB - (RightSB - SB)) : if doSerifLT
-				[mix df.leftSB df.rightSB 0.35] - [HSwToV : 0.50 * sw]
-				[mix df.leftSB df.rightSB 0.20] - [HSwToV : 0.25 * sw]
-
-			local mockWidth : (df.rightSB - xMidBarLeft) + SB * 2
-			local mockAdws  : mockWidth / Width
-			local archDepth : ArchDepth * mockAdws
 
 			include : VBar.l xMidBarLeft 0 CAP sw
 			include : nShoulder.earlessCorner
@@ -40,14 +50,9 @@ glyph-block Letter-Cyrillic-Dje-Tshe : begin
 				right  -- df.rightSB
 				top    -- ([mix 0 CAP YeriBarPos] + sw / 2)
 				bottom -- 0
-				ada    -- [ArchDepthAOf archDepth mockWidth]
-				adb    -- [ArchDepthBOf archDepth mockWidth]
+				ada    -- ada
+				adb    -- adb
 				stroke -- sw
-
-			local xTopBarLeft : mix 0 df.leftSB : if doSerifLT 0.250 0.375
-			local xTopBarRight : Math.max
-				mix xTopBarLeft (xMidBarLeft + [HSwToV : 0.5 * sw]) 2
-				mix xMidBarLeft df.rightSB 0.475
 
 			include : HBar.t xTopBarLeft xTopBarRight CAP sw
 			if doSerifLT : begin
@@ -59,16 +64,43 @@ glyph-block Letter-Cyrillic-Dje-Tshe : begin
 					tagged 'serifLT' : VSerif.dl xTopBarLeft  CAP jutTop swVJut
 					tagged 'serifRT' : VSerif.dr xTopBarRight CAP jutTop swVJut
 
-			local sf : SerifFrame CAP 0 xMidBarLeft df.rightSB (swRef -- sw) (adws -- mockAdws)
 			if doSerifLB : include sf.lb.full
 			if doSerifRB : include sf.rb.[if fMotion 'outer' 'full']
 
 		create-glyph "cyrl/Dje.\(suffix)" : glyph-proc
 			set-width df.width
-			include : df.markSet.capDesc
-			include [refer-glyph "cyrl/Tshe.\(suffix)"]
-			eject-contour 'serifRB'
-			include : EngHook df.rightSB 0 Descender (sw -- sw)
+			include : df.markSet.capital
+
+			include : VBar.l xMidBarLeft 0 CAP sw
+			include : nShoulder.earlessCorner
+				left   -- xMidBarLeft
+				right  -- df.rightSB
+				top    -- ([mix 0 CAP YeriBarPos] + sw / 2)
+				bottom -- (O + Hook + sw / 2)
+				ada    -- [ArchDepthAOf archDepth mockWidth]
+				adb    -- [ArchDepthBOf archDepth mockWidth]
+				stroke -- sw
+			local xHookDepth : Math.min (1.2 * HookX)
+				mix ((df.rightSB - [HSwToV : 0.5 * sw]) - [mix xMidBarLeft df.rightSB 0.5]) sf.jutIn
+					clamp 0 [boole doSerifLB] : StrokeWidthBlend 0 1
+			include : VerticalHook.r
+				x      -- df.rightSB
+				y      -- (O + Hook + sw / 2)
+				xDepth -- (-xHookDepth)
+				yDepth -- Hook
+				sw     -- sw
+
+			include : HBar.t xTopBarLeft xTopBarRight CAP sw
+			if doSerifLT : begin
+				local { jutTop jutBot jutMid } : EFVJutLength CAP 0 YeriBarPos sw
+				local swVJut : Math.min
+					VJutStroke * (sw / Stroke)
+					VSwToH : 0.625 * (xMidBarLeft - xTopBarLeft)
+				include : composite-proc
+					tagged 'serifLT' : VSerif.dl xTopBarLeft  CAP jutTop swVJut
+					tagged 'serifRT' : VSerif.dr xTopBarRight CAP jutTop swVJut
+
+			if doSerifLB : include sf.lb.full
 
 	select-variant 'cyrl/Tshe' 0x40B (follow -- 'hCap')
-	select-variant 'cyrl/Dje'  0x402 (follow -- 'hCap/descBase')
+	select-variant 'cyrl/Dje'  0x402 (follow -- 'hengCap')

--- a/packages/font-glyphs/src/letter/latin/lower-n.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-n.ptl
@@ -1,6 +1,6 @@
 $$include '../../meta/macros.ptl'
 
-import [mix clamp fallback SuffixCfg] from "@iosevka/util"
+import [mix clamp fallback SuffixCfg boole] from "@iosevka/util"
 import [MathSansSerif Joining] from "@iosevka/glyph/relation"
 
 glyph-module
@@ -12,7 +12,7 @@ glyph-block Letter-Latin-Lower-N : begin
 	glyph-block-import Letter-Shared : CreateAccentedComposition
 	glyph-block-import Letter-Shared-Shapes : CurlyTail nShoulder RightwardTailedBar
 	glyph-block-import Letter-Shared-Shapes : MidHook CyrDescender PalatalHook RetroflexHook
-	glyph-block-import Letter-Shared-Shapes : EngHook SerifFrame
+	glyph-block-import Letter-Shared-Shapes : VerticalHook EngHook SerifFrame
 
 	define [AdjustTrailingAnchor] : glyph-proc
 		define trAnchor currentGlyph.baseAnchors.trailing
@@ -168,10 +168,17 @@ glyph-block Letter-Latin-Lower-N : begin
 			if sLB : include : sLB [DivFrame 1] 0
 			if sRB : include : sRB [DivFrame 1] 0
 
-		if (!tailed) : create-glyph "Eng.\(suffix)" : glyph-proc
-			include : MarkSet.capDesc
-			include : Body CAP SB RightSB 0 Stroke ArchDepthA ArchDepthB
-			include : EngHook RightSB 0 Descender
+		if (!tailed) : create-glyph "engCap.\(suffix)" : glyph-proc
+			include : MarkSet.capital
+			include : Body CAP SB RightSB (O + Hook + HalfStroke) Stroke ArchDepthA ArchDepthB
+			local xHookDepth : Math.min (1.2 * HookX)
+				mix ((RightSB - [HSwToV HalfStroke]) - Middle) Jut
+					clamp 0 [boole sLB] : StrokeWidthBlend 0 1
+			include : VerticalHook.r
+				x      -- RightSB
+				y      -- (O + Hook + HalfStroke)
+				xDepth -- (-xHookDepth)
+				yDepth -- Hook
 			if sLT : include : sLT [DivFrame 1] CAP
 			if sLB : include : sLB [DivFrame 1] 0
 
@@ -329,7 +336,7 @@ glyph-block Letter-Latin-Lower-N : begin
 	select-variant 'cyrl/pe.italic/descBase' (shapeFrom -- 'n')
 	alias 'cyrl/pe.BGR' null 'cyrl/pe.italic'
 
-	select-variant 'Eng' 0x14A (follow -- 'eng')
+	select-variant 'engCap' 0x14A (follow -- 'eng')
 	select-variant 'eng' 0x14B
 	link-reduced-variant 'eng/phoneticRight' 'eng'
 	select-variant 'nHookLeft' 0x272

--- a/packages/font-glyphs/src/letter/latin/upper-n.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-n.ptl
@@ -157,7 +157,7 @@ glyph-block Letter-Latin-Upper-N : begin
 			include : RevNShape [DivFrame 1] CAP bodyType slabType
 				swDiag -- [AdviceStroke crDiag]
 
-		create-glyph "Eng.NSM.\(suffix)" : glyph-proc
+		create-glyph "Eng.\(suffix)" : glyph-proc
 			include : MarkSet.capDesc
 			local dim : include : NShape [DivFrame 1] CAP bodyType slabType
 				swDiag -- [AdviceStroke crDiag]
@@ -197,7 +197,7 @@ glyph-block Letter-Latin-Upper-N : begin
 	alias 'grek/Nu' 0x39D 'N'
 	alias-reduced-variant 'grek/Nu/sansSerif' 'grek/Nu' 'N/sansSerif' MathSansSerif
 
-	select-variant 'Eng.NSM' (follow -- 'N')
+	select-variant 'Eng' (follow -- 'N')
 	select-variant 'NHookLeft' 0x19D (follow -- 'N')
 
 	select-variant 'currency/nairaSign/base' (follow -- 'N')
@@ -215,7 +215,7 @@ glyph-block Letter-Latin-Upper-N : begin
 	CreateAccentedComposition 'cyrl/IBreve' 0x419 'cyrl/I' 'breveAbove'
 	CreateAccentedComposition 'cyrl/IGrave' 0x40D 'cyrl/I' 'graveAbove'
 
-	CreateAccentedComposition 'cyrl/IShortTail' 0x48A 'cyrl/ITail' 'breveAbove'
+	CreateAccentedComposition 'cyrl/IBreveTail' 0x48A 'cyrl/ITail' 'breveAbove'
 
 	create-glyph 'cyrl/I.BGR' : glyph-proc
 		include : MarkSet.capital

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -929,8 +929,10 @@ glyph-block Letter-Shared-Shapes : begin
 			local rBarCenter : right - 0.5 * ink
 			local rBarInner  : right - 1.0 * ink
 
-			set this.jut     jut
-			set this.sideJut sideJut
+			set this.jut       jut
+			set this.jutIn     jutIn
+			set this.sideJut   sideJut
+			set this.sideJutIn sideJutIn
 
 			set this.enoughSpaceForFullSerifs : 0.5 * ink + 0.375 * gap > para.refJut
 

--- a/packages/font-glyphs/src/orthography/index.ptl
+++ b/packages/font-glyphs/src/orthography/index.ptl
@@ -132,7 +132,7 @@ glyph-block Orthography : begin
 	CreateAccentedComposition 'cyrl/gje'    0x453 'cyrl/ghe' 'acuteAbove'
 	CreateAccentedComposition 'cyrl/iGrave' 0x45D 'cyrl/i'   'graveAbove'
 
-	CreateAccentedComposition 'cyrl/iShortTail' 0x48B 'cyrl/iTail' 'breveAbove'
+	CreateAccentedComposition 'cyrl/iBreveTail' 0x48B 'cyrl/iTail' 'breveAbove'
 
 	# Link localization forms
 	link-gr LocalizedForm.SRB.Upright 'cyrl/be'            'cyrl/be.SRB'

--- a/packages/font-otl/src/gsub-locl.ptl
+++ b/packages/font-otl/src/gsub-locl.ptl
@@ -77,7 +77,7 @@ export : define [buildLOCL gsub para glyphStore] : begin
 	loclNSM.addLookup : gsub.createLookup
 		.type 'gsub_single'
 		.substitutions : object
-			'Eng' : glyphStore.ensureExists 'Eng.NSM'
+			'engCap' : glyphStore.ensureExists 'Eng'
 
 	# PLK
 	define loclPLK : latnPLK.addFeature : gsub.createFeature 'locl'

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -1027,6 +1027,7 @@ selector.HHookLeft = "serifless"
 selector.hCap = "serifless"
 selector."hCap/descBase" = "serifless"
 selector.hCapHookTop = "serifless"
+selector.hengCap = "serifless"
 
 [prime.capital-h.variants.top-left-serifed]
 rank = 2
@@ -1041,6 +1042,7 @@ selector.HHookLeft = "serifless"
 selector.hCap = "topLeftSerifed"
 selector."hCap/descBase" = "topLeftSerifed"
 selector.hCapHookTop = "serifless"
+selector.hengCap = "topLeftSerifed"
 
 [prime.capital-h.variants.top-left-bottom-right-serifed]
 rank = 3
@@ -1055,6 +1057,7 @@ selector.HHookLeft = "topLeftBottomRightSerifed"
 selector.hCap = "topLeftBottomRightSerifed"
 selector."hCap/descBase" = "topLeftSerifed"
 selector.hCapHookTop = "topLeftBottomRightSerifed"
+selector.hengCap = "topLeftSerifed"
 
 [prime.capital-h.variants.serifed]
 rank = 4
@@ -1069,6 +1072,7 @@ selector.HHookLeft = "serifed"
 selector.hCap = "serifed"
 selector."hCap/descBase" = "serifed"
 selector.hCapHookTop = "serifed"
+selector.hengCap = "serifed"
 
 
 


### PR DESCRIPTION
### Motivation and Context

This makes Dje (`Ђ`) less confusable against T with Middle Hook (`Ꚋ`), and makes Eng (`Ŋ`) match.

Also implement a new method of balancing the horizontal hook depth with the serifs, facilitated by #3236 :
```
local xHookDepth : Math.min (1.2 * HookX)
	mix ((RightSB - [HSwToV HalfStroke]) - Middle) Jut
		clamp 0 [boole sLB] : StrokeWidthBlend 0 1
…
include : VerticalHook.r
	…
	xDepth -- (-xHookDepth)
```

### Influenced Characters

  - LATIN CAPITAL LETTER ENG (`U+014A`).
  - CYRILLIC CAPITAL LETTER DJE (`U+0402`).

### Glyph Quantity

N/A (Zero new glyphs; Existing glyphs are simply reworked.)

### Samples

Sans Monospace:
<img width="1839" height="1235" alt="image" src="https://github.com/user-attachments/assets/803036a6-716a-4512-9325-a36ec1edcbb3" />
Slab Monospace:
<img width="1861" height="1229" alt="image" src="https://github.com/user-attachments/assets/981dfc56-0851-4fa8-883c-25a7d835a0a1" />
Aile:
<img width="2025" height="1241" alt="image" src="https://github.com/user-attachments/assets/6d2cd345-dd9b-4ad8-8124-e403f0ad1454" />
Etoile:
<img width="2020" height="1232" alt="image" src="https://github.com/user-attachments/assets/9b596eda-4b89-4ff0-a33a-e94a88d4cac6" />