### PR TITLE
Add `diagonal-tailed` variants for Lower Eszet (`ß`).

### DIFF
--- a/changes/34.8.0.md
+++ b/changes/34.8.0.md
@@ -1,3 +1,4 @@
+* Add `diagonal-tailed` variants for Lower Eszet (`ß`).
 * Add Characters:
   - LATIN CAPITAL LETTER VISIGOTHIC Z (`U+A762`).
   - LATIN SMALL LETTER VISIGOTHIC Z (`U+A763`).

--- a/packages/font-glyphs/src/letter/latin-ext/eszet.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/eszet.ptl
@@ -1,6 +1,6 @@
 $$include '../../meta/macros.ptl'
 
-import [mix fallback SuffixCfg] from "@iosevka/util"
+import [mix clamp fallback SuffixCfg] from "@iosevka/util"
 
 import [maskBits] from "@iosevka/util/mask-bit"
 
@@ -9,13 +9,15 @@ glyph-module
 glyph-block Letter-Latin-Lower-Eszet : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
-	glyph-block-import Letter-Shared-Shapes : FlatHookDepth PalatalHook SerifFrame
+	glyph-block-import Letter-Shared-Shapes : LeftwardDiagTailedBar SerifFrame
+	glyph-block-import Letter-Shared-Shapes : FlatHookDepth PalatalHook
 	glyph-block-import Letter-Latin-S : AdviceSArchDepth
 	glyph-block-import Letter-Latin-Lower-F : ySmallFBarPos
 
-	define NO-TAIL             0
-	define DESCENDING          1
-	define TAILED              2
+	define TERMINAL-BASELINE   0
+	define TERMINAL-DESCENDING 1
+	define TERMINAL-TAILED     2
+	define TERMINAL-DIAGONAL   3
 
 	define SERIF-NONE          0
 	define SERIF-BOT           1
@@ -29,7 +31,7 @@ glyph-block Letter-Latin-Lower-Eszet : begin
 
 	define [EszetSerifs df fTraditional slab] : glyph-proc
 		local sf : SerifFrame.fromDf df ySmallFBarPos 0
-		if [maskBits slab SERIF-BOT] : include : if fTraditional sf.lb.full sf.lb.outer
+		if [maskBits slab SERIF-BOT] : include sf.lb.[if fTraditional 'full' 'outer']
 		if [maskBits slab SERIF-MID] : include sf.lt.outer
 
 		if [maskBits slab SERIF-MID-XH] : begin
@@ -40,24 +42,24 @@ glyph-block Letter-Latin-Lower-Eszet : begin
 			local sfHalfAsc : SerifFrame.fromDf df ([mix 0 Ascender 0.5] + HalfStroke) 0
 			include sfHalfAsc.lt.outer
 
-	define [Traditional fFlathook] : function [slab tail] : glyph-proc
+	define [Traditional fFlathook] : function [slab term] : glyph-proc
 		include : MarkSet.bp
 		local xHook : [mix SB RightSB 0.75] + [HSwToV HalfStroke]
 		local hd : FlatHookDepth [DivFrame 1]
-		if fFlathook
-		: then : include : dispiro
-			widths.lhs
-			flat xHook Ascender
-			curl (SB + hd.x) Ascender
-			archv
-			flat SB (Ascender - hd.y)
-			curl SB 0 [heading Downward]
-		: else : include : dispiro
-			widths.lhs
-			g4   xHook (Ascender - Hook)
-			HookStart Ascender
-			flat SB XH
-			curl SB 0 [heading Downward]
+		include : if fFlathook
+			dispiro
+				widths.lhs
+				flat xHook Ascender
+				curl (SB + hd.x) Ascender
+				archv
+				flat SB (Ascender - hd.y)
+				curl SB 0 [heading Downward]
+			dispiro
+				widths.lhs
+				g4   xHook (Ascender - Hook)
+				HookStart Ascender
+				flat SB XH
+				curl SB 0 [heading Downward]
 		local t : mix 0 Ascender 0.7
 		local tm : [mix Descender t 0.625] + HalfStroke
 		local tl : [mix SB RightSB 0.35] + [HSwToV HalfStroke]
@@ -69,20 +71,20 @@ glyph-block Letter-Latin-Lower-Eszet : begin
 			g2   (RightSB - OX * 1.5) [mix Descender tm 0.70]
 			g2   (RightSB - OX * 1.5) [mix Descender tm 0.67]
 			alsoThru 0.5 0.75
-			g4   ([mix SB RightSB 0.35] + [if tail 0.625 0] * [HSwToV Stroke]) Descender
+			g4   ([mix SB RightSB 0.35] + [if term 0.625 0] * [HSwToV Stroke]) Descender
 		include : dispiro
 			widths.center (Stroke * 1.1)
 			corner tl (tm - Stroke) [heading Upward]
 			corner (RightSB - HalfStroke * 1.2 - OX) t [heading Upward]
 
 		include : EszetSerifs [DivFrame 1] true slab
-		include : match tail
-			[Just DESCENDING] : VBar.l SB Descender 0
-			[Just TAILED]     : PalatalHook.lExt SB 0
-			__ : glyph-proc
+		include : match term
+			[Just TERMINAL-DESCENDING] : VBar.l SB Descender 0
+			[Just TERMINAL-TAILED]     : PalatalHook.lExt SB 0
+			[Just TERMINAL-DIAGONAL]   : LeftwardDiagTailedBar SB Descender 0
+			__                         : no-shape
 
-
-	define [Sulzbacher slab tail] : glyph-proc
+	define [Sulzbacher slab term] : glyph-proc
 		include : MarkSet.b
 
 		define yMiddle : mix 0 Ascender 0.5
@@ -111,67 +113,65 @@ glyph-block Letter-Latin-Lower-Eszet : begin
 			g4   (RightSB - O) [YSmoothMidR (yMiddle + HalfStroke) 0 ada adb]
 			arcvh
 			flat xMiddleBot 0 [heading Leftward]
-			curl xFinal 0 [heading Leftward]
+			curl xFinal     0 [heading Leftward]
 
 		include : EszetSerifs [DivFrame 1] false slab
-		include : match tail
-			[Just DESCENDING] : VBar.l SB Descender 0
-			[Just TAILED]     : PalatalHook.lExt SB 0
-			__ : glyph-proc
+		include : match term
+			[Just TERMINAL-DESCENDING] : VBar.l SB Descender 0
+			[Just TERMINAL-TAILED]     : PalatalHook.lExt SB 0
+			[Just TERMINAL-DIAGONAL]   : LeftwardDiagTailedBar SB Descender 0
+			__                         : no-shape
 
-
-	define [LongSSLig slab tail] : glyph-proc
+	define [LongSSLig slab term] : glyph-proc
 		include : MarkSet.b
 
-		define swOuter : AdviceStroke2 2 3 Ascender
-		define strokeCoeff : StrokeWidthBlend 0 1 swInner
+		define swOuter : AdviceStroke2 2.0 3 Ascender
+		define swInner : AdviceStroke2 2.5 3 Ascender
 		define sEndX : Math.max
 			mix (SB + [HSwToV Stroke]) RightSB 0.1
-			mix SB RightSB 0.3
-		define swInner : AdviceStroke2 2.5 3 Ascender
-		define ess: swInner * EssLower / Stroke
-		define sTurnX : Math.max sEndX [mix SB RightSB 0.3]
-		define sBotX : Math.max (sEndX + 1) [mix sEndX RightSB 0.30]
+			mix  SB                    RightSB 0.3
+		define sTurnX : Math.max  sEndX      [mix SB    RightSB 0.3]
+		define sBotX  : Math.max (sEndX + 1) [mix sEndX RightSB 0.3]
 		define sTopX : sTurnX + (RightSB - sBotX)
 
 		define sTopHookX : sTopX + [HSwToV : 0.5 * swInner]
-		define archDepthATop : ArchDepthAOf (ArchDepth * (sTopHookX - SB - swInner * 0.5) / (RightSB - SB)) (Width - (RightSB - sTopHookX))
-		define archDepthBTop : ArchDepthBOf (ArchDepth * (sTopHookX - SB - swInner * 0.5) / (RightSB - SB)) (Width - (RightSB - sTopHookX))
-		define innerSmoothB : 1 * archDepthBTop # ArchDepthBOf (0.5 * swInner + (widthInner / Width) * [AdviceSArchDepth XH (-1) swInner]) widthInner
+		define archDepth : ArchDepth * (sTopHookX - SB - swInner * 0.5) / (RightSB - SB)
+		define mockWidth : sTopHookX + SB
+		define ada : ArchDepthAOf archDepth mockWidth
+		define adb : ArchDepthBOf archDepth mockWidth
 
 		include : dispiro
 			widths.rhs swOuter
 			flat SB 0 [heading Upward]
-			curl SB (Ascender - archDepthATop)
-			Arch.rhs Ascender
-				sw -- [mix swOuter swInner 0.5]
-				swBefore -- swOuter
-				swAfter -- swInner
-			g4.down.mid sTopHookX (Ascender - archDepthBTop + TanSlope * swInner) [widths.rhs.heading swInner Downward]
-			alsoThru.g2 0.5 0.50 [widths.center swInner]
-			g4   sTurnX [mix innerSmoothB (Ascender - archDepthBTop) 0.5] [widths.lhs.heading swInner Downward]
-			alsoThru.g2 0.5 0.50 [widths.center swInner]
-			g4   (RightSB - OX) (innerSmoothB - 2 * TanSlope * swInner) [widths.rhs.heading swInner Downward]
+			curl SB [Math.max XH : Ascender - ada]
+			Arch.rhs Ascender (swBefore -- swOuter) (sw -- [mix swOuter swInner 0.5]) (swAfter -- swInner)
+			g4.down.mid sTopHookX (Ascender - adb + TanSlope * swInner) [widths.rhs.heading swInner Downward]
+			alsoThru.g2 0.5 0.5 [widths.center swInner]
+			g4   sTurnX [mix (0 + adb) (Ascender - adb) 0.5] [widths.lhs.heading swInner Downward]
+			alsoThru.g2 0.5 0.5 [widths.center swInner]
+			g4   (RightSB - OX) (0 + adb - 2 * TanSlope * swInner) [widths.rhs.heading swInner Downward]
 			arcvh
-			flat [Arch.adjust-x.bot ([Math.max (sEndX + TINY + TanSlope * swInner) : Math.min (RightSB - innerSmoothB) : mix sEndX RightSB 0.375] + TanSlope * swInner) (swInner / 2)] 0
+			flat [Arch.adjust-x.bot ([clamp (sEndX + TINY + TanSlope * swInner) (RightSB - adb) : mix sEndX RightSB 0.375] + TanSlope * swInner) (swInner / 2)] 0
 			curl sEndX 0 [heading Leftward]
 
 		include : EszetSerifs [DivFrame 1] false slab
-		include : match tail
-			[Just DESCENDING] : VBar.l SB Descender 0 swOuter
-			[Just TAILED]     : PalatalHook.lExt SB 0 (sw -- swOuter)
-			__ : no-shape
+		include : match term
+			[Just TERMINAL-DESCENDING] : VBar.l SB Descender 0 swOuter
+			[Just TERMINAL-TAILED]     : PalatalHook.lExt SB 0 (sw -- swOuter)
+			[Just TERMINAL-DIAGONAL]   : LeftwardDiagTailedBar SB Descender 0 swOuter
+			__                         : no-shape
 
 	define EszetConfig : SuffixCfg.weave
 		object # body
-			traditional              [Traditional false]
+			traditionalBentHook      [Traditional false]
 			traditionalFlatHook      [Traditional true]
 			sulzbacher                Sulzbacher
 			longSSLig                 LongSSLig
 		object # terminal
-			''                        NO-TAIL
-			'descending'              DESCENDING
-			'tailed'                  TAILED
+			""                        TERMINAL-BASELINE
+			descending                TERMINAL-DESCENDING
+			tailed                    TERMINAL-TAILED
+			diagonalTailed            TERMINAL-DIAGONAL
 		object # serifs
 			serifless                 SERIF-NONE
 			bottomSerifed             SERIF-BOT
@@ -182,8 +182,8 @@ glyph-block Letter-Latin-Lower-Eszet : begin
 			middleSerifedHalfAscender SERIF-MID-HALF-ASC
 			dualSerifedHalfAscender   SERIF-DUAL-HALF-ASC
 
-	foreach { suffix { Base tail serif } } [pairs-of EszetConfig] : do
-		create-glyph "eszet.\(suffix)" : Base serif tail
+	foreach { suffix { Body terminal serif } } [pairs-of EszetConfig] : do
+		create-glyph "eszet.\(suffix)" : Body serif terminal
 
 	select-variant 'eszet' 0xDF
 
@@ -307,7 +307,7 @@ glyph-block Letter-Latin-Upper-Eszet : begin
 			cornerMotionSerifed { EszetCornerShape SERIF-MOTION }
 			cornerBottomSerifed { EszetCornerShape SERIF-BOTTOM }
 
-	foreach { suffix { Base serif } } [pairs-of CapitalEszetConfig] : do
-		create-glyph "Eszet.\(suffix)" : Base serif
+	foreach { suffix { Body serif } } [pairs-of CapitalEszetConfig] : do
+		create-glyph "Eszet.\(suffix)" : Body serif
 
 	select-variant 'Eszet' 0x1E9E

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -169,8 +169,8 @@ glyph-block Letter-Shared-Shapes : begin
 			flat (x + hookTurn) (low + O) [heading Rightward]
 			curl (x + hookDepth + sw * TanSlope) (low + O)
 
-	glyph-block-export InvRightwardTailedBar
-	define [InvRightwardTailedBar] : with-params [x low high [sw Stroke]] : begin
+	glyph-block-export LeftwardTailedBar
+	define [LeftwardTailedBar] : with-params [x low high [sw Stroke]] : begin
 		local hookDepth : Math.max SideJut
 			AdviceStroke 8
 			0.625 * (SB - 0)
@@ -179,17 +179,23 @@ glyph-block Letter-Shared-Shapes : begin
 			hookDepth - [AdviceStroke 16]
 		return : dispiro
 			widths.rhs sw
-			flat (x - [HSwToV sw]) low [heading Upward]
-			curl (x - [HSwToV sw]) (high - O - sw - hookTurn) [heading Upward]
+			flat (x + [HSwToV sw]) high [heading Downward]
+			curl (x + [HSwToV sw]) (low + O + sw + hookTurn) [heading Downward]
 			arcvh
-			flat (x + hookTurn) (high - O) [heading Rightward]
-			curl (x + hookDepth + sw * TanSlope) (high - O)
+			flat (x - hookTurn) (low + O) [heading Leftward]
+			curl (x - hookDepth - sw * TanSlope) (low + O)
 
 	glyph-block-export RightwardDiagTailedBar
 	define [RightwardDiagTailedBar] : with-params [x low high [sw Stroke]] : dispiro
 		widths.center sw
 		flat       (x - [HSwToV : 0.5 * sw]) high [heading Downward]
 		DiagTail.R (x - [HSwToV : 0.5 * sw]) low (0.875 * Hook - 0.375 * sw) sw
+
+	glyph-block-export LeftwardDiagTailedBar
+	define [LeftwardDiagTailedBar] : with-params [x low high [sw Stroke]] : dispiro
+		widths.center sw
+		flat       (x + [HSwToV : 0.5 * sw]) high [heading Downward]
+		DiagTail.L (x + [HSwToV : 0.5 * sw]) low (0.875 * Hook - 0.375 * sw) sw
 
 	glyph-block-export CurlyTail
 	define CurlyTail : namespace

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -5786,7 +5786,7 @@ selectorAffix."longsBar" = ""
 [prime.long-s.variants-buildup.stages.bottom.descending]
 rank = 2
 groupRank = 2
-descriptionAffix = "terminal descends baseline"
+descriptionAffix = "straight terminal that descends below the baseline"
 selectorAffix."longs" = "descending"
 selectorAffix."longs/compLigLeft" = "descending"
 selectorAffix."longsBar" = "descending"
@@ -5794,7 +5794,7 @@ selectorAffix."longsBar" = "descending"
 [prime.long-s.variants-buildup.stages.bottom.tailed]
 rank = 3
 groupRank = 3
-descriptionAffix = "terminal has a tail"
+descriptionAffix = "terminal with tail"
 selectorAffix."longs" = "tailed"
 selectorAffix."longs/compLigLeft" = "tailed"
 selectorAffix."longsBar" = "tailed"
@@ -5802,7 +5802,7 @@ selectorAffix."longsBar" = "tailed"
 [prime.long-s.variants-buildup.stages.bottom.diagonal-tailed]
 rank = 4
 groupRank = 4
-descriptionAffix = "terminal has a diagonal tail"
+descriptionAffix = "terminal with diagonal tail"
 selectorAffix."longs" = "diagonalTailed"
 selectorAffix."longs/compLigLeft" = "diagonalTailed"
 selectorAffix."longsBar" = "diagonalTailed"
@@ -5898,22 +5898,31 @@ next = "terminal"
 
 [prime.eszet.variants-buildup.stages.body.traditional]
 rank = 1
+next = "hook"
 descriptionAffix = "traditional, Fraktur-like shape"
 selectorAffix.eszet = "traditional"
 
-[prime.eszet.variants-buildup.stages.body.traditional-flat-hook]
+[prime.eszet.variants-buildup.stages.hook."*"]
+next = "terminal"
+
+[prime.eszet.variants-buildup.stages.hook.bent-hook]
+rank = 1
+keyAffix = ""
+selectorAffix.eszet = "bentHook"
+
+[prime.eszet.variants-buildup.stages.hook.flat-hook]
 rank = 2
-descriptionAffix = "traditional Fraktur-like shape (containing a flat top hook)"
-selectorAffix.eszet = "traditionalFlatHook"
+descriptionAffix = "flat top hook"
+selectorAffix.eszet = "flatHook"
 
 [prime.eszet.variants-buildup.stages.body.sulzbacher]
-rank = 3
+rank = 2
 descriptionAffix = "more modern, beta-like shape"
 selectorAffix.eszet = "sulzbacher"
 
 [prime.eszet.variants-buildup.stages.body.longs-s-lig]
-rank = 4
-descriptionAffix = "ligature of long-S (`ſ`) and `s`"
+rank = 3
+descriptionAffix = "shape like a ligature of long-S (`ſ`) and `s`"
 selectorAffix.eszet = "longSSLig"
 
 [prime.eszet.variants-buildup.stages.terminal."*"]
@@ -5926,13 +5935,19 @@ selectorAffix.eszet = ""
 
 [prime.eszet.variants-buildup.stages.terminal.descending]
 rank = 2
-descriptionAffix = "terminal descends baseline"
+descriptionAffix = "straight terminal that descends below the baseline"
 selectorAffix.eszet = "descending"
 
 [prime.eszet.variants-buildup.stages.terminal.tailed]
 rank = 3
-descriptionAffix = "terminal containing tail"
+descriptionAffix = "terminal with tail"
 selectorAffix.eszet = "tailed"
+
+[prime.eszet.variants-buildup.stages.terminal.diagonal-tailed]
+rank = 4
+nonBreakingVariantAdditionPriority = 200
+descriptionAffix = "terminal with diagonal tail"
+selectorAffix.eszet = "diagonalTailed"
 
 [prime.eszet.variants-buildup.stages.serifs.serifless]
 rank = 1
@@ -5940,52 +5955,63 @@ descriptionAffix = "serifs"
 descriptionJoiner = "without"
 selectorAffix.eszet = "serifless"
 
-[prime.eszet.variants-buildup.stages.serifs.middle-serifed]
+[prime.eszet.variants-buildup.stages.serifs.middle-serifed__traditional]
 rank = 2
+keyAffix = "middle-serifed"
+enableIf = [{ body = "traditional" }]
 descriptionAffix = "serif at middle"
-selectorAffix.eszet = { if = [{ body = "traditional" }, { body = "traditional-flat-hook" }], then = "middleSerifedXH", else = "middleSerifed" }
+selectorAffix.eszet = "middleSerifedXH"
+
+[prime.eszet.variants-buildup.stages.serifs.middle-serifed__modern]
+rank = 2
+keyAffix = "middle-serifed"
+enableIf = [{ body = "NOT traditional" }]
+descriptionAffix = "serif at middle"
+selectorAffix.eszet = "middleSerifed"
 
 [prime.eszet.variants-buildup.stages.serifs.middle-serifed-xh]
 rank = 3
-enableIf = [{ body = "sulzbacher" }, { body = "longs-s-lig" }]
+enableIf = [{ body = "NOT traditional" }]
 descriptionAffix = "serif at middle at x-height"
 selectorAffix.eszet = "middleSerifedXH"
 
 [prime.eszet.variants-buildup.stages.serifs.middle-serifed-half-ascender]
 rank = 4
 nonBreakingVariantAdditionPriority = 100
-enableIf = [{ body = "sulzbacher" }, { body = "longs-s-lig" }]
+enableIf = [{ body = "NOT traditional" }]
 descriptionAffix = "serif at middle at half ascender-height"
 selectorAffix.eszet = "middleSerifedHalfAscender"
 
 [prime.eszet.variants-buildup.stages.serifs.bottom-serifed]
-enableIf = [{ terminal = "non-descending" }]
 rank = 5
+enableIf = [{ terminal = "non-descending" }]
 descriptionAffix = "serif at bottom"
 selectorAffix.eszet = "bottomSerifed"
 
-[prime.eszet.variants-buildup.stages.serifs.dual-serifed]
-enableIf = [{ terminal = "non-descending" }]
+[prime.eszet.variants-buildup.stages.serifs.dual-serifed__traditional]
 rank = 6
+keyAffix = "dual-serifed"
+enableIf = [{ terminal = "non-descending", body = "traditional" }]
 descriptionAffix = "serif at middle and bottom"
-selectorAffix.eszet = { if = [{ body = "traditional" }, { body = "traditional-flat-hook" }], then = "dualSerifedXH", else = "dualSerifed" }
+selectorAffix.eszet = "dualSerifedXH"
+
+[prime.eszet.variants-buildup.stages.serifs.dual-serifed__modern]
+rank = 6
+keyAffix = "dual-serifed"
+enableIf = [{ terminal = "non-descending", body = "NOT traditional" }]
+descriptionAffix = "serif at middle and bottom"
+selectorAffix.eszet = "dualSerifed"
 
 [prime.eszet.variants-buildup.stages.serifs.dual-serifed-xh]
-enableIf = [
-	{ terminal = "non-descending", body = "sulzbacher" },
-	{ terminal = "non-descending", body = "longs-s-lig" }
-]
 rank = 7
+enableIf = [{ terminal = "non-descending", body = "NOT traditional" }]
 descriptionAffix = "serif at middle (x-height) and bottom"
 selectorAffix.eszet = "dualSerifedXH"
 
 [prime.eszet.variants-buildup.stages.serifs.dual-serifed-half-ascender]
-enableIf = [
-	{ terminal = "non-descending", body = "sulzbacher" },
-	{ terminal = "non-descending", body = "longs-s-lig" }
-]
 rank = 8
 nonBreakingVariantAdditionPriority = 100
+enableIf = [{ terminal = "non-descending", body = "NOT traditional" }]
 descriptionAffix = "serif at middle (half ascender-height) and bottom"
 selectorAffix.eszet = "dualSerifedHalfAscender"
 
@@ -10585,7 +10611,7 @@ x = "straight-serifed"
 y = "straight-turn-serifed"
 z = "straight-serifed"
 long-s = "flat-hook-double-serifed-xh"
-eszet = "longs-s-lig-bottom-serifed"
+eszet = "longs-s-lig-dual-serifed-xh"
 lower-thorn = "serifed"
 lower-gamma = "straight-serifed"
 lower-iota = "tailed-serifed"
@@ -10717,7 +10743,7 @@ u = "toothed-serifed"
 v = "straight-serifed"
 w = "straight-flat-top-serifed"
 y = "straight-turn-serifed"
-eszet = "longs-s-lig-bottom-serifed"
+eszet = "longs-s-lig-dual-serifed-xh"
 lower-thorn = "serifed"
 lower-kappa = "straight-tri-serifed"
 lower-mu = "tailed-serifed"
@@ -11030,7 +11056,7 @@ y = "straight-turn-serifed"
 z = "straight-serifed"
 capital-eszet = "rounded-serifed"
 long-s = "flat-hook-double-serifed-xh"
-eszet = "longs-s-lig-bottom-serifed"
+eszet = "longs-s-lig-dual-serifed-xh"
 lower-thorn = "serifed"
 lower-kappa = "straight-tri-serifed"
 lower-mu = "tailed-serifed"
@@ -11429,7 +11455,7 @@ x = "straight-serifed"
 y = "straight-turn-serifed"
 z = "straight-serifed"
 long-s = "bent-hook-double-serifed"
-eszet = "longs-s-lig-bottom-serifed"
+eszet = "longs-s-lig-dual-serifed"
 lower-thorn = "serifed"
 lower-kappa = "symmetric-touching-tri-serifed"
 lower-mu = "toothed-serifed"
@@ -11576,7 +11602,7 @@ y = "curly-serifed"
 z = "curly-serifed"
 capital-eszet = "corner-bottom-serifed"
 long-s = "bent-hook-double-serifed"
-eszet = "longs-s-lig-bottom-serifed"
+eszet = "longs-s-lig-dual-serifed"
 lower-kappa = "curly-tri-serifed"
 capital-lambda = "curly-base-serifed"
 lower-mu = "toothed-serifed"
@@ -11606,7 +11632,7 @@ x = "curly-bilateral-motion-serifed"
 y = "curly-motion-serifed"
 capital-eszet = "flat-top-serifed"
 long-s = "bent-hook-middle-serifed"
-eszet = "longs-s-lig-serifless"
+eszet = "longs-s-lig-middle-serifed"
 lower-kappa = "curly-top-left-and-bottom-right-serifed"
 lower-mu = "toothed-motion-serifed"
 cyrl-ve = "cursive"
@@ -11726,7 +11752,7 @@ y = "straight-turn-serifed"
 z = "straight-serifed"
 capital-eszet = "rounded-serifed"
 long-s = "bent-hook-double-serifed"
-eszet = "longs-s-lig-bottom-serifed"
+eszet = "longs-s-lig-dual-serifed"
 lower-kappa = "straight-tri-serifed"
 lower-chi = "straight-bilateral-motion-serifed"
 lower-psi = "short-neck2-serifed"
@@ -11757,7 +11783,7 @@ w = "straight-flat-top-motion-serifed"
 x = "straight-bilateral-motion-serifed"
 y = "straight-turn-motion-serifed"
 long-s = "bent-hook-middle-serifed"
-eszet = "longs-s-lig-serifless"
+eszet = "longs-s-lig-middle-serifed"
 lower-kappa = "straight-top-left-and-bottom-right-serifed"
 cyrl-ve = "standard-unilateral-serifed"
 cyrl-ka = "symmetric-connected-top-left-and-bottom-right-serifed"
@@ -11882,7 +11908,7 @@ x = "straight-serifed"
 y = "cursive-flat-hook-serifed"
 z = "straight-serifed"
 long-s = "flat-hook-double-serifed"
-eszet = "sulzbacher-bottom-serifed"
+eszet = "sulzbacher-dual-serifed"
 lower-kappa = "symmetric-connected-tri-serifed"
 lower-chi = "straight-bilateral-motion-serifed"
 cyrl-a = "double-storey-flat-bottom-serifed"
@@ -11915,7 +11941,7 @@ w = "rounded-vertical-sides-motion-serifed"
 x = "straight-bilateral-motion-serifed"
 y = "cursive-flat-hook-motion-serifed"
 long-s = "flat-hook-middle-serifed"
-eszet = "sulzbacher-serifless"
+eszet = "sulzbacher-middle-serifed"
 lower-kappa = "symmetric-connected-top-left-and-bottom-right-serifed"
 cyrl-a = "single-storey-top-cut-tailed"
 cyrl-ka = "symmetric-connected-top-left-and-bottom-right-serifed"
@@ -12266,7 +12292,7 @@ y = "straight-turn-serifed"
 z = "straight-serifed"
 capital-eszet = "rounded-serifed"
 long-s = "bent-hook-double-serifed"
-eszet = "longs-s-lig-bottom-serifed"
+eszet = "longs-s-lig-dual-serifed"
 lower-thorn = "serifed"
 lower-iota = "tailed-serifed"
 lower-kappa = "symmetric-touching-tri-serifed"
@@ -12599,7 +12625,7 @@ x = "straight-serifed"
 y = "straight-turn-serifed"
 z = "straight-serifed"
 capital-eszet = "corner-serifed"
-eszet = "traditional-flat-hook-bottom-serifed"
+eszet = "traditional-flat-hook-dual-serifed"
 lower-kappa = "straight-tri-serifed"
 lower-upsilon = "straight-serifed"
 lower-psi = "short-neck-serifed"
@@ -12625,7 +12651,7 @@ w = "cursive-serifed"
 x = "cursive"
 y = "cursive-motion-serifed"
 z = "cursive"
-eszet = "traditional-flat-hook-serifless"
+eszet = "traditional-flat-hook-middle-serifed"
 cyrl-ve = "cursive"
 cyrl-ka = "symmetric-connected-top-left-and-bottom-right-serifed"
 cyrl-u = "cursive-motion-serifed"
@@ -13114,7 +13140,7 @@ x = "straight-serifed"
 y = "straight-turn-serifed"
 z = "straight-serifed"
 long-s = "bent-hook-double-serifed-xh"
-eszet = "longs-s-lig-bottom-serifed"
+eszet = "longs-s-lig-dual-serifed-xh"
 lower-alpha = "barred-tailed-serifed"
 lower-gamma = "straight-serifed"
 lower-kappa = "symmetric-connected-tri-serifed"
@@ -13146,7 +13172,7 @@ w = "straight-motion-serifed"
 x = "straight-bilateral-motion-serifed"
 y = "straight-turn-motion-serifed"
 long-s = "bent-hook-descending-middle-serifed-xh"
-eszet = "longs-s-lig-descending-serifless"
+eszet = "longs-s-lig-descending-middle-serifed-xh"
 lower-alpha = "barred-tailed"
 lower-kappa = "symmetric-connected-top-left-and-bottom-right-serifed"
 cyrl-ve = "standard-unilateral-serifed"


### PR DESCRIPTION
### Motivation and Context

This provides full parity between the variants of Long S (`ſ`) and Lower Eszet (`ß`).

Originally I had tried importing the diagonal tail function from `Letter-Latin-Lower-F` but it overflowed too much into the preceding character cell, so I opted to instead make a horizontally-mirrored equivalent of `[RightwardDiagTailedBar …]` called `[LeftwardDiagTailedBar …]` to save space when the tail is all the way at the left side&shy;bearing.

### Influenced Characters

  - LATIN SMALL LETTER SHARP S (`U+00DF`).

### Glyph Quantity

1 * (2 + 1 * 2) * 3 = 12

### Samples

```
ABC.DEF.GHI.JKL.MNO.PQRS.TUV.WXYZ
abc.def.ghi.jkl.mno.pqrs.tuv.wxyz
!iIlL17|¦ ¢coO08BDQ $5SZ2zs ∂96µm
float il1[]={1-2/3.4,5+6=7/8%90};
1234567890 ,._-+= >< «¯-¬_» ~–÷+×
{*}[]()<>`+-=$/#_%^@\&|~?'" !,.;:
g9q¶ Þẞðþſß ΓΔΛαβγδηθικλμνξπτυφχψ
ЖЗКНРУЭЯавжзклмнруфчьыэя <= != ==
```

Sans Italic under `font-feature-settings:'ss15','cv63'51;`:
<img width="1905" height="1135" alt="image" src="https://github.com/user-attachments/assets/7363af64-a856-4f78-98cb-f2729a51598f" />
Slab Italic under `font-feature-settings:'ss15','cv63'52;`:
<img width="1907" height="1138" alt="image" src="https://github.com/user-attachments/assets/7eb24dfa-cbcd-44a4-a91a-a3d76ef4ab27" />
