### PR TITLE
Add new constant `SquareDotScalar` based on `DesignParameters.squareDotScalar`.

### DIFF
--- a/packages/font-glyphs/src/common/shapes.ptl
+++ b/packages/font-glyphs/src/common/shapes.ptl
@@ -544,9 +544,9 @@ glyph-block CommonShapes : begin
 			local-parameter : x              # X-position of the stroke, without overshoot
 			local-parameter : d              # Y-position of the ring's bottom
 			local-parameter : u              # Y-position of the ring's top
-			local-parameter : ada -- ArchDepthA
-			local-parameter : adb -- ArchDepthB
-			local-parameter : ox  -- OX
+			local-parameter : ada     -- ArchDepthA
+			local-parameter : adb     -- ArchDepthB
+			local-parameter : ox      -- OX
 			# Additional function(s) for the control knots
 			local-parameter : af      -- nothing
 			local-parameter : startAf -- af
@@ -563,9 +563,9 @@ glyph-block CommonShapes : begin
 			local-parameter : x              # X-position of the stroke, without overshoot
 			local-parameter : d              # Y-position of the ring's bottom
 			local-parameter : u              # Y-position of the ring's top
-			local-parameter : ada -- ArchDepthA
-			local-parameter : adb -- ArchDepthB
-			local-parameter : ox  -- OX
+			local-parameter : ada     -- ArchDepthA
+			local-parameter : adb     -- ArchDepthB
+			local-parameter : ox      -- OX
 			# Additional function(s) for the control knots
 			local-parameter : af      -- nothing
 			local-parameter : startAf -- af
@@ -582,9 +582,9 @@ glyph-block CommonShapes : begin
 			local-parameter : x              # X-position of the stroke, without overshoot
 			local-parameter : d              # Y-position of the ring's bottom
 			local-parameter : u              # Y-position of the ring's top
-			local-parameter : ada -- ArchDepthA
-			local-parameter : adb -- ArchDepthB
-			local-parameter : ox  -- OX
+			local-parameter : ada     -- ArchDepthA
+			local-parameter : adb     -- ArchDepthB
+			local-parameter : ox      -- OX
 			# Additional function(s) for the control knots
 			local-parameter : af      -- nothing
 			local-parameter : startAf -- af
@@ -601,9 +601,9 @@ glyph-block CommonShapes : begin
 			local-parameter : x              # X-position of the stroke, without overshoot
 			local-parameter : d              # Y-position of the ring's bottom
 			local-parameter : u              # Y-position of the ring's top
-			local-parameter : ada -- ArchDepthA
-			local-parameter : adb -- ArchDepthB
-			local-parameter : ox  -- OX
+			local-parameter : ada     -- ArchDepthA
+			local-parameter : adb     -- ArchDepthB
+			local-parameter : ox      -- OX
 			# Additional function(s) for the control knots
 			local-parameter : af      -- nothing
 			local-parameter : startAf -- af
@@ -864,8 +864,8 @@ glyph-block CommonShapes : begin
 	# Dot variant constructor
 	glyph-block-export DotVariants
 	define DotVariants : object
-		round  { DotAt    1                                O }
-		square { SquareAt DesignParameters.squareDotScalar 0 }
+		round  { DotAt    1               O }
+		square { SquareAt SquareDotScalar 0 }
 
 	glyph-block-export WithDotVariants
 	define [WithDotVariants name unicode F] : begin

--- a/packages/font-glyphs/src/letter/latin/lower-t.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-t.ptl
@@ -210,7 +210,7 @@ glyph-block Letter-Latin-Lower-T : begin
 			set-base-anchor 'topRight' xCrossRight  Ascender
 			set-base-anchor 'overlay' (xBarLeft + [HSwToV : 0.625 * Stroke]) (XH * 0.58)
 			set-base-anchor 'bottomRight' xTailEnd bot
-			set-base-anchor 'lTailHookAttach' xTailEnd (bot + Stroke)
+			set-base-anchor 'palatalHookAttach' xTailEnd (bot + Stroke)
 
 	define UprightTailed : namespace
 		export : define BarLeftPos FlatHook.BarLeftPos
@@ -249,7 +249,7 @@ glyph-block Letter-Latin-Lower-T : begin
 			set-base-anchor 'overlay' (xLeft + [HSwToV HalfStroke]) (XH * 0.58)
 			set-base-anchor 'hooktopAttach' (xLeft + [HSwToV HalfStroke]) top
 			set-base-anchor 'bottomRight' xEnd (bot + Stroke)
-			set-base-anchor 'lTailHookAttach' xEnd (bot + Stroke)
+			set-base-anchor 'palatalHookAttach' xEnd (bot + Stroke)
 
 		export : define [Retroflex df sym top bot] : FlatHook.CrossRTBody df sym top bot
 
@@ -313,7 +313,7 @@ glyph-block Letter-Latin-Lower-T : begin
 			include : df.markSet.bp
 			include : Style.Body df sym top 0
 
-			local attach : currentGlyph.gizmo.unapply (currentGlyph.baseAnchors.lTailHookAttach || currentGlyph.baseAnchors.bottomRight)
+			local attach : currentGlyph.gizmo.unapply (currentGlyph.baseAnchors.palatalHookAttach || currentGlyph.baseAnchors.bottomRight)
 			include : PalatalHook.r
 				x -- attach.x
 				y -- 0

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -20,10 +20,10 @@ glyph-block Mark-Above : begin
 	glyph-block-import Mark-Shared-Metrics : markMiddle markDotsRadius dialytikaRadius
 
 	glyph-block-export aboveMarkTop aboveMarkBot aboveMarkMid aboveMarkStack
-	define aboveMarkTop   (XH + AccentClearance + AccentHeight)
-	define aboveMarkBot   (XH + AccentClearance)
-	define aboveMarkMid   [mix aboveMarkBot aboveMarkTop 0.5]
-	define aboveMarkStack (XH + AccentStackOffset)
+	define aboveMarkTop   : XH + AccentClearance + AccentHeight
+	define aboveMarkBot   : XH + AccentClearance
+	define aboveMarkMid   : mix aboveMarkBot aboveMarkTop 0.5
+	define aboveMarkStack : XH + AccentStackOffset
 
 	glyph-block-export commaOvershoot commaOvershoot2 commaAboveRadius
 	define commaOvershoot  : O * [linreg 16 0 90 (-1) markStroke]
@@ -579,7 +579,7 @@ glyph-block Mark-Above : begin
 		include : dispiro
 			widths.center (markFine * 2)
 			g2 (markMiddle - markFine * 0.5) aboveMarkBot [heading Upward]
-			alsoThruThem {{0.9 0.36} {0.1 0.64}} [heading Upward]
+			alsoThruThem { { 0.9 0.36 } { 0.1 0.64 } } [heading Upward]
 			g2 (markMiddle + markFine * 0.5) aboveMarkTop [heading Upward]
 
 	#### Macron/Overline Marks
@@ -833,7 +833,7 @@ glyph-block Mark-Above : begin
 		set-width 0
 		include : StdAnchors.narrow
 
-		local radius : commaAboveRadius * DesignParameters.squareDotScalar
+		local radius : commaAboveRadius * SquareDotScalar
 		include : Rect aboveMarkTop (aboveMarkTop - radius * 2) (markMiddle - radius) (markMiddle + radius)
 		include : dispiro
 			widths.rhs [Math.min radius : markFine * [linreg 16 2 90 1.75 markStroke]]
@@ -847,7 +847,7 @@ glyph-block Mark-Above : begin
 	select-variant 'commaAbove/asPunctuation' (shapeFrom -- 'commaAbove') (follow -- 'punctuationDot')
 
 	derive-composites 'commaAboveZero.round'  null 'commaAbove.round'  [ApparentTranslate (-markMiddle) ((-aboveMarkTop) + commaAboveRadius)]
-	derive-composites 'commaAboveZero.square' null 'commaAbove.square' [ApparentTranslate (-markMiddle) ((-aboveMarkTop) + commaAboveRadius * DesignParameters.squareDotScalar)]
+	derive-composites 'commaAboveZero.square' null 'commaAbove.square' [ApparentTranslate (-markMiddle) ((-aboveMarkTop) + commaAboveRadius * SquareDotScalar)]
 	select-variant 'commaAboveZero' (follow -- 'punctuationDot')
 
 	derive-glyphs 'commaGrekUpperTonos' null 'commaAbove' : function [src gr] : glyph-proc

--- a/packages/font-glyphs/src/marks/horn-and-angle.ptl
+++ b/packages/font-glyphs/src/marks/horn-and-angle.ptl
@@ -16,29 +16,29 @@ glyph-block Mark-Horn-And-Angle : begin
 	glyph-block-import Mark-Below : belowMarkBot belowMarkTop belowMarkMid
 
 	# horn and angle marks
-	define [HornDim attX attY overshootX overshootY yrP] : begin
+	define [HornDim attX attY overshootX overshootY krY] : begin
 		local radius commaAboveRadius
 		local hornFine   : Math.min (radius * 0.75) (markFine * 1.75)
 		local hornStroke : Math.min (radius * 1)    (markFine * 1.75)
 		local startX : attX + 2 * radius
-		local startY : attY + yrP * radius + (aboveMarkTop - aboveMarkBot) / 2
+		local startY : attY + krY * radius + (aboveMarkTop - aboveMarkBot) / 2
 		return : object radius hornFine hornStroke startX startY
 
-	define [HornMarkAnchor attX attY overshootX overshootY yrP] : glyph-proc
-		local [object radius hornFine startX startY] : HornDim attX attY overshootX overshootY yrP
+	define [HornMarkAnchor attX attY overshootX overshootY krY] : glyph-proc
+		local [object radius hornFine startX startY] : HornDim attX attY overshootX overshootY krY
 		set-mark-anchor 'topRight' attX attY startX startY
 		set-base-anchor 'aboveBraceL' (startX - radius) startY
 		set-base-anchor 'aboveBraceR' (startX - radius) startY
 
 	glyph-block-export HornBaseAnchor
-	define [HornBaseAnchor attX attY overshootX overshootY yrP] : glyph-proc
-		local [object radius hornFine startX startY] : HornDim attX attY overshootX overshootY yrP
+	define [HornBaseAnchor attX attY overshootX overshootY krY] : glyph-proc
+		local [object radius hornFine startX startY] : HornDim attX attY overshootX overshootY krY
 		set-base-anchor 'topRight' startX startY
 		set-base-anchor 'aboveBraceL' (startX - radius) startY
 		set-base-anchor 'aboveBraceR' (startX - radius) startY
 
-	define [HornShape attX attY overshootX overshootY yrP] : glyph-proc
-		local [object radius hornFine hornStroke startX startY] : HornDim attX attY overshootX overshootY yrP
+	define [HornShape attX attY overshootX overshootY krY] : glyph-proc
+		local [object radius hornFine hornStroke startX startY] : HornDim attX attY overshootX overshootY krY
 		include : union
 			RingAt (startX - radius) startY (radius - hornFine / 8)
 			dispiro
@@ -55,9 +55,9 @@ glyph-block Mark-Horn-And-Angle : begin
 					widths.rhs [mix hornFine hornStroke t]
 				g4 (attX - overshootX - [HSwToV HalfStroke]) (attY - overshootY - Stroke) [widths.rhs hornStroke]
 
-	define [SquareHornShape attX attY overshootX overshootY yrP] : glyph-proc
-		local [object [radius r] hornFine hornStroke startX startY] : HornDim attX attY overshootX overshootY yrP
-		local radius : r * DesignParameters.squareDotScalar
+	define [SquareHornShape attX attY overshootX overshootY krY] : glyph-proc
+		local [object [radius r] hornFine hornStroke startX startY] : HornDim attX attY overshootX overshootY krY
+		local radius : r * SquareDotScalar
 		include : union
 			SquareAt (startX - radius) startY radius
 			dispiro
@@ -99,7 +99,7 @@ glyph-block Mark-Horn-And-Angle : begin
 		set-base-anchor 'aboveBraceL' ((-0.75) * markExtend) aboveMarkMid
 		set-base-anchor 'aboveBraceR' 0 aboveMarkMid
 
-	create-glyph 'ltailBR' 0x321 : glyph-proc
+	create-glyph 'palatalHookBR' 0x321 : glyph-proc
 		set-width 0
 		set-mark-anchor 'bottomRight' 0 0 0 belowMarkBot
 		set-base-anchor 'belowBraceL' ((-0.5) * HookX - 0.25 * markExtend - [HSwToV : 0.25 * Stroke]) ((-0.5) * Hook - HalfStroke)
@@ -110,7 +110,7 @@ glyph-block Mark-Horn-And-Angle : begin
 			curl 0 0 [heading Downward]
 			straight.left.end ((-HookX) - [HSwToV HalfStroke]) ((-Hook) - HalfStroke)
 
-	create-glyph 'rtailBR' 0x322 : glyph-proc
+	create-glyph 'retroflexHookBR' 0x322 : glyph-proc
 		set-width 0
 		set-mark-anchor 'bottomRight' 0 0 0 belowMarkBot
 		set-base-anchor 'belowBraceL' (0.5 * HookX - 0.25 * markExtend - [HSwToV : 0.75 * Stroke]) ((-0.5) * Hook - HalfStroke)

--- a/packages/font-glyphs/src/meta/aesthetics.ptl
+++ b/packages/font-glyphs/src/meta/aesthetics.ptl
@@ -16,7 +16,7 @@ export : define [calculateMetrics para] : begin
 	define CAP       : Math.round para.cap
 	define XH        : Math.round para.xHeight
 	define Ascender  : Math.round para.ascender
-	define Descender : Math.round : fallback para.descender (XH - Ascender)
+	define Descender : Math.round [fallback para.descender (XH - Ascender)]
 
 	# Key metrics for symbols
 	define SymbolMid : Math.round para.symbolMid
@@ -89,18 +89,24 @@ export : define [calculateMetrics para] : begin
 	define Stroke : AdviceStroke 2
 	define HalfStroke : Stroke / 2
 	define QuarterStroke : Stroke / 4
+
 	define DotSize : fallback para.dotSize Stroke
 	define PeriodSize : fallback para.periodSize DotSize
+	define SquareDotScalar DesignParameters.squareDotScalar
+
 	define HBarPos : DesignParameters.hBarPos - 0.09 * Stroke / CAP
 	define OverlayPos DesignParameters.overlayPos
 	define OverlayStroke : AdviceStroke 3.75
+
 	define Jut para.jut
 	define LongJut para.longjut
 	define MidJutSide   : Math.max Jut : mix [HSwToV HalfStroke] LongJut 0.5
 	define MidJutCenter : Math.max Jut : mix [HSwToV HalfStroke] LongJut 0.6
+
 	define VJut para.vjut
 	define LongVJut : fallback para.longvjut LongJut
 	define VJutStroke : AdviceStroke 3.5
+
 	define AccentStackOffset para.accentStackOffset
 	define AccentWidth       para.accentWidth
 	define AccentClearance   para.accentClearance
@@ -222,13 +228,13 @@ export : define [calculateMetrics para] : begin
 		BgTkTop BgTkBot Italify Upright Scale Translate ApparentTranslate Rotate GlobalTransform
 		TanSlope HVContrast VHContrast Upward Downward Rightward Leftward O OX OXHook Hook AHook SHook
 		RHook JHook HookX TailX TailY DiagTailAngle DiagTailDepth ArchDepth SmallArchDepth Stroke
-		HalfStroke QuarterStroke DotSize PeriodSize HBarPos OverlayPos Jut LongJut VJut LongVJut
-		VJutStroke AccentStackOffset AccentWidth AccentClearance AccentHeight CThin CThinB SLAB
-		IBalance IBalance2 JBalance JBalance2 TBalance TBalance2 RBalance RBalance2 FBalance
-		OneBalance WideWidth0 WideWidth1 WideWidth2 WideWidth3 WideWidth4 EssRatioUpper EssRatioLower
-		EssRatioQuestion EssUpper EssLower EssQuestion RightSB Middle DotRadius PeriodRadius
-		ArchDepthA ArchDepthB SmallArchDepthA SmallArchDepthB CorrectionOMidX CorrectionOMidS
-		AdviceStroke AdviceStroke2 AdviceStrokeInSpace OverlayStroke OperatorStroke GeometryStroke
+		HalfStroke QuarterStroke DotSize PeriodSize SquareDotScalar HBarPos OverlayPos OverlayStroke
+		Jut LongJut VJut LongVJut VJutStroke AccentStackOffset AccentWidth AccentClearance
+		AccentHeight CThin CThinB SLAB IBalance IBalance2 JBalance JBalance2 TBalance TBalance2
+		RBalance RBalance2 FBalance OneBalance WideWidth0 WideWidth1 WideWidth2 WideWidth3 WideWidth4
+		EssRatioUpper EssRatioLower EssRatioQuestion EssUpper EssLower EssQuestion RightSB Middle
+		DotRadius PeriodRadius ArchDepthA ArchDepthB SmallArchDepthA SmallArchDepthB CorrectionOMidX
+		CorrectionOMidS AdviceStroke AdviceStroke2 AdviceStrokeInSpace OperatorStroke GeometryStroke
 		UnicodeWeightGrade StrokeWidthBlend ArchDepthAOf ArchDepthBOf ArchDepthAClamped
 		ArchDepthBClamped SmoothAdjust SideJut MidJutSide MidJutCenter YSmoothMidR YSmoothMidL
 		DToothlessRise ShoulderFine TightBendInnerRadius HSwToV VSwToH NarrowUnicodeT WideUnicodeT

--- a/packages/font-glyphs/src/meta/macros.ptl
+++ b/packages/font-glyphs/src/meta/macros.ptl
@@ -396,17 +396,17 @@ define-macro glyph-block : syntax-rules
 			ApparentTranslate Rotate GlobalTransform TanSlope HVContrast VHContrast Upward
 			Downward Rightward Leftward O OX OXHook Hook AHook SHook RHook JHook HookX TailX TailY
 			DiagTailAngle DiagTailDepth ArchDepth SmallArchDepth Stroke HalfStroke QuarterStroke
-			DotSize PeriodSize HBarPos OverlayPos Jut LongJut VJut LongVJut VJutStroke
-			AccentStackOffset AccentWidth AccentClearance AccentHeight CThin CThinB SLAB IBalance
-			IBalance2 JBalance JBalance2 TBalance TBalance2 RBalance RBalance2 FBalance OneBalance
-			WideWidth0 WideWidth1 WideWidth2 WideWidth3 WideWidth4 EssRatioUpper EssRatioLower
-			EssRatioQuestion EssUpper EssLower EssQuestion RightSB Middle DotRadius PeriodRadius
-			ArchDepthA ArchDepthB SmallArchDepthA SmallArchDepthB CorrectionOMidX CorrectionOMidS
-			AdviceStroke AdviceStroke2 AdviceStrokeInSpace OverlayStroke OperatorStroke
-			GeometryStroke UnicodeWeightGrade StrokeWidthBlend ArchDepthAOf ArchDepthBOf
-			ArchDepthAClamped ArchDepthBClamped SmoothAdjust SideJut MidJutSide MidJutCenter
-			YSmoothMidR YSmoothMidL DToothlessRise ShoulderFine TightBendInnerRadius HSwToV VSwToH
-			NarrowUnicodeT WideUnicodeT VERY-FAR TINY]
+			DotSize PeriodSize SquareDotScalar HBarPos OverlayPos OverlayStroke Jut LongJut VJut
+			LongVJut VJutStroke AccentStackOffset AccentWidth AccentClearance AccentHeight CThin
+			CThinB SLAB IBalance IBalance2 JBalance JBalance2 TBalance TBalance2 RBalance
+			RBalance2 FBalance OneBalance WideWidth0 WideWidth1 WideWidth2 WideWidth3 WideWidth4
+			EssRatioUpper EssRatioLower EssRatioQuestion EssUpper EssLower EssQuestion RightSB
+			Middle DotRadius PeriodRadius ArchDepthA ArchDepthB SmallArchDepthA SmallArchDepthB
+			CorrectionOMidX CorrectionOMidS AdviceStroke AdviceStroke2 AdviceStrokeInSpace
+			OperatorStroke GeometryStroke UnicodeWeightGrade StrokeWidthBlend ArchDepthAOf
+			ArchDepthBOf ArchDepthAClamped ArchDepthBClamped SmoothAdjust SideJut MidJutSide
+			MidJutCenter YSmoothMidR YSmoothMidL DToothlessRise ShoulderFine TightBendInnerRadius
+			HSwToV VSwToH NarrowUnicodeT WideUnicodeT VERY-FAR TINY]
 
 		define spiroFnImports `[g4 g2 corner flat curl virt close end straight g2c cg2 flatc ccurl
 			widths disable-contrast heading unimportant important alsoThru alsoThruThem bezControls

--- a/packages/font-glyphs/src/symbol/punctuation/small.ptl
+++ b/packages/font-glyphs/src/symbol/punctuation/small.ptl
@@ -144,13 +144,13 @@ glyph-block Symbol-Punctuation-Small : begin
 	select-variant 'revComma/asDiacritic' (follow -- 'diacriticDot')
 
 	turned "turnComma.round"  null "comma.round"  [DivFrame para.advanceScaleI].middle PeriodRadius
-	turned "turnComma.square" null "comma.square" [DivFrame para.advanceScaleI].middle (PeriodRadius * DesignParameters.squareDotScalar)
+	turned "turnComma.square" null "comma.square" [DivFrame para.advanceScaleI].middle (PeriodRadius * SquareDotScalar)
 	select-variant 'turnComma' 0x2E32 (follow -- 'punctuationDot')
 
 	derive-composites 'raisedPeriod.round'  null 'period.round'  [ApparentTranslate 0 (XH / 2 - PeriodRadius)]
-	derive-composites 'raisedPeriod.square' null 'period.square' [ApparentTranslate 0 (XH / 2 - PeriodRadius * DesignParameters.squareDotScalar)]
+	derive-composites 'raisedPeriod.square' null 'period.square' [ApparentTranslate 0 (XH / 2 - PeriodRadius * SquareDotScalar)]
 	derive-composites 'raisedComma.round'   null 'comma.round'   [ApparentTranslate 0 (XH / 2 - PeriodRadius)]
-	derive-composites 'raisedComma.square'  null 'comma.square'  [ApparentTranslate 0 (XH / 2 - PeriodRadius * DesignParameters.squareDotScalar)]
+	derive-composites 'raisedComma.square'  null 'comma.square'  [ApparentTranslate 0 (XH / 2 - PeriodRadius * SquareDotScalar)]
 	select-variant 'raisedPeriod' 0x2E33 (follow -- 'punctuationDot')
 	select-variant 'raisedComma'  0x2E34 (follow -- 'punctuationDot')
 


### PR DESCRIPTION
### Motivation and Context

This sets up a potential future PR I wanted to do involving adjusting square dots via `[StrokeWidthBlend …]`, but I will save that for some other time. If that ends up not working out, then this PR at least serves to make the variable name shorter for the handful of places in the code where it is referenced by name.

As it stands currently, nothing is visually changed by this PR.

Also rename:
  - `ltailBR` → `palatalHookBR`.
  - `rtailBR` → `retroflexHookBR`.

(The aforementioned renamed glyphs are for the hard-Unicode combining characters, not the shape functions).

### Influenced Characters

N/A

### Glyph Quantity

N/A

### Samples

N/A
