### PR TITLE
Fix anchors for {`dot`|`comma`}{`TR`|`TL`|`BR`|`BL`}.

### DIFF
--- a/packages/font-glyphs/src/letter/latin/lower-n.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-n.ptl
@@ -208,9 +208,11 @@ glyph-block Letter-Latin-Lower-N : begin
 			local rinner : clamp (Width * 0.065) (XH * 0.05) (fine * 0.35)
 			local sw : AdviceStroke 2.75
 			local m1 : Math.min RightSB : Width - rinner * 2 - fine - OX
+			local mockWidth : m1 + SB
+			local mockAdws : mockWidth / Width
 			include : Body XH SB m1 (rinner * 2 + fine) sw
-				ArchDepthAOf (SmallArchDepth * ((m1 + SB) / Width)) (m1 + SB)
-				ArchDepthBOf (SmallArchDepth * ((m1 + SB) / Width)) (m1 + SB)
+				ArchDepthAOf (SmallArchDepth * mockAdws) mockWidth
+				ArchDepthBOf (SmallArchDepth * mockAdws) mockWidth
 			include : dispiro
 				widths.lhs sw
 				straight.down.start (m1 - [HSwToV sw]) (rinner * 2 + fine - O) [heading Downward]
@@ -367,13 +369,7 @@ glyph-block Letter-Latin-Lower-N : begin
 	CreateAccentedComposition 'nAcute' 0x144 'n' 'acuteAbove'
 	CreateAccentedComposition 'nAcute.PLK' null 'n' 'kreskaAbove'
 
-	do "n with Apostrophe"
-		glyph-block-import Mark-Shared-Metrics : markMiddle
-
-		derive-glyphs 'nApostrophe/commaTL' null 'commaAbove/asPunctuation' : function [src gr] : glyph-proc
-			include : with-transform [Translate (SB - markMiddle) 0] [refer-glyph src]
-
-		derive-composites 'nApostrophe' 0x149 'n' 'nApostrophe/commaTL'
+	CreateAccentedComposition 'nApostrophe' 0x149 'n' 'commaTL/asPunctuation'
 
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarLeft
 	create-glyph 'mathbb/n' 0x1D55F : glyph-proc

--- a/packages/font-glyphs/src/marks/horn-and-angle.ptl
+++ b/packages/font-glyphs/src/marks/horn-and-angle.ptl
@@ -91,7 +91,7 @@ glyph-block Mark-Horn-And-Angle : begin
 
 	select-variant 'longHorn' null (follow -- 'diacriticDot')
 
-	create-glyph 'leftangleTR' 0x31A : glyph-proc
+	create-glyph 'leftAngleTR' 0x31A : glyph-proc
 		set-width 0
 		include : VBar.l 0 aboveMarkBot aboveMarkTop (markFine * 2)
 		include : HBar.t ((-1.5) * markExtend) 0 aboveMarkTop (markFine * 2)
@@ -122,34 +122,34 @@ glyph-block Mark-Horn-And-Angle : begin
 			straight.right.end (HookX - [HSwToV HalfStroke]) (-Hook + HalfStroke)
 
 	foreach { suffix { DrawAt kdr } } [Object.entries DotVariants] : do
-		create-glyph "dotTL.\(suffix)" : glyph-proc
-			set-width 0
-			local [object radius attX attY startX startY] : HornDim 0 XH 0 0 0.5
-			local r : mix radius DotRadius 0.5
-			include : DrawAt ((-startX) + r) startY (r * kdr)
-			set-mark-anchor 'topLeft' 0 XH (-startX) startY
-			set-base-anchor 'aboveBraceL' (startX - r) startY
-			set-base-anchor 'aboveBraceR' (startX - r) startY
 		create-glyph "dotTR.\(suffix)" : glyph-proc
 			set-width 0
-			local [object radius attX attY startX startY] : HornDim 0 XH 0 0 0.5
+			local [object radius startX startY] : HornDim 0 XH 0 0 0.5
 			local r : mix radius DotRadius 0.5
-			include : DrawAt (startX - r) startY (r * kdr)
-			set-mark-anchor 'topRight' 0 XH startX startY
-			set-base-anchor 'aboveBraceL' (startX - r) startY
-			set-base-anchor 'aboveBraceR' (startX - r) startY
+			include : DrawAt ((+startX) - r) (0 + startY) (r * kdr)
+			set-mark-anchor 'topRight' 0 XH (+startX) (0 + startY)
+			set-base-anchor 'aboveBraceL' ((+startX) - r) (0 + startY)
+			set-base-anchor 'aboveBraceR' ((+startX) - r) (0 + startY)
+		create-glyph "dotTL.\(suffix)" : glyph-proc
+			set-width 0
+			local [object radius startX startY] : HornDim 0 XH 0 0 0.5
+			local r : mix radius DotRadius 0.5
+			include : DrawAt ((-startX) + r) (0 + startY) (r * kdr)
+			set-mark-anchor 'topLeft' 0 XH (-startX) (0 + startY)
+			set-base-anchor 'aboveBraceL' ((-startX) + r) (0 + startY)
+			set-base-anchor 'aboveBraceR' ((-startX) + r) (0 + startY)
 		create-glyph "dotBL.\(suffix)" : glyph-proc
 			set-width 0
-			local [object radius attX attY startX startY] : HornDim 0 XH 0 0 0.5
+			local [object radius startX startY] : HornDim 0 XH 0 0 0.5
 			local r : mix radius DotRadius 0.5
 			include : DrawAt ((-startX) + r) (XH - startY) (r * kdr)
 			set-mark-anchor 'bottomLeft' 0 0 (-startX) (XH - startY)
-			set-base-anchor 'belowBraceL' (startX - r) startY
-			set-base-anchor 'belowBraceR' (startX - r) startY
+			set-base-anchor 'belowBraceL' ((-startX) + r) (XH - startY)
+			set-base-anchor 'belowBraceR' ((-startX) + r) (XH - startY)
 
-	select-variant "dotBL" 0x1DFA (follow -- "diacriticDot")
-	select-variant "dotTL" 0x1DF8 (follow -- "diacriticDot")
-	select-variant "dotTR" 0x358 (follow -- "diacriticDot")
+	select-variant 'dotTR' 0x358  (follow -- 'diacriticDot')
+	select-variant 'dotTL' 0x1DF8 (follow -- 'diacriticDot')
+	select-variant 'dotBL' 0x1DFA (follow -- 'diacriticDot')
 
 	derive-glyphs 'commaTR' 0x315 'commaAbove' : function [src gr] : glyph-proc
 		set-width 0
@@ -158,7 +158,7 @@ glyph-block Mark-Horn-And-Angle : begin
 		include : ApparentTranslate ((RightSB + DotRadius) - Middle) 0
 		currentGlyph.clearAnchors
 
-		set-mark-anchor 'topRight' 0 XH 0 aboveMarkTop
+		set-mark-anchor 'topRight' (markMiddle + (RightSB - SB) / 2) XH (markMiddle + (RightSB - SB) / 2 + DotRadius) aboveMarkTop
 		set-base-anchor 'aboveBraceL' (markMiddle + (RightSB - SB) / 2 + DotRadius) aboveMarkMid
 		set-base-anchor 'aboveBraceR' (markMiddle + (RightSB - SB) / 2 + DotRadius) aboveMarkMid
 
@@ -169,7 +169,7 @@ glyph-block Mark-Horn-And-Angle : begin
 		include : ApparentTranslate ((RightSB + DotRadius) - Middle) 0
 		currentGlyph.clearAnchors
 
-		set-mark-anchor 'bottomRight' 0 0 0 belowMarkBot
+		set-mark-anchor 'bottomRight' (markMiddle + (RightSB - SB) / 2) 0 (markMiddle + (RightSB - SB) / 2 + DotRadius) belowMarkBot
 		set-base-anchor 'belowBraceL' (markMiddle + (RightSB - SB) / 2 + DotRadius) belowMarkMid
 		set-base-anchor 'belowBraceR' (markMiddle + (RightSB - SB) / 2 + DotRadius) belowMarkMid
 

--- a/packages/font-glyphs/src/marks/horn-and-angle.ptl
+++ b/packages/font-glyphs/src/marks/horn-and-angle.ptl
@@ -162,6 +162,17 @@ glyph-block Mark-Horn-And-Angle : begin
 		set-base-anchor 'aboveBraceL' (markMiddle + (RightSB - SB) / 2 + DotRadius) aboveMarkMid
 		set-base-anchor 'aboveBraceR' (markMiddle + (RightSB - SB) / 2 + DotRadius) aboveMarkMid
 
+	derive-glyphs 'commaTL/asPunctuation' null 'commaAbove/asPunctuation' : function [src gr] : glyph-proc
+		set-width 0
+
+		include : refer-glyph src
+		include : ApparentTranslate ((SB - DotRadius) - Middle) 0
+		currentGlyph.clearAnchors
+
+		set-mark-anchor 'topLeft' (markMiddle - (RightSB - SB) / 2) XH (markMiddle - (RightSB - SB) / 2 - DotRadius) aboveMarkTop
+		set-base-anchor 'aboveBraceL' (markMiddle - (RightSB - SB) / 2 - DotRadius) aboveMarkMid
+		set-base-anchor 'aboveBraceR' (markMiddle - (RightSB - SB) / 2 - DotRadius) aboveMarkMid
+
 	derive-glyphs 'commaBR' null 'commaBelow' : function [src gr] : glyph-proc
 		set-width 0
 

--- a/packages/font-glyphs/src/meta/unicode-knowledge.ptl
+++ b/packages/font-glyphs/src/meta/unicode-knowledge.ptl
@@ -189,8 +189,6 @@ export : define decompOverrides : object
 	0x2C65 { 'a' 'shortSlash' }
 	0x2C66 { 't' 'longSlash' }
 
-	0xA72E { 'Cuatrillo' 'commaBR' }
-	0xA72F { 'cuatrillo' 'commaBR' }
 	0xA74A { 'O' 'hStrike' }
 	0xA74B { 'o' 'hStrike' }
 	0xA799 { 'f' 'barOver' }

--- a/packages/font-glyphs/src/number/4.ptl
+++ b/packages/font-glyphs/src/number/4.ptl
@@ -97,13 +97,13 @@ glyph-block Digits-Four : begin
 				include : MarkSet.capDesc
 				define [object swVBar xVertBar yBarBot] : include : body CAP crossing slab
 				include : EngHook xVertBar 0 Descender (sw -- swVBar)
-				set-base-anchor 'bottomRight' (xVertBar + SB) yBarBot
+				set-base-anchor 'bottomRight' xVertBar yBarBot
 
 			create-glyph "cuatrillo.\(suffix)" : glyph-proc
 				include : MarkSet.p
 				define [object swVBar xVertBar yBarBot] : include : body XH crossing slab
 				include : EngHook xVertBar 0 Descender (sw -- swVBar)
-				set-base-anchor 'bottomRight' (xVertBar + SB) yBarBot
+				set-base-anchor 'bottomRight' xVertBar yBarBot
 
 	select-variant 'four.lnum' [CodeLnum '4'] (follow -- 'four')
 	select-variant 'four.onum' [CodeOnum '4'] (follow -- 'four')

--- a/packages/font-glyphs/src/number/4.ptl
+++ b/packages/font-glyphs/src/number/4.ptl
@@ -8,6 +8,7 @@ glyph-module
 glyph-block Digits-Four : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
+	glyph-block-import Letter-Shared : CreateAccentedComposition
 	glyph-block-import Letter-Shared-Shapes : EngHook
 	glyph-block-import Digits-Shared : OnumMarks ShiftDown CodeLnum CodeOnum
 
@@ -113,6 +114,9 @@ glyph-block Digits-Four : begin
 
 	select-variant 'Cuatrillo' 0xA72C (follow -- 'four/sansSerif')
 	select-variant 'cuatrillo' 0xA72D (follow -- 'four/sansSerif')
+
+	CreateAccentedComposition 'CuatrilloComma' 0xA72E 'Cuatrillo' 'commaBR'
+	CreateAccentedComposition 'cuatrilloComma' 0xA72F 'cuatrillo' 'commaBR'
 
 	glyph-block-import Letter-Blackboard : BBS BBD BBBarCenter
 	create-glyph 'mathbb/four' 0x1D7DC : glyph-proc


### PR DESCRIPTION
### Motivation and Context

Previously, these marks were anchored at `0` or `-Width` and yet positioned at `-SB` or `-RightSB`, making them actually realized at the positions `-SB * 2` or `-Width + SB * 2`, with effectively _negative clearance_. This PR makes their anchor point account for the default `topRight` etc. anchor points of e.g. `RightSB` etc.

Also fix `diacriticDot` variant linking for Cuatrillo with Comma (`Ꜯ`, `ꜯ`).

Also simplify glyph construction of `n` with Apostrophe (`ŉ`).

### Samples

```
a᪻͘ a᷸᪻ a᷺᪽
a᪻̕ ŉ᪻ Ꜯ᪽ ꜯ᪽
```

`ss04` Before:
<img width="1357" height="862" alt="image" src="https://github.com/user-attachments/assets/67d260ca-0eeb-4d4a-b5bf-42d8b03a4d69" />

`ss04` After:
(please excuse the far-left column. The lack of combining parentheses behavior is possibly a bug in Firefox, because it appears correct in Notepad++ etc.)
<img width="1336" height="868" alt="image" src="https://github.com/user-attachments/assets/15896ab4-a7c9-44e4-b140-9f56a61a4113" />

