### PR TITLE
Fix SGr TTC size

### DIFF
--- a/verdafile.mjs
+++ b/verdafile.mjs
@@ -785,6 +785,8 @@ async function getCollectPlans(target, rawCollectPlans) {
 			const [gri] = await target.need(BuildPlanOf(prefix));
 			const ttfFileNameSet = new Set(gri.targets);
 			const suffixMap = getSuffixMapping(gri.weights, gri.slopes, gri.widths);
+
+			// Standard TTC Collection (cross-family)
 			for (const suffix in suffixMap) {
 				const sfi = suffixMap[suffix];
 
@@ -798,14 +800,26 @@ async function getCollectPlans(target, rawCollectPlans) {
 				const ttcFileName = fnStandardTtc(false, collectPrefix, suffixMap, sfi);
 				if (!ttcComposition[ttcFileName]) ttcComposition[ttcFileName] = [];
 				ttcComposition[ttcFileName].push(glyfTtcFileName);
+			}
 
-				if (shouldProduceSgr) {
-					const sgrPrefix = SGR_PREFIX_PREFIX + prefix;
-					const sgrTtcFileName = fnStandardTtc(false, sgrPrefix, suffixMap, sfi);
-					const sgrInfo = singleGroupTtcInfos[sgrPrefix];
-					if (!sgrInfo.comp[sgrTtcFileName]) sgrInfo.comp[sgrTtcFileName] = [];
-					sgrInfo.comp[sgrTtcFileName].push(ttfTargetName);
-				}
+			// Sgr TTC Collection (single-family, but still allow sharing across Italic and Oblique)
+			for (const suffix in suffixMap) {
+				if (!shouldProduceSgr) continue;
+				const sgrPrefix = SGR_PREFIX_PREFIX + prefix;
+
+				const sfi = suffixMap[suffix];
+
+				const ttfTargetName = makeFileName(prefix, suffix);
+				if (!ttfFileNameSet.has(ttfTargetName)) continue;
+
+				const glyfTtcFileName = fnStandardTtc(true, sgrPrefix, suffixMap, sfi);
+				if (!glyfTtcComposition[glyfTtcFileName]) glyfTtcComposition[glyfTtcFileName] = [];
+				glyfTtcComposition[glyfTtcFileName].push({ dir: prefix, file: ttfTargetName });
+
+				const sgrTtcFileName = fnStandardTtc(false, sgrPrefix, suffixMap, sfi);
+				const sgrInfo = singleGroupTtcInfos[sgrPrefix];
+				if (!sgrInfo.comp[sgrTtcFileName]) sgrInfo.comp[sgrTtcFileName] = [];
+				sgrInfo.comp[sgrTtcFileName].push(glyfTtcFileName);
 			}
 		}
 		plans[collectPrefix] = {
@@ -933,7 +947,7 @@ const SGrTtcFile = file.make(
 		const [cp] = await target.need(CollectPlans, de`${out.dir}`);
 		const sgrInfo = cp[cgr].singleGroupTtcInfos[sgr];
 		const parts = Array.from(new Set(sgrInfo.comp[f] || []));
-		const [inputs] = await target.need(parts.map(pt => DistHintedTTF(sgrInfo.from, pt)));
+		const [inputs] = await target.need(parts.map(pt => GlyfTtc(cgr, pt)));
 		await buildCompositeTtc(out, inputs);
 	},
 );


### PR DESCRIPTION
This change fixes SGr TTC's size as they _shall_ be smaller than normal TTCs.

Our code does glyph sharing for Italic vs Oblique for normal TTCs but not enabled for SGr. This change enables them.

Fixes #3051.