### PR TITLE
Cleanup surrounding `cyrl/de.italic` , add italic form to Cyrillic Lower Dwe (`ꚁ`) based on Brill V5.00.

### DIFF
--- a/packages/font-glyphs/src/letter/cyrillic/dche.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/dche.ptl
@@ -9,30 +9,32 @@ glyph-block Letter-Cyrillic-Dche : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Adjustment : LeaningAnchor ExtendBelowBaseAnchors
 	glyph-block-import Letter-Cyrillic-Che : CyrCheShape ItalicConfig BODY SERIFS
-	glyph-block-import Letter-Cyrillic-De : CyrDeBottom BottomExtension CyrDeItalicShapeT
+	glyph-block-import Letter-Cyrillic-De : CyrDeBottom BottomExtension CyrDeItalicShape
 
 	create-glyph 'cyrl/Dche' 0x52C : glyph-proc
 		include : MarkSet.capital
 		include : ExtendBelowBaseAnchors BottomExtension
-		include : CyrCheShape [DivFrame 1] CAP [if SLAB 0.45 0.4] BODY.STRAIGHT
+		include : CyrCheShape [DivFrame 1] CAP 0.4 BODY.STRAIGHT
 			if SLAB SERIFS.TOP SERIFS.NONE
 		include : CyrDeBottom SB RightSB
 
 		local fine : AdviceStroke 3.5
 		include : dispiro
-			flat SB Stroke [widths.rhs fine]
+			widths.rhs fine
+			flat SB Stroke
 			curl (RightSB - [HSwToV Stroke]) (CAP - [if SLAB Stroke 0])
 
 	create-glyph 'cyrl/dche.upright' : glyph-proc
 		include : MarkSet.e
 		include : ExtendBelowBaseAnchors BottomExtension
-		include : CyrCheShape [DivFrame 1] XH [if SLAB 0.45 0.4] BODY.STRAIGHT
+		include : CyrCheShape [DivFrame 1] XH 0.4 BODY.STRAIGHT
 			if SLAB SERIFS.TOP SERIFS.NONE
 		include : CyrDeBottom SB RightSB
 
 		local fine : AdviceStroke 3.5
 		include : dispiro
-			flat SB Stroke [widths.rhs fine]
+			widths.rhs fine
+			flat SB Stroke
 			curl (RightSB - [HSwToV Stroke]) (XH - [if SLAB Stroke 0])
 
 	foreach { suffix { body slabUpright slabUprightBGR slabItalic } } [pairs-of ItalicConfig] : do
@@ -43,9 +45,9 @@ glyph-block Letter-Cyrillic-Dche : begin
 			local sw : df.adviceThinnerStroke 2 0.75
 			local gap : 0.375 * (df.rightSB - df.leftSB) - [HSwToV : 0.25 * sw] + sw / 16
 			local subDf : DivFrame [Math.min ((df.width - gap) / Width) (0.75 * df.adws)] 2
-			include : CyrDeItalicShapeT dispiro subDf sw
+			include : CyrDeItalicShape subDf sw
 			include : difference
 				CyrCheShape df XH 0.5 body [if SLAB slabItalic SERIFS.NONE] (sw -- sw)
-				MaskLeft : subDf.rightSB - [HSwToV : 0.5 * sw]
+				MaskLeft (subDf.rightSB - [HSwToV : 0.5 * sw])
 
 	select-variant 'cyrl/dche.italic' (follow -- 'cyrl/che')

--- a/packages/font-glyphs/src/letter/cyrillic/de.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/de.ptl
@@ -159,8 +159,7 @@ glyph-block Letter-Cyrillic-De : begin
 		include : VBar.l de.xTopLeft (XH + O) asc [Math.min de.swInner : VJutStroke * (de.swOuter / Stroke)]
 
 	## Italic
-	glyph-block-export CyrDeItalicShapeT
-	define [CyrDeItalicShapeT sink df _sw] : begin
+	define [CyrDeItalicKnots df _sw] : begin
 		local sw : fallback _sw df.mvs
 		local fine : ShoulderFine * (sw / Stroke)
 
@@ -168,9 +167,8 @@ glyph-block Letter-Cyrillic-De : begin
 		local ada : df.archDepthAOf (SmallArchDepth * (yRingTop / XH)) sw
 		local adb : df.archDepthBOf (SmallArchDepth * (yRingTop / XH)) sw
 
-		return : sink
-			widths.lhs fine
-			straight.up.start ((df.rightSB - OX) - [HSwToV : sw - fine]) (yRingTop - adb)
+		return : list
+			straight.up.start ((df.rightSB - OX) - [HSwToV : sw - fine]) (yRingTop - adb) [widths.lhs fine]
 			Arch.lhs yRingTop (sw -- sw) (swBefore -- fine)
 			flatside.ld df.leftSB  0 yRingTop ada adb
 			Arch.lhs 0 (sw -- sw)
@@ -178,10 +176,17 @@ glyph-block Letter-Cyrillic-De : begin
 			quadControls 0 0.8
 			g4 (df.leftSB + sw * 1.1) Ascender
 
+	glyph-block-export CyrDeItalicShape
+	define [CyrDeItalicShape df _sw] : dispiro
+		CyrDeItalicKnots df _sw
+
+	glyph-block-export CyrDeItalicMask
+	define [CyrDeItalicMask df _sw] : spiro-outline
+		CyrDeItalicKnots df _sw
+
 	create-glyph 'cyrl/de.italic' : glyph-proc
-		local df : include : DivFrame 1
-		include : df.markSet.b
-		include : CyrDeItalicShapeT dispiro df
+		include : MarkSet.b
+		include : CyrDeItalicShape [DivFrame 1]
 
 	foreach { suffix { { desc } { st sb } } } [Object.entries ZeConfig] : do
 		if (desc && !st) : begin
@@ -190,7 +195,7 @@ glyph-block Letter-Cyrillic-De : begin
 				include : df.markSet.bp
 
 				local subDf : df.slice 3 2 OX
-				include : CyrDeItalicShapeT dispiro subDf df.mvs
+				include : CyrDeItalicShape subDf df.mvs
 
 				local shift : df.width - subDf.width
 				local ze : CyrZe 1 sb XH Descender

--- a/packages/font-glyphs/src/letter/cyrillic/de.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/de.ptl
@@ -8,6 +8,7 @@ glyph-block Letter-Cyrillic-De : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors ExtendBelowBaseAnchors
+	glyph-block-import Letter-Shared : CreateAccentedComposition
 	glyph-block-import Letter-Cyrillic-Ze : CyrZe ZeConfig
 
 	glyph-block-export BottomExtension
@@ -142,7 +143,7 @@ glyph-block Letter-Cyrillic-De : begin
 				eject-contour 'footR'
 				include : DzzeDescendershape de SmallArchDepthA SmallArchDepthB
 
-	create-glyph "cyrl/Dwe" 0xA680 : glyph-proc
+	create-glyph 'cyrl/Dwe' 0xA680 : glyph-proc
 		include : MarkSet.capital
 		local asc : CAP + LongVJut - QuarterStroke
 		include : ExtendAboveBaseAnchors asc
@@ -150,7 +151,7 @@ glyph-block Letter-Cyrillic-De : begin
 		local de : include : CyrDeShape true CAP SB RightSB
 		include : VBar.l de.xTopLeft (CAP + O) asc [Math.min de.swInner : VJutStroke * (de.swOuter / Stroke)]
 
-	create-glyph "cyrl/dwe" 0xA681 : glyph-proc
+	create-glyph 'cyrl/dwe.upright' : glyph-proc
 		include : MarkSet.e
 		local asc : XH + LongVJut - QuarterStroke
 		include : ExtendAboveBaseAnchors asc
@@ -187,6 +188,14 @@ glyph-block Letter-Cyrillic-De : begin
 	create-glyph 'cyrl/de.italic' : glyph-proc
 		include : MarkSet.b
 		include : CyrDeItalicShape [DivFrame 1]
+
+	create-glyph 'cyrl/dwe.italic/base' : glyph-proc
+		local df : DivFrame [StrokeWidthBlend 1.00 0.95] 2
+		include : df.markSet.b
+		include : CyrDeItalicShape df
+		set-base-anchor 'topRight' (df.rightSB - DotRadius) XH
+
+	CreateAccentedComposition 'cyrl/dwe.italic' null 'cyrl/dwe.italic/base' 'commaTR'
 
 	foreach { suffix { { desc } { st sb } } } [Object.entries ZeConfig] : do
 		if (desc && !st) : begin

--- a/packages/font-glyphs/src/letter/cyrillic/dzzhe-zhwe.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/dzzhe-zhwe.ptl
@@ -14,21 +14,21 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 		local subDf : df.slice 4 keeps _o
 		local subDfFullShift : (df.rightSB - subDf.rightSB) / (4 - keeps)
 		local shift : pShift * subDfFullShift
-		local sw : AdviceStroke 3.3 [df.slice 4 3 _o].adws
+		local sw : [df.slice 4 3 _o].adviceStroke 3.3
 		return : object subDf shift sw
 
-	do "de subglyph"
+	do "De subglyphs"
 		glyph-block-import Mark-Adjustment : ExtendBelowBaseAnchors
-		glyph-block-import Letter-Cyrillic-De : CyrDeShape CyrDeItalicShapeT BottomExtension
+		glyph-block-import Letter-Cyrillic-De : CyrDeShape CyrDeItalicShape BottomExtension
 
 		define [CyrDzzheDeShape fCapital df top] : glyph-proc
 			local [object subDf sw] : SubDfDimBy4 0 2 df OX
-			local left : if SLAB (subDf.leftSB + 0.5 * SideJut) subDf.leftSB
+			local left : subDf.leftSB + [if SLAB 0.5 0] * SideJut
 			include : CyrDeShape fCapital top left subDf.rightSB sw
 
 		define [CyrDzzheDeItalicShape df] : glyph-proc
 			local [object subDf sw] : SubDfDimBy4 0 2 df OX
-			include : CyrDeItalicShapeT dispiro subDf sw
+			include : CyrDeItalicShape subDf sw
 
 		create-glyph "cyrl/Dzzhe/left" : glyph-proc
 			define df : include : DivFrame [mix 1 para.advanceScaleMM 2] 3.5
@@ -50,7 +50,7 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 			set-base-anchor 'cvDecompose' 0 0
 			include : CyrDzzheDeItalicShape df
 
-	do "ze subglyph"
+	do "Ze subglyphs"
 		define [CyrZhweZeShape slabTop slabBot df top bot hook ada adb] : glyph-proc
 			local [object subDf sw] : SubDfDimBy4 0 2 df OX
 			local ze : CyrZe slabTop slabBot top bot
@@ -77,8 +77,10 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 					set-base-anchor 'cvDecompose' 0 0
 					include : CyrZhweZeShape slabTop slabBot df XH 0 SHook SmallArchDepthA SmallArchDepthB
 
-	do "zhe subglyphs"
+	do "Zhe subglyphs"
+		glyph-block-import Letter-Cyrillic-De : CyrDeItalicMask
 		glyph-block-import Letter-Cyrillic-Zhe : Zhe
+
 		define [CyrRightZheShape legShape fSlab fMidSlab df top barLeft] : glyph-proc
 			local [object subDf shift sw] : SubDfDimBy4 1 3 df OX
 			include : with-transform [ApparentTranslate shift 0] : Zhe.HalfShape legShape fSlab fMidSlab subDf 0 top top
@@ -102,12 +104,11 @@ glyph-block Letter-Cyrillic-Dzzhe-Zhwe : begin
 				adb    -- adb
 			include : difference [CyrRightZheShape legShape fSlab fMidSlab df top subDf.middle] [zeNoO.ShapeMask]
 
-		glyph-block-import Letter-Cyrillic-De : CyrDeItalicShapeT
 		define [DzzheZheItalicShape legShape fSlab fMidSlab df top] : glyph-proc
 			local [object subDf sw] : SubDfDimBy4 0 2 df OX
 			include : difference
 				CyrRightZheShape legShape fSlab fMidSlab df top subDf.middle
-				CyrDeItalicShapeT spiro-outline subDf sw
+				CyrDeItalicMask subDf sw
 
 		define ZheConfig : object
 			straight            { Zhe.StraightLegs   SLAB  SLAB }

--- a/packages/font-glyphs/src/orthography/index.ptl
+++ b/packages/font-glyphs/src/orthography/index.ptl
@@ -120,6 +120,7 @@ glyph-block Orthography : begin
 	orthographic-italic 'cyrl/tje'            0x1C8A
 	orthographic-italic 'cyrl/este'           null
 	orthographic-italic 'cyrl/revtse'         0xA661
+	orthographic-italic 'cyrl/dwe'            0xA681
 	orthographic-italic 'cyrl/dzze'           0xA689
 	orthographic-italic 'cyrl/teMidHook'      0xA68B
 	orthographic-italic 'cyrl/tswe'           0xA68F


### PR DESCRIPTION
### Motivation and Context

[Full explanation by Tiro Typeworks on Mastodon](https://typo.social/@TiroTypeworks/111375959537905476)

> …based on Marrs 'yaphetidological' alphabet (fourth column)&nbsp;**†**&nbsp;, which references Uslar's original handwritten style (first column)&nbsp;**†**&nbsp;.

**†** Presumably in reference to this chart ([source](https://www.unicode.org/L2/L2007/07003r-n3194r-cyrillic.pdf#page=39)):

<img width="577" height="821" alt="image" src="https://github.com/user-attachments/assets/5b183272-fa06-45ce-92b8-39fd472ca065" />

-----

Brill V5.00 for comparison:

`ДдꚀꚁ`

<img width="1228" height="1086" alt="image" src="https://github.com/user-attachments/assets/a3cdc524-6e09-4f6e-9d32-4737c75ad34f" />

### Influenced Characters

  - CYRILLIC SMALL LETTER DWE (`U+A681`).

### Glyph Quantity

1 to 2

### Samples

`ДдꚀꚁ`

<img width="811" height="1213" alt="image" src="https://github.com/user-attachments/assets/79fe3928-20b9-4ae3-a7ad-e6546add8fc9" />
