### PR TITLE
Add italic form to Cyrillic Lower Long‑Legged De (`ᲁ`) based on Brill V5.00.

### DIFF
--- a/packages/font-glyphs/src/letter/cyrillic/de.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/de.ptl
@@ -75,7 +75,7 @@ glyph-block Letter-Cyrillic-De : begin
 		include : ExtendBelowBaseAnchors BottomExtension
 		include : CyrDeShape false XH SB RightSB
 
-	create-glyph 'cyrl/deLongLeg' 0x1C81 : glyph-proc
+	create-glyph 'cyrl/deLongLeg.upright' : glyph-proc
 		include : MarkSet.p
 		include : CyrDeShape false XH SB RightSB nothing Descender
 

--- a/packages/font-glyphs/src/letter/cyrillic/de.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/de.ptl
@@ -190,10 +190,9 @@ glyph-block Letter-Cyrillic-De : begin
 		include : CyrDeItalicShape [DivFrame 1]
 
 	create-glyph 'cyrl/dwe.italic/base' : glyph-proc
-		local df : DivFrame [StrokeWidthBlend 1.00 0.95] 2
-		include : df.markSet.b
-		include : CyrDeItalicShape df
-		set-base-anchor 'topRight' (df.rightSB - DotRadius) XH
+		include : MarkSet.b
+		include : CyrDeItalicShape [DivFrame 0.95]
+		set-base-anchor 'topRight' (RightSB - DotRadius) XH
 
 	CreateAccentedComposition 'cyrl/dwe.italic' null 'cyrl/dwe.italic/base' 'commaTR'
 

--- a/packages/font-glyphs/src/letter/latin/lower-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-g.ptl
@@ -237,7 +237,7 @@ glyph-block Letter-Latin-Lower-G : begin
 			include [refer-glyph "g.\(suffix)"] AS_BASE ALSO_METRICS
 			include : OverlayW [Math.min OverlayStroke : AdviceStroke2 2 3 XH]
 
-		create-glyph "gScriptCrossedTail.\(suffix)" : glyph-proc
+		create-glyph "gCrossedTail.\(suffix)" : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.p
 			set-base-anchor 'overlay' df.middle (XH / 2)
@@ -256,7 +256,7 @@ glyph-block Letter-Latin-Lower-G : begin
 	select-variant 'gScript'            0x261  (follow -- [conditional-follow SLAB 'g/singleStorey/autoSerifed/slab' 'g/singleStorey/autoSerifed/sans']) (shapeFrom -- 'g')
 	select-variant 'gScriptPalatalHook' 0x1D83 (follow -- [conditional-follow SLAB 'g/singleStorey/autoSerifed/slab' 'g/singleStorey/autoSerifed/sans']) (shapeFrom -- 'gPalatalHook')
 	select-variant 'gScriptBar'                (follow -- [conditional-follow SLAB 'g/singleStorey/autoSerifed/slab' 'g/singleStorey/autoSerifed/sans']) (shapeFrom -- 'gStroke')
-	select-variant 'gScriptCrossedTail' 0xAB36 (follow -- [conditional-follow SLAB 'g/singleStoreyBentHook/autoSerifed/slab' 'g/singleStoreyBentHook/autoSerifed/sans'])
+	select-variant 'gScriptCrossedTail' 0xAB36 (follow -- [conditional-follow SLAB 'gCrossedTail/singleStorey/autoSerifed/slab' 'gCrossedTail/singleStorey/autoSerifed/sans']) (shapeFrom -- 'gCrossedTail')
 
 	alias 'cyrl/de.BGR' null 'gScript'
 	alias 'cyrl/de.SRB' null 'gScript'

--- a/packages/font-glyphs/src/letter/latin/lower-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-g.ptl
@@ -258,8 +258,9 @@ glyph-block Letter-Latin-Lower-G : begin
 	select-variant 'gScriptBar'                (follow -- [conditional-follow SLAB 'g/singleStorey/autoSerifed/slab' 'g/singleStorey/autoSerifed/sans']) (shapeFrom -- 'gStroke')
 	select-variant 'gScriptCrossedTail' 0xAB36 (follow -- [conditional-follow SLAB 'gCrossedTail/singleStorey/autoSerifed/slab' 'gCrossedTail/singleStorey/autoSerifed/sans']) (shapeFrom -- 'gCrossedTail')
 
-	alias 'cyrl/de.BGR' null 'gScript'
-	alias 'cyrl/de.SRB' null 'gScript'
+	alias 'cyrl/de.BGR'           null 'gScript'
+	alias 'cyrl/de.SRB'           null 'gScript'
+	alias 'cyrl/deLongLeg.italic' null 'gScript'
 
 	select-variant 'g/hookTopBase' (shapeFrom -- 'g')
 	derive-glyphs 'gHookTop' 0x260 "g/hookTopBase" : function [src gr] : glyph-proc

--- a/packages/font-glyphs/src/orthography/index.ptl
+++ b/packages/font-glyphs/src/orthography/index.ptl
@@ -116,6 +116,7 @@ glyph-block Orthography : begin
 	orthographic-italic 'cyrl/peDescender'    0x525
 	orthographic-italic 'cyrl/dzzhe'          0x52B
 	orthographic-italic 'cyrl/dche'           0x52D
+	orthographic-italic 'cyrl/deLongLeg'      0x1C81
 	orthographic-italic 'cyrl/teThreeLeg'     0x1C85
 	orthographic-italic 'cyrl/tje'            0x1C8A
 	orthographic-italic 'cyrl/este'           null

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -3056,8 +3056,8 @@ selectorAffix."g/hookTopBase" = "singleStoreyBentHookSerifless"
 selectorAffix."g/doubleStorey" = "doubleStorey"
 selectorAffix."g/singleStorey/autoSerifed/slab" = "singleStoreyBentHookSerifed"
 selectorAffix."g/singleStorey/autoSerifed/sans" = "singleStoreyBentHookSerifless"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/slab" = "singleStoreyBentHookSerifed"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/sans" = "singleStoreyBentHookSerifless"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/slab" = "singleStoreyBentHookSerifed"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/sans" = "singleStoreyBentHookSerifless"
 
 [prime.g.variants-buildup.stages.openness."*"]
 next = "END"
@@ -3071,8 +3071,8 @@ selectorAffix."g/hookTopBase" = ""
 selectorAffix."g/doubleStorey" = "closed"
 selectorAffix."g/singleStorey/autoSerifed/slab" = ""
 selectorAffix."g/singleStorey/autoSerifed/sans" = ""
-selectorAffix."g/singleStoreyBentHook/autoSerifed/slab" = ""
-selectorAffix."g/singleStoreyBentHook/autoSerifed/sans" = ""
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/slab" = ""
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/sans" = ""
 
 [prime.g.variants-buildup.stages.openness.open]
 rank = 1
@@ -3083,8 +3083,8 @@ selectorAffix."g/hookTopBase" = ""
 selectorAffix."g/doubleStorey" = "open"
 selectorAffix."g/singleStorey/autoSerifed/slab" = ""
 selectorAffix."g/singleStorey/autoSerifed/sans" = ""
-selectorAffix."g/singleStoreyBentHook/autoSerifed/slab" = ""
-selectorAffix."g/singleStoreyBentHook/autoSerifed/sans" = ""
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/slab" = ""
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/sans" = ""
 
 [prime.g.variants-buildup.stages.storey.single-storey]
 next = "hook"
@@ -3096,8 +3096,8 @@ selectorAffix."g/hookTopBase" = "singleStorey"
 selectorAffix."g/doubleStorey" = "doubleStoreyClosed"
 selectorAffix."g/singleStorey/autoSerifed/slab" = "singleStorey"
 selectorAffix."g/singleStorey/autoSerifed/sans" = "singleStorey"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/slab" = "singleStorey"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/sans" = "singleStorey"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/slab" = "singleStorey"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/sans" = "singleStorey"
 
 [prime.g.variants-buildup.stages.hook."*"]
 next = "ear"
@@ -3111,8 +3111,8 @@ selectorAffix."g/hookTopBase" = "bentHook"
 selectorAffix."g/doubleStorey" = ""
 selectorAffix."g/singleStorey/autoSerifed/slab" = "bentHook"
 selectorAffix."g/singleStorey/autoSerifed/sans" = "bentHook"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/slab" = "bentHook"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/sans" = "bentHook"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/slab" = "bentHook"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/sans" = "bentHook"
 
 [prime.g.variants-buildup.stages.hook.flat-hook]
 rank = 2
@@ -3123,8 +3123,8 @@ selectorAffix."g/hookTopBase" = "flatHook"
 selectorAffix."g/doubleStorey" = ""
 selectorAffix."g/singleStorey/autoSerifed/slab" = "flatHook"
 selectorAffix."g/singleStorey/autoSerifed/sans" = "flatHook"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/slab" = "bentHook"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/sans" = "bentHook"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/slab" = "bentHook"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/sans" = "bentHook"
 
 [prime.g.variants-buildup.stages.ear.serifless]
 rank = 1
@@ -3134,8 +3134,8 @@ selectorAffix."g/hookTopBase" = "serifless"
 selectorAffix."g/doubleStorey" = ""
 selectorAffix."g/singleStorey/autoSerifed/slab" = "serifless"
 selectorAffix."g/singleStorey/autoSerifed/sans" = "serifless"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/slab" = "serifless"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/sans" = "serifless"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/slab" = "serifless"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/sans" = "serifless"
 
 [prime.g.variants-buildup.stages.ear.serifed]
 rank = 2
@@ -3146,8 +3146,8 @@ selectorAffix."g/hookTopBase" = "serifless"
 selectorAffix."g/doubleStorey" = ""
 selectorAffix."g/singleStorey/autoSerifed/slab" = "serifed"
 selectorAffix."g/singleStorey/autoSerifed/sans" = "serifed"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/slab" = "serifed"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/sans" = "serifed"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/slab" = "serifed"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/sans" = "serifed"
 
 [prime.g.variants-buildup.stages.ear.top-cut]
 rank = 3
@@ -3158,8 +3158,8 @@ selectorAffix."g/hookTopBase" = "serifless"
 selectorAffix."g/doubleStorey" = ""
 selectorAffix."g/singleStorey/autoSerifed/slab" = "topCut"
 selectorAffix."g/singleStorey/autoSerifed/sans" = "topCut"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/slab" = "topCut"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/sans" = "topCut"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/slab" = "topCut"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/sans" = "topCut"
 
 [prime.g.variants-buildup.stages.ear.flat-top-serifless]
 rank = 4
@@ -3171,8 +3171,8 @@ selectorAffix."g/hookTopBase" = "flatTopSerifless"
 selectorAffix."g/doubleStorey" = ""
 selectorAffix."g/singleStorey/autoSerifed/slab" = "flatTopSerifless"
 selectorAffix."g/singleStorey/autoSerifed/sans" = "flatTopSerifless"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/slab" = "flatTopSerifless"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/sans" = "flatTopSerifless"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/slab" = "flatTopSerifless"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/sans" = "flatTopSerifless"
 
 [prime.g.variants-buildup.stages.ear.flat-top-serifed]
 rank = 5
@@ -3184,8 +3184,8 @@ selectorAffix."g/hookTopBase" = "flatTopSerifless"
 selectorAffix."g/doubleStorey" = ""
 selectorAffix."g/singleStorey/autoSerifed/slab" = "flatTopSerifed"
 selectorAffix."g/singleStorey/autoSerifed/sans" = "flatTopSerifed"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/slab" = "flatTopSerifed"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/sans" = "flatTopSerifed"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/slab" = "flatTopSerifed"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/sans" = "flatTopSerifed"
 
 [prime.g.variants-buildup.stages.ear.earless-corner]
 rank = 6
@@ -3196,8 +3196,8 @@ selectorAffix."g/hookTopBase" = "earlessCornerHTB"
 selectorAffix."g/doubleStorey" = ""
 selectorAffix."g/singleStorey/autoSerifed/slab" = "earlessCorner"
 selectorAffix."g/singleStorey/autoSerifed/sans" = "earlessCorner"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/slab" = "earlessCorner"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/sans" = "earlessCorner"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/slab" = "earlessCorner"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/sans" = "earlessCorner"
 
 [prime.g.variants-buildup.stages.ear.earless-rounded]
 rank = 7
@@ -3208,8 +3208,8 @@ selectorAffix."g/hookTopBase" = "serifless"
 selectorAffix."g/doubleStorey" = ""
 selectorAffix."g/singleStorey/autoSerifed/slab" = "earlessRounded"
 selectorAffix."g/singleStorey/autoSerifed/sans" = "earlessRounded"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/slab" = "earlessRounded"
-selectorAffix."g/singleStoreyBentHook/autoSerifed/sans" = "earlessRounded"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/slab" = "earlessRounded"
+selectorAffix."gCrossedTail/singleStorey/autoSerifed/sans" = "earlessRounded"
 
 
 


### PR DESCRIPTION
### Motivation and Context

Cyrillic Long‑Legged De (`ᲁ`) is based on the medieval [Poluustav](https://ru.wikipedia.org/wiki/%D0%9F%D0%BE%D0%BB%D1%83%D1%83%D1%81%D1%82%D0%B0%D0%B2_(%D1%88%D1%80%D0%B8%D1%84%D1%82)) handwriting style for De (`д`), which evolved into Cursive Cyrillic via developments from [Skoropis](https://commons.wikimedia.org/wiki/Category:Skoropis). The long legs were gradually written as a descending swash, which gives rise to the modern handwritten (cursive) form of De (`д`), which also happens to be the basis for the Bulgarian/Serbian italic forms in otherwise non-handwritten fonts.

Also cleanup of side&shy;bearings of Italic Cyrillic Lower Dwe (_`ꚁ`_).

-----

Brill V5.00 for comparison:

`ДдᲁꚀꚁ`

<img width="1200" height="1141" alt="image" src="https://github.com/user-attachments/assets/004f0bc6-1925-4c4f-ae79-c1f6e99162e4" />


### Influenced Characters

  - CYRILLIC SMALL LETTER LONG-LEGGED DE (`U+1C81`).

### Glyph Quantity

0 to 1.

### Samples

`ДдᲁꚀꚁ`

<img width="992" height="1219" alt="image" src="https://github.com/user-attachments/assets/19b0f1cb-37ce-4123-a776-e789ba5ba808" />

