### PR TITLE
Make `[`{`Inv`}`BreveShape …]` use `[widths.`{`lhs`|`rhs`}` …]`.

### DIFF
--- a/packages/font-glyphs/src/letter/latin/x.ptl
+++ b/packages/font-glyphs/src/letter/latin/x.ptl
@@ -126,7 +126,7 @@ glyph-block Letter-Latin-X : begin
 
 		if setMark : begin
 			define lowerHalfLastKnot lowerHalf.rhsKnots.(lowerHalf.rhsKnots.length - 1)
-			set-base-anchor 'cyrlDescenderAttach' lowerHalfLastKnot.x lowerHalfLastKnot.y
+			set-base-anchor 'palatalHookAttach' lowerHalfLastKnot.x lowerHalfLastKnot.y
 
 	define STROKE-STRAIGHT     0
 	define STROKE-CURLY        1
@@ -268,7 +268,7 @@ glyph-block Letter-Latin-X : begin
 
 	define [AddDescender Ctor] : function [src sel] : glyph-proc
 		include [refer-glyph src] AS_BASE ALSO_METRICS
-		local attachAnchor currentGlyph.baseAnchors.cyrlDescenderAttach
+		local attachAnchor currentGlyph.baseAnchors.palatalHookAttach
 		if attachAnchor
 		: then : begin
 			local attach : currentGlyph.gizmo.unapply attachAnchor

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -661,7 +661,6 @@ glyph-block Mark-Above : begin
 			close
 
 	#### Breve Marks
-	glyph-block-export BreveShape
 	define [BreveShape] : with-params [top bottom xMiddle width hs] : glyph-proc
 		local leftEnd  : xMiddle - width / 2
 		local rightEnd : xMiddle + width / 2
@@ -673,7 +672,6 @@ glyph-block Mark-Above : begin
 			archv
 			g4.up.end     rightEnd top          [heading Upward]
 
-	glyph-block-export InvBreveShape
 	define [InvBreveShape] : with-params [top bottom xMiddle width hs] : glyph-proc
 		local leftEnd  : xMiddle - width / 2
 		local rightEnd : xMiddle + width / 2
@@ -1298,10 +1296,34 @@ glyph-block Mark-Above : begin
 		include : VBar.m (markMiddle + ext) aboveMarkBot aboveMarkTop (markFine * 2)
 		include : HBar.t (markMiddle - ext) (markMiddle + ext) aboveMarkTop (markFine * 2)
 
+	glyph-block-export CyrKavykaShape
+	define [CyrKavykaShape] : with-params [top bottom xMiddle width hs] : glyph-proc
+		local leftEnd  : xMiddle - width / 2
+		local rightEnd : xMiddle + width / 2
+		include : dispiro
+			widths.center (hs * 2)
+			g4.down.start leftEnd  top          [heading Downward]
+			arcvh
+			g4.right.mid  xMiddle (bottom + hs) [heading Rightward]
+			archv
+			g4.up.end     rightEnd top          [heading Upward]
+
+	glyph-block-export CyrInvKavykaShape
+	define [CyrInvKavykaShape] : with-params [top bottom xMiddle width hs] : glyph-proc
+		local leftEnd  : xMiddle - width / 2
+		local rightEnd : xMiddle + width / 2
+		include : dispiro
+			widths.center (hs * 2)
+			g4.up.start  leftEnd  bottom    [heading Upward]
+			arcvh
+			g4.right.mid xMiddle (top - hs) [heading Rightward]
+			archv
+			g4.down.end  rightEnd bottom    [heading Downward]
+
 	create-glyph 'cyrlKavykaAbove' 0xA67C : glyph-proc
 		set-width 0
 		include : StdAnchors.extraWide
-		include : BreveShape
+		include : CyrKavykaShape
 			xMiddle -- markMiddle
 			width   -- (2 * (markExtend * 1.5))
 			top     -- aboveMarkTop
@@ -1311,7 +1333,7 @@ glyph-block Mark-Above : begin
 	create-glyph 'cyrlInvKavykaAbove' : glyph-proc
 		set-width 0
 		include : StdAnchors.extraWide
-		include : InvBreveShape
+		include : CyrInvKavykaShape
 			xMiddle -- markMiddle
 			width   -- (2 * (markExtend * 1.5))
 			top     -- aboveMarkTop

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -661,47 +661,57 @@ glyph-block Mark-Above : begin
 			close
 
 	#### Breve Marks
-	define [BreveShape] : with-params [top bottom xMiddle width hs] : glyph-proc
+	define [BreveShape] : with-params [top bottom xMiddle width sw] : glyph-proc
 		local leftEnd  : xMiddle - width / 2
 		local rightEnd : xMiddle + width / 2
+		local swEnd : Math.min sw : VSwToH : 0.375 * (rightEnd - leftEnd)
+		local swMid : Math.min sw :          0.375 * (2 * (top - bottom))
+		local xMiddleAdjusted : clamp
+			leftEnd  + [HSwToV : 1.125 * swEnd] + TINY + [Math.abs : TanSlope * swMid]
+			rightEnd - [HSwToV : 1.125 * swEnd] - TINY - [Math.abs : TanSlope * swMid]
+			Arch.adjust-x.bot xMiddle (sw -- swMid)
 		include : dispiro
-			widths.center (hs * 2)
-			g4.down.start leftEnd  top          [heading Downward]
+			g4.down.start leftEnd         top    [widths.lhs.heading swEnd Downward]
 			arcvh
-			g4.right.mid  xMiddle (bottom + hs) [heading Rightward]
+			g4.right.mid  xMiddleAdjusted bottom [widths.lhs swMid]
 			archv
-			g4.up.end     rightEnd top          [heading Upward]
+			g4.up.end     rightEnd        top    [widths.lhs.heading swEnd Upward]
 
-	define [InvBreveShape] : with-params [top bottom xMiddle width hs] : glyph-proc
+	define [InvBreveShape] : with-params [top bottom xMiddle width sw] : glyph-proc
 		local leftEnd  : xMiddle - width / 2
 		local rightEnd : xMiddle + width / 2
+		local swEnd : Math.min sw : VSwToH : 0.375 * (rightEnd - leftEnd)
+		local swMid : Math.min sw :          0.375 * (2 * (top - bottom))
+		local xMiddleAdjusted : clamp
+			leftEnd  + [HSwToV : 1.125 * swEnd] + TINY + [Math.abs : TanSlope * swMid]
+			rightEnd - [HSwToV : 1.125 * swEnd] - TINY - [Math.abs : TanSlope * swMid]
+			Arch.adjust-x.top xMiddle (sw -- swMid)
 		include : dispiro
-			widths.center (hs * 2)
-			g4.up.start  leftEnd  bottom    [heading Upward]
+			g4.up.start  leftEnd         bottom [widths.rhs.heading swEnd Upward]
 			arcvh
-			g4.right.mid xMiddle (top - hs) [heading Rightward]
+			g4.right.mid xMiddleAdjusted top    [widths.rhs swMid]
 			archv
-			g4.down.end  rightEnd bottom    [heading Downward]
+			g4.down.end  rightEnd        bottom [widths.rhs.heading swEnd Downward]
 
 	create-glyph 'breveAbove' 0x306 : glyph-proc
 		set-width 0
 		include : StdAnchors.wide
 		include : BreveShape
 			xMiddle -- markMiddle
-			width   -- (2 * (markExtend * 1.2))
+			width   -- (2 * (markExtend * 1.2 + [HSwToV markHalfStroke]))
 			top     -- aboveMarkTop
 			bottom  -- aboveMarkBot
-			hs      -- markHalfStroke
+			sw      -- markStroke
 
 	create-glyph 'invBreveAbove' 0x311 : glyph-proc
 		set-width 0
 		include : StdAnchors.wide
 		include : InvBreveShape
 			xMiddle -- markMiddle
-			width   -- (2 * (markExtend * 1.2))
+			width   -- (2 * (markExtend * 1.2 + [HSwToV markHalfStroke]))
 			top     -- aboveMarkTop
 			bottom  -- aboveMarkBot
-			hs      -- markHalfStroke
+			sw      -- markStroke
 
 	create-glyph 'breveMacronAbove' 0x1DCB : glyph-proc
 		set-width 0
@@ -709,17 +719,17 @@ glyph-block Mark-Above : begin
 
 		local fine : Math.min markFine : 0.5 * ([AdviceStroke 3.5] * (markStroke / Stroke))
 
-		local leftEnd  : markMiddle - ((aboveMarkTop - aboveMarkBot) - fine) * 1.25
-		local rightEnd : markMiddle + ((aboveMarkTop - aboveMarkBot) - fine) * 1.25
+		local leftEnd  : markMiddle - ((aboveMarkTop - aboveMarkBot) - fine) * 1.25 - [HSwToV fine]
+		local rightEnd : markMiddle + ((aboveMarkTop - aboveMarkBot) - fine) * 1.25 + [HSwToV fine]
 
 		include : dispiro
-			widths.center (fine * 2)
-			g4.down.start     leftEnd                  aboveMarkTop         [heading Downward]
+			widths.lhs (fine * 2)
+			g4.down.start     leftEnd                                   aboveMarkTop [heading Downward]
 			arcvh
-			g4.right.mid [mix leftEnd markMiddle 0.5] (aboveMarkBot + fine) [heading Rightward]
+			g4.right.mid [mix leftEnd (markMiddle + [HSwToV fine]) 0.5] aboveMarkBot [heading Rightward]
 			archv
-			g4.up.end                 markMiddle       aboveMarkTop         [heading Upward]
-		include : HBar.t markMiddle (rightEnd + 0.5 * markStress) aboveMarkTop (fine * 2)
+			g4.up.end                 (markMiddle + [HSwToV fine])      aboveMarkTop [heading Upward]
+		include : HBar.t markMiddle rightEnd aboveMarkTop (fine * 2)
 
 	create-glyph 'macronBreveAbove' 0x1DCC : glyph-proc
 		set-width 0
@@ -727,17 +737,17 @@ glyph-block Mark-Above : begin
 
 		local fine : Math.min markFine : 0.5 * ([AdviceStroke 3.5] * (markStroke / Stroke))
 
-		local leftEnd  : markMiddle - ((aboveMarkTop - aboveMarkBot) - fine) * 1.25
-		local rightEnd : markMiddle + ((aboveMarkTop - aboveMarkBot) - fine) * 1.25
+		local leftEnd  : markMiddle - ((aboveMarkTop - aboveMarkBot) - fine) * 1.25 - [HSwToV fine]
+		local rightEnd : markMiddle + ((aboveMarkTop - aboveMarkBot) - fine) * 1.25 + [HSwToV fine]
 
-		include : HBar.t (leftEnd - 0.5 * markStress) markMiddle aboveMarkTop (fine * 2)
+		include : HBar.t leftEnd markMiddle aboveMarkTop (fine * 2)
 		include : dispiro
-			widths.center (fine * 2)
-			g4.down.start     markMiddle                aboveMarkTop         [heading Downward]
+			widths.lhs (fine * 2)
+			g4.down.start     (markMiddle - [HSwToV fine])               aboveMarkTop [heading Downward]
 			arcvh
-			g4.right.mid [mix markMiddle rightEnd 0.5] (aboveMarkBot + fine) [heading Rightward]
+			g4.right.mid [mix (markMiddle - [HSwToV fine]) rightEnd 0.5] aboveMarkBot [heading Rightward]
 			archv
-			g4.up.end                    rightEnd       aboveMarkTop         [heading Upward]
+			g4.up.end                                      rightEnd      aboveMarkTop [heading Upward]
 
 	foreach { suffix { DrawAt kdr } } [Object.entries DotVariants] : do
 		create-glyph "candrabinduAbove.\(suffix)" : glyph-proc

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -782,7 +782,7 @@ glyph-block Mark-Above : begin
 			include : DrawAt markMiddle yDot (fine * kdr)
 			include : ApparentTranslate 0 (fine * (-0.5))
 			include : StdAnchors.extraWide
-		create-glyph "cyrlKavykaWithDotAbove.\(suffix)" : glyph-proc
+		create-glyph "cyrl/kavykaWithDotAbove.\(suffix)" : glyph-proc
 			set-width 0
 			local radius : markExtend * 1.5
 			local arcHs : Math.min markHalfStroke (radius * 0.4)
@@ -803,7 +803,7 @@ glyph-block Mark-Above : begin
 	select-variant 'candrabinduAbove' 0x310 (follow -- 'diacriticDot')
 	turned 'fermataAbove' 0x352 'candrabinduAbove' markMiddle aboveMarkMid
 	select-variant 'largeFermataAbove' (follow -- 'diacriticDot')
-	select-variant 'cyrlKavykaWithDotAbove' (follow -- 'diacriticDot')
+	select-variant 'cyrl/kavykaWithDotAbove' (follow -- 'diacriticDot')
 
 	create-glyph 'hookAbove' 0x309 : glyph-proc
 		set-width 0
@@ -1246,10 +1246,10 @@ glyph-block Mark-Above : begin
 		include : MarkArrow.lhsShape MarkArrowDims.arrowSB aboveMarkMid MarkArrowDims.arrowRSB aboveMarkMid HArrowHeadSize
 
 	#### Cyrillic Marks
-	alias 'cyrlDasiaAbove' 0x485 'revCommaAbove'
-	alias 'cyrlPsiliAbove' 0x486 'commaAbove'
+	alias 'cyrl/dasiaAbove' 0x485 'revCommaAbove'
+	alias 'cyrl/psiliAbove' 0x486 'commaAbove'
 
-	create-glyph 'cyrlPalatilizationAbove' 0x484 : glyph-proc
+	create-glyph 'cyrl/palatilizationAbove' 0x484 : glyph-proc
 		set-width 0
 		include : StdAnchors.wide
 
@@ -1264,7 +1264,7 @@ glyph-block Mark-Above : begin
 			alsoThru.g2 0.5 0.5
 			g2.left.end leftEnd    (aboveMarkMid - markHalfStroke) [heading Leftward]
 
-	create-glyph 'cyrlPokrytieAbove' 0x487 : glyph-proc
+	create-glyph 'cyrl/pokrytieAbove' 0x487 : glyph-proc
 		set-width 0
 		include : StdAnchors.wide
 
@@ -1279,7 +1279,7 @@ glyph-block Mark-Above : begin
 			alsoThru.g2 0.5 0.5
 			g2.right.end rightEnd   (aboveMarkMid - markHalfStroke) [heading Rightward]
 
-	create-glyph 'cyrlTitloAbove' 0x483 : glyph-proc
+	create-glyph 'cyrl/titloAbove' 0x483 : glyph-proc
 		set-width 0
 		include : StdAnchors.wide
 
@@ -1287,7 +1287,7 @@ glyph-block Mark-Above : begin
 		include : VBar.m (markMiddle + markExtend) (aboveMarkMid - markFine) aboveMarkTop (markFine * 2)
 		include : HBar.m (markMiddle - markExtend) (markMiddle + markExtend) aboveMarkMid (markFine * 2)
 
-	create-glyph 'cyrlVzmetAbove' 0xA66F : glyph-proc
+	create-glyph 'cyrl/vzmetAbove' 0xA66F : glyph-proc
 		set-width 0
 		include : StdAnchors.wide
 
@@ -1295,7 +1295,7 @@ glyph-block Mark-Above : begin
 		include : VBar.m (markMiddle + markExtend) aboveMarkBot (aboveMarkMid + markFine) (markFine * 2)
 		include : HBar.m (markMiddle - markExtend) (markMiddle + markExtend) aboveMarkMid (markFine * 2)
 
-	create-glyph 'cyrlTeAbove' : glyph-proc
+	create-glyph 'cyrl/teAbove' : glyph-proc
 		set-width 0
 		include : StdAnchors.wide
 
@@ -1330,7 +1330,7 @@ glyph-block Mark-Above : begin
 			archv
 			g4.down.end  rightEnd bottom    [heading Downward]
 
-	create-glyph 'cyrlKavykaAbove' 0xA67C : glyph-proc
+	create-glyph 'cyrl/kavykaAbove' 0xA67C : glyph-proc
 		set-width 0
 		include : StdAnchors.extraWide
 		include : CyrKavykaShape
@@ -1340,7 +1340,7 @@ glyph-block Mark-Above : begin
 			bottom  -- aboveMarkBot
 			hs      -- markHalfStroke
 
-	create-glyph 'cyrlInvKavykaAbove' : glyph-proc
+	create-glyph 'cyrl/invKavykaAbove' : glyph-proc
 		set-width 0
 		include : StdAnchors.extraWide
 		include : CyrInvKavykaShape
@@ -1350,7 +1350,7 @@ glyph-block Mark-Above : begin
 			bottom  -- aboveMarkBot
 			hs      -- markHalfStroke
 
-	create-glyph 'cyrlPayerokAbove' 0xA67D : glyph-proc
+	create-glyph 'cyrl/payerokAbove' 0xA67D : glyph-proc
 		set-width 0
 		include : StdAnchors.mediumWide
 

--- a/packages/font-glyphs/src/marks/composite.ptl
+++ b/packages/font-glyphs/src/marks/composite.ptl
@@ -107,7 +107,7 @@ glyph-block Mark-Composite : begin
 		set-width [query-glyph 'markBaseSpace'].advanceWidth
 		include : refer-glyph src
 
-	derive-glyphs 'cyrlPsiliPokrytieAbove' null 'commaAbove' : function [src gr] : glyph-proc
+	derive-glyphs 'cyrl/psiliPokrytieAbove' null 'commaAbove' : function [src gr] : glyph-proc
 		set-width 0
 		include : refer-glyph src
 		local radius : Math.max (markExtend - commaAboveRadius) (commaAboveRadius * 1.25)

--- a/packages/font-glyphs/src/marks/horn-and-angle.ptl
+++ b/packages/font-glyphs/src/marks/horn-and-angle.ptl
@@ -184,7 +184,7 @@ glyph-block Mark-Horn-And-Angle : begin
 		set-base-anchor 'belowBraceL' (markMiddle + (RightSB - SB) / 2 + DotRadius) belowMarkMid
 		set-base-anchor 'belowBraceR' (markMiddle + (RightSB - SB) / 2 + DotRadius) belowMarkMid
 
-	create-glyph 'cyrlKavykaTR' 0x1DF6 : glyph-proc
+	create-glyph 'cyrl/kavykaTR' 0x1DF6 : glyph-proc
 		set-width 0
 		include : CyrKavykaShape
 			xMiddle -- 0
@@ -196,7 +196,7 @@ glyph-block Mark-Horn-And-Angle : begin
 		set-base-anchor 'aboveBraceL' ((-0.75) * markExtend) aboveMarkMid
 		set-base-anchor 'aboveBraceR' ((+0.75) * markExtend) aboveMarkMid
 
-	create-glyph 'cyrlKavykaTL' 0x1DF7 : glyph-proc
+	create-glyph 'cyrl/kavykaTL' 0x1DF7 : glyph-proc
 		set-width 0
 		include : CyrKavykaShape
 			xMiddle -- 0

--- a/packages/font-glyphs/src/marks/horn-and-angle.ptl
+++ b/packages/font-glyphs/src/marks/horn-and-angle.ptl
@@ -12,7 +12,7 @@ glyph-block Mark-Horn-And-Angle : begin
 	glyph-block-import Mark-Shared-Metrics : markExtend markStroke markStress markFine
 	glyph-block-import Mark-Shared-Metrics : markHalfStroke markMiddle markDotsRadius
 	glyph-block-import Mark-Above : aboveMarkTop aboveMarkBot aboveMarkMid aboveMarkStack
-	glyph-block-import Mark-Above : BreveShape commaAboveRadius
+	glyph-block-import Mark-Above : CyrKavykaShape commaAboveRadius
 	glyph-block-import Mark-Below : belowMarkBot belowMarkTop belowMarkMid
 
 	# horn and angle marks
@@ -186,7 +186,7 @@ glyph-block Mark-Horn-And-Angle : begin
 
 	create-glyph 'cyrlKavykaTR' 0x1DF6 : glyph-proc
 		set-width 0
-		include : BreveShape
+		include : CyrKavykaShape
 			xMiddle -- 0
 			width   -- (2 * (markExtend * 1.5 - [HSwToV markHalfStroke]))
 			top     -- aboveMarkTop
@@ -198,7 +198,7 @@ glyph-block Mark-Horn-And-Angle : begin
 
 	create-glyph 'cyrlKavykaTL' 0x1DF7 : glyph-proc
 		set-width 0
-		include : BreveShape
+		include : CyrKavykaShape
 			xMiddle -- 0
 			width   -- (2 * (markExtend * 1.5 - [HSwToV markHalfStroke]))
 			top     -- aboveMarkTop

--- a/packages/font-glyphs/src/marks/overlay.ptl
+++ b/packages/font-glyphs/src/marks/overlay.ptl
@@ -12,8 +12,8 @@ glyph-block Mark-Overlay : begin
 	glyph-block-import Mark-Shared-Metrics : markMiddle markDotsRadius
 	glyph-block-import Mark-Above : aboveMarkTop aboveMarkBot aboveMarkMid TildeShape RingShape
 
-	local tildeHeight : 0.75 * (aboveMarkTop - aboveMarkBot)
-	local tildeHalfWidth : markExtend + [HSwToV : 0.4 * Stroke]
+	define tildeHeight : 0.75 * (aboveMarkTop - aboveMarkBot)
+	define tildeHalfWidth : markExtend + [HSwToV : 0.4 * Stroke]
 
 	do "Overlay on stems"
 		create-glyph 'tildeOver' 0x334 : glyph-proc
@@ -41,10 +41,10 @@ glyph-block Mark-Overlay : begin
 
 			local shift : (ttop - tbot) * 1.2
 			include : addTilde
-			include : ApparentTranslate 0 (shift * (+1.0))
+			include : ApparentTranslate 0 ((+1.0) * shift)
 
 			include : addTilde
-			include : ApparentTranslate 0 (shift * (-0.5))
+			include : ApparentTranslate 0 ((-0.5) * shift)
 
 		create-glyph 'tildeOverOnExension' : glyph-proc
 			set-width 0
@@ -157,8 +157,8 @@ glyph-block Mark-Overlay : begin
 			include : TildeShape
 				ttop      --  (XH / 2 + tildeHeight / 2)
 				tbot      --  (XH / 2 - tildeHeight / 2)
-				leftEnd   --  (markMiddle - Width / 2 + SB)
-				rightEnd  --  (markMiddle + Width / 2 - SB)
+				leftEnd   --  (markMiddle - (RightSB - SB) / 2)
+				rightEnd  --  (markMiddle + (RightSB - SB) / 2)
 				hs        --  (OverlayStroke / 2)
 
 		create-glyph 'tildeStrike/adwsMM' : glyph-proc
@@ -224,9 +224,9 @@ glyph-block Mark-Overlay : begin
 
 		create-glyph 'dblLongVStrokeOver' 0x20E6 : glyph-proc
 			set-width 0
+			set-mark-anchor 'slash' markMiddle (XH / 2) markMiddle (XH / 2)
 			local dy : CAP * 0.6
 			local gap : Math.max fineDbl (Width * 0.1)
-			set-mark-anchor 'slash' markMiddle (XH / 2) markMiddle (XH / 2)
 			include : dispiro
 				widths.center fineDbl
 				flat (markMiddle - gap) ((XH / 2) - dy)
@@ -238,10 +238,10 @@ glyph-block Mark-Overlay : begin
 
 		create-glyph 'dblLongSlash' 0x20EB : glyph-proc
 			set-width 0
+			set-mark-anchor 'slash' markMiddle (XH / 2) markMiddle (XH / 2)
 			local dx : (RightSB - SB) / 2 + O * 3 - 0.5 * fineDbl
 			local dy : CAP * 0.6
 			local gap : Math.max fineDbl (Width * 0.1)
-			set-mark-anchor 'slash' markMiddle (XH / 2) markMiddle (XH / 2)
 			include : dispiro
 				widths.center fineDbl
 				flat ((markMiddle - gap) - dx) ((XH / 2) - dy)
@@ -254,9 +254,9 @@ glyph-block Mark-Overlay : begin
 		create-glyph 'wideSlash' : glyph-proc
 			local df : DivFrame para.advanceScaleMM 3
 			set-width 0
+			set-mark-anchor 'slash' markMiddle (XH / 2) markMiddle (XH / 2)
 			local dx : (df.rightSB - df.leftSB) / 2 - O * 3 - 0.5 * fine
 			local dy : XH * 0.6
-			set-mark-anchor 'slash' markMiddle (XH / 2) markMiddle (XH / 2)
 			include : dispiro
 				widths.center fine
 				flat (markMiddle - dx) ((XH / 2) - dy)
@@ -269,25 +269,25 @@ glyph-block Mark-Overlay : begin
 			define dims : ArrowDims MosaicWidth
 
 			define {
-				.arrowWidth arrowWidth
+				.arrowWidth    arrowWidth
 				.arrowHeadSize arrowHeadSize
 
-				.arrowSw arrowSw
-				.fine fine
-				.overlaySw overlaySw
-				.strokeSpan strokeSpan
+				.arrowSw     arrowSw
+				.fine        fine
+				.overlaySw   overlaySw
+				.strokeSpan  strokeSpan
 				.strokeSpan2 strokeSpan2
 				.dblArrSpace dblArrSpace
 				.dhtArrSpace dhtArrSpace
-				.dblArrSw dblArrSw
-				.dhtArrSw dhtArrSw
-				.terminal terminal
+				.dblArrSw    dblArrSw
+				.dhtArrSw    dhtArrSw
+				.terminal    terminal
 			} dims
 
-			local VRingRadius : arrowHeadSize * 0.7
-			local HRingRadius : Math.min VRingRadius : arrowWidth - 2 * arrowHeadSize - 0.3 * terminal
-			local VRingSw : AdviceStrokeInSpace VRingRadius 2.25
-			local HRingSw : AdviceStrokeInSpace HRingRadius 2.25
+			define VRingRadius : arrowHeadSize * 0.7
+			define HRingRadius : Math.min VRingRadius : arrowWidth - 2 * arrowHeadSize - 0.3 * terminal
+			define VRingSw : AdviceStrokeInSpace VRingRadius 2.25
+			define HRingSw : AdviceStrokeInSpace HRingRadius 2.25
 
 			create-glyph [MangleName 'arrSlashOver'] : glyph-proc
 				set-width 0
@@ -295,105 +295,119 @@ glyph-block Mark-Overlay : begin
 				local dy : arrowHeadSize * 1.1
 				set-mark-anchor 'slash' 0 0 0 0
 				include : dispiro
-					flat (-dx) (-dy) [widths.center overlaySw]
+					widths.center overlaySw
+					flat (-dx) (-dy)
 					curl (+dx) (+dy)
 
 			create-glyph [MangleName 'arrDblSlashOver'] : glyph-proc
 				set-width 0
+				set-mark-anchor 'slash' 0 0 0 0
 				local gap : clamp dblArrSw (dblArrSpace - 2 * dblArrSw) (dblArrSpace / 4)
 				local dx : arrowHeadSize * 0.4
 				local dy : arrowHeadSize * 1.1
-				set-mark-anchor 'slash' 0 0 0 0
 				include : dispiro
-					flat (+gap - dx) (-dy) [widths.center dblArrSw]
-					curl (+gap + dx) (+dy)
+					widths.center dblArrSw
+					flat ((+gap) - dx) (-dy)
+					curl ((+gap) + dx) (+dy)
 				include : dispiro
-					flat (-gap - dx) (-dy) [widths.center dblArrSw]
-					curl (-gap + dx) (+dy)
+					widths.center dblArrSw
+					flat ((-gap) - dx) (-dy)
+					curl ((-gap) + dx) (+dy)
 
 			create-glyph [MangleName 'arrVStrokeOver'] : glyph-proc
 				set-width 0
-				local dy strokeSpan
 				set-mark-anchor 'slash' 0 0 0 0
+				local dy strokeSpan
 				include : dispiro
-					flat 0 (-dy) [widths.center overlaySw]
+					widths.center overlaySw
+					flat 0 (-dy)
 					curl 0 (+dy)
 
 			create-glyph [MangleName 'dblArrVStrokeOver'] : glyph-proc
 				set-width 0
-				local dy strokeSpan2
 				set-mark-anchor 'slash' 0 0 0 0
+				local dy strokeSpan2
 				include : dispiro
-					flat 0 (-dy) [widths.center overlaySw]
+					widths.center overlaySw
+					flat 0 (-dy)
 					curl 0 (+dy)
 
 			create-glyph [MangleName 'arrDblVStrokeOver'] : glyph-proc
 				set-width 0
+				set-mark-anchor 'slash' 0 0 0 0
 				local dy strokeSpan
 				local gap : clamp dblArrSw (dblArrSpace - 2 * dblArrSw) (dblArrSpace / 4)
-				set-mark-anchor 'slash' 0 0 0 0
 				include : dispiro
-					flat (-gap) (-dy) [widths.center dblArrSw]
+					widths.center dblArrSw
+					flat (-gap) (-dy)
 					curl (-gap) (+dy)
 				include : dispiro
-					flat (+gap) (-dy) [widths.center dblArrSw]
+					widths.center dblArrSw
+					flat (+gap) (-dy)
 					curl (+gap) (+dy)
 
 			create-glyph [MangleName 'arrDhtVStrokeOver'] : glyph-proc
 				set-width 0
+				set-mark-anchor 'slash' 0 0 0 0
 				local dy strokeSpan
 				local gap : clamp dhtArrSw (dhtArrSpace - 2 * dhtArrSw) (dhtArrSpace / 4)
-				set-mark-anchor 'slash' 0 0 0 0
 				include : dispiro
-					flat (-gap) (-dy) [widths.center dhtArrSw]
+					widths.center dhtArrSw
+					flat (-gap) (-dy) 
 					curl (-gap) (+dy)
 				include : dispiro
-					flat (+gap) (-dy) [widths.center dhtArrSw]
+					widths.center dhtArrSw
+					flat (+gap) (-dy)
 					curl (+gap) (+dy)
 
 			create-glyph [MangleName 'arrHStrokeOver'] : glyph-proc
 				set-width 0
-				local dx strokeSpan
 				set-mark-anchor 'slash' 0 0 0 0
+				local dx strokeSpan
 				include : dispiro
-					flat (-dx) 0 [widths.center overlaySw]
+					widths.center overlaySw
+					flat (-dx) 0
 					curl (+dx) 0
 
 			create-glyph [MangleName 'arrDblHStrokeOver'] : glyph-proc
 				set-width 0
-				local dx strokeSpan
-				local gap : clamp overlaySw (1.5 * arrowHeadSize - 2 * overlaySw) (1.5 * arrowHeadSize / 4)
 				set-mark-anchor 'slash' 0 0 0 0
+				local dx strokeSpan
+				local gap : clamp overlaySw (1.5 * arrowHeadSize - 2 * overlaySw) ((1.5 * arrowHeadSize) / 4)
 				include : dispiro
-					flat (-dx) (-gap) [widths.center overlaySw]
+					widths.center overlaySw
+					flat (-dx) (-gap)
 					curl (+dx) (-gap)
 				include : dispiro
-					flat (-dx) (+gap) [widths.center overlaySw]
+					widths.center overlaySw
+					flat (-dx) (+gap)
 					curl (+dx) (+gap)
 
 			create-glyph [MangleName 'arrCrossOver'] : glyph-proc
 				set-width 0
-				local r : 0.7 * HRingRadius + 0.5 * overlaySw
 				set-mark-anchor 'slash' 0 0 0 0
+				local r : 0.7 * HRingRadius + 0.5 * overlaySw
 				include : dispiro
-					flat (-r) (-r) [widths.center overlaySw]
+					widths.center overlaySw
+					flat (-r) (-r)
 					curl (+r) (+r)
 				include : dispiro
-					flat (-r) (+r) [widths.center overlaySw]
+					widths.center overlaySw
+					flat (-r) (+r)
 					curl (+r) (-r)
 
 			create-glyph [MangleName 'arrLobeOver'] : glyph-proc
 				set-width 0
 				set-mark-anchor 'slash' 0 0 0 0
+				local xSide : HRingRadius * 0.8
 				local ySide : HRingRadius * (-1.2)
-				local xSide : HRingRadius *   0.8
-				local yBot  : HRingRadius * (-2)
+				local yBot  : HRingRadius * (-2.0)
 				include : dispiro
 					widths.rhs arrowSw
 					g4 0 (arrowSw / 2)
-					g4.down.mid xSide  ySide [widths.rhs fine]
+					g4.down.mid (+xSide) ySide [widths.rhs fine]
 					Arch.rhs yBot (sw -- arrowSw)
-					g4.up.mid (-xSide) ySide [widths.rhs fine]
+					g4.up.mid   (-xSide) ySide [widths.rhs fine]
 					g4 0 (arrowSw / 2)
 
 			define [ArrowRingOverlay r sw] :  glyph-proc
@@ -406,22 +420,22 @@ glyph-block Mark-Overlay : begin
 				set-mark-anchor 'slash' 0 0 0 0
 				local rin : r - 0.5 * sw
 				include : RingStrokeAt 0 0 r sw
-				include : VBar.m 0 (-rin) rin sw
-				include : HBar.m (-rin) rin 0 sw
+				include : VBar.m 0 (-rin) (+rin) sw
+				include : HBar.m (-rin) (+rin) 0 sw
 
 			define [ArrowRingMaskOverlay r sw] :  glyph-proc
 				set-width 0
 				set-mark-anchor 'slash' 0 0 0 0
 				include : RingAt 0 0 r sw
 
-			# create-glyph [MangleName 'arrRingOver'] : ArrowRingOverlay VRingRadius VRingSw
-			# create-glyph [MangleName 'arrRingOverMask'] : ArrowRingMaskOverlay VRingSw VRingSw
-			create-glyph [MangleName 'arrRingOverLR'] : ArrowRingOverlay HRingRadius HRingSw
+			# create-glyph [MangleName 'arrRingOver']     : ArrowRingOverlay     VRingRadius VRingSw
+			# create-glyph [MangleName 'arrRingOverMask'] : ArrowRingMaskOverlay VRingSw     VRingSw
+			create-glyph [MangleName 'arrRingOverLR']     : ArrowRingOverlay     HRingRadius HRingSw
 			create-glyph [MangleName 'arrRingPlusOverLR'] : ArrowRingPlusOverlay HRingRadius HRingSw
 			create-glyph [MangleName 'arrRingOverLRMask'] : ArrowRingMaskOverlay HRingRadius HRingSw
 
 	do "Half-XH marks for spacing modifiers"
-		local ext : Math.min markExtend (aboveMarkTop - aboveMarkBot)
+		define ext : Math.min markExtend (aboveMarkTop - aboveMarkBot)
 
 		create-glyph 'leftTackOver' : glyph-proc
 			set-width 0
@@ -487,29 +501,29 @@ glyph-block Mark-Overlay : begin
 			include : with-transform [ApparentTranslate (-markMiddle) (-aboveMarkMid)]
 				refer-glyph 'leftHalfRingAbove'
 
-		create-glyph 'cyrlInvKavykaOver' : glyph-proc
+		create-glyph 'cyrl/invKavykaOver' : glyph-proc
 			set-width 0
 			set-mark-anchor 'overlay' 0 0 0 0
 
 			include : with-transform [ApparentTranslate (-markMiddle) (-aboveMarkMid)]
-				refer-glyph 'cyrlInvKavykaAbove'
+				refer-glyph 'cyrl/invKavykaAbove'
 
-		create-glyph 'cyrlKavykaOver' : glyph-proc
+		create-glyph 'cyrl/kavykaOver' : glyph-proc
 			set-width 0
 			set-mark-anchor 'overlay' 0 0 0 0
 
 			include : with-transform [ApparentTranslate (-markMiddle) (-aboveMarkMid)]
-				refer-glyph 'cyrlKavykaAbove'
+				refer-glyph 'cyrl/kavykaAbove'
 
 		foreach { suffix { DrawAt kdr } } [Object.entries DotVariants] : do
-			create-glyph "cyrlKavykaWithDotOver.\(suffix)" : glyph-proc
+			create-glyph "cyrl/kavykaWithDotOver.\(suffix)" : glyph-proc
 				set-width 0
 				set-mark-anchor 'overlay' 0 0 0 0
 
 				include : with-transform [ApparentTranslate (-markMiddle) (-aboveMarkMid)]
-					refer-glyph "cyrlKavykaWithDotAbove.\(suffix)"
+					refer-glyph "cyrl/kavykaWithDotAbove.\(suffix)"
 
-		select-variant 'cyrlKavykaWithDotOver' (follow -- 'diacriticDot')
+		select-variant 'cyrl/kavykaWithDotOver' (follow -- 'diacriticDot')
 
 	do "Inner dots"
 		glyph-block-export InnerDot

--- a/packages/font-glyphs/src/meta/unicode-knowledge.ptl
+++ b/packages/font-glyphs/src/meta/unicode-knowledge.ptl
@@ -28,11 +28,11 @@ export : define markCompositionTf : list
 	list { 'commaAbove' 'graveAbove'        } 'psiliVaria'
 	list { 'commaAbove' 'acuteAbove'        } 'psiliOxia'
 	list { 'commaAbove' 'perispomeniAbove'  } 'psiliPerispomeni'
-	list { 'commaAbove' 'cyrlPokrytieAbove' } 'commaCyrlPorkytieAbove'
+	list { 'commaAbove' 'cyrl/pokrytieAbove' } 'cyrl/commaPorkytieAbove'
 	list { 'revCommaAbove' 'graveAbove'       } 'dasiaVaria'
 	list { 'revCommaAbove' 'acuteAbove'       } 'dasiaOxia'
 	list { 'revCommaAbove' 'perispomeniAbove' } 'dasiaPerispomeni'
-	list { 'cyrlPsiliAbove' 'cyrlPokrytieAbove' } 'cyrlPsiliPokrytieAbove'
+	list { 'cyrl/psiliAbove' 'cyrl/pokrytieAbove' } 'cyrl/psiliPokrytieAbove'
 
 export : define decompOverrides : object
 	# Latvians use comma instead of cedillas in several letters.
@@ -99,11 +99,11 @@ export : define decompOverrides : object
 	0x1FFD { 'markBaseSpace' 'acuteAbove' }
 	0x1FFE { 'markBaseSpace' 'revCommaAbove' }
 	0x2E2F { 'markBaseSpace' 'yerikAbove' }
-	0x2E45 { 'markBaseSpace' 'cyrlInvKavykaOver' }
-	0x2E47 { 'markBaseSpace' 'cyrlKavykaOver' }
-	0x2E48 { 'markBaseSpace' 'cyrlKavykaWithDotOver' }
-	0xA67E { 'markBaseSpace' 'cyrlKavykaAbove' }
-	0xA67F { 'markBaseSpace' 'cyrlPayerokAbove' }
+	0x2E45 { 'markBaseSpace' 'cyrl/invKavykaOver' }
+	0x2E47 { 'markBaseSpace' 'cyrl/kavykaOver' }
+	0x2E48 { 'markBaseSpace' 'cyrl/kavykaWithDotOver' }
+	0xA67E { 'markBaseSpace' 'cyrl/kavykaAbove' }
+	0xA67F { 'markBaseSpace' 'cyrl/payerokAbove' }
 	0xA788 { 'markBaseSpace' 'circumflexBelow' }
 	0xA78A { 'markBaseSpace' 'equalOver' }
 	0xAB6A { 'markBaseSpace' 'leftTackOver' }
@@ -145,10 +145,10 @@ export : define decompOverrides : object
 
 	0x46E  { 'cyrl/Ksi/base' 'caronAbove' }
 	0x46F  { 'cyrl/ksi/base' 'caronAbove' }
-	0x47C  { 'cyrl/BroadOmega' 'cyrlPsiliAbove' 'cyrlPokrytieAbove' }
-	0x47D  { 'cyrl/broadOmega' 'cyrlPsiliAbove' 'cyrlPokrytieAbove' }
-	0x47E  { 'cyrl/Omega' 'cyrlTeAbove' }
-	0x47F  { 'cyrl/omega' 'cyrlTeAbove' }
+	0x47C  { 'cyrl/BroadOmega' 'cyrl/psiliAbove' 'cyrl/pokrytieAbove' }
+	0x47D  { 'cyrl/broadOmega' 'cyrl/psiliAbove' 'cyrl/pokrytieAbove' }
+	0x47E  { 'cyrl/Omega' 'cyrl/teAbove' }
+	0x47F  { 'cyrl/omega' 'cyrl/teAbove' }
 
 	0x1D6C { 'b' 'tildeOverOnExension' }
 	0x1D6D { 'd' 'tildeOverOnExension' }

--- a/packages/font-glyphs/src/symbol/letter.ptl
+++ b/packages/font-glyphs/src/symbol/letter.ptl
@@ -382,7 +382,7 @@ glyph-block Symbol-Letter : begin
 glyph-block Symbol-Cyrl-Thousands : begin
 	glyph-block-import CommonShapes
 
-	create-glyph 'cyrlThousandsSign' 0x482 : glyph-proc
+	create-glyph 'cyrl/thousandsSign' 0x482 : glyph-proc
 		local fine : AdviceStroke 3
 		include : ExtLineCenter      SB                      Descender                 RightSB                        XH      fine (-0.1)
 		include : ExtLineCenter [mix SB RightSB (+0.1)] [mix Descender XH 0.8] [mix SB RightSB (+1.1)] [mix Descender XH 0.5] fine (-0.1)
@@ -409,7 +409,7 @@ glyph-block Symbol-Letter-Phonetic : begin
 			Arch.lhs (XH - archHeight)
 			g4.up.end     (RightSB - OX) XH [heading Upward]
 
-	create-glyph 'cyrlInvLowKavykaKavyka' 0x2E46 : glyph-proc
+	create-glyph 'cyrl/invLowKavykaKavyka' 0x2E46 : glyph-proc
 		local df : include : DivFrame para.advanceScaleSp
 		include : df.markSet.e
 

--- a/packages/font-glyphs/src/symbol/letter.ptl
+++ b/packages/font-glyphs/src/symbol/letter.ptl
@@ -299,13 +299,13 @@ glyph-block Symbol-Letter : begin
 
 	create-glyph 'mathGimel' 0x2137 : glyph-proc
 		local df : include : DivFrame para.advanceScaleF
+		include : df.markSet.capital
+
 		local hd : FlatHookDepth df
 
 		local xStart : mix df.leftSB df.rightSB 0.1
 		local xVertBar : [mix df.leftSB df.rightSB 0.625] + [HSwToV : 0.375 * Stroke]
 		local yBranch : mix 0 CAP 0.5
-
-		include : df.markSet.capital
 
 		include : intersection [MaskAbove 0] : dispiro
 			widths.rhs
@@ -390,7 +390,7 @@ glyph-block Symbol-Cyrl-Thousands : begin
 
 glyph-block Symbol-Letter-Phonetic : begin
 	glyph-block-import CommonShapes
-	glyph-block-import Mark-Above : BreveShape InvBreveShape
+	glyph-block-import Mark-Above : CyrKavykaShape CyrInvKavykaShape
 	glyph-block-import Mark-Shared-Metrics : markExtend markHalfStroke
 
 	create-glyph 'mdfInvBreveBreve' 0xAB5B : glyph-proc
@@ -413,14 +413,14 @@ glyph-block Symbol-Letter-Phonetic : begin
 		local df : include : DivFrame para.advanceScaleSp
 		include : df.markSet.e
 
-		include : BreveShape
+		include : CyrKavykaShape
 			xMiddle -- df.middle
 			width   -- (2 * (markExtend * 1.5))
 			top     -- XH
 			bottom  -- (XH - AccentHeight)
 			hs      -- markHalfStroke
 
-		include : InvBreveShape
+		include : CyrInvKavykaShape
 			xMiddle -- df.middle
 			width   -- (2 * (markExtend * 1.5))
 			top     -- (0 + AccentHeight)


### PR DESCRIPTION
### Motivation and Context

This makes it behave more like a bowl, and also allowing for usage of `[Arch.adjust-x.`{`top`|`bot`}` …]` and limiting the stroke width to a (more easily) predictable range of safe values via `[clamp …]` or `[Math.min …]` with the full apparent width/height of the glyph always known to the function as exact values.

### Influenced Characters

Any composite using {`Inv`}`Breve`{`Above`|`Below`};
However, composites using {`Inv`}`Kavyka`{`WithDot`}{`Above`|`Below`|`Over`|`TL`|`TR`} use the original shape function with `[widths.center …]`.

### Glyph Quantity

N/A (Zero new glyphs; Existing glyphs are simply reworked).

### Samples

I preserved the apparent width by adding `[HSwToV markHalfStroke]` to each end, so I don't know how well the difference even comes across in the screenshot below, but I'm posting it anyway for transparency:

`ăắằẳẵȃ`
<img width="1833" height="1208" alt="image" src="https://github.com/user-attachments/assets/465748c1-fda4-411d-8254-abbd341aa255" />

