### PR TITLE
Improve glyph for Combining Seagull Above⁠/⁠Below (`◌᫥`, `◌̼`).

### DIFF
--- a/changes/34.8.1.md
+++ b/changes/34.8.1.md
@@ -1,0 +1,3 @@
+* Refine shape of the following characters:
+  - COMBINING SEAGULL BELOW (`U+033C`).
+  - COMBINING SEAGULL ABOVE (`U+1AE5`).

--- a/packages/font-glyphs/src/marks/above.ptl
+++ b/packages/font-glyphs/src/marks/above.ptl
@@ -1050,24 +1050,24 @@ glyph-block Mark-Above : begin
 		include : StdAnchors.wide
 
 		local fine : Math.min markFine : 0.5 * ([AdviceStroke 3.5] * (markStroke / Stroke))
-		local coFine : (fine * 2) * (CThin - 0.5)
+		local coFine : fine * (2 * CThin - 1)
 
 		local leftEnd  : markMiddle - ((aboveMarkTop - aboveMarkBot) - fine) * 1.25
 		local rightEnd : markMiddle + ((aboveMarkTop - aboveMarkBot) - fine) * 1.25
 
 		include : union
 			dispiro
-				g4.up.start       leftEnd                  aboveMarkBot         [widths.heading fine fine Upward]
-				arcvh
+				widths.center (fine * 2)
+				g4                leftEnd                  aboveMarkMid
 				g4.right.mid [mix leftEnd markMiddle 0.5] (aboveMarkTop - fine) [heading Rightward]
 				archv
 				g4.down.end               markMiddle       aboveMarkBot         [widths.heading coFine fine Downward]
 			dispiro
-				g4.up.start       markMiddle                aboveMarkBot         [widths.heading coFine fine Upward]
-				arcvh
-				g4.right.mid [mix markMiddle rightEnd 0.5] (aboveMarkTop - fine) [widths.heading fine fine Rightward]
+				widths.center (fine * 2)
+				g4               rightEnd                  aboveMarkMid
+				g4.left.mid [mix rightEnd markMiddle 0.5] (aboveMarkTop - fine) [heading Leftward]
 				archv
-				g4.down.end                  rightEnd       aboveMarkBot         [heading Downward]
+				g4.down.end               markMiddle       aboveMarkBot         [widths.heading fine coFine Downward]
 
 		create-forked-glyph 'turnSeagullAbove' : FlipAround markMiddle aboveMarkMid
 


### PR DESCRIPTION
### Motivation and Context

The Combining Seagull (`◌᫥`, `◌̼`) is distinct from the Combining Inverted Double Arch (`◌᫧`, `◌᫦`) in that it's an [icon representation of the upper lip](https://www.unicode.org/L2/L2024/24080-ipa-diacritics-above.pdf#page=3), and its sides should be more open instead of flatly touching the bottom of the mark boundary.

### Influenced Characters

  - COMBINING SEAGULL BELOW (`U+033C`).
  - COMBINING SEAGULL ABOVE (`U+1AE5`).

### Glyph Quantity

N/A (Zero new glyphs; Existing glyphs are simply reworked).

### Samples

`a᫥a̼a͆a̪a᫤a̻a᫣a̺a᫨a͇`

Before:
<img width="1679" height="1097" alt="image" src="https://github.com/user-attachments/assets/42d627ae-b0df-4806-b6a5-e33d594df938" />
After:
<img width="1683" height="1093" alt="image" src="https://github.com/user-attachments/assets/d18cad8d-b7d1-4118-af18-5d32fb2830a4" />

