### PR TITLE
Improve glyph composition for Cyrillic Upper⁠/⁠Lower Tsse (`Ꚑ`, `ꚑ`).

### DIFF
--- a/changes/34.8.1.md
+++ b/changes/34.8.1.md
@@ -1,3 +1,5 @@
 * Refine shape of the following characters:
   - COMBINING SEAGULL BELOW (`U+033C`).
   - COMBINING SEAGULL ABOVE (`U+1AE5`).
+  - CYRILLIC CAPITAL LETTER TSSE (`U+A690`).
+  - CYRILLIC SMALL LETTER TSSE (`U+A691`).

--- a/packages/font-glyphs/src/letter/cyrillic/de.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/de.ptl
@@ -110,38 +110,39 @@ glyph-block Letter-Cyrillic-De : begin
 	select-variant 'cyrl/DeSoft' 0xA662 (follow -- 'cyrl/EnGhe/Ghe')
 	select-variant 'cyrl/deSoft' 0xA663 (follow -- 'cyrl/enghe/ghe')
 
-	foreach { suffix { { desc } { st sb } } } [Object.entries ZeConfig] : do
-		define [DzzeDescendershape de ada adb] : begin
+	foreach { suffix { { desc } { styTop styBot } } } [Object.entries ZeConfig] : do
+		define [DzzeDescenderShape de ada adb] : begin
 			local sr : [mix RightSB Width 0.5] - O * 2
 			local sl : mix sr de.xTopRight 2
-			local sw : AdviceStroke 2.5 : ((sr - sl) + 2 * SB) / Width
-			local shapeBot : de.desc - 0.5 * sw
-			local hook : Hook * (0 - shapeBot) / CAP
-			local ze : CyrZe 3 sb sw shapeBot
+			local sw : AdviceStroke 2.5 (((sr - sl) + 2 * SB) / Width)
+			local st : 0 + sw
+			local sb : de.desc - 0.5 * sw
+			local p : (st - sb) / (CAP - 0)
+			local ze : CyrZe 3 styBot st sb
 				left   -- sl
 				right  -- sr
-				hook   -- hook
+				hook   -- (Hook * p)
 				stroke -- sw
 				xo     -- (0.5 * O)
 				barPos -- 0.5
-				ada    -- ada
-				adb    -- adb
+				ada    -- (ada * p)
+				adb    -- (adb * p)
 			return : union [ze.Shape] [ze.AutoEndSerifL]
 
-		if (!desc && !st) : begin
+		if (!desc && !styTop) : begin
 			create-glyph "cyrl/Dzze.\(suffix)" : glyph-proc
 				include : MarkSet.capital
 				include : ExtendBelowBaseAnchors BottomExtension
 				local de : include : CyrDeShape true CAP SB RightSB
 				eject-contour 'footR'
-				include : DzzeDescendershape de ArchDepthA ArchDepthB
+				include : DzzeDescenderShape de ArchDepthA ArchDepthB
 
 			create-glyph "cyrl/dzze.upright.\(suffix)" : glyph-proc
 				include : MarkSet.e
 				include : ExtendBelowBaseAnchors BottomExtension
 				local de : include : CyrDeShape false XH SB RightSB
 				eject-contour 'footR'
-				include : DzzeDescendershape de SmallArchDepthA SmallArchDepthB
+				include : DzzeDescenderShape de SmallArchDepthA SmallArchDepthB
 
 	create-glyph 'cyrl/Dwe' 0xA680 : glyph-proc
 		include : MarkSet.capital
@@ -196,8 +197,8 @@ glyph-block Letter-Cyrillic-De : begin
 
 	CreateAccentedComposition 'cyrl/dwe.italic' null 'cyrl/dwe.italic/base' 'commaTR'
 
-	foreach { suffix { { desc } { st sb } } } [Object.entries ZeConfig] : do
-		if (desc && !st) : begin
+	foreach { suffix { { desc } { styTop styBot } } } [Object.entries ZeConfig] : do
+		if (desc && !styTop) : begin
 			create-glyph "cyrl/dzze.italic.\(suffix)" : glyph-proc
 				local df : include : DivFrame para.advanceScaleMM 3
 				include : df.markSet.bp
@@ -206,7 +207,7 @@ glyph-block Letter-Cyrillic-De : begin
 				include : CyrDeItalicShape subDf df.mvs
 
 				local shift : df.width - subDf.width
-				local ze : CyrZe 1 sb XH Descender
+				local ze : CyrZe 1 styBot XH Descender
 					left      -- ((subDf.leftSB  + OX) + shift)
 					right     -- ((subDf.rightSB - OX) + shift)
 					blend     -- 0.7

--- a/packages/font-glyphs/src/letter/cyrillic/de.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/de.ptl
@@ -112,15 +112,15 @@ glyph-block Letter-Cyrillic-De : begin
 
 	foreach { suffix { { desc } { styTop styBot } } } [Object.entries ZeConfig] : do
 		define [DzzeDescenderShape de ada adb] : begin
-			local sr : [mix RightSB Width 0.5] - O * 2
-			local sl : mix sr de.xTopRight 2
-			local sw : AdviceStroke 2.5 (((sr - sl) + 2 * SB) / Width)
-			local st : 0 + sw
-			local sb : de.desc - 0.5 * sw
-			local p : (st - sb) / (CAP - 0)
-			local ze : CyrZe 3 styBot st sb
-				left   -- sl
-				right  -- sr
+			local zeRight : [mix RightSB Width 0.5] - O * 2
+			local zeLeft : mix zeRight de.xTopRight 2
+			local sw : AdviceStroke 2.5 (((zeRight - zeLeft) + 2 * SB) / Width)
+			local zeTop : 0 + sw
+			local zeBot : de.desc - 0.5 * sw
+			local p : (zeTop - zeBot) / (CAP - 0)
+			local ze : CyrZe 3 styBot zeTop zeBot
+				left   -- zeLeft
+				right  -- zeRight
 				hook   -- (Hook * p)
 				stroke -- sw
 				xo     -- (0.5 * O)

--- a/packages/font-glyphs/src/letter/cyrillic/ze.ptl
+++ b/packages/font-glyphs/src/letter/cyrillic/ze.ptl
@@ -65,7 +65,7 @@ glyph-block Letter-Cyrillic-Ze : begin
 					[Just SLAB-CLASSICAL] : SerifedArcStart.LtrRhs left top stroke hook (o -- yo)
 					[Just SLAB-INWARD] : InwardSlabArcStart.LtrRhs left top stroke hook (o -- yo)
 					[Just FLAT-CONNECTION] : list
-						flat (left - xo) top [widths.rhs.heading stroke Rightward]
+						flat (left + TINY) top [widths.rhs.heading stroke Rightward]
 						curl [Arch.adjust-x.top middle stroke] top [heading Rightward]
 						archv
 					[Just OPEN-VERTICAL] : flat right top [widths.rhs.heading stroke Downward]
@@ -101,7 +101,7 @@ glyph-block Letter-Cyrillic-Ze : begin
 					[Just FLAT-CONNECTION] : list
 						arcvh
 						flat [Arch.adjust-x.bot middle stroke] bot [heading Leftward]
-						curl (left - xo) bot [heading Leftward]
+						curl (left + TINY) bot [heading Leftward]
 					[Just OPEN-HALF] : list
 					[Just OPEN-VERTICAL] : curl (right - xo * 2) bot [heading Downward]
 					([Just CLOSED-CIRCLE] || [Just CLOSED-ROUND]) : list
@@ -195,7 +195,7 @@ glyph-block Letter-Cyrillic-Ze : begin
 					[Just SLAB-CLASSICAL] : SerifedArcStart.RtlLhs right top stroke hook (o -- yo)
 					[Just SLAB-INWARD] : InwardSlabArcStart.RtlLhs right top stroke hook (o -- yo)
 					[Just FLAT-CONNECTION] : list
-						flat (right + xo) top [widths.lhs.heading stroke Leftward]
+						flat (right - TINY) top [widths.lhs.heading stroke Leftward]
 						curl [Arch.adjust-x.top middle stroke] top [heading Leftward]
 						archv
 					[Just OPEN-VERTICAL] : flat left top [widths.lhs.heading stroke Downward]
@@ -229,7 +229,7 @@ glyph-block Letter-Cyrillic-Ze : begin
 					[Just FLAT-CONNECTION] : list
 						arcvh
 						flat [Arch.adjust-x.bot middle stroke] bot [heading Rightward]
-						curl (right + xo) bot [heading Rightward]
+						curl (right - TINY) bot [heading Rightward]
 					[Just OPEN-VERTICAL] : curl (left + xo * 2) bot [heading Downward]
 					([Just CLOSED-CIRCLE] || [Just CLOSED-ROUND]) : list
 						Arch.lhs bot (sw -- stroke) (o -- yo)

--- a/packages/font-glyphs/src/letter/latin/upper-t.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-t.ptl
@@ -1,7 +1,7 @@
 $$include '../../meta/macros.ptl'
 
 import [mix linreg clamp fallback] from "@iosevka/util"
-import [MathSansSerif] from "@iosevka/glyph/relation"
+import [MathSansSerif DependentSelector] from "@iosevka/glyph/relation"
 
 glyph-module
 
@@ -10,14 +10,15 @@ glyph-block Letter-Latin-Upper-T : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Adjustment : LeaningAnchor
 	glyph-block-import Letter-Shared : CreateAccentedComposition CreateTurnedLetter
+	glyph-block-import Letter-Shared : CreateSelectorVariants DefineSelectorGlyph
 	glyph-block-import Letter-Shared-Metrics : EFVJutLength
-	glyph-block-import Letter-Shared-Shapes : LetterBarOverlay UpwardHookShape MidHook
-	glyph-block-import Letter-Shared-Shapes : CyrDescender HalfRingDescender SerifFrame
-	glyph-block-import Letter-Shared-Shapes : LeftHook RetroflexHook
+	glyph-block-import Letter-Shared-Shapes : LetterBarOverlay SerifFrame UpwardHookShape
+	glyph-block-import Letter-Shared-Shapes : CyrDescender RetroflexHook MidHook LeftHook
+	glyph-block-import Letter-Latin-C : CLetterForm CConfig
 
 	define [TLeftX  df] : df.leftSB  + 0.75 * OX
 	define [TRightX df] : df.rightSB - 0.75 * OX
-	define [TShape df top doTopSerifs doBottomSerifs doBottomSerifsRightHalfOnly] : glyph-proc
+	define [TShape df top doTopSerifs doBottomSerif fBottomSerifRightHalfOnly] : glyph-proc
 		include : tagged 'strokeV' : VBar.m df.middle 0 top
 
 		local l : TLeftX  df
@@ -30,12 +31,10 @@ glyph-block Letter-Latin-Upper-T : begin
 			local swVJut : Math.min VJutStroke : VSwToH : 0.625 * ((df.middle - [HSwToV HalfStroke]) - l)
 			include : tagged 'serifRT' : VSerif.dr r top VJut swVJut
 			include : tagged 'serifLT' : VSerif.dl l top VJut swVJut
-		if doBottomSerifs : begin
-			include : tagged 'serifMB' : HSerif.rb df.middle 0 MidJutCenter
-			if [not doBottomSerifsRightHalfOnly]
-				include : tagged 'serifMB' : HSerif.lb df.middle 0 MidJutCenter
+		if doBottomSerif : begin
+			include : tagged 'serifMB' : HSerif.[if fBottomSerifRightHalfOnly 'rb' 'mb'] df.middle 0 MidJutCenter
 
-	define [CyrKomiTjeShape df top doTopSerifs doBottomSerifs] : glyph-proc
+	define [CyrKomiTjeShape df top doTopSerifs doBottomSerif] : glyph-proc
 		local sw : df.adviceThinnerStroke 2.75
 		local left : [mix df.leftSB df.rightSB 0.3] + OX
 		local right : df.rightSB - OX
@@ -62,7 +61,7 @@ glyph-block Letter-Latin-Upper-T : begin
 			include : tagged 'serifLT' : VSerif.dl xTopBarLeft  top jutTop swVJut
 		if SLAB : include [SerifFrame (top / 2 + HalfStroke) 0 left right (swRef -- sw)].rt.full
 
-	define [CyrTeMidHookShape pArc] : function [df top doTopSerifs doBottomSerifs] : glyph-proc
+	define [CyrTeMidHookShape pArc] : function [df top doTopSerifs doBottomSerif] : glyph-proc
 		local sw : df.adviceThinnerStroke 2.75
 		local left : [mix df.leftSB df.rightSB 0.3] + OX
 		local right : df.rightSB - OX
@@ -83,23 +82,23 @@ glyph-block Letter-Latin-Upper-T : begin
 			sw     -- sw
 
 		if doTopSerifs : begin
-			local { jutTop jutBot jutMid } : EFVJutLength top 0 HBarPos sw
+			local { jutTop jutBot jutMid } : EFVJutLength top 0 (HBarPos - (sw / 4 + O) / top) sw
 			local swVJut : Math.min (VJutStroke * (sw / Stroke)) : VSwToH : 0.625 * (left - xTopBarLeft)
 			include : tagged 'serifRT' : VSerif.dr xTopBarRight top jutTop swVJut
 			include : tagged 'serifLT' : VSerif.dl xTopBarLeft  top jutTop swVJut
 
-		if doBottomSerifs : begin
+		if doBottomSerif : begin
 			local jut : Math.max Jut : mix [HSwToV HalfStroke] MidJutCenter ((6 / 7) * df.adws)
-			include : intersection
+			include : tagged 'serifMB' : intersection
 				MaskLeft : mix (left + [HSwToV sw]) (right - [HSwToV sw]) 0.625
 				HSerif.mb (left + [HSwToV : 0.5 * sw]) 0 (jut - [HSwToV : 0.5 * (Stroke - sw)]) sw
 
-	define [CyrTweUpperShape df top doTopSerifs doBottomSerifs] : glyph-proc
+	define [CyrTweUpperShape df top doTopSerifs doBottomSerif] : glyph-proc
 		include : TShape df top doTopSerifs false
 		eject-contour 'strokeV'
 
-	define [CyrTallTeShape df top doTopSerifs doBottomSerifs] : glyph-proc
-		define doFullSerifs : doTopSerifs && doBottomSerifs && !para.isItalic
+	define [CyrTallTeShape df top doTopSerifs doBottomSerif] : glyph-proc
+		define doFullSerifs : doTopSerifs && doBottomSerif && !para.isItalic
 
 		local xLeft : df.leftSB + 0.75 * OX
 		local xBarRight : mix df.width df.rightSB 1.5
@@ -109,7 +108,7 @@ glyph-block Letter-Latin-Upper-T : begin
 
 		if doTopSerifs : begin
 			include : tagged 'serifLT' : VSerif.dl xLeft top VJut
-		if doBottomSerifs : begin
+		if doBottomSerif : begin
 			include : tagged 'serifMB' : if para.isItalic [HSerif.rb xBarRight 0 SideJut] : union
 				HSerif.rb (xBarRight - [HSwToV HalfStroke]) 0 Jut
 				HSerif.lb (xBarRight - [HSwToV HalfStroke]) 0 MidJutSide
@@ -175,12 +174,12 @@ glyph-block Letter-Latin-Upper-T : begin
 				jut -- [if doSB MidJutCenter Jut]
 
 		create-glyph "cyrl/TeMidHook.\(suffix)" : glyph-proc
-			local df : include : DivFrame adws
+			local df : include : DivFrame adws 3
 			include : df.markSet.capDesc
 			include : [CyrTeMidHookShape 1] df CAP doST doSB
 
 		create-glyph "cyrl/teMidHook.upright.\(suffix)" : glyph-proc
-			local df : include : DivFrame adws
+			local df : include : DivFrame adws 3
 			include : df.markSet.p
 			include : [CyrTeMidHookShape (HBarPos ** 0.3)] df XH doST doSB
 
@@ -206,22 +205,48 @@ glyph-block Letter-Latin-Upper-T : begin
 			include : CyrTweUpperShape df XH doST doSB
 			set-base-anchor 'cvDecompose' (df.width / 2) XH
 
-		create-glyph "cyrl/Tsse.\(suffix)" : glyph-proc
-			local df : include : DivFrame adws
-			include : df.markSet.capDesc
-			include : TShape df CAP doST doSB true
-			include : HalfRingDescender (df.middle - [HSwToV : 0.5 * Stroke]) 0
+		DefineSelectorGlyph "cyrl/Tsse" suffix [DivFrame adws] 'capDesc'
+		DefineSelectorGlyph "cyrl/tsse" suffix [DivFrame adws] 'p'
 
-		create-glyph "cyrl/tsse.\(suffix)" : glyph-proc
-			local df : include : DivFrame adws
-			include : df.markSet.p
-			include : TShape df XH doST doSB true
-			include : HalfRingDescender (df.middle - [HSwToV : 0.5 * Stroke]) 0
+		foreach { suffixEs { styTop styBot } } [Object.entries CConfig] : do
+			define [TsseDescenderShape df ada adb] : begin
+				local left : df.middle - [HSwToV HalfStroke]
+				local left0 : left - SB
+				local sl : [mix left0 left 0.5] + O * 2
+				local sr : mix sl (left0 + [mix RightSB SB : StrokeWidthBlend 0.95 0.96]) 2
+				local subDf : DivFrame (((sr - sl) + 2 * SB) / Width) 2.5 1.0
+				local st : 0 + subDf.mvs
+				local sb : 0 - (LongVJut - QuarterStroke) - 0.5 * subDf.mvs
+				local p : (st - sb) / (XH - 0)
+				local es : CLetterForm subDf 3 styBot st sb
+					hook   -- (Hook * p)
+					sw     -- subDf.mvs
+					ada    -- (ada * p)
+					adb    -- (adb * p)
+				return : difference
+					with-transform [ApparentTranslate (sl - subDf.leftSB) 0] [es.full]
+					intersection [MaskAbove O] [MaskRight df.middle]
+
+			if (!styTop) : begin
+				create-glyph "cyrl/Tsse.\(suffix).\(suffixEs)" : glyph-proc
+					set-width 0
+					set-mark-anchor 'cvDecompose' 0 0
+					include : TShape [DivFrame adws] CAP doST doSB true
+					include : TsseDescenderShape [DivFrame adws] ArchDepthA ArchDepthB
+
+				create-glyph "cyrl/tsse.\(suffix).\(suffixEs)" : glyph-proc
+					set-width 0
+					set-mark-anchor 'cvDecompose' 0 0
+					include : TShape [DivFrame adws] XH doST doSB true
+					include : TsseDescenderShape [DivFrame adws] SmallArchDepthA SmallArchDepthB
+
+		select-variant "cyrl/Tsse.\(suffix)" (follow -- 'C/bottomSerif')
+		select-variant "cyrl/tsse.\(suffix)" (follow -- 'c/bottomSerif')
 
 		create-glyph "currency/tengeSign.\(suffix)" : glyph-proc
 			local df : include : DivFrame adws
 			include : df.markSet.capital
-			local gap : Math.max (CAP * 0.1) HalfStroke
+			local gap : Math.max HalfStroke : 0.1 * (CAP - 0)
 			include : HBar.t [TLeftX df] [TRightX df] CAP OverlayStroke
 			include : TShape df (CAP - OverlayStroke - gap) doST doSB
 
@@ -262,8 +287,8 @@ glyph-block Letter-Latin-Upper-T : begin
 	derive-composites 'cyrl/Twe' 0xA68C 'cyrl/Twe/upper' 'cyrl/Twe/middle'
 	derive-composites 'cyrl/twe' 0xA68D 'cyrl/twe/upper' 'cyrl/twe/middle'
 
-	select-variant 'cyrl/Tsse' 0xA690 (follow -- 'T')
-	select-variant 'cyrl/tsse' 0xA691 (follow -- 'T')
+	CreateSelectorVariants 'cyrl/Tsse' 0xA690 [Object.keys TConfig] (follow -- 'T')
+	CreateSelectorVariants 'cyrl/tsse' 0xA691 [Object.keys TConfig] (follow -- 'T')
 
 	select-variant 'currency/tengeSign' 0x20B8 (follow -- 'T')
 
@@ -288,7 +313,7 @@ glyph-block Letter-Latin-Upper-T : begin
 			include : tagged 'serifRB' : VSerif.ur r 0   VJut swVJut
 			include : tagged 'serifLB' : VSerif.ul l 0   VJut swVJut
 
-	define [SampiShape df top bottom doTopSerifs doBottomSerifs] : glyph-proc
+	define [SampiShape df top bottom doTopSerifs doBottomSerif] : glyph-proc
 		define kSampiDepth 0.45
 
 		local l : TLeftX  df
@@ -301,7 +326,7 @@ glyph-block Letter-Latin-Upper-T : begin
 		include : VBar.l l top [mix (top - Stroke) bottom kSampiDepth] swVJut
 		include : VBar.r r top [mix (top - Stroke) bottom kSampiDepth] swVJut
 
-		if doBottomSerifs : include : HSerif.mb df.middle bottom MidJutCenter
+		if doBottomSerif : include : HSerif.mb df.middle bottom MidJutCenter
 
 	create-glyph 'grek/SampiArchaic' 0x372 : glyph-proc
 		local df : include : DivFrame para.advanceScaleT

--- a/packages/font-glyphs/src/letter/latin/upper-t.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-t.ptl
@@ -210,21 +210,20 @@ glyph-block Letter-Latin-Upper-T : begin
 
 		foreach { suffixEs { styTop styBot } } [Object.entries CConfig] : do
 			define [TsseDescenderShape df ada adb] : begin
-				local left : df.middle - [HSwToV HalfStroke]
-				local left0 : left - SB
-				local sl : [mix left0 left 0.5] + O * 2
-				local sr : mix sl (left0 + [mix RightSB SB : StrokeWidthBlend 0.95 0.96]) 2
-				local subDf : DivFrame (((sr - sl) + 2 * SB) / Width) 2.5 1.0
-				local st : 0 + subDf.mvs
-				local sb : 0 - (LongVJut - QuarterStroke) - 0.5 * subDf.mvs
-				local p : (st - sb) / (XH - 0)
-				local es : CLetterForm subDf 3 styBot st sb
+				local teLeft : df.middle - [HSwToV HalfStroke]
+				local esLeft : teLeft - 0.5 * (SB - 0) + O * 2 - (RightSB - SB) * [StrokeWidthBlend 0.05 0.06]
+				local esRight : mix esLeft teLeft 2
+				local subDf : DivFrame (((esRight - esLeft) + 2 * SB) / Width) 2.5 1.0
+				local esTop : 0 + subDf.mvs
+				local esBot : 0 - (LongVJut - QuarterStroke) - 0.5 * subDf.mvs
+				local p : (esTop - esBot) / (XH - 0)
+				local es : CLetterForm subDf 3 styBot esTop esBot
 					hook   -- (Hook * p)
 					sw     -- subDf.mvs
 					ada    -- (ada * p)
 					adb    -- (adb * p)
 				return : difference
-					with-transform [ApparentTranslate (sl - subDf.leftSB) 0] [es.full]
+					with-transform [ApparentTranslate (esLeft - subDf.leftSB) 0] [es.full]
 					intersection [MaskAbove O] [MaskRight df.middle]
 
 			if (!styTop) : begin

--- a/packages/font-glyphs/src/letter/shared.ptl
+++ b/packages/font-glyphs/src/letter/shared.ptl
@@ -1217,20 +1217,6 @@ glyph-block Letter-Shared-Shapes : begin
 					sw     -- sw
 					yExtension -- [Math.max 0 : yAttach + yOverflow - y + (fullDepth - TailY)]
 
-		# Half-circle hook, used by Tsse
-		glyph-block-export HalfRingDescender
-		define [HalfRingDescender x y] : glyph-proc
-			local sw : Math.min (0.5 * (0 - Descender)) [AdviceStroke 3]
-			local r : (sw - Descender) / 2
-			include : lift-@ : dispiro
-				widths.lhs sw
-				g4.left.start x (@yT = y + sw) [heading Leftward]
-				archv
-				g4.down.mid (x - r) [mix @yT @yB 0.5] [heading Downward]
-				arcvh
-				flat x (@yB = y + sw - 2 * r) [heading Rightward]
-				curl (x + [HSwToV Stroke]) @yB
-
 		# Cyrillic "Middle Hook" Characters
 		glyph-block-export MidHook
 		define MidHook : namespace


### PR DESCRIPTION
### Motivation and Context

The "half ring descender" is actually [a _very small_ Cyrillic Es (`С`, `с`)](https://www.unicode.org/L2/L2007/07003r-n3194r-cyrillic.pdf#page=6), which is analogous to the construction of Cyrillic Dzze (`Ꚉ`, `ꚉ`).

### Influenced Characters

  - CYRILLIC CAPITAL LETTER TSSE (`U+A690`).
  - CYRILLIC SMALL LETTER TSSE (`U+A691`).

### Glyph Quantity

2 * (3 * (3 - 1)) = +12 new glyphs, accounting for how the half-ring shape corresponds to `c.serifless`.

### Samples

`ДдꚈꚉТтꚐꚑ`

Sans Monospace Before:
<img width="1285" height="1087" alt="image" src="https://github.com/user-attachments/assets/e6204ff2-9d20-4503-8604-e433fdda192a" />
Sans Monospace After:
<img width="1290" height="1084" alt="image" src="https://github.com/user-attachments/assets/b6e7bad5-92b1-44aa-b59b-c05b3d97b5f6" />
Slab Monospace Before:
<img width="1287" height="1085" alt="image" src="https://github.com/user-attachments/assets/2fbe6fcb-3f2b-49ee-92ff-a2b04e5aed00" />
Slab Monospace After:
<img width="1292" height="1074" alt="image" src="https://github.com/user-attachments/assets/01b0464c-48a0-4323-99f7-c02171ceaac9" />
Aile Before:
<img width="1586" height="1084" alt="image" src="https://github.com/user-attachments/assets/0ab4fec3-e6a3-4de3-9d67-b88e90a84ac6" />
Aile After:
<img width="1591" height="1089" alt="image" src="https://github.com/user-attachments/assets/7ace5fa7-5b0e-4d35-81d7-b0205b177591" />
Etoile Before:
<img width="1677" height="1095" alt="image" src="https://github.com/user-attachments/assets/0eee3d36-7324-4792-b3e9-524d9dd90865" />
Etoile After:
<img width="1654" height="1082" alt="image" src="https://github.com/user-attachments/assets/fdb5174f-8982-4797-b420-dc3cec81ce45" />

