### PR TITLE
Optimize x-overshoot for `С`⁠/⁠`с`-part of Cyrillic Upper⁠/⁠Lower Tsse (`Ꚑ`, `ꚑ`).

### DIFF
--- a/packages/font-glyphs/src/letter/latin/c.ptl
+++ b/packages/font-glyphs/src/letter/latin/c.ptl
@@ -25,53 +25,53 @@ glyph-block Letter-Latin-C : begin
 	define FLAT-CONNECTION 3
 
 	glyph-block-export CShapeT
-	define [CShapeT sink offset df st sb top bot ada adb hook sw origBar] : sink
+	define [CShapeT sink offset df st sb top bot ada adb hook sw origBar ox oy] : sink
 		widths.lhs sw
 		match st
-			[Just SLAB-CLASSICAL] : SerifedArcStart.RtlLhs (df.rightSB - offset) top sw [fallback hook Hook] origBar
-			[Just SLAB-INWARD] : InwardSlabArcStart.RtlLhs (df.rightSB - offset) top sw [fallback hook Hook] origBar
+			[Just SLAB-CLASSICAL] : SerifedArcStart.RtlLhs (df.rightSB - offset) top sw [fallback hook Hook] origBar (o -- oy)
+			[Just SLAB-INWARD] : InwardSlabArcStart.RtlLhs (df.rightSB - offset) top sw [fallback hook Hook] origBar (o -- oy)
 			[Just FLAT-CONNECTION] : list
 				flat (df.width - offset) (top - offset)
 				curl [Arch.adjust-x.top df.middle (sw -- sw)] (top - offset)
 				archv
 			__ : list
-				g4 (df.rightSB - offset) (top - [fallback hook Hook])
-				HookStart (top - offset) (sw -- sw)
-		flatside.ld (df.leftSB + offset) bot top ada adb
+				g4   (df.rightSB - offset) (top - [fallback hook Hook])
+				HookStart (top - offset) (sw -- sw) (o -- oy)
+		flatside.ld (df.leftSB + offset) bot top ada adb ox
 		match sb
-			[Just SLAB-CLASSICAL] : SerifedArcEnd.LtrLhs (df.rightSB - offset) bot sw [fallback hook Hook] origBar
-			[Just SLAB-INWARD] : InwardSlabArcEnd.LtrLhs (df.rightSB - offset) bot sw [fallback hook Hook] origBar
+			[Just SLAB-CLASSICAL] : SerifedArcEnd.LtrLhs (df.rightSB - offset) bot sw [fallback hook Hook] origBar (o -- oy)
+			[Just SLAB-INWARD] : InwardSlabArcEnd.LtrLhs (df.rightSB - offset) bot sw [fallback hook Hook] origBar (o -- oy)
 			[Just FLAT-CONNECTION] : list
 				arcvh
 				flat [Arch.adjust-x.bot df.middle (sw -- sw)] (bot + offset)
 				curl (df.width - offset) (bot + offset)
 			__ : list
-				HookEnd (bot + offset) (sw -- sw)
-				g4 (df.rightSB - offset) (bot + [fallback hook Hook])
+				HookEnd (bot + offset) (sw -- sw) (o -- oy)
+				g4   (df.rightSB - offset) (bot + [fallback hook Hook])
 
-	define [RevCShapeT sink offset df st sb top bot ada adb hook sw origBar] : sink
+	define [RevCShapeT sink offset df st sb top bot ada adb hook sw origBar ox oy] : sink
 		widths.rhs sw
 		match st
-			[Just SLAB-CLASSICAL] : SerifedArcStart.LtrRhs (df.leftSB + offset) top sw [fallback hook Hook] origBar
-			[Just SLAB-INWARD] : InwardSlabArcStart.LtrRhs (df.leftSB + offset) top sw [fallback hook Hook] origBar
+			[Just SLAB-CLASSICAL] : SerifedArcStart.LtrRhs (df.leftSB + offset) top sw [fallback hook Hook] origBar (o -- oy)
+			[Just SLAB-INWARD] : InwardSlabArcStart.LtrRhs (df.leftSB + offset) top sw [fallback hook Hook] origBar (o -- oy)
 			[Just FLAT-CONNECTION] : list
 				flat (0 + offset) (top - offset)
 				curl [Arch.adjust-x.top df.middle (sw -- sw)] (top - offset)
 				archv
 			__ : list
-				g4 (df.leftSB + offset) (top - [fallback hook Hook])
-				HookStart (top - offset) (sw -- sw)
-		flatside.rd (df.rightSB - offset) bot top ada adb
+				g4   (df.leftSB + offset) (top - [fallback hook Hook])
+				HookStart (top - offset) (sw -- sw) (o -- oy)
+		flatside.rd (df.rightSB - offset) bot top ada adb ox
 		match sb
-			[Just SLAB-CLASSICAL] : SerifedArcEnd.RtlRhs (df.leftSB + offset) bot sw [fallback hook Hook]
-			[Just SLAB-INWARD] : InwardSlabArcEnd.RtlRhs (df.leftSB + offset) bot sw [fallback hook Hook]
+			[Just SLAB-CLASSICAL] : SerifedArcEnd.RtlRhs (df.leftSB + offset) bot sw [fallback hook Hook] origBar (o -- oy)
+			[Just SLAB-INWARD] : InwardSlabArcEnd.RtlRhs (df.leftSB + offset) bot sw [fallback hook Hook] origBar (o -- oy)
 			[Just FLAT-CONNECTION] : list
 				arcvh
 				flat [Arch.adjust-x.bot df.middle (sw -- sw)] (bot + offset)
 				curl (0 + offset) (bot + offset)
 			__ : list
-				HookEnd (bot + offset) (sw -- sw)
-				g4 (df.leftSB + offset) (bot + [fallback hook Hook])
+				HookEnd (bot + offset) (sw -- sw) (o -- oy)
+				g4   (df.leftSB + offset) (bot + [fallback hook Hook])
 
 	define [AutoStartSerifR df sty top hook sw] : match sty
 		[Just SLAB-CLASSICAL] : ArcStartSerif.R       df.rightSB top [fallback sw Stroke] [fallback hook Hook]
@@ -107,20 +107,20 @@ glyph-block Letter-Latin-C : begin
 			CurlyTail.n fine bot df.rightSB 0 bot (yLoopTop -- loopTop)
 
 	glyph-block-export CLetterForm
-	define [CLetterForm] : with-params [df sty styBot top bot [ada ArchDepthA] [adb ArchDepthB] [hook Hook] [sw Stroke] [ob nothing]] : namespace
-		export : define [base] : CShapeT dispiro 0 df sty styBot top bot ada adb hook sw ob
+	define [CLetterForm] : with-params [df sty styBot top bot [ada ArchDepthA] [adb ArchDepthB] [hook Hook] [sw Stroke] [ob nothing] [ox nothing] [oy nothing]] : namespace
+		export : define [base] : CShapeT dispiro 0 df sty styBot top bot ada adb hook sw ob ox oy
 		export : define [topSerif] : AutoStartSerifR  df sty    top hook sw
 		export : define [botSerif] : AutoStartSerifRB df styBot bot hook sw
 
-		export : define [revBase] : RevCShapeT dispiro 0 df sty styBot top bot ada adb hook sw ob
+		export : define [revBase] : RevCShapeT dispiro 0 df sty styBot top bot ada adb hook sw ob ox oy
 		export : define [revTopSerif] : AutoStartSerifL  df sty    top hook sw
 		export : define [revBotSerif] : AutoStartSerifLB df styBot bot hook sw
 
 		export : define [hookTop] : TopHook.toRight.arcStart df.rightSB top hook (refSw -- sw)
 
 		# Used by Cyrillic Koppa
-		export : define [baseTopOnly] : CShapeT dispiro 0 df sty SLAB-NONE                  top bot ada adb hook sw ob
-		export : define [descBase]    : CShapeT dispiro 0 df sty (styBot || SLAB-CLASSICAL) top bot ada adb hook sw ob
+		export : define [baseTopOnly] : CShapeT dispiro 0 df sty SLAB-NONE                  top bot ada adb hook sw ob ox oy
+		export : define [descBase]    : CShapeT dispiro 0 df sty (styBot || SLAB-CLASSICAL) top bot ada adb hook sw ob ox oy
 
 		export : define [full]    : composite-proc [base]    [topSerif]    [botSerif]
 		export : define [revFull] : composite-proc [revBase] [revTopSerif] [revBotSerif]

--- a/packages/font-glyphs/src/letter/latin/upper-t.ptl
+++ b/packages/font-glyphs/src/letter/latin/upper-t.ptl
@@ -55,7 +55,7 @@ glyph-block Letter-Latin-Upper-T : begin
 			sw     -- sw
 
 		if doTopSerifs : begin
-			local { jutTop jutBot jutMid } : EFVJutLength top 0 0.5 sw
+			local { jutTop jutBot jutMid } : EFVJutLength top 0 (0.5 - (sw / 2 - HalfStroke) / top) sw
 			local swVJut : Math.min (VJutStroke * (sw / Stroke)) : VSwToH : 0.625 * (left - xTopBarLeft)
 			include : tagged 'serifRT' : VSerif.dr xTopBarRight top jutTop swVJut
 			include : tagged 'serifLT' : VSerif.dl xTopBarLeft  top jutTop swVJut
@@ -220,6 +220,7 @@ glyph-block Letter-Latin-Upper-T : begin
 				local es : CLetterForm subDf 3 styBot esTop esBot
 					hook   -- (Hook * p)
 					sw     -- subDf.mvs
+					ox     -- (0.5 * O)
 					ada    -- (ada * p)
 					adb    -- (adb * p)
 				return : difference


### PR DESCRIPTION
### Motivation and Context

This makes the horizontal overshoot of the `С`⁠/⁠`с`-part of Cyrillic Upper⁠/⁠Lower Tsse (`Ꚑ`, `ꚑ`) match that of Cyrillic Upper⁠/⁠Lower Dzze (`Ꚉ`, `ꚉ`).

### Influenced Characters

  - CYRILLIC CAPITAL LETTER TSSE (`U+A690`).
  - CYRILLIC SMALL LETTER TSSE (`U+A691`).

### Glyph Quantity

N/A (Zero new glyphs since 6bbdfc2cd )

### Samples

The "before" samples below are duplicated from the "after" samples in #3262 .

`ДдꚈꚉТтꚐꚑ`

Sans Monospace Before:
<img width="1290" height="1084" alt="image" src="https://github.com/user-attachments/assets/b6e7bad5-92b1-44aa-b59b-c05b3d97b5f6" />
Sans Monospace After:
<img width="1286" height="1080" alt="image" src="https://github.com/user-attachments/assets/bb968436-8c3f-40d3-96e1-cded7d777f22" />

Slab Monospace Before:
<img width="1292" height="1074" alt="image" src="https://github.com/user-attachments/assets/01b0464c-48a0-4323-99f7-c02171ceaac9" />
Slab Monospace After:
<img width="1292" height="1090" alt="image" src="https://github.com/user-attachments/assets/6517cfe9-c39a-49b9-a94c-b037ba2a8a1d" />

Aile Before:
<img width="1591" height="1089" alt="image" src="https://github.com/user-attachments/assets/7ace5fa7-5b0e-4d35-81d7-b0205b177591" />
Aile After:
<img width="1601" height="1118" alt="image" src="https://github.com/user-attachments/assets/bcdc9059-c1a8-4e1e-879f-fbca92c86a10" />

Etoile Before:
<img width="1654" height="1082" alt="image" src="https://github.com/user-attachments/assets/fdb5174f-8982-4797-b420-dc3cec81ce45" />
Etoile After:
<img width="1664" height="1083" alt="image" src="https://github.com/user-attachments/assets/7abe1477-424e-4104-901a-580578b9b56f" />
