### PR TITLE
Allow `fPalatalHook` (`ᶂ`) to respond to tailed/descending variants of `f`.

### DIFF
--- a/packages/font-glyphs/src/letter/latin/lower-f.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-f.ptl
@@ -95,10 +95,10 @@ glyph-block Letter-Latin-Lower-F : begin
 
 		include : match counterHook
 			[Just CH-NONE]          : SetPalatalHookPos barLeft
+			[Just CH-SERIF]         : SmallFBottomSerif df
 			[Just CH-EXTENSION]     : SmallFDownExtension barLeft
 			[Just CH-HOOK]          : SmallFDownHook df barRight [Math.max SB : barRight - (crossRight - barLeft)]
 			[Just CH-DIAGONAL-HOOK] : SmallFDiagonalTail df barLeft
-			[Just CH-SERIF]         : SmallFBottomSerif df
 
 	define [NarrowStdFShapeT sink df offset barleft sw] : begin
 		local pAdaptive : if (para.advanceScaleF < 1) ((1 - df.adws) / (1 - para.advanceScaleF)) 0
@@ -135,10 +135,10 @@ glyph-block Letter-Latin-Lower-F : begin
 
 		include : match counterHook
 			[Just CH-NONE]          : SetPalatalHookPos barLeft
+			[Just CH-SERIF]         : SmallFBottomSerif df
 			[Just CH-EXTENSION]     : SmallFDownExtension barLeft
 			[Just CH-HOOK]          : SmallFDownHook df barRight [Math.max df.leftSB : barRight - 0.75 * (crossRight - barLeft)]
 			[Just CH-DIAGONAL-HOOK] : SmallFDiagonalTail df barLeft
-			[Just CH-SERIF]         : SmallFBottomSerif df
 
 	define [NarrowFShape clcStyle] : function [df m bh counterHook] : glyph-proc
 		local topHookExt : match clcStyle
@@ -179,10 +179,10 @@ glyph-block Letter-Latin-Lower-F : begin
 
 		include : match counterHook
 			[Just CH-NONE]          : SetPalatalHookPos barLeft
+			[Just CH-SERIF]         : NarrowBottomSerif df
 			[Just CH-EXTENSION]     : SmallFDownExtension barLeft
 			[Just CH-HOOK]          : SmallFDownHook df barRight (barRight - (crossRight - barLeft))
 			[Just CH-DIAGONAL-HOOK] : SmallFDiagonalTail df barLeft
-			[Just CH-SERIF]         : NarrowBottomSerif df
 
 	define SmallFConfig : SuffixCfg.weave
 		object # body
@@ -213,20 +213,23 @@ glyph-block Letter-Latin-Lower-F : begin
 
 		create-glyph "fPalatalHook.\(suffix)" : glyph-proc
 			include [refer-glyph "f.\(suffix)"] AS_BASE ALSO_METRICS
-			if currentGlyph.baseAnchors.palatalHookPos : begin
-				local attach : currentGlyph.gizmo.unapply currentGlyph.baseAnchors.overlay
-				local pos    : currentGlyph.gizmo.unapply currentGlyph.baseAnchors.palatalHookPos
-				local gap : Math.max (Width / 8) [AdviceStroke 8]
-				include : PalatalHook.r
-					xLink -- attach.x
-					x -- pos.x
-					y -- pos.y
+			local attach : currentGlyph.gizmo.unapply          currentGlyph.baseAnchors.overlay
+			local pos    : currentGlyph.gizmo.unapplyIfPresent currentGlyph.baseAnchors.palatalHookPos
+			include : PalatalHook.r
+				xLink   -- attach.x
+				x       -- [if pos pos.x : attach.x + (RightSB - SB) / 2]
+				y       -- [if pos pos.y 0]
+				refSw   -- [AdviceStroke : if pos 2 3]
+				maskOut -- [if pos [no-shape] [intersection [MaskBelow 0] [MaskLeft : attach.x + [HSwToV HalfStroke]]]]
 
 	select-variant 'f' 'f'
 	link-reduced-variant 'f/sansSerif' 'f' MathSansSerif
-	select-variant 'fHookBottom'  0x192  (shapeFrom -- 'f')
-	select-variant 'fPalatalHook' 0x1D82 (follow -- 'fLenis')
-	select-variant 'fLenis'       0xAB35 (shapeFrom -- 'f')
+	select-variant 'fHookBottom' 0x192  (shapeFrom -- 'f')
+	select-variant 'fLenis'      0xAB35 (shapeFrom -- 'f')
+
+	select-variant 'fPalatalHook' 0x1D82 (follow -- 'f')
+	select-variant 'fLenisPalatalHook'   (follow -- 'fLenis') (shapeFrom -- 'fPalatalHook')
+
 	select-variant 'f/phoneticLeft' (shapeFrom -- 'f')
 	select-variant 'f/compLigLeft1' (shapeFrom -- 'f')
 	select-variant 'f/compLigLeft2' (shapeFrom -- 'f')

--- a/packages/font-glyphs/src/orthography/index.ptl
+++ b/packages/font-glyphs/src/orthography/index.ptl
@@ -65,6 +65,7 @@ glyph-block Orthography : begin
 	link-gr LocalizedForm.IPPH 'dStroke'             'dBar'
 	link-gr LocalizedForm.IPPH 'f'                   'fLenis'
 	link-gr LocalizedForm.IPPH 'fTildeOver'          'fLenisTildeOver'
+	link-gr LocalizedForm.IPPH 'fPalatalHook'        'fLenisPalatalHook'
 	link-gr LocalizedForm.IPPH 'fDot'                'fLenisDot'
 	link-gr LocalizedForm.IPPH 'g'                   'g/doubleStorey'
 	link-gr LocalizedForm.IPPH 'gCircumflex'         'gCircumflex/doubleStorey'


### PR DESCRIPTION
### Motivation and Context

Basically allowing all variants of `f` for `fPalatalHook` (`ᶂ`), unless under an IPA locale (`'IPPH'`).

### Influenced Characters

  - LATIN SMALL LETTER F WITH PALATAL HOOK (`U+1D82`).

### Glyph Quantity

+3 glyphs now accessible in the font, although they existed internally and inaccessible before.

### Samples

In the screenshots below, `IPPH` is equivalent to "before", and `DFLT` is equivalent to "after".

`aȧfḟᵮᶂgġ`

Sans Monospace:
<img width="1599" height="1128" alt="image" src="https://github.com/user-attachments/assets/cb57b118-be75-4d7a-82da-3fddae1ffc63" />
Slab Monospace:
<img width="1608" height="1131" alt="image" src="https://github.com/user-attachments/assets/99ffb68b-3821-413a-be94-6ec3d13748eb" />
Aile (unchanged; Included for the sake of completion):
<img width="1736" height="1125" alt="image" src="https://github.com/user-attachments/assets/447b96cd-9ee4-4f3a-a2ae-19bbfd7e2015" />
Etoile:
<img width="1754" height="1122" alt="image" src="https://github.com/user-attachments/assets/85a64047-88a1-46b2-a22d-c2c39bc238fb" />

