### PR TITLE
Improve `single-storey` glyphs for Latin Lower G with Stroke (`ǥ`).

### DIFF
--- a/changes/34.8.1.md
+++ b/changes/34.8.1.md
@@ -1,4 +1,5 @@
 * Refine shape of the following characters:
+  - LATIN SMALL LETTER G WITH STROKE (`U+01E5`).
   - COMBINING SEAGULL BELOW (`U+033C`).
   - COMBINING SEAGULL ABOVE (`U+1AE5`).
   - CYRILLIC CAPITAL LETTER TSSE (`U+A690`).

--- a/packages/font-glyphs/src/letter/latin/lower-a.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-a.ptl
@@ -48,7 +48,7 @@ glyph-block Letter-Latin-Lower-A : begin
 						list
 							g4 df.leftSB (XH - AHook)
 							HookStart XH (sw -- stroke)
-				flat (df.rightSB - [HSwToV : stroke - [fallback fine stroke]]) [Math.max (XH - [ADoubleStoreySmoothB df]) (y0 + TINY)] [if fine [widths.rhs fine] nothing]
+				flat (df.rightSB - [HSwToV : stroke - [fallback fine stroke]]) [Math.max (XH - [ADoubleStoreySmoothB df]) (y0 + TINY + [HSwToV : Math.abs : TanSlope * [fallback fine stroke]])] [if fine [widths.rhs fine] nothing]
 				[if isMask corner curl] (df.rightSB - [HSwToV : stroke - [fallback fine stroke]]) y0 [heading Downward]
 				if isMask { [corner df.leftSB y0] } {}
 
@@ -115,8 +115,8 @@ glyph-block Letter-Latin-Lower-A : begin
 			begin [SerifFrame.fromDf df XH 0 (swRef -- [fallback _sw : ADoubleStoreyStroke df]) (swSerif -- df.mvs)].rb.outer
 
 		export : define [Tailed df hookStyle _sw] : union
-			HookAndBar df hookStyle (XH - [ADoubleStoreySmoothB df] + O) _sw
-			Arc        df 0         0                                    _sw
+			HookAndBar df hookStyle [ADoubleStoreySmoothA df] _sw
+			Arc        df 0         0                         _sw
 			RightwardTailedBar df.rightSB 0 (XH - [ADoubleStoreySmoothB df]) [fallback _sw : ADoubleStoreyStroke df]
 
 		export : define [FlatBottomSerifless df hookStyle _sw] : union

--- a/packages/font-glyphs/src/letter/latin/lower-a.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-a.ptl
@@ -142,15 +142,6 @@ glyph-block Letter-Latin-Lower-A : begin
 			[Just ToothlessRounded]    : ArcMask df 2 [ADoubleStoreySmoothA df] _sw
 			__                         : ArcMask df 0 0                         _sw
 
-	define [OverlayW bw] : glyph-proc
-		define l : mix 0     SB      0.3
-		define r : mix Width RightSB 0.3
-		local y : mix 0 XH 0.5
-		include : dispiro
-			widths.center bw
-			flat l y
-			curl r y
-
 	glyph-block-export DoubleStoreyConfig
 	define DoubleStoreyConfig : object
 		doubleStoreySerifless                            { DoubleStorey.Serifless           RightSB            HOOK-SLAB-NONE   }
@@ -358,9 +349,6 @@ glyph-block Letter-Latin-Lower-A : begin
 			include [refer-glyph "a.\(suffix)"] AS_BASE ALSO_METRICS
 			eject-contour 'serifRB'
 			include : RetroflexHook.rSideJut RightSB 0 (yOverflow -- Stroke)
-		create-glyph "aBar.\(suffix)" : glyph-proc
-			include [refer-glyph "a.\(suffix)"] AS_BASE ALSO_METRICS
-			include : OverlayW [Math.min OverlayStroke : AdviceStroke2 2 3 XH]
 
 	select-variant 'a' 'a'
 	link-reduced-variant 'a/sansSerif' 'a' MathSansSerif
@@ -379,8 +367,6 @@ glyph-block Letter-Latin-Lower-A : begin
 	select-variant 'aScript' 0x251  (follow -- [conditional-follow SLAB 'a/singleStorey/autoSerifed/slab' 'a/singleStorey/autoSerifed/sans']) (shapeFrom -- 'a')
 
 	select-variant 'aScriptRetroflexHook' 0x1D90 (follow -- [conditional-follow SLAB 'aRetroflexHook/singleStorey/autoSerifed/slab' 'aRetroflexHook/singleStorey/autoSerifed/sans']) (shapeFrom -- 'aRetroflexHook')
-
-	select-variant 'aScriptBar' 0xAB30 (follow -- [conditional-follow SLAB 'a/singleStorey/autoSerifed/slab' 'a/singleStorey/autoSerifed/sans']) (shapeFrom -- 'aBar')
 
 	CreateTurnedLetter 'turnAScript' 0x2C70 'AScript' HalfAdvance (CAP / 2)
 	CreateTurnedLetter 'turnaScript' 0x252  'aScript' HalfAdvance (XH / 2)

--- a/packages/font-glyphs/src/letter/latin/lower-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-g.ptl
@@ -220,7 +220,9 @@ glyph-block Letter-Latin-Lower-G : begin
 
 		create-glyph "gStroke.\(suffix)" : glyph-proc
 			include [refer-glyph "g.\(suffix)"] AS_BASE ALSO_METRICS
-			include : OverlayW [Math.min OverlayStroke : 0.625 * (O - hookEnd)]
+			include : HOverlayBar Middle [mix Width RightSB 0.3]
+				mix 0 (Descender + Stroke) 0.5
+				Math.min OverlayStroke : 0.625 * (0 - (Descender + Stroke))
 
 		create-glyph "gPalatalHook.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleM 1

--- a/packages/font-glyphs/src/letter/latin/lower-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-g.ptl
@@ -10,7 +10,7 @@ glyph-block Letter-Latin-Lower-G : begin
 	glyph-block-import Common-Derivatives
 	glyph-block-import Mark-Adjustment : ExtendAboveBaseAnchors LeaningAnchor
 	glyph-block-import Letter-Shared : CreateAccentedComposition CreateTurnedLetter
-	glyph-block-import Letter-Shared-Shapes : OBarRight FlatHookDepth
+	glyph-block-import Letter-Shared-Shapes : LetterBarOverlay OBarRight FlatHookDepth
 	glyph-block-import Letter-Shared-Shapes : CurlyTail PalatalHook TopHook
 
 	define [OverlayW bw] : glyph-proc
@@ -220,9 +220,7 @@ glyph-block Letter-Latin-Lower-G : begin
 
 		create-glyph "gStroke.\(suffix)" : glyph-proc
 			include [refer-glyph "g.\(suffix)"] AS_BASE ALSO_METRICS
-			include : HOverlayBar Middle [mix Width RightSB 0.3]
-				mix 0 (Descender + Stroke) 0.5
-				Math.min OverlayStroke : 0.625 * (0 - (Descender + Stroke))
+			include : LetterBarOverlay.r.in RightSB (Descender + Stroke) 0
 
 		create-glyph "gPalatalHook.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleM 1

--- a/packages/font-glyphs/src/letter/latin/lower-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-g.ptl
@@ -189,8 +189,8 @@ glyph-block Letter-Latin-Lower-G : begin
 
 	define SingleStoreyConfig : SuffixCfg.weave
 		object # hook
-			singleStoreyBentHook  { SingleStorey.BentHook             (Descender + SHook)    }
-			singleStoreyFlatHook  { SingleStorey.FlatHook             (Descender + Stroke)   }
+			singleStoreyBentHook  { SingleStorey.BentHook             SHook                  }
+			singleStoreyFlatHook  { SingleStorey.FlatHook             0                      }
 		object # ear/serif
 			serifless             { SingleStorey.SeriflessBody        0                      }
 			serifed               { SingleStorey.SerifedBody          0                      }
@@ -205,7 +205,7 @@ glyph-block Letter-Latin-Lower-G : begin
 		create-glyph "g.\(suffix)" : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.p
-			set-base-anchor 'overlay' df.middle [mix O hookEnd 0.5]
+			set-base-anchor 'overlay' df.middle [mix O (Descender + [Math.max hookEnd df.mvs]) 0.5]
 			set-base-anchor 'strike'  df.middle (XH / 2)
 			include : bodyShape df  XH
 			include : hookShape df (XH - hookStart)
@@ -213,20 +213,24 @@ glyph-block Letter-Latin-Lower-G : begin
 		create-glyph "gCap.\(suffix)" : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.capDesc
-			set-base-anchor 'overlay' df.middle [mix O hookEnd 0.5]
+			set-base-anchor 'overlay' df.middle [mix O (Descender + [Math.max hookEnd df.mvs]) 0.5]
 			set-base-anchor 'strike'  df.middle (CAP / 2)
 			include : bodyShape df  CAP              ArchDepthA ArchDepthB
 			include : hookShape df (CAP - hookStart) ArchDepthA ArchDepthB
 
 		create-glyph "gStroke.\(suffix)" : glyph-proc
 			include [refer-glyph "g.\(suffix)"] AS_BASE ALSO_METRICS
-			include : LetterBarOverlay.r.in RightSB (Descender + Stroke) 0
+			include : LetterBarOverlay.r.in
+				x     -- RightSB
+				top   -- 0
+				bot   -- (Descender + Stroke)
+				space -- { [if hookEnd (SB + [HSwToV Stroke]) 0] Width }
 
 		create-glyph "gPalatalHook.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleM 1
 			include : df.markSet.p
 			local subDf : DivFrame (0.75 * para.advanceScaleM) 2
-			set-base-anchor 'overlay' subDf.middle [mix O hookEnd 0.5]
+			set-base-anchor 'overlay' subDf.middle [mix O (Descender + [Math.max hookEnd subDf.mvs]) 0.5]
 			set-base-anchor 'strike'  subDf.middle (XH / 2)
 			include : bodyShape subDf  XH
 			include : hookShape subDf (XH - hookStart)
@@ -240,7 +244,7 @@ glyph-block Letter-Latin-Lower-G : begin
 		create-glyph "gCrossedTail.\(suffix)" : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.p
-			set-base-anchor 'overlay' df.middle [mix O hookEnd 0.5]
+			set-base-anchor 'overlay' df.middle [mix O (Descender + [Math.max hookEnd df.mvs]) 0.5]
 			set-base-anchor 'strike'  df.middle (XH / 2)
 			include : bodyShape                df  XH
 			include : SingleStorey.CrossedHook df (XH - hookStart)

--- a/packages/font-glyphs/src/letter/latin/lower-g.ptl
+++ b/packages/font-glyphs/src/letter/latin/lower-g.ptl
@@ -189,8 +189,8 @@ glyph-block Letter-Latin-Lower-G : begin
 
 	define SingleStoreyConfig : SuffixCfg.weave
 		object # hook
-			singleStoreyBentHook    SingleStorey.BentHook
-			singleStoreyFlatHook    SingleStorey.FlatHook
+			singleStoreyBentHook  { SingleStorey.BentHook             (Descender + SHook)    }
+			singleStoreyFlatHook  { SingleStorey.FlatHook             (Descender + Stroke)   }
 		object # ear/serif
 			serifless             { SingleStorey.SeriflessBody        0                      }
 			serifed               { SingleStorey.SerifedBody          0                      }
@@ -201,11 +201,11 @@ glyph-block Letter-Latin-Lower-G : begin
 			earlessCornerHTB      { SingleStorey.EarlessCornerBody    0                      }
 			earlessRounded        { SingleStorey.EarlessRoundedBody   (XH - SmallArchDepthA) }
 
-	foreach { suffix { hookShape {bodyShape hookStart} } } [Object.entries SingleStoreyConfig] : do
+	foreach { suffix { { hookShape hookEnd } { bodyShape hookStart } } } [Object.entries SingleStoreyConfig] : do
 		create-glyph "g.\(suffix)" : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.p
-			set-base-anchor 'overlay' df.middle (XH / 2)
+			set-base-anchor 'overlay' df.middle [mix O hookEnd 0.5]
 			set-base-anchor 'strike'  df.middle (XH / 2)
 			include : bodyShape df  XH
 			include : hookShape df (XH - hookStart)
@@ -213,16 +213,20 @@ glyph-block Letter-Latin-Lower-G : begin
 		create-glyph "gCap.\(suffix)" : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.capDesc
-			set-base-anchor 'overlay' df.middle (CAP / 2)
+			set-base-anchor 'overlay' df.middle [mix O hookEnd 0.5]
 			set-base-anchor 'strike'  df.middle (CAP / 2)
 			include : bodyShape df  CAP              ArchDepthA ArchDepthB
 			include : hookShape df (CAP - hookStart) ArchDepthA ArchDepthB
+
+		create-glyph "gStroke.\(suffix)" : glyph-proc
+			include [refer-glyph "g.\(suffix)"] AS_BASE ALSO_METRICS
+			include : OverlayW [Math.min OverlayStroke : 0.625 * (O - hookEnd)]
 
 		create-glyph "gPalatalHook.\(suffix)" : glyph-proc
 			local df : include : DivFrame para.advanceScaleM 1
 			include : df.markSet.p
 			local subDf : DivFrame (0.75 * para.advanceScaleM) 2
-			set-base-anchor 'overlay' subDf.middle (XH / 2)
+			set-base-anchor 'overlay' subDf.middle [mix O hookEnd 0.5]
 			set-base-anchor 'strike'  subDf.middle (XH / 2)
 			include : bodyShape subDf  XH
 			include : hookShape subDf (XH - hookStart)
@@ -233,14 +237,10 @@ glyph-block Letter-Latin-Lower-G : begin
 				refSw   -- subDf.mvs
 				maskOut -- [intersection [MaskBelow 0] [MaskLeft subDf.rightSB]]
 
-		create-glyph "gStroke.\(suffix)" : glyph-proc
-			include [refer-glyph "g.\(suffix)"] AS_BASE ALSO_METRICS
-			include : OverlayW [Math.min OverlayStroke : AdviceStroke2 2 3 XH]
-
 		create-glyph "gCrossedTail.\(suffix)" : glyph-proc
 			local df : include : DivFrame 1
 			include : df.markSet.p
-			set-base-anchor 'overlay' df.middle (XH / 2)
+			set-base-anchor 'overlay' df.middle [mix O hookEnd 0.5]
 			set-base-anchor 'strike'  df.middle (XH / 2)
 			include : bodyShape                df  XH
 			include : SingleStorey.CrossedHook df (XH - hookStart)
@@ -255,8 +255,9 @@ glyph-block Letter-Latin-Lower-G : begin
 	select-variant 'GScript'            0xA7AC (follow -- [conditional-follow SLAB 'g/singleStorey/autoSerifed/slab' 'g/singleStorey/autoSerifed/sans']) (shapeFrom -- 'gCap')
 	select-variant 'gScript'            0x261  (follow -- [conditional-follow SLAB 'g/singleStorey/autoSerifed/slab' 'g/singleStorey/autoSerifed/sans']) (shapeFrom -- 'g')
 	select-variant 'gScriptPalatalHook' 0x1D83 (follow -- [conditional-follow SLAB 'g/singleStorey/autoSerifed/slab' 'g/singleStorey/autoSerifed/sans']) (shapeFrom -- 'gPalatalHook')
-	select-variant 'gScriptBar'                (follow -- [conditional-follow SLAB 'g/singleStorey/autoSerifed/slab' 'g/singleStorey/autoSerifed/sans']) (shapeFrom -- 'gStroke')
 	select-variant 'gScriptCrossedTail' 0xAB36 (follow -- [conditional-follow SLAB 'gCrossedTail/singleStorey/autoSerifed/slab' 'gCrossedTail/singleStorey/autoSerifed/sans']) (shapeFrom -- 'gCrossedTail')
+
+	CreateAccentedComposition 'gScriptBar' null 'gScript' 'hStrike'
 
 	alias 'cyrl/de.BGR'           null 'gScript'
 	alias 'cyrl/de.SRB'           null 'gScript'

--- a/packages/font-glyphs/src/meta/unicode-knowledge.ptl
+++ b/packages/font-glyphs/src/meta/unicode-knowledge.ptl
@@ -214,6 +214,7 @@ export : define decompOverrides : object
 	0xA7CC { 'S' 'longSlash' }
 	0xA7CD { 's' 'shortSlash' }
 
+	0xAB30 { 'aScript'   'hStrike' }
 	0xAB3E { 'frak/o'    'shortSlash' }
 	0xAB4F { 'uShortLeg' 'hStrike' }
 	0xAB68 { 'turnr'     'tildeOver' }


### PR DESCRIPTION
### Motivation and Context

This moves the overlay stroke of _Lower G with Stroke_ (`ǥ`) to the descending hook.
The original style is preserved for the IPA localization override (`'IPPH'`).

Also simplify glyph construction of Latin Lower Script A with Bar (`ꬰ`).

### Influenced Characters

  - LATIN SMALL LETTER G WITH STROKE (`U+01E5`).

### Glyph Quantity

N/A (zero new glyphs; Possibly _fewer_ due to moving `ꬰ` to `meta/unicode-knowledge.ptl`)

### Samples

```
AⱭ BɃDĐGꞬǤⱣ
aɑꬰbƀdđgɡǥᵽ
```

<img width="687" height="1192" alt="image" src="https://github.com/user-attachments/assets/4b53e46e-e74b-44b6-9dbb-484d698db0da" />
