### PR TITLE
Make `lyogh` (`ɮ`) respond to `cursive` variants of `ʒ`.

### DIFF
--- a/packages/font-glyphs/src/auto-build/composite.ptl
+++ b/packages/font-glyphs/src/auto-build/composite.ptl
@@ -932,15 +932,15 @@ glyph-block AutoBuild-Enclosure : begin
 	do "Single-digit circled"
 		local compositions : list
 			list 0xA9    {'C'}                       WideWidth2
-			list 0x1F12F {'revC'}                    WideWidth2
 			list 0x2117  {'P'}                       WideWidth2
-			list 0x267E  {'infty'}                   WideWidth1
-			list 0x1F10E {'ccCcwArrow'}              WideWidth2
-			list 0x1F16F {'ccHumanFigure'}           WideWidth2
-			list 0x1F1AD {'M'}                       WideWidth2
 			list 0x24EA  {'zero.lnum'}               WideWidth1
+			list 0x267E  {'infty'}                   WideWidth1
 			list 0x1F10B {'zero.lnum'}               WideWidth1 # We don't have serifs for digit 0, so make an alias here
 			list 0x1F10D {'zero.lnum/forceSlashed'}  WideWidth2
+			list 0x1F10E {'ccCcwArrow'}              WideWidth2
+			list 0x1F12F {'revC'}                    WideWidth2
+			list 0x1F16F {'ccHumanFigure'}           WideWidth2
+			list 0x1F1AD {'M'}                       WideWidth2
 		foreach [j : range 1 till 9] : compositions.push : list (0x2460 + j - 1) [digitGlyphNames j] WideWidth1
 		foreach [j : range 1 till 9] : compositions.push : list (0x2780 + j - 1) [digitGlyphNames j digitSansSerifSuffix] WideWidth1
 		foreach [j : range 0 26] : compositions.push {(0x24B6 + j) {[glyphStore.queryNameByUnicode (['A'.charCodeAt 0] + j)]} WideWidth1}
@@ -961,9 +961,9 @@ glyph-block AutoBuild-Enclosure : begin
 		local compositions : list
 			list null    {'sp1'} WideWidth1
 			list 0x2789  {'one/sansSerif.lnum' 'zero.lnum'} WideWidth1
-			list 0x1F16D {'C' 'C'} WideWidth2
 			list 0x1F12D {'C' 'D'} WideWidth1
 			list 0x1F12E {'W' 'smcpZ'} WideWidth1
+			list 0x1F16D {'C' 'C'} WideWidth2
 		foreach [j : range 10 till 20] : compositions.push : list (0x2460 + j - 1)  [digitGlyphNames j] WideWidth1
 		foreach [j : range 21 till 35] : compositions.push : list (0x3251 + j - 21) [digitGlyphNames j] WideWidth1
 		foreach [j : range 36 till 50] : compositions.push : list (0x32B1 + j - 36) [digitGlyphNames j] WideWidth1
@@ -1783,23 +1783,23 @@ glyph-block Autobuild-Pnonetic-Ligatures : begin
 		list 0xFB02  { 'f/compLigLeft3'  'l/compLigRight'        } null
 
 	createPhoneticLigatures ToLetter 'phonetic2' para.advanceScaleMM 2 stdShrink 1 : list
-		list 0x02A3  { 'd/phoneticLeft'    'z/phoneticRight'                } 'b'
-		list 0x02A4  { 'd/phoneticLeft'    'ezh/phoneticRight'              } 'bp'
-		list 0x02A5  { 'd/phoneticLeft'    'zCurlyTail/phoneticRight'       } 'b'
-		list 0x02A6  { 't/phoneticLeft2'   's/phoneticRight'                } 'b'
-		list 0x02A7  { 't/teshLeft'        'esh'                            } 'bp'
-		list 0x02A8  { 't/phoneticLeft1'   'cCurlyTail'                     } 'b'
-		list 0x02A9  { 'f/phoneticLeft'    'eng/phoneticRight'              } 'bp'
-		list 0x02AA  { 'l/phoneticLeft'    's/phoneticRight'                } 'b'
-		list 0x02AB  { 'l/phoneticLeft'    'z'                              } 'b'
-		list 0xAB66  { 'd/phoneticLeft'    'zRTail/phoneticRight'           } 'bp'
-		list 0xAB67  { 't/phoneticLeft1'   'sRTail'                         } 'bp'
-		list 0x1DF12 { 'd/phoneticLeft'    'ezhPalatalHook/phoneticRight'   } 'bp'
-		list 0x1DF17 { 't/teshLeft'        'eshPalatalHook'                 } 'bp'
-		list 0x1DF19 { 'd/phoneticLeft'    'ezhRetroflexHook/phoneticRight' } 'bp'
-		list 0x1DF1C { 't/teshLeft'        'eshRetroflexHook/teshRight'     } 'bp'
-		list 0xFB05  { 'longs/compLigLeft' 't/compLigRight'                 } null
-		list 0xFB06  { 's/compLigLeft'     't/compLigRight'                 } null
+		list 0x02A3  { 'd/phoneticLeft'    'z/phoneticRight'              } 'b'
+		list 0x02A4  { 'd/phoneticLeft'    'ezh/phoneticRight'            } 'bp'
+		list 0x02A5  { 'd/phoneticLeft'    'zCurlyTail/phoneticRight'     } 'b'
+		list 0x02A6  { 't/phoneticLeft2'   's/phoneticRight'              } 'b'
+		list 0x02A7  { 't/teshLeft'        'esh'                          } 'bp'
+		list 0x02A8  { 't/phoneticLeft1'   'cCurlyTail'                   } 'b'
+		list 0x02A9  { 'f/phoneticLeft'    'eng/phoneticRight'            } 'bp'
+		list 0x02AA  { 'l/phoneticLeft'    's/phoneticRight'              } 'b'
+		list 0x02AB  { 'l/phoneticLeft'    'z'                            } 'b'
+		list 0xAB66  { 'd/phoneticLeft'    'zRTail/phoneticRight'         } 'bp'
+		list 0xAB67  { 't/phoneticLeft1'   'sRTail'                       } 'bp'
+		list 0x1DF12 { 'd/phoneticLeft'    'ezhPalatalHook/phoneticRight' } 'bp'
+		list 0x1DF17 { 't/teshLeft'        'eshPalatalHook'               } 'bp'
+		list 0x1DF19 { 'd/phoneticLeft'    'ezhRTail/phoneticRight'       } 'bp'
+		list 0x1DF1C { 't/teshLeft'        'eshRTail/teshRight'           } 'bp'
+		list 0xFB05  { 'longs/compLigLeft' 't/compLigRight'               } null
+		list 0xFB06  { 's/compLigLeft'     't/compLigRight'               } null
 
 	createPhoneticLigatures ToLetter 'phonetic3' [mix 1 para.advanceScaleM 2] 3 stdShrink 1 : list
 		list 0xFB03  { 'f/compLigLeft2' 'f/compLigLeft1' 'dotlessi/compLigRight' } null

--- a/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
@@ -1,12 +1,14 @@
 $$include '../../meta/macros.ptl'
 
-import [mix fallback SuffixCfg] from "@iosevka/util"
+import [mix fallback] from "@iosevka/util"
+import [DependentSelector] from "@iosevka/glyph/relation"
 
 glyph-module
 
 glyph-block Letter-Latin-Ezh : begin
 	glyph-block-import CommonShapes
 	glyph-block-import Common-Derivatives
+	glyph-block-import Letter-Shared : CreateSelectorVariants DefineSelectorGlyph
 	glyph-block-import Letter-Shared-Metrics : EFVJutLength
 	glyph-block-import Letter-Shared-Shapes : CurlyTail SerifedArcEnd PalatalHook RetroflexHook
 	glyph-block-import Letter-Latin-S : AdviceSArchDepth SNeck
@@ -314,7 +316,7 @@ glyph-block Letter-Latin-Ezh : begin
 				terminal  -- TERMINAL-CURL
 			include : ezh.Shape
 
-		create-glyph "ezhRetroflexHook.\(suffix)" : glyph-proc
+		create-glyph "ezhRTail.\(suffix)" : glyph-proc
 			include : MarkSet.e
 			local stroke : AdviceStroke2 2 3 (XH - 0)
 			define ezh : Ezh [DivFrame 1] XH 0
@@ -356,6 +358,48 @@ glyph-block Letter-Latin-Ezh : begin
 				maskOut -- [intersection [MaskBelow (yArcMid - stroke / 2)] [MaskLeft (xArcMid + O)]]
 
 		if [not fSerifed] : begin
+			DefineSelectorGlyph "lyogh"      suffix [DivFrame 1] 'bp'
+			DefineSelectorGlyph "lyoghRTail" suffix [DivFrame 1] 'b'
+
+			create-glyph "lyogh.\(suffix).serifless" : glyph-proc
+				set-width 0
+				set-mark-anchor 'cvDecompose' 0 0
+				define yogh : Ezh [DivFrame 1] XH Descender
+					fCursive  -- fCursive
+					fSerifed  -- fSerifed
+					pxMidLeft -- 0.40
+					pyMidLeft -- [if fCursive 0.50 0.55]
+					stroke    -- [AdviceStroke2 2 3 (XH - Descender)]
+					hook      -- SHook
+					origBar   -- Stroke
+					ada       -- SmallArchDepthA
+					adb       -- SmallArchDepthB
+				include : yogh.Shape
+				include : VBar.l SB 0 Ascender
+				create-forked-glyph "lyogh.\(suffix).hooky" : HSerif.lt SB Ascender SideJut
+
+			create-glyph "lyoghRTail.\(suffix).serifless" : glyph-proc
+				set-width 0
+				set-mark-anchor 'cvDecompose' 0 0
+				define yogh : Ezh [DivFrame 1] XH 0
+					fCursive  -- fCursive
+					fSerifed  -- fSerifed
+					pxMidLeft -- 0.40
+					pyMidLeft -- [if fCursive 0.50 0.52]
+					stroke    -- [AdviceStroke2 2 3 XH]
+					hook      -- SHook
+					origBar   -- Stroke
+					ada       -- SmallArchDepthA
+					adb       -- SmallArchDepthB
+					terminal  -- TERMINAL-DESC
+				include : yogh.Shape
+				include : VBar.l SB 0 Ascender
+				include : RetroflexHook.lExt SB 0
+				create-forked-glyph "lyoghRTail.\(suffix).hooky" : HSerif.lt SB Ascender SideJut
+
+			select-variant "lyogh.\(suffix)"      (follow -- 'lyogh/l')
+			select-variant "lyoghRTail.\(suffix)" (follow -- 'lyogh/l')
+
 			create-glyph "ezh/phoneticRight.\(suffix)" : glyph-proc
 				include : MarkSet.p
 				define ezh : Ezh [DivFrame 1] XH Descender
@@ -369,7 +413,7 @@ glyph-block Letter-Latin-Ezh : begin
 					adb       -- SmallArchDepthB
 				include : ezh.Shape
 
-			create-glyph "ezhRetroflexHook/phoneticRight.\(suffix)" : glyph-proc
+			create-glyph "ezhRTail/phoneticRight.\(suffix)" : glyph-proc
 				include : MarkSet.p
 				local stroke : AdviceStroke2 2 3 (XH - Descender)
 				define ezh : Ezh [DivFrame 1] XH Descender
@@ -414,106 +458,74 @@ glyph-block Letter-Latin-Ezh : begin
 	select-variant 'revEzh'  0x1B8  (follow -- 'Ezh')
 	select-variant 'smcpEzh' 0x1D23 (follow -- 'Ezh')
 
-	select-variant 'ezh'              0x292
-	select-variant 'revezh'           0x1B9   (follow -- 'ezh')
-	select-variant 'ezhTail'          0x1BA   (follow -- 'ezh')
-	select-variant 'ezhCurlyTail'     0x293   (follow -- 'ezh')
-	select-variant 'ezhRetroflexHook' 0x1D9A  (follow -- 'ezh')
-	select-variant 'ezhPalatalHook'   0x1DF18 (follow -- 'ezh')
+	select-variant 'ezh'            0x292
+	select-variant 'revezh'         0x1B9   (follow -- 'ezh')
+	select-variant 'ezhTail'        0x1BA   (follow -- 'ezh')
+	select-variant 'ezhCurlyTail'   0x293   (follow -- 'ezh')
+	select-variant 'ezhRTail'       0x1D9A  (follow -- 'ezh')
+	select-variant 'ezhPalatalHook' 0x1DF18 (follow -- 'ezh')
 
 	select-variant 'ezh/phoneticRight'
-	select-variant 'ezhRetroflexHook/phoneticRight' (follow -- 'ezh/phoneticRight')
-	select-variant 'ezhPalatalHook/phoneticRight'   (follow -- 'ezh/phoneticRight')
+	select-variant 'ezhRTail/phoneticRight'       (follow -- 'ezh/phoneticRight')
+	select-variant 'ezhPalatalHook/phoneticRight' (follow -- 'ezh/phoneticRight')
 
 	alias 'cyrl/abk/Dze' 0x4E0 'Ezh'
 	alias 'cyrl/abk/dze' 0x4E1 'ezh'
 
-	# Variants for Ezh don't make sense for Lyogh.
-	create-glyph 'lyogh.serifless' : glyph-proc
-		include : MarkSet.bp
-		define yogh : Ezh [DivFrame 1] XH Descender
-			pxMidLeft -- 0.40
-			pyMidLeft -- 0.55
-			stroke    -- [AdviceStroke2 2 3 (XH - Descender)]
-			hook      -- SHook
-			origBar   -- Stroke
-			ada       -- SmallArchDepthA
-			adb       -- SmallArchDepthB
-		include : yogh.Shape
-		include : VBar.l SB 0 Ascender
-		create-forked-glyph 'lyogh.hooky' : HSerif.lt SB Ascender SideJut
-
-	select-variant 'lyogh' 0x26E
-
-	create-glyph 'lyoghRTail.serifless' : glyph-proc
-		include : MarkSet.b
-		define yogh : Ezh [DivFrame 1] XH 0
-			pxMidLeft -- 0.40
-			pyMidLeft -- 0.52
-			stroke    -- [AdviceStroke2 2 3 XH]
-			hook      -- SHook
-			origBar   -- Stroke
-			ada       -- SmallArchDepthA
-			adb       -- SmallArchDepthB
-			terminal  -- TERMINAL-DESC
-		include : yogh.Shape
-		include : VBar.l SB 0 Ascender
-		include : RetroflexHook.lExt SB 0
-		create-forked-glyph 'lyoghRTail.hooky' : HSerif.lt SB Ascender SideJut
-
-	select-variant 'lyoghRTail' 0x1DF05 (follow -- 'lyogh')
+	CreateSelectorVariants 'lyogh'      0x26E   [Object.keys EzhConfig] (follow -- 'ezh/phoneticRight')
+	CreateSelectorVariants 'lyoghRTail' 0x1DF05 [Object.keys EzhConfig] (follow -- 'ezh/phoneticRight')
 
 	do "Visigothic Z"
 		glyph-block-import Letter-Latin-C : CLetterForm CConfig
 
 		define FLAT-CONNECTION 3
 
-		foreach { suffix { sty styBot } } [Object.entries CConfig] : do
+		foreach { suffix { styTop styBot } } [Object.entries CConfig] : do
 			if [not styBot] : begin
 				create-glyph "ZVisigothic.\(suffix)" : glyph-proc
 					include : MarkSet.capital
 					local stroke : AdviceStroke2 2 3 (XH - 0)
-					define C : CLetterForm [DivFrame 1] sty FLAT-CONNECTION CAP (XH - stroke)
+					define c : CLetterForm [DivFrame 1] styTop FLAT-CONNECTION CAP (XH - stroke)
 						sw   -- stroke
 						hook -- [Math.max AHook (Hook * ((CAP - (XH - stroke)) / XH))]
 						ada  -- ArchDepthA
 						adb  -- ArchDepthB
-					define Z : Ezh [DivFrame 1] XH 0
+					define z : Ezh [DivFrame 1] XH 0
 						pyMidLeft -- 0.52
 						stroke    -- stroke
 						hook      -- [Math.max AHook (Hook * (XH / CAP))]
 						ada       -- ArchDepthA
 						adb       -- ArchDepthB
-					define [object xTopRight] : Z.Dim
+					define [object xTopRight] : z.Dim
 					include : union
-						difference [C.full] : intersection
+						difference [c.full] : intersection
 							MaskBelow (XH - O)
 							MaskRight xTopRight
 						new-glyph : glyph-proc
-							include : Z.Shape
+							include : z.Shape
 							eject-contour 'strokeTop'
 
 				create-glyph "zVisigothic.\(suffix)" : glyph-proc
 					include : MarkSet.bp
 					local stroke : AdviceStroke2 2 3 (XH - Descender)
-					define C : CLetterForm [DivFrame 1] sty FLAT-CONNECTION Ascender (XH - stroke)
+					define c : CLetterForm [DivFrame 1] styTop FLAT-CONNECTION Ascender (XH - stroke)
 						sw   -- stroke
 						hook -- SHook
 						ada  -- SmallArchDepthA
 						adb  -- SmallArchDepthB
-					define Z : Ezh [DivFrame 1] XH Descender
+					define z : Ezh [DivFrame 1] XH Descender
 						pyMidLeft -- 0.55
 						stroke    -- stroke
 						hook      -- SHook
 						ada       -- SmallArchDepthA
 						adb       -- SmallArchDepthB
-					define [object xTopRight] : Z.Dim
+					define [object xTopRight] : z.Dim
 					include : union
-						difference [C.full] : intersection
+						difference [c.full] : intersection
 							MaskBelow (XH - O)
 							MaskRight xTopRight
 						new-glyph : glyph-proc
-							include : Z.Shape
+							include : z.Shape
 							eject-contour 'strokeTop'
 
 		select-variant 'ZVisigothic' 0xA762 (follow -- 'C/topSerif')

--- a/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/ezh.ptl
@@ -359,7 +359,7 @@ glyph-block Letter-Latin-Ezh : begin
 
 		if [not fSerifed] : begin
 			DefineSelectorGlyph "lyogh"      suffix [DivFrame 1] 'bp'
-			DefineSelectorGlyph "lyoghRTail" suffix [DivFrame 1] 'b'
+			DefineSelectorGlyph "lyoghRTail" suffix [DivFrame 1] 'bp'
 
 			create-glyph "lyogh.\(suffix).serifless" : glyph-proc
 				set-width 0

--- a/packages/font-glyphs/src/letter/latin-ext/long-s.ptl
+++ b/packages/font-glyphs/src/letter/latin-ext/long-s.ptl
@@ -230,7 +230,7 @@ glyph-block Letter-Latin-Long-S : begin
 		refSw   -- [AdviceStroke 3]
 		maskOut -- [intersection [MaskBelow 0] [MaskLeft : Middle + [HSwToV HalfStroke]]]
 
-	create-glyph "eshRetroflexHook" 0x1D98 : glyph-proc
+	create-glyph "eshRTail" 0x1D98 : glyph-proc
 		include : MarkSet.bp
 		include : LongSShape Ascender 0 (HookX + QuarterStroke) Hook
 		include : RetroflexHook.l
@@ -238,7 +238,7 @@ glyph-block Letter-Latin-Long-S : begin
 			y -- 0
 			yOverflow -- Stroke
 
-	create-glyph "eshRetroflexHook/teshRight" : glyph-proc
+	create-glyph "eshRTail/teshRight" : glyph-proc
 		include : MarkSet.bp
 		include : LongSShape Ascender Descender (HookX + QuarterStroke) Hook
 		include : RetroflexHook.l

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -3680,7 +3680,7 @@ selector.lRTail = "seriflessRTail"
 selector."lRTail/reduced/decompress" = "seriflessRTailDec"
 selector."l/phoneticLeft" = "seriflessPL"
 selector.lCurlyTail = "serifless"
-selector.lyogh = "serifless"
+selector."lyogh/l" = "serifless"
 
 [prime.l.variants.hooky]
 rank = 2
@@ -3694,7 +3694,7 @@ selector.lRTail = "hookyRTail"
 selector."lRTail/reduced/decompress" = "hookyRTailDec"
 selector."l/phoneticLeft" = "hookyPL"
 selector.lCurlyTail = "hooky"
-selector.lyogh = "hooky"
+selector."lyogh/l" = "hooky"
 
 [prime.l.variants.hooky-bottom]
 rank = 3
@@ -3708,7 +3708,7 @@ selector.lRTail = "seriflessRTail"
 selector."lRTail/reduced/decompress" = "seriflessRTailDec"
 selector."l/phoneticLeft" = "seriflessPL"
 selector.lCurlyTail = "serifless"
-selector.lyogh = "serifless"
+selector."lyogh/l" = "serifless"
 
 [prime.l.variants.zshaped]
 rank = 4
@@ -3722,7 +3722,7 @@ selector.lRTail = "hookyRTail"
 selector."lRTail/reduced/decompress" = "hookyRTailDec"
 selector."l/phoneticLeft" = "hookyPL"
 selector.lCurlyTail = "hooky"
-selector.lyogh = "hooky"
+selector."lyogh/l" = "hooky"
 
 [prime.l.variants.serifed]
 rank = 5
@@ -3736,7 +3736,7 @@ selector.lRTail = "hookyRTail"
 selector."lRTail/reduced/decompress" = "hookyRTailDec"
 selector."l/phoneticLeft" = "hookyPL"
 selector.lCurlyTail = "hooky"
-selector.lyogh = "hooky"
+selector."lyogh/l" = "hooky"
 
 [prime.l.variants.serifed-asymmetric]
 rank = 6
@@ -3750,7 +3750,7 @@ selector.lRTail = "hookyRTail"
 selector."lRTail/reduced/decompress" = "hookyRTailDec"
 selector."l/phoneticLeft" = "hookyPL"
 selector.lCurlyTail = "hooky"
-selector.lyogh = "hooky"
+selector."lyogh/l" = "hooky"
 
 [prime.l.variants.tailed]
 rank = 7
@@ -3764,7 +3764,7 @@ selector.lRTail = "seriflessRTail"
 selector."lRTail/reduced/decompress" = "seriflessRTailDec"
 selector."l/phoneticLeft" = "seriflessPL"
 selector.lCurlyTail = "serifless"
-selector.lyogh = "serifless"
+selector."lyogh/l" = "serifless"
 
 [prime.l.variants.tailed-serifed]
 rank = 8
@@ -3778,7 +3778,7 @@ selector.lRTail = "hookyRTail"
 selector."lRTail/reduced/decompress" = "hookyRTailDec"
 selector."l/phoneticLeft" = "hookyPL"
 selector.lCurlyTail = "hooky"
-selector.lyogh = "hooky"
+selector."lyogh/l" = "hooky"
 
 [prime.l.variants.flat-tailed]
 rank = 9
@@ -3792,7 +3792,7 @@ selector.lRTail = "seriflessRTail"
 selector."lRTail/reduced/decompress" = "seriflessRTailDec"
 selector."l/phoneticLeft" = "seriflessPL"
 selector.lCurlyTail = "serifless"
-selector.lyogh = "serifless"
+selector."lyogh/l" = "serifless"
 
 [prime.l.variants.serifed-flat-tailed]
 rank = 10
@@ -3806,7 +3806,7 @@ selector.lRTail = "hookyRTail"
 selector."lRTail/reduced/decompress" = "hookyRTailDec"
 selector."l/phoneticLeft" = "hookyPL"
 selector.lCurlyTail = "hooky"
-selector.lyogh = "hooky"
+selector."lyogh/l" = "hooky"
 
 [prime.l.variants.diagonal-tailed]
 rank = 11
@@ -3820,7 +3820,7 @@ selector.lRTail = "seriflessRTail"
 selector."lRTail/reduced/decompress" = "seriflessRTailDec"
 selector."l/phoneticLeft" = "seriflessPL"
 selector.lCurlyTail = "serifless"
-selector.lyogh = "serifless"
+selector."lyogh/l" = "serifless"
 
 [prime.l.variants.serifed-diagonal-tailed]
 rank = 12
@@ -3834,7 +3834,7 @@ selector.lRTail = "hookyRTail"
 selector."lRTail/reduced/decompress" = "hookyRTailDec"
 selector."l/phoneticLeft" = "hookyPL"
 selector.lCurlyTail = "hooky"
-selector.lyogh = "hooky"
+selector."lyogh/l" = "hooky"
 
 [prime.l.variants.semi-tailed]
 rank = 13
@@ -3848,7 +3848,7 @@ selector.lRTail = "seriflessRTail"
 selector."lRTail/reduced/decompress" = "seriflessRTailDec"
 selector."l/phoneticLeft" = "seriflessPL"
 selector.lCurlyTail = "serifless"
-selector.lyogh = "serifless"
+selector."lyogh/l" = "serifless"
 
 [prime.l.variants.serifed-semi-tailed]
 rank = 14
@@ -3862,7 +3862,7 @@ selector.lRTail = "hookyRTail"
 selector."lRTail/reduced/decompress" = "hookyRTailDec"
 selector."l/phoneticLeft" = "hookyPL"
 selector.lCurlyTail = "hooky"
-selector.lyogh = "hooky"
+selector."lyogh/l" = "hooky"
 
 
 


### PR DESCRIPTION
### Motivation and Context

While `serifed` variants do not make sense due to the serif being obscured by the `l` part, `cursive` variants _do_ make sense, to match with ExtIPA `ʫ` as well as IPA `ʣ`/`ʤ`.

### Influenced Characters

  - LATIN SMALL LETTER LEZH (`U+026E`).
  - MODIFIER LETTER SMALL LEZH (`U+1079E`).
  - MODIFIER LETTER SMALL LEZH WITH RETROFLEX HOOK (`U+1079F`).
  - LATIN SMALL LETTER LEZH WITH RETROFLEX HOOK (`U+1DF05`).

### Glyph Quantity

+1 (`ʒ` cursive variant) \* 2 (`l` top serif variants) \* 2 (baseline characters defined in `letter/latin-ext/ezh.ptl`) = 4 new glyphs.

### Samples

`lzʫ lʒɮ ɭᶚ𝼅`

Slab:
<img width="1343" height="1155" alt="image" src="https://github.com/user-attachments/assets/4d3100a7-98a8-4e16-8af4-025469ab67e2" />

